### PR TITLE
Persist admin agent conversation history in PostgreSQL

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -113,8 +113,8 @@ CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_id
-  ON infra.a2a_tasks (context_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_wallet
+  ON infra.a2a_tasks (context_id, owner_wallet, created_at);
 
 GRANT USAGE ON SCHEMA infra TO app_postgraphile;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA infra TO app_postgraphile;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -99,7 +99,23 @@ CREATE POLICY clients_postgraphile ON clients
 COMMENT ON COLUMN clients.token_hash IS E'@omit';
 
 -- ============================================================
--- 4. Grants
+-- 4. A2A task store (persists admin agent conversation history)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS a2a_tasks (
+  task_id    TEXT PRIMARY KEY,
+  context_id TEXT NOT NULL,
+  state      TEXT NOT NULL,
+  task_json  JSONB NOT NULL,
+  owner_wallet TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_id
+  ON a2a_tasks (context_id, created_at);
+
+-- ============================================================
+-- 5. Grants
 -- ============================================================
 GRANT USAGE ON SCHEMA public TO app_postgraphile, app_anonymous, app_authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_postgraphile;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -99,9 +99,11 @@ CREATE POLICY clients_postgraphile ON clients
 COMMENT ON COLUMN clients.token_hash IS E'@omit';
 
 -- ============================================================
--- 4. A2A task store (persists admin agent conversation history)
+-- 4. Infra schema (not exposed via PostGraphile / GraphQL)
 -- ============================================================
-CREATE TABLE IF NOT EXISTS a2a_tasks (
+CREATE SCHEMA IF NOT EXISTS infra;
+
+CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
   task_id    TEXT PRIMARY KEY,
   context_id TEXT NOT NULL,
   state      TEXT NOT NULL,
@@ -112,7 +114,12 @@ CREATE TABLE IF NOT EXISTS a2a_tasks (
 );
 
 CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_id
-  ON a2a_tasks (context_id, created_at);
+  ON infra.a2a_tasks (context_id, created_at);
+
+GRANT USAGE ON SCHEMA infra TO app_postgraphile;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA infra TO app_postgraphile;
+ALTER DEFAULT PRIVILEGES IN SCHEMA infra
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_postgraphile;
 
 -- ============================================================
 -- 5. Grants

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
   context_id TEXT NOT NULL,
   state      TEXT NOT NULL,
   task_json  JSONB NOT NULL,
-  owner_wallet TEXT,
+  owner_wallet VARCHAR(42),
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -223,7 +223,7 @@ class AdminAgentExecutor implements AgentExecutor {
         const tools = { ...schemaTools, ...customTools };
 
         // Load conversation history from previous tasks in the same context
-        const previousTasks = await this.taskStore.loadByContextId(contextId, taskId);
+        const previousTasks = await this.taskStore.loadByContextId(contextId, walletAddress, taskId);
         const contextHistory: Message[] = [];
         for (const prev of previousTasks) {
           if (prev.history) contextHistory.push(...prev.history);

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -100,6 +100,10 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`execute_graphql\` for complex queries not covered by auto-generated tools.
 
+## Conversation memory
+
+Your conversation history is persisted in PostgreSQL. You remember all previous messages in this context, even across server restarts. The messages above this one are real history — treat them as your own memory. Do not claim you have forgotten or cannot recall earlier parts of the conversation.
+
 ## Important rules
 
 - When registering a client, always warn the user that the token is shown only once.

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -222,11 +222,18 @@ class AdminAgentExecutor implements AgentExecutor {
         const customTools = buildCustomTools(this.db, this.registry, walletAddress);
         const tools = { ...schemaTools, ...customTools };
 
-        // Load conversation history from previous tasks in the same context
+        // Load conversation history from previous tasks in the same context.
+        // The SDK's ResultManager normally appends status.message into history
+        // before saving, but as a fallback we also include status.message if
+        // it wasn't recorded in history (e.g. edge cases around failures).
         const previousTasks = await this.taskStore.loadByContextId(contextId, walletAddress, taskId);
         const contextHistory: Message[] = [];
         for (const prev of previousTasks) {
           if (prev.history) contextHistory.push(...prev.history);
+          const statusMsg = prev.status?.message;
+          if (statusMsg && !prev.history?.some((m) => m.messageId === statusMsg.messageId)) {
+            contextHistory.push(statusMsg);
+          }
         }
         const currentHistory = task?.history ?? [];
         const history = [...contextHistory, ...currentHistory];

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -17,7 +17,7 @@ import { hashToken, generateToken } from './token.js';
 import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
-import { PostgresTaskStore } from './postgres-task-store.js';
+import { PostgresTaskStore, type ContextAwareTaskStore } from './postgres-task-store.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -175,7 +175,7 @@ class AdminAgentExecutor implements AgentExecutor {
   constructor(
     private readonly db: Sql,
     private readonly registry: Registry,
-    private readonly taskStore: PostgresTaskStore,
+    private readonly taskStore: ContextAwareTaskStore,
   ) {}
 
   async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -6,7 +6,6 @@ import type { Message } from '@a2a-js/sdk';
 import {
   A2AError,
   DefaultRequestHandler,
-  InMemoryTaskStore,
   JsonRpcTransportHandler,
   type AgentExecutor,
   type ExecutionEventBus,
@@ -18,6 +17,7 @@ import { hashToken, generateToken } from './token.js';
 import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
+import { PostgresTaskStore } from './postgres-task-store.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -175,6 +175,7 @@ class AdminAgentExecutor implements AgentExecutor {
   constructor(
     private readonly db: Sql,
     private readonly registry: Registry,
+    private readonly taskStore: PostgresTaskStore,
   ) {}
 
   async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {
@@ -220,7 +221,15 @@ class AdminAgentExecutor implements AgentExecutor {
         const { tools: schemaTools, sdl } = await getSchemaTools();
         const customTools = buildCustomTools(this.db, this.registry, walletAddress);
         const tools = { ...schemaTools, ...customTools };
-        const history: Message[] = task?.history ?? [];
+
+        // Load conversation history from previous tasks in the same context
+        const previousTasks = await this.taskStore.loadByContextId(contextId, taskId);
+        const contextHistory: Message[] = [];
+        for (const prev of previousTasks) {
+          if (prev.history) contextHistory.push(...prev.history);
+        }
+        const currentHistory = task?.history ?? [];
+        const history = [...contextHistory, ...currentHistory];
 
         return generateText({
           model: anthropic('claude-sonnet-4-6'),
@@ -310,7 +319,8 @@ export interface AdminAgentOptions {
 
 export function createAdminTransport(opts: AdminAgentOptions): JsonRpcTransportHandler {
   const card = buildAdminAgentCard(opts.publicUrl);
-  const executor = new AdminAgentExecutor(opts.db, opts.registry);
-  const handler = new DefaultRequestHandler(card, new InMemoryTaskStore(), executor);
+  const taskStore = new PostgresTaskStore(opts.db);
+  const executor = new AdminAgentExecutor(opts.db, opts.registry, taskStore);
+  const handler = new DefaultRequestHandler(card, taskStore, executor);
   return new JsonRpcTransportHandler(handler);
 }

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -54,7 +54,7 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
         ${task.id},
         ${task.contextId},
         ${task.status.state},
-        ${this.sql.json(sanitized as never)},
+        ${this.sql.json(JSON.parse(JSON.stringify(sanitized)))},
         ${ownerWallet ?? null}
       )
       ON CONFLICT (task_id) DO UPDATE SET

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -32,7 +32,11 @@ function stripSensitiveMetadata(task: Task): Task {
   };
 }
 
-export class PostgresTaskStore implements TaskStore {
+export interface ContextAwareTaskStore extends TaskStore {
+  loadByContextId(contextId: string, walletAddress: string, excludeTaskId?: string): Promise<Task[]>;
+}
+
+export class PostgresTaskStore implements ContextAwareTaskStore {
   constructor(private readonly sql: Sql) {}
 
   async save(task: Task): Promise<void> {

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -14,22 +14,24 @@ function extractOwnerWallet(task: Task): string | undefined {
   return undefined;
 }
 
+function stripMessageMetadata(msg: Message): Message {
+  const { _bearerToken, _walletAddress, ...rest } =
+    (msg as MessageWithMetadata).metadata ?? {};
+  const clean = Object.keys(rest).length ? rest : undefined;
+  if (clean) return { ...msg, metadata: clean } as Message;
+  const { metadata: _, ...m } = msg as MessageWithMetadata;
+  return m as Message;
+}
+
 function stripSensitiveMetadata(task: Task): Task {
-  if (!task.history?.length) return task;
-  return {
-    ...task,
-    history: task.history.map((msg) => {
-      const { _bearerToken, _walletAddress, ...rest } =
-        (msg as MessageWithMetadata).metadata ?? {};
-      const clean = Object.keys(rest).length ? rest : undefined;
-      return clean
-        ? ({ ...msg, metadata: clean } as Message)
-        : ((() => {
-            const { metadata: _, ...m } = msg as MessageWithMetadata;
-            return m as Message;
-          })());
-    }),
-  };
+  const result = { ...task };
+  if (result.history?.length) {
+    result.history = result.history.map(stripMessageMetadata);
+  }
+  if (result.status?.message) {
+    result.status = { ...result.status, message: stripMessageMetadata(result.status.message) };
+  }
+  return result;
 }
 
 export interface ContextAwareTaskStore extends TaskStore {
@@ -60,8 +62,9 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
         updated_at = now()
     `;
 
-    // Enforce retention: delete only terminal tasks beyond MAX_CONTEXT_TASKS
-    if (ownerWallet) {
+    // Enforce retention only when this task reaches a terminal state
+    const isTerminal = ['completed', 'failed', 'canceled'].includes(task.status.state);
+    if (ownerWallet && isTerminal) {
       await this.sql`
         DELETE FROM infra.a2a_tasks
         WHERE task_id IN (

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -9,7 +9,7 @@ export class PostgresTaskStore implements TaskStore {
 
   async save(task: Task): Promise<void> {
     await this.sql`
-      INSERT INTO a2a_tasks (task_id, context_id, state, task_json)
+      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json)
       VALUES (${task.id}, ${task.contextId}, ${task.status.state}, ${this.sql.json(task as never)})
       ON CONFLICT (task_id) DO UPDATE SET
         context_id = EXCLUDED.context_id,
@@ -21,7 +21,7 @@ export class PostgresTaskStore implements TaskStore {
 
   async load(taskId: string): Promise<Task | undefined> {
     const rows = await this.sql<{ task_json: Task }[]>`
-      SELECT task_json FROM a2a_tasks WHERE task_id = ${taskId} LIMIT 1
+      SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} LIMIT 1
     `;
     return rows[0]?.task_json;
   }
@@ -29,13 +29,13 @@ export class PostgresTaskStore implements TaskStore {
   async loadByContextId(contextId: string, excludeTaskId?: string): Promise<Task[]> {
     const rows = excludeTaskId
       ? await this.sql<{ task_json: Task }[]>`
-          SELECT task_json FROM a2a_tasks
+          SELECT task_json FROM infra.a2a_tasks
           WHERE context_id = ${contextId} AND task_id != ${excludeTaskId}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
         `
       : await this.sql<{ task_json: Task }[]>`
-          SELECT task_json FROM a2a_tasks
+          SELECT task_json FROM infra.a2a_tasks
           WHERE context_id = ${contextId}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -11,6 +11,9 @@ function extractOwnerWallet(task: Task): string | undefined {
     const wallet = (msg as MessageWithMetadata).metadata?._walletAddress;
     if (typeof wallet === 'string') return wallet.toLowerCase();
   }
+  const statusWallet = (task.status?.message as MessageWithMetadata | undefined)?.metadata
+    ?._walletAddress;
+  if (typeof statusWallet === 'string') return statusWallet.toLowerCase();
   return undefined;
 }
 

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -1,0 +1,45 @@
+import type { Task } from '@a2a-js/sdk';
+import type { TaskStore } from '@a2a-js/sdk/server';
+import type { Sql } from './db.js';
+
+const MAX_CONTEXT_TASKS = 10;
+
+export class PostgresTaskStore implements TaskStore {
+  constructor(private readonly sql: Sql) {}
+
+  async save(task: Task): Promise<void> {
+    await this.sql`
+      INSERT INTO a2a_tasks (task_id, context_id, state, task_json)
+      VALUES (${task.id}, ${task.contextId}, ${task.status.state}, ${this.sql.json(task as never)})
+      ON CONFLICT (task_id) DO UPDATE SET
+        context_id = EXCLUDED.context_id,
+        state = EXCLUDED.state,
+        task_json = EXCLUDED.task_json,
+        updated_at = now()
+    `;
+  }
+
+  async load(taskId: string): Promise<Task | undefined> {
+    const rows = await this.sql<{ task_json: Task }[]>`
+      SELECT task_json FROM a2a_tasks WHERE task_id = ${taskId} LIMIT 1
+    `;
+    return rows[0]?.task_json;
+  }
+
+  async loadByContextId(contextId: string, excludeTaskId?: string): Promise<Task[]> {
+    const rows = excludeTaskId
+      ? await this.sql<{ task_json: Task }[]>`
+          SELECT task_json FROM a2a_tasks
+          WHERE context_id = ${contextId} AND task_id != ${excludeTaskId}
+          ORDER BY created_at DESC, task_id DESC
+          LIMIT ${MAX_CONTEXT_TASKS}
+        `
+      : await this.sql<{ task_json: Task }[]>`
+          SELECT task_json FROM a2a_tasks
+          WHERE context_id = ${contextId}
+          ORDER BY created_at DESC, task_id DESC
+          LIMIT ${MAX_CONTEXT_TASKS}
+        `;
+    return rows.map((r) => r.task_json).reverse();
+  }
+}

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -60,13 +60,15 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
         updated_at = now()
     `;
 
-    // Enforce retention: delete tasks beyond MAX_CONTEXT_TASKS per context+wallet
+    // Enforce retention: delete only terminal tasks beyond MAX_CONTEXT_TASKS
     if (ownerWallet) {
       await this.sql`
         DELETE FROM infra.a2a_tasks
         WHERE task_id IN (
           SELECT task_id FROM infra.a2a_tasks
-          WHERE context_id = ${task.contextId} AND owner_wallet = ${ownerWallet}
+          WHERE context_id = ${task.contextId}
+            AND owner_wallet = ${ownerWallet}
+            AND state IN ('completed', 'failed', 'canceled')
           ORDER BY created_at DESC, task_id DESC
           OFFSET ${MAX_CONTEXT_TASKS}
         )

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -1,22 +1,73 @@
-import type { Task } from '@a2a-js/sdk';
+import type { Task, Message } from '@a2a-js/sdk';
 import type { TaskStore } from '@a2a-js/sdk/server';
 import type { Sql } from './db.js';
 
 const MAX_CONTEXT_TASKS = 10;
 
+type MessageWithMetadata = Message & { metadata?: Record<string, unknown> };
+
+function extractOwnerWallet(task: Task): string | undefined {
+  for (const msg of task.history ?? []) {
+    const wallet = (msg as MessageWithMetadata).metadata?._walletAddress;
+    if (typeof wallet === 'string') return wallet.toLowerCase();
+  }
+  return undefined;
+}
+
+function stripSensitiveMetadata(task: Task): Task {
+  if (!task.history?.length) return task;
+  return {
+    ...task,
+    history: task.history.map((msg) => {
+      const { _bearerToken, _walletAddress, ...rest } =
+        (msg as MessageWithMetadata).metadata ?? {};
+      const clean = Object.keys(rest).length ? rest : undefined;
+      return clean
+        ? ({ ...msg, metadata: clean } as Message)
+        : ((() => {
+            const { metadata: _, ...m } = msg as MessageWithMetadata;
+            return m as Message;
+          })());
+    }),
+  };
+}
+
 export class PostgresTaskStore implements TaskStore {
   constructor(private readonly sql: Sql) {}
 
   async save(task: Task): Promise<void> {
+    const ownerWallet = extractOwnerWallet(task);
+    const sanitized = stripSensitiveMetadata(task);
+
     await this.sql`
-      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json)
-      VALUES (${task.id}, ${task.contextId}, ${task.status.state}, ${this.sql.json(task as never)})
+      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json, owner_wallet)
+      VALUES (
+        ${task.id},
+        ${task.contextId},
+        ${task.status.state},
+        ${this.sql.json(sanitized as never)},
+        ${ownerWallet ?? null}
+      )
       ON CONFLICT (task_id) DO UPDATE SET
         context_id = EXCLUDED.context_id,
         state = EXCLUDED.state,
         task_json = EXCLUDED.task_json,
+        owner_wallet = COALESCE(infra.a2a_tasks.owner_wallet, EXCLUDED.owner_wallet),
         updated_at = now()
     `;
+
+    // Enforce retention: delete tasks beyond MAX_CONTEXT_TASKS per context+wallet
+    if (ownerWallet) {
+      await this.sql`
+        DELETE FROM infra.a2a_tasks
+        WHERE task_id IN (
+          SELECT task_id FROM infra.a2a_tasks
+          WHERE context_id = ${task.contextId} AND owner_wallet = ${ownerWallet}
+          ORDER BY created_at DESC, task_id DESC
+          OFFSET ${MAX_CONTEXT_TASKS}
+        )
+      `;
+    }
   }
 
   async load(taskId: string): Promise<Task | undefined> {
@@ -26,17 +77,24 @@ export class PostgresTaskStore implements TaskStore {
     return rows[0]?.task_json;
   }
 
-  async loadByContextId(contextId: string, excludeTaskId?: string): Promise<Task[]> {
+  async loadByContextId(
+    contextId: string,
+    walletAddress: string,
+    excludeTaskId?: string,
+  ): Promise<Task[]> {
     const rows = excludeTaskId
       ? await this.sql<{ task_json: Task }[]>`
           SELECT task_json FROM infra.a2a_tasks
-          WHERE context_id = ${contextId} AND task_id != ${excludeTaskId}
+          WHERE context_id = ${contextId}
+            AND owner_wallet = ${walletAddress.toLowerCase()}
+            AND task_id != ${excludeTaskId}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
         `
       : await this.sql<{ task_json: Task }[]>`
           SELECT task_json FROM infra.a2a_tasks
           WHERE context_id = ${contextId}
+            AND owner_wallet = ${walletAddress.toLowerCase()}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
         `;


### PR DESCRIPTION
## Summary

- Add `infra.a2a_tasks` table (separate schema to avoid PostGraphile/GraphQL exposure)
- Implement `PostgresTaskStore` with `save`/`load` (TaskStore interface) + `loadByContextId` via `ContextAwareTaskStore` interface
- Replace `InMemoryTaskStore` with `PostgresTaskStore` in `createAdminTransport`
- Executor loads previous tasks from the same contextId to restore conversation history across server restarts
- Strip `_bearerToken` and `_walletAddress` from message metadata before persisting to prevent credential leakage
- Filter by `owner_wallet` to prevent cross-wallet history leaks

Reference: follows `vicoop-db-agent-builder`'s `PostgresTaskStore` pattern (JSONB upsert, contextId-based history)

Closes #15

## Retention policy

- Maximum 10 tasks per context+wallet are kept in the database
- Retention cleanup only runs when a task reaches a **terminal state** (`completed`, `failed`, `canceled`)
- In-flight tasks (`submitted`, `working`) are never pruned, even if they exceed the limit — this prevents deleting tasks that may still receive status updates

## Test plan

- [ ] Server starts and `ensureSchema` creates `infra.a2a_tasks` table
- [ ] Admin agent conversation persists: send message → restart server → send follow-up in same context → agent recalls prior conversation
- [ ] New context starts with empty history
- [ ] Bearer tokens are not stored in task_json
- [ ] Different wallets cannot see each other's history
- [ ] Existing typecheck errors unchanged (no new type errors introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)