### PR TITLE
Add per-agent SIWE authentication for A2A endpoints

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -63,6 +63,15 @@ export const AgentSkill = z.object({
   tags: z.array(z.string()).optional(),
 });
 
+export const SecurityScheme = z.object({
+  type: z.string(),
+  scheme: z.string().optional(),
+  bearerFormat: z.string().optional(),
+  description: z.string().optional(),
+  in: z.enum(['header', 'query', 'cookie']).optional(),
+  name: z.string().optional(),
+}).passthrough();
+
 export const AgentCard = z.object({
   name: z.string(),
   description: z.string().optional(),
@@ -78,6 +87,8 @@ export const AgentCard = z.object({
   defaultInputModes: z.array(z.string()).optional(),
   defaultOutputModes: z.array(z.string()).optional(),
   skills: z.array(AgentSkill).optional(),
+  securitySchemes: z.record(z.string(), SecurityScheme).optional(),
+  security: z.array(z.record(z.string(), z.array(z.string()))).optional(),
 });
 export type AgentCard = z.infer<typeof AgentCard>;
 

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -134,8 +134,9 @@ CREATE TABLE IF NOT EXISTS agent_policies (
 
 ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 
--- allowed_callers must only be modified via custom tools (add_caller/remove_caller)
--- to keep the in-memory Registry cache in sync. Hide from GraphQL mutations.
+-- agent_policies rows are server-managed (auto-created on WS registration).
+-- Only expose SELECT to authenticated users; all mutations go through custom tools.
+COMMENT ON TABLE agent_policies IS E'@omit create,update,delete';
 COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit create,update';
 
 -- Authenticated users see their own policies; admins see all
@@ -144,24 +145,11 @@ CREATE POLICY agent_policies_select ON agent_policies
   FOR SELECT TO app_authenticated
   USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
--- Users can insert policies they own
+-- No INSERT/UPDATE/DELETE policies for app_authenticated — only the server
+-- (via app_postgraphile) and custom admin tools manage these rows.
 DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
-CREATE POLICY agent_policies_insert ON agent_policies
-  FOR INSERT TO app_authenticated
-  WITH CHECK (owner_wallet = lower(current_wallet_address()));
-
--- Users can update their own policies; admins can update all
 DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
-CREATE POLICY agent_policies_update ON agent_policies
-  FOR UPDATE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin())
-  WITH CHECK (owner_wallet = lower(current_wallet_address()) OR is_admin());
-
--- No DELETE policy for app_authenticated — policy rows are managed by the server
--- and must persist as long as the agent_id exists. Use allowed_callers to toggle
--- public/restricted. Omit delete mutations from PostGraphile.
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
-COMMENT ON TABLE agent_policies IS E'@omit delete';
 
 -- app_postgraphile bypasses RLS (used by server for auth checks)
 DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -134,6 +134,10 @@ CREATE TABLE IF NOT EXISTS agent_policies (
 
 ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 
+-- allowed_callers must only be modified via custom tools (add_caller/remove_caller)
+-- to keep the in-memory Registry cache in sync. Hide from GraphQL mutations.
+COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit update';
+
 -- Authenticated users see their own policies; admins see all
 DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
 CREATE POLICY agent_policies_select ON agent_policies
@@ -150,7 +154,8 @@ CREATE POLICY agent_policies_insert ON agent_policies
 DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
 CREATE POLICY agent_policies_update ON agent_policies
   FOR UPDATE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (owner_wallet = lower(current_wallet_address()) OR is_admin())
+  WITH CHECK (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
 -- Users can delete their own policies; admins can delete all
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -136,7 +136,7 @@ ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 
 -- allowed_callers must only be modified via custom tools (add_caller/remove_caller)
 -- to keep the in-memory Registry cache in sync. Hide from GraphQL mutations.
-COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit update';
+COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit create,update';
 
 -- Authenticated users see their own policies; admins see all
 DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
@@ -157,11 +157,11 @@ CREATE POLICY agent_policies_update ON agent_policies
   USING (owner_wallet = lower(current_wallet_address()) OR is_admin())
   WITH CHECK (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
--- Users can delete their own policies; admins can delete all
+-- No DELETE policy for app_authenticated — policy rows are managed by the server
+-- and must persist as long as the agent_id exists. Use allowed_callers to toggle
+-- public/restricted. Omit delete mutations from PostGraphile.
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
-CREATE POLICY agent_policies_delete ON agent_policies
-  FOR DELETE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+COMMENT ON TABLE agent_policies IS E'@omit delete';
 
 -- app_postgraphile bypasses RLS (used by server for auth checks)
 DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -122,7 +122,51 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA infra
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_postgraphile;
 
 -- ============================================================
--- 5. Grants
+-- 5. Agent Policies table
+-- ============================================================
+CREATE TABLE IF NOT EXISTS agent_policies (
+  agent_id         TEXT PRIMARY KEY,
+  owner_wallet     VARCHAR(42) NOT NULL,
+  allowed_callers  TEXT[] NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users see their own policies; admins see all
+DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
+CREATE POLICY agent_policies_select ON agent_policies
+  FOR SELECT TO app_authenticated
+  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+
+-- Users can insert policies they own
+DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
+CREATE POLICY agent_policies_insert ON agent_policies
+  FOR INSERT TO app_authenticated
+  WITH CHECK (owner_wallet = lower(current_wallet_address()));
+
+-- Users can update their own policies; admins can update all
+DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
+CREATE POLICY agent_policies_update ON agent_policies
+  FOR UPDATE TO app_authenticated
+  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+
+-- Users can delete their own policies; admins can delete all
+DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
+CREATE POLICY agent_policies_delete ON agent_policies
+  FOR DELETE TO app_authenticated
+  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+
+-- app_postgraphile bypasses RLS (used by server for auth checks)
+DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;
+CREATE POLICY agent_policies_postgraphile ON agent_policies
+  FOR ALL TO app_postgraphile
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================
+-- 6. Grants
 -- ============================================================
 GRANT USAGE ON SCHEMA public TO app_postgraphile, app_anonymous, app_authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_postgraphile;

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -95,10 +95,19 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 
 ## Tool Usage
 
-- Use \`query_*\` and \`mutate_*\` tools for standard CRUD operations on clients. RLS enforces ownership.
+- Use \`query_*\` and \`mutate_*\` tools for standard CRUD operations on clients and agent policies. RLS enforces ownership.
 - Use \`register_client\` to create a new client — this generates a token and hashes it before storing.
 - Use \`list_active_agents\` to see currently connected agents.
+- Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control.
 - Use \`execute_graphql\` for complex queries not covered by auto-generated tools.
+
+## Agent Access Control
+
+Each agent has an access policy (\`agent_policies\` table) with an \`allowed_callers\` list:
+- **Empty \`allowed_callers\`**: Agent is public — anyone can call it via A2A.
+- **Non-empty \`allowed_callers\`**: Agent requires SIWE Bearer authentication, and only listed wallet addresses can call.
+
+When an agent registers via WebSocket, a default policy (public) is auto-created. Use \`add_caller\` to restrict access to specific wallets. The agent card automatically includes \`securitySchemes\` when callers are configured.
 
 ## Conversation memory
 
@@ -107,6 +116,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 ## Important rules
 
 - When registering a client, always warn the user that the token is shown only once.
+- When adding a caller, explain that the agent will require SIWE authentication from that point on.
 - Present data clearly in tables or lists.
 - If asked about something outside client management, politely explain your scope.
 
@@ -164,8 +174,100 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
           agent_id: a.agentId,
           client_id: a.clientId,
           agent_name: a.agentCard.name,
+          allowed_callers: a.allowedCallers,
           connected_at: new Date(a.connectedAt).toISOString(),
         }));
+      },
+    }),
+
+    add_caller: tool({
+      description:
+        'Add a wallet address to an agent\'s allowed callers. Once any caller is added, the agent requires SIWE authentication.',
+      inputSchema: z.object({
+        agent_id: z.string().describe('The agent ID to add the caller to'),
+        wallet_address: z.string().describe('Ethereum wallet address to allow (e.g. 0x1234...)'),
+      }),
+      execute: async ({ agent_id, wallet_address }) => {
+        const wallet = wallet_address.toLowerCase();
+        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
+        const result = await db.begin(async (tx) => {
+          await tx`SELECT set_config('role', 'app_authenticated', true)`;
+          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
+          return tx`
+            UPDATE agent_policies
+            SET allowed_callers = array_append(allowed_callers, ${wallet}),
+                updated_at = now()
+            WHERE agent_id = ${agent_id}
+              AND NOT (${wallet} = ANY(allowed_callers))
+            RETURNING agent_id, owner_wallet, allowed_callers
+          `;
+        });
+        if (result.length === 0) {
+          const existing = await db`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
+          if (existing.length === 0) return { error: 'Agent policy not found. Agent may not have connected yet.' };
+          if ((existing[0].allowed_callers as string[]).includes(wallet)) return { agent_id, message: 'Wallet already in allowed callers', allowed_callers: existing[0].allowed_callers };
+          return { error: 'Not authorized to modify this agent policy.' };
+        }
+        const callers = result[0].allowed_callers as string[];
+        registry.updateAllowedCallers(agent_id, callers);
+        return { agent_id, allowed_callers: callers };
+      },
+    }),
+
+    remove_caller: tool({
+      description:
+        'Remove a wallet address from an agent\'s allowed callers. If the list becomes empty, the agent becomes public again.',
+      inputSchema: z.object({
+        agent_id: z.string().describe('The agent ID to remove the caller from'),
+        wallet_address: z.string().describe('Ethereum wallet address to remove'),
+      }),
+      execute: async ({ agent_id, wallet_address }) => {
+        const wallet = wallet_address.toLowerCase();
+        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
+        const result = await db.begin(async (tx) => {
+          await tx`SELECT set_config('role', 'app_authenticated', true)`;
+          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
+          return tx`
+            UPDATE agent_policies
+            SET allowed_callers = array_remove(allowed_callers, ${wallet}),
+                updated_at = now()
+            WHERE agent_id = ${agent_id}
+            RETURNING agent_id, owner_wallet, allowed_callers
+          `;
+        });
+        if (result.length === 0) return { error: 'Agent policy not found or not authorized.' };
+        const callers = result[0].allowed_callers as string[];
+        registry.updateAllowedCallers(agent_id, callers);
+        return { agent_id, allowed_callers: callers };
+      },
+    }),
+
+    list_callers: tool({
+      description: 'List the allowed callers for an agent. Empty list means the agent is public.',
+      inputSchema: z.object({
+        agent_id: z.string().describe('The agent ID to list callers for'),
+      }),
+      execute: async ({ agent_id }) => {
+        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
+        const result = await db.begin(async (tx) => {
+          await tx`SELECT set_config('role', 'app_authenticated', true)`;
+          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
+          return tx`
+            SELECT agent_id, owner_wallet, allowed_callers, created_at, updated_at
+            FROM agent_policies WHERE agent_id = ${agent_id}
+          `;
+        });
+        if (result.length === 0) return { error: 'Agent policy not found.' };
+        const policy = result[0];
+        return {
+          agent_id: policy.agent_id,
+          owner_wallet: policy.owner_wallet,
+          allowed_callers: policy.allowed_callers,
+          is_public: (policy.allowed_callers as string[]).length === 0,
+        };
       },
     }),
   };

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -95,11 +95,11 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 
 ## Tool Usage
 
-- Use \`query_*\` and \`mutate_*\` tools for standard CRUD operations on clients and agent policies. RLS enforces ownership.
+- Use \`query_*\` and \`mutate_*\` tools for standard CRUD operations on clients. Use \`query_*\` tools to inspect agent policies. RLS enforces ownership.
 - Use \`register_client\` to create a new client — this generates a token and hashes it before storing.
 - Use \`list_active_agents\` to see currently connected agents.
-- Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control.
-- Use \`execute_graphql\` for complex queries not covered by auto-generated tools.
+- Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
+- Use \`execute_graphql\` for complex queries and inspection not covered by auto-generated tools.
 
 ## Agent Access Control
 

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -167,16 +167,19 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
     }),
 
     list_active_agents: tool({
-      description: 'List currently connected agents with their client identity and connection time.',
+      description: 'List currently connected agents with their client identity and connection time. Non-admin users only see their own agents.',
       inputSchema: z.object({}),
       execute: async () => {
-        return registry.listAgents().map((a) => ({
-          agent_id: a.agentId,
-          client_id: a.clientId,
-          agent_name: a.agentCard.name,
-          allowed_callers: a.allowedCallers,
-          connected_at: new Date(a.connectedAt).toISOString(),
-        }));
+        const admin = isAdmin(walletAddress);
+        return registry.listAgents()
+          .filter((a) => admin || a.ownerWallet.toLowerCase() === walletAddress.toLowerCase())
+          .map((a) => ({
+            agent_id: a.agentId,
+            client_id: a.clientId,
+            agent_name: a.agentCard.name,
+            allowed_callers: a.allowedCallers,
+            connected_at: new Date(a.connectedAt).toISOString(),
+          }));
       },
     }),
 
@@ -204,8 +207,14 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
           `;
         });
         if (result.length === 0) {
-          const existing = await db`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
-          if (existing.length === 0) return { error: 'Agent policy not found. Agent may not have connected yet.' };
+          const adminAddrs = process.env.ADMIN_WALLET_ADDRESSES ?? '';
+          const existing = await db.begin(async (tx) => {
+            await tx`SELECT set_config('role', 'app_authenticated', true)`;
+            await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+            await tx`SELECT set_config('app.admin_addresses', ${adminAddrs}, true)`;
+            return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
+          });
+          if (existing.length === 0) return { error: 'Agent policy not found or not authorized.' };
           if ((existing[0].allowed_callers as string[]).includes(wallet)) return { agent_id, message: 'Wallet already in allowed callers', allowed_callers: existing[0].allowed_callers };
           return { error: 'Not authorized to modify this agent policy.' };
         }

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -137,6 +137,14 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 
 // ── Custom Tools (token generation, active agents) ───────────────
 
+const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+
+function validateWalletAddress(address: string): string | null {
+  const trimmed = address.trim();
+  if (!ETH_ADDRESS_RE.test(trimmed)) return null;
+  return trimmed.toLowerCase();
+}
+
 function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
   return {
     register_client: tool({
@@ -191,7 +199,8 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         wallet_address: z.string().describe('Ethereum wallet address to allow (e.g. 0x1234...)'),
       }),
       execute: async ({ agent_id, wallet_address }) => {
-        const wallet = wallet_address.toLowerCase();
+        const wallet = validateWalletAddress(wallet_address);
+        if (!wallet) return { error: 'Invalid wallet address. Expected 0x followed by 40 hex characters.' };
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
@@ -232,7 +241,8 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         wallet_address: z.string().describe('Ethereum wallet address to remove'),
       }),
       execute: async ({ agent_id, wallet_address }) => {
-        const wallet = wallet_address.toLowerCase();
+        const wallet = validateWalletAddress(wallet_address);
+        if (!wallet) return { error: 'Invalid wallet address. Expected 0x followed by 40 hex characters.' };
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -253,10 +253,11 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
             SET allowed_callers = array_remove(allowed_callers, ${wallet}),
                 updated_at = now()
             WHERE agent_id = ${agent_id}
+              AND ${wallet} = ANY(allowed_callers)
             RETURNING agent_id, owner_wallet, allowed_callers
           `;
         });
