### PR TITLE
[codex] Fix connector release bundle

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -41,16 +41,16 @@ jobs:
         with:
           draft: false
           files: |
-            dist-release/vicoop-connector-*.tgz
-            dist-release/vicoop-connector-*.tgz.sha256
+            dist-release/vicoop-bridge-connector-*.tgz
+            dist-release/vicoop-bridge-connector-*.tgz.sha256
           generate_release_notes: true
           body: |
-            Portable `vicoop-connector` bundle for direct GitHub download.
+            Portable `vicoop-bridge-connector` bundle for direct GitHub download.
 
             Quick start:
 
             ```bash
-            tar -xzf vicoop-connector-<version>.tgz
-            cd vicoop-connector-<version>
+            tar -xzf vicoop-bridge-connector-<version>.tgz
+            cd vicoop-bridge-connector-<version>
             ./bin/vicoop-connector --help
             ```

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -50,8 +50,7 @@ jobs:
             Quick start:
 
             ```bash
-            tar -xzf vicoop-connector-${{ github.ref_name }}.tgz
-            cd vicoop-connector-${{ github.ref_name }}
+            tar -xzf vicoop-connector-<version>.tgz
+            cd vicoop-connector-<version>
             node dist/cli.js --help
             ```
-

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -52,5 +52,5 @@ jobs:
             ```bash
             tar -xzf vicoop-connector-<version>.tgz
             cd vicoop-connector-<version>
-            node dist/cli.js --help
+            ./bin/vicoop-connector --help
             ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ See [`docs/design.md`](./docs/design.md) for the full design.
 
 ## Connector Releases
 
-Tagging the repository with `connector-v*` publishes a portable `vicoop-connector` bundle to GitHub Releases.
+Tagging the repository with `connector-v*` publishes a portable `vicoop-bridge-connector` bundle to GitHub Releases.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ git tag connector-v0.1.0
 git push origin connector-v0.1.0
 ```
 
+After extracting the release bundle, run the connector with:
+
+```bash
+./bin/vicoop-connector --help
+```
+
 ## Status
 
 Pre-implementation. Design phase only.

--- a/packages/connector/package.json
+++ b/packages/connector/package.json
@@ -4,9 +4,14 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "bin": {
     "vicoop-connector": "./dist/cli.js"
   },
