### PR TITLE
[codex] Fix connector release workflow in CI

### DIFF
--- a/scripts/package-connector-release.sh
+++ b/scripts/package-connector-release.sh
@@ -18,7 +18,7 @@ CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
 rm -rf "$WORK_DIR" "$ARCHIVE_PATH" "$CHECKSUM_PATH"
 mkdir -p "$WORK_DIR"
 
-pnpm --dir "$ROOT_DIR" --offline --filter @vicoop-bridge/connector deploy --prod "$BUNDLE_DIR"
+pnpm --dir "$ROOT_DIR" --filter @vicoop-bridge/connector deploy --prod "$BUNDLE_DIR"
 mkdir -p "$BUNDLE_DIR/bin"
 
 cat > "$BUNDLE_DIR/bin/vicoop-connector" <<'EOF'


### PR DESCRIPTION
## Summary
- remove `--offline` from the connector release packaging script

## Why
The `connector-v0.1.1` release workflow failed in GitHub Actions during `pnpm deploy` with `ERR_PNPM_NO_OFFLINE_META` because the runner did not have the required registry metadata cached. The release bundle script worked locally but was too strict for CI.

This change keeps the artifact format from PR #4 and makes the packaging step work reliably in GitHub Actions.

## Validation
- `bash -n scripts/package-connector-release.sh`
- `./scripts/package-connector-release.sh connector-v0.1.1`