-        if (result.length === 0) return { error: 'Agent policy not found or not authorized.' };
+        if (result.length === 0) return { error: 'Wallet not found in allowed callers, agent policy not found, or not authorized.' };
         const callers = result[0].allowed_callers as string[];
         registry.updateAllowedCallers(agent_id, callers);
         return { agent_id, allowed_callers: callers };

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -6,7 +6,11 @@ export function getAgentConn(c: Context): ClientConnection {
   return c.get('agentConn') as ClientConnection;
 }
 
-export function agentAuthMiddleware(registry: Registry) {
+export interface AgentAuthOptions {
+  domain?: string;
+}
+
+export function agentAuthMiddleware(registry: Registry, opts?: AgentAuthOptions) {
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
@@ -32,7 +36,7 @@ export function agentAuthMiddleware(registry: Registry) {
 
     let walletAddress: string;
     try {
-      walletAddress = await verifySiweToken(bearerToken);
+      walletAddress = await verifySiweToken(bearerToken, { domain: opts?.domain });
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,6 +1,10 @@
 import type { Context, Next } from 'hono';
-import type { Registry } from './registry.js';
+import type { ClientConnection, Registry } from './registry.js';
 import { verifySiweToken } from './siwe-token.js';
+
+export function getAgentConn(c: Context): ClientConnection {
+  return c.get('agentConn') as ClientConnection;
+}
 
 export function agentAuthMiddleware(registry: Registry) {
   return async (c: Context, next: Next) => {
@@ -9,6 +13,8 @@ export function agentAuthMiddleware(registry: Registry) {
     if (!conn) {
       return c.json({ error: 'agent not connected' }, 404);
     }
+
+    c.set('agentConn', conn);
 
     if (conn.allowedCallers.length === 0) {
       return next();

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,0 +1,48 @@
+import type { Context, Next } from 'hono';
+import type { Registry } from './registry.js';
+import { verifySiweToken } from './siwe-token.js';
+
+export function agentAuthMiddleware(registry: Registry) {
+  return async (c: Context, next: Next) => {
+    const agentId = c.req.param('id')!;
+    const conn = registry.getAgent(agentId);
+    if (!conn) {
+      return c.json({ error: 'agent not connected' }, 404);
+    }
+
+    if (conn.allowedCallers.length === 0) {
+      return next();
+    }
+
+    const authHeader = c.req.header('Authorization');
+    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    if (!bearerToken) {
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32001, message: 'Authentication required (Bearer SIWE token)' },
+      }, 401);
+    }
+
+    let walletAddress: string;
+    try {
+      walletAddress = await verifySiweToken(bearerToken);
+    } catch (err) {
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32001, message: `Invalid SIWE token: ${(err as Error).message}` },
+      }, 401);
+    }
+
+    if (!conn.allowedCallers.includes(walletAddress.toLowerCase())) {
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32001, message: 'Wallet not authorized for this agent' },
+      }, 403);
+    }
+
+    return next();
+  };
+}

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -15,7 +15,11 @@ export function agentAuthMiddleware(registry: Registry, opts?: AgentAuthOptions)
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
     if (!conn) {
-      return c.json({ error: 'agent not connected' }, 404);
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: -32000, message: 'Agent not connected' },
+      }, 404);
     }
 
     c.set('agentConn', conn);

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -21,7 +21,7 @@ export function agentAuthMiddleware(registry: Registry) {
     }
 
     const authHeader = c.req.header('Authorization');