+  "files": [
+    "dist",
+    "cards"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -3,15 +3,18 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/scripts/package-connector-release.sh
+++ b/scripts/package-connector-release.sh
@@ -19,6 +19,17 @@ rm -rf "$WORK_DIR" "$ARCHIVE_PATH" "$CHECKSUM_PATH"
 mkdir -p "$WORK_DIR"
 
 pnpm --dir "$ROOT_DIR" --offline --filter @vicoop-bridge/connector deploy --prod "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR/bin"
+
+cat > "$BUNDLE_DIR/bin/vicoop-connector" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "$SCRIPT_DIR/../dist/cli.js" "$@"
+EOF
+
+chmod +x "$BUNDLE_DIR/bin/vicoop-connector"
 
 cat > "$BUNDLE_DIR/README.md" <<EOF
 # vicoop-connector $VERSION
@@ -28,13 +39,14 @@ Portable release bundle for the standalone connector daemon.
 ## Usage
 
 \`\`\`bash
-node dist/cli.js --relay <ws://...> --token <token> --agentId <id> --card ./cards/openclaw.json --backend openclaw
+./bin/vicoop-connector --relay <ws://...> --token <token> --agentId <id> --card ./cards/openclaw.json --backend openclaw
 \`\`\`
 
 ## Notes
 
 - This bundle is built from the Git tag \`$TAG\`.
 - Node.js 20 or newer is required.
+- The \`bin/vicoop-connector\` wrapper runs \`node dist/cli.js\` for convenience.
 EOF
 
 tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-connector-$VERSION"

--- a/scripts/package-connector-release.sh
+++ b/scripts/package-connector-release.sh
@@ -7,20 +7,21 @@ if [[ $# -ne 1 ]]; then
 fi
 
 TAG="$1"
+VERSION="${TAG#connector-v}"
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/dist-release"
 WORK_DIR="$OUT_DIR/work"
-BUNDLE_DIR="$WORK_DIR/vicoop-connector-$TAG"
-ARCHIVE_PATH="$OUT_DIR/vicoop-connector-$TAG.tgz"
+BUNDLE_DIR="$WORK_DIR/vicoop-connector-$VERSION"
+ARCHIVE_PATH="$OUT_DIR/vicoop-connector-$VERSION.tgz"
 CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
 
 rm -rf "$WORK_DIR" "$ARCHIVE_PATH" "$CHECKSUM_PATH"
 mkdir -p "$WORK_DIR"
 
-pnpm --dir "$ROOT_DIR" --filter @vicoop-bridge/connector deploy --prod "$BUNDLE_DIR"
+pnpm --dir "$ROOT_DIR" --offline --filter @vicoop-bridge/connector deploy --prod "$BUNDLE_DIR"
 
 cat > "$BUNDLE_DIR/README.md" <<EOF
-# vicoop-connector $TAG
+# vicoop-connector $VERSION
 
 Portable release bundle for the standalone connector daemon.
 
@@ -36,7 +37,7 @@ node dist/cli.js --relay <ws://...> --token <token> --agentId <id> --card ./card
 - Node.js 20 or newer is required.
 EOF
 
-tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-connector-$TAG"
+tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-connector-$VERSION"
 shasum -a 256 "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
 
 echo "created $ARCHIVE_PATH"

--- a/scripts/package-connector-release.sh
+++ b/scripts/package-connector-release.sh
@@ -11,8 +11,8 @@ VERSION="${TAG#connector-v}"
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/dist-release"
 WORK_DIR="$OUT_DIR/work"
-BUNDLE_DIR="$WORK_DIR/vicoop-connector-$VERSION"
-ARCHIVE_PATH="$OUT_DIR/vicoop-connector-$VERSION.tgz"
+BUNDLE_DIR="$WORK_DIR/vicoop-bridge-connector-$VERSION"
+ARCHIVE_PATH="$OUT_DIR/vicoop-bridge-connector-$VERSION.tgz"
 CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
 
 rm -rf "$WORK_DIR" "$ARCHIVE_PATH" "$CHECKSUM_PATH"
@@ -32,7 +32,7 @@ EOF
 chmod +x "$BUNDLE_DIR/bin/vicoop-connector"
 
 cat > "$BUNDLE_DIR/README.md" <<EOF
-# vicoop-connector $VERSION
+# vicoop-bridge-connector $VERSION
 
 Portable release bundle for the standalone connector daemon.
 
@@ -49,7 +49,7 @@ Portable release bundle for the standalone connector daemon.
 - The \`bin/vicoop-connector\` wrapper runs \`node dist/cli.js\` for convenience.
 EOF
 
-tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-connector-$VERSION"
+tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-bridge-connector-$VERSION"
 shasum -a 256 "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
 
 echo "created $ARCHIVE_PATH"


### PR DESCRIPTION
## Summary
- point the bundled `@vicoop-bridge/protocol` package at built `dist` outputs instead of TypeScript sources
- limit the deployed connector and protocol package contents to release-relevant files
- rename the generated connector release archive and extraction directory to use the semantic version only

## Why
The `connector-v0.1.0` release uploaded successfully, but the portable bundle had two real problems:

1. the asset name was awkward: `vicoop-connector-connector-v0.1.0.tgz`
2. the unpacked bundle failed at runtime because `@vicoop-bridge/protocol` still exported `src/index.ts`

This change makes the GitHub release artifact both cleaner and actually runnable after download.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm -r build`
- `pnpm -r typecheck`
- `./scripts/package-connector-release.sh connector-v0.1.0`
- unpack the generated tarball and run `node dist/cli.js` to confirm the CLI starts and prints usage