-    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken) {
       return c.json({
         jsonrpc: '2.0',

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -93,11 +93,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   // Invalidate cached transport when allowedCallers changes so the
   // handler's card reflects the updated security fields.
-  const origUpdate = opts.registry.updateAllowedCallers.bind(opts.registry);
-  opts.registry.updateAllowedCallers = (agentId: string, callers: string[]) => {
+  opts.registry.onCallerChange((agentId) => {
     transports.delete(agentId);
-    origUpdate(agentId, callers);
-  };
+  });
 
   async function handleTransportResult(result: unknown, c: Context) {
     if (Symbol.asyncIterator in (result as object)) {
@@ -209,7 +207,8 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  const authMw = agentAuthMiddleware(opts.registry);
+  const siweDomain = opts.publicUrl ? new URL(opts.publicUrl).hostname : undefined;
+  const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
 

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -135,10 +135,20 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     }),
   );
 
+  // Derive SIWE domain early so both admin and agent endpoints use it
+  let siweDomain: string | undefined;
+  if (opts.publicUrl) {
+    try {
+      siweDomain = new URL(opts.publicUrl).hostname;
+    } catch {
+      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
+    }
+  }
+
   // Root POST — admin agent A2A endpoint (SIWE auth)
   app.post('/', async (c) => {
     const authHeader = c.req.header('Authorization');
-    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken) {
       return c.json({
         jsonrpc: '2.0',
@@ -149,7 +159,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
     let walletAddress: string;
     try {
-      walletAddress = await verifySiweToken(bearerToken);
+      walletAddress = await verifySiweToken(bearerToken, { domain: siweDomain });
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',
@@ -207,14 +217,6 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  let siweDomain: string | undefined;
-  if (opts.publicUrl) {
-    try {
-      siweDomain = new URL(opts.publicUrl).hostname;
-    } catch {
-      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
-    }
-  }
   const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -14,6 +14,7 @@ import { ServerAgentExecutor } from './executor.js';
 import type { ClientConnection, Registry } from './registry.js';
 import { createAdminTransport, buildAdminAgentCard } from './admin.js';
 import { verifySiweToken } from './siwe-token.js';
+import { agentAuthMiddleware } from './agent-auth.js';
 import type { Sql } from './db.js';
 
 export interface ServerHttpOptions {
@@ -30,7 +31,7 @@ function toSdkAgentCard(
   const url = publicUrl
     ? `${publicUrl}/agents/${conn.agentId}`
     : `/agents/${conn.agentId}`;
-  return {
+  const card: SdkAgentCard = {
     name: wire.name,
     description: wire.description ?? '',
     version: wire.version,
@@ -50,6 +51,18 @@ function toSdkAgentCard(
       tags: s.tags ?? [],
     })),
   };
+  if (conn.allowedCallers.length > 0) {
+    card.securitySchemes = {
+      siwe: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'SIWE',
+        description: 'Sign-In with Ethereum (EIP-4361) bearer token',
+      },
+    };
+    card.security = [{ siwe: [] }];
+  }
+  return card;
 }
 
 export function createHttpApp(opts: ServerHttpOptions): Hono {
@@ -186,11 +199,11 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     return c.json(toSdkAgentCard(conn.agentCard, conn, opts.publicUrl));
   });
 
-  // Client agent A2A endpoints
-  app.post('/agents/:id', async (c) => {
-    const id = c.req.param('id');
-    const conn = opts.registry.getAgent(id);
-    if (!conn) return c.json({ error: 'agent not connected' }, 404);
+  // Client agent A2A endpoints (auth middleware checks allowedCallers)
+  const authMw = agentAuthMiddleware(opts.registry);
+  app.post('/agents/:id', authMw, async (c) => {
+    const id = c.req.param('id')!;
+    const conn = opts.registry.getAgent(id)!;
 
     const rawBody = await c.req.text();
     const transport = getTransport(conn);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -212,7 +212,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     try {
       siweDomain = new URL(opts.publicUrl).hostname;
     } catch {
-      console.warn(`[server] WARNING: publicUrl "${opts.publicUrl}" is not a valid URL — SIWE domain verification disabled`);
+      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
     }
   }
   const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -207,7 +207,10 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  const siweDomain = opts.publicUrl ? new URL(opts.publicUrl).hostname : undefined;
+  let siweDomain: string | undefined;
+  if (opts.publicUrl) {
+    try { siweDomain = new URL(opts.publicUrl).hostname; } catch { /* ignore malformed publicUrl */ }
+  }
   const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -80,6 +80,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   const adminCard = buildAdminAgentCard(opts.publicUrl);
 
   function getTransport(conn: ClientConnection): JsonRpcTransportHandler {
+    // Rebuild transport when security state changes (allowedCallers toggled)
     const cached = transports.get(conn.agentId);
     if (cached) return cached;
     const card = toSdkAgentCard(conn.agentCard, conn, opts.publicUrl);
@@ -89,6 +90,14 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     transports.set(conn.agentId, transport);
     return transport;
   }
+
+  // Invalidate cached transport when allowedCallers changes so the
+  // handler's card reflects the updated security fields.
+  const origUpdate = opts.registry.updateAllowedCallers.bind(opts.registry);
+  opts.registry.updateAllowedCallers = (agentId: string, callers: string[]) => {
+    transports.delete(agentId);
+    origUpdate(agentId, callers);
+  };
 
   async function handleTransportResult(result: unknown, c: Context) {
     if (Symbol.asyncIterator in (result as object)) {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -209,7 +209,11 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
   let siweDomain: string | undefined;
   if (opts.publicUrl) {
-    try { siweDomain = new URL(opts.publicUrl).hostname; } catch { /* ignore malformed publicUrl */ }
+    try {
+      siweDomain = new URL(opts.publicUrl).hostname;
+    } catch {
+      console.warn(`[server] WARNING: publicUrl "${opts.publicUrl}" is not a valid URL — SIWE domain verification disabled`);
+    }
   }
   const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });
   app.post('/agents/:id', authMw, async (c) => {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -14,7 +14,7 @@ import { ServerAgentExecutor } from './executor.js';
 import type { ClientConnection, Registry } from './registry.js';
 import { createAdminTransport, buildAdminAgentCard } from './admin.js';
 import { verifySiweToken } from './siwe-token.js';
-import { agentAuthMiddleware } from './agent-auth.js';
+import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
 import type { Sql } from './db.js';
 
 export interface ServerHttpOptions {
@@ -202,8 +202,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
   const authMw = agentAuthMiddleware(opts.registry);
   app.post('/agents/:id', authMw, async (c) => {
-    const id = c.req.param('id')!;
-    const conn = opts.registry.getAgent(id)!;
+    const conn = getAgentConn(c);
 
     const rawBody = await c.req.text();
     const transport = getTransport(conn);

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -99,7 +99,7 @@ export class Registry {
     const conn = this.agents.get(agentId);
     if (conn) conn.allowedCallers = normalized;
     for (const listener of this.callerChangeListeners) {
-      listener(agentId, callers);
+      listener(agentId, normalized);
     }
   }
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -6,7 +6,9 @@ import type { ExecutionEventBus } from '@a2a-js/sdk/server';
 export interface ClientConnection {
   agentId: string;
   clientId: string;
+  ownerWallet: string;
   agentCard: AgentCard;
+  allowedCallers: string[];
   ws: WebSocket;
   connectedAt: number;
 }
@@ -83,6 +85,11 @@ export class Registry {
 
   unbindTask(taskId: string): void {
     this.bindings.delete(taskId);
+  }
+
+  updateAllowedCallers(agentId: string, callers: string[]): void {
+    const conn = this.agents.get(agentId);
+    if (conn) conn.allowedCallers = callers;
   }
 
   sendToAgent(agentId: string, frame: DownFrame): boolean {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -20,9 +20,12 @@ export interface TaskBinding {
   eventBus: ExecutionEventBus;
 }
 
+export type CallerChangeListener = (agentId: string, callers: string[]) => void;
+
 export class Registry {
   private agents = new Map<string, ClientConnection>();
   private bindings = new Map<string, TaskBinding>();
+  private callerChangeListeners: CallerChangeListener[] = [];
 
   registerAgent(conn: ClientConnection): { ok: true } | { ok: false; reason: string } {
     const existing = this.agents.get(conn.agentId);
@@ -87,9 +90,16 @@ export class Registry {
     this.bindings.delete(taskId);
   }
 
+  onCallerChange(listener: CallerChangeListener): void {
+    this.callerChangeListeners.push(listener);
+  }
+
   updateAllowedCallers(agentId: string, callers: string[]): void {
     const conn = this.agents.get(agentId);
     if (conn) conn.allowedCallers = callers;
+    for (const listener of this.callerChangeListeners) {
+      listener(agentId, callers);
+    }
   }
 
   sendToAgent(agentId: string, frame: DownFrame): boolean {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -95,8 +95,9 @@ export class Registry {
   }
 
   updateAllowedCallers(agentId: string, callers: string[]): void {
+    const normalized = callers.map((c) => c.toLowerCase());
     const conn = this.agents.get(agentId);
-    if (conn) conn.allowedCallers = callers;
+    if (conn) conn.allowedCallers = normalized;
     for (const listener of this.callerChangeListeners) {
       listener(agentId, callers);
     }

--- a/packages/server/src/siwe-token.ts
+++ b/packages/server/src/siwe-token.ts
@@ -50,7 +50,8 @@ function evictExpired() {
 export async function verifySiweToken(token: string, opts?: { domain?: string }): Promise<string> {
   evictExpired();
 
-  const cached = verifyCache.get(token);
+  const cacheKey = opts?.domain ? `${token}\0${opts.domain.toLowerCase()}` : token;
+  const cached = verifyCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.address;
   }
@@ -82,6 +83,6 @@ export async function verifySiweToken(token: string, opts?: { domain?: string })
     throw new Error(`SIWE domain mismatch: expected ${opts.domain}, got ${siweMessage.domain}`);
   }
 
-  verifyCache.set(token, { address: siweMessage.address, expiresAt: expires });
+  verifyCache.set(cacheKey, { address: siweMessage.address, expiresAt: expires });
   return siweMessage.address;
 }

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -7,14 +7,31 @@ import { hashToken } from './token.js';
 
 interface ClientRow {
   id: string;
+  owner_wallet: string;
   allowed_agent_ids: string[];
 }
 
 async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
   const rows = await sql<ClientRow[]>`
-    SELECT id, allowed_agent_ids FROM clients WHERE token_hash = ${hash} AND revoked = false
+    SELECT id, owner_wallet, allowed_agent_ids FROM clients WHERE token_hash = ${hash} AND revoked = false
   `;
   return rows[0] ?? null;
+}
+
+interface PolicyRow {
+  allowed_callers: string[];
+}
+
+async function ensureAgentPolicy(sql: Sql, agentId: string, ownerWallet: string): Promise<string[]> {
+  await sql`
+    INSERT INTO agent_policies (agent_id, owner_wallet)
+    VALUES (${agentId}, ${ownerWallet.toLowerCase()})
+    ON CONFLICT (agent_id) DO NOTHING
+  `;
+  const rows = await sql<PolicyRow[]>`
+    SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
+  `;
+  return rows[0]?.allowed_callers ?? [];
 }
 
 export interface ServerWsOptions {
@@ -69,11 +86,16 @@ async function authenticateAndRegister(
     return { ok: false, code: 4008, reason: 'agent id not authorized for this client' };
   }
   const clientId = client.id;
+  const ownerWallet = client.owner_wallet;
+
+  const allowedCallers = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet);
 
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
+    ownerWallet,
     agentCard: frame.agentCard,
+    allowedCallers,
     ws,
     connectedAt: Date.now(),
   });

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -196,6 +196,9 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           name: frame.agentCard.name,
           ts: new Date().toISOString(),
         }));
+      }).catch((err) => {
+        console.error('[server] auth error:', err);
+        ws.close(1011, 'internal error');
       });
       return;
     }

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -42,7 +42,7 @@ async function ensureAgentPolicy(
   if (rows[0].owner_wallet.toLowerCase() !== ownerWallet.toLowerCase()) {
     return { ok: false, reason: 'agent id owned by a different wallet' };
   }
-  return { ok: true, allowedCallers: rows[0].allowed_callers };
+  return { ok: true, allowedCallers: rows[0].allowed_callers.map((a) => a.toLowerCase()) };
 }
 
 export interface ServerWsOptions {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -19,19 +19,30 @@ async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | nu
 }
 
 interface PolicyRow {
+  owner_wallet: string;
   allowed_callers: string[];
 }
 
-async function ensureAgentPolicy(sql: Sql, agentId: string, ownerWallet: string): Promise<string[]> {
+async function ensureAgentPolicy(
+  sql: Sql,
+  agentId: string,
+  ownerWallet: string,
+): Promise<{ ok: true; allowedCallers: string[] } | { ok: false; reason: string }> {
   await sql`
     INSERT INTO agent_policies (agent_id, owner_wallet)
     VALUES (${agentId}, ${ownerWallet.toLowerCase()})
     ON CONFLICT (agent_id) DO NOTHING
   `;
   const rows = await sql<PolicyRow[]>`
-    SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
+    SELECT owner_wallet, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
   `;
-  return rows[0]?.allowed_callers ?? [];
+  if (rows.length === 0) {
+    return { ok: false, reason: 'failed to create agent policy' };
+  }
+  if (rows[0].owner_wallet.toLowerCase() !== ownerWallet.toLowerCase()) {
+    return { ok: false, reason: 'agent id owned by a different wallet' };
+  }
+  return { ok: true, allowedCallers: rows[0].allowed_callers };
 }
 
 export interface ServerWsOptions {
@@ -88,14 +99,24 @@ async function authenticateAndRegister(
   const clientId = client.id;
   const ownerWallet = client.owner_wallet;
 
-  const allowedCallers = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet);
+  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet);
+  if (!policyResult.ok) {
+    console.log(JSON.stringify({
+      event: 'client_rejected',
+      reason: policyResult.reason,
+      agentId: frame.agentId,
+      clientId,
+      ts: new Date().toISOString(),
+    }));
+    return { ok: false, code: 4010, reason: policyResult.reason };
+  }
 
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
     ownerWallet,
     agentCard: frame.agentCard,
-    allowedCallers,
+    allowedCallers: policyResult.allowedCallers,
     ws,
     connectedAt: Date.now(),
   });


### PR DESCRIPTION
## Summary

- `POST /agents/:id` was completely unauthenticated. This adds per-agent access control using SIWE bearer tokens with a wallet allowlist.
- New `agent_policies` table (auto-created on agent WebSocket registration) with `allowed_callers` array
- Empty `allowed_callers` = public agent, non-empty = SIWE required + wallet check
- Agent card automatically includes A2A-spec `securitySchemes`/`security` fields when auth is configured
- Admin agent gets `add_caller`/`remove_caller`/`list_callers` tools for ACL management

Refs #10

## Changes

| File | What |
|---|---|
| `packages/server/schema.sql` | `agent_policies` table + RLS |
| `packages/protocol/src/index.ts` | `AgentCard` security fields |
| `packages/server/src/registry.ts` | `allowedCallers` cache in `ClientConnection` |
| `packages/server/src/ws.ts` | Auto-create policy on agent registration |
| `packages/server/src/agent-auth.ts` | **NEW** SIWE auth middleware |
| `packages/server/src/http.ts` | Apply middleware, enrich agent cards |
| `packages/server/src/admin.ts` | Caller management tools + prompt update |

## Test plan

- [ ] Deploy with DB — `ensureSchema` creates `agent_policies` table
- [ ] Register client + agent via WebSocket → `agent_policies` row auto-created (public)
- [ ] `GET /agents/:id/.well-known/agent-card.json` → no security fields
- [ ] Via admin agent: add a wallet to allowed callers
- [ ] `GET /agents/:id/.well-known/agent-card.json` → includes `securitySchemes`
- [ ] `POST /agents/:id` without auth → 401
- [ ] `POST /agents/:id` with SIWE (allowed wallet) → passes
- [ ] `POST /agents/:id` with SIWE (unknown wallet) → 403
- [ ] Via admin agent: remove wallet → agent becomes public again

🤖 Generated with [Claude Code](https://claude.com/claude-code)