### PR TITLE
Cascade agent_policies cleanup with owning client (#23)

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -144,7 +144,9 @@ ALTER TABLE agent_policies ADD COLUMN IF NOT EXISTS client_id TEXT;
 
 DO $$ BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'agent_policies_client_id_fkey'
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_policies_client_id_fkey'
+      AND conrelid = 'agent_policies'::regclass
   ) THEN
     ALTER TABLE agent_policies
       ADD CONSTRAINT agent_policies_client_id_fkey
@@ -189,7 +191,21 @@ WHERE ap.client_id IS NULL
 
 ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_fkey;
 
-ALTER TABLE agent_policies ALTER COLUMN client_id SET NOT NULL;
+-- Enforce NOT NULL via a validated CHECK constraint instead of ALTER COLUMN
+-- SET NOT NULL so the migration avoids the ACCESS EXCLUSIVE full-table scan.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_policies_client_id_not_null'
+      AND conrelid = 'agent_policies'::regclass
+  ) THEN
+    ALTER TABLE agent_policies
+      ADD CONSTRAINT agent_policies_client_id_not_null
+      CHECK (client_id IS NOT NULL) NOT VALID;
+  END IF;
+END $$;
+
+ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_not_null;
 
 CREATE INDEX IF NOT EXISTS idx_agent_policies_client_id
   ON agent_policies (client_id);

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -217,11 +217,13 @@ ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 COMMENT ON TABLE agent_policies IS E'@omit create,update,delete';
 COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit create,update';
 
--- Authenticated users see their own policies; admins see all
+-- Authenticated users see their own policies; admins see all.
+-- lower(owner_wallet) compare tolerates any legacy mixed-case rows, matching
+-- the normalization used in the migration backfill and WS upsert guard.
 DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
 CREATE POLICY agent_policies_select ON agent_policies
   FOR SELECT TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
 
 -- No INSERT/UPDATE policies for app_authenticated — only the server
 -- (via app_postgraphile) and custom admin tools manage these rows.
@@ -234,7 +236,7 @@ DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
 CREATE POLICY agent_policies_delete ON agent_policies
   FOR DELETE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
 
 -- app_postgraphile bypasses RLS (used by server for auth checks)
 DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -124,13 +124,48 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA infra
 -- ============================================================
 -- 5. Agent Policies table
 -- ============================================================
+-- Each policy is owned by the client that registered the agent. When the
+-- owning client is deleted the policy cascades, so orphan rows cannot
+-- accumulate (see #23). client_id is set in INSERT/upsert on WS registration.
 CREATE TABLE IF NOT EXISTS agent_policies (
   agent_id         TEXT PRIMARY KEY,
   owner_wallet     VARCHAR(42) NOT NULL,
+  client_id        TEXT REFERENCES clients(id) ON DELETE CASCADE,
   allowed_callers  TEXT[] NOT NULL DEFAULT '{}',
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- Idempotent migration for pre-#23 deployments: add the column, attach the FK,
+-- backfill it from clients.allowed_agent_ids, drop orphans, then enforce NOT NULL.
+ALTER TABLE agent_policies ADD COLUMN IF NOT EXISTS client_id TEXT;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'agent_policies_client_id_fkey'
+  ) THEN
+    ALTER TABLE agent_policies
+      ADD CONSTRAINT agent_policies_client_id_fkey
+      FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+
+UPDATE agent_policies ap
+SET client_id = sub.client_id
+FROM (
+  SELECT DISTINCT ON (p.agent_id) p.agent_id, c.id AS client_id
+  FROM agent_policies p
+  JOIN clients c
+    ON c.owner_wallet = p.owner_wallet
+   AND p.agent_id = ANY(c.allowed_agent_ids)
+  WHERE p.client_id IS NULL
+  ORDER BY p.agent_id, c.created_at DESC
+) sub
+WHERE ap.agent_id = sub.agent_id AND ap.client_id IS NULL;
+
+DELETE FROM agent_policies WHERE client_id IS NULL;
+
+ALTER TABLE agent_policies ALTER COLUMN client_id SET NOT NULL;
 
 ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -153,16 +153,25 @@ DO $$ BEGIN
   END IF;
 END $$;
 
+-- Partial-run safety: if a row already has a client_id but it points at a
+-- missing client (e.g. deleted while the FK was NOT VALID), reset it to NULL
+-- rather than deleting — the backfill below will try to reassign the policy
+-- to another client of the same wallet and preserve allowed_callers.
+UPDATE agent_policies ap
+SET client_id = NULL
+WHERE ap.client_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM clients c WHERE c.id = ap.client_id);
+
 -- Backfill: prefer a client whose allowed_agent_ids still lists this agent,
 -- otherwise fall back to the most recent client of the same wallet. The
--- fallback preserves existing allowed_callers configuration when
--- allowed_agent_ids is out of sync with historical registrations.
+-- fallback preserves existing allowed_callers when allowed_agent_ids is out
+-- of sync. Case-insensitive wallet compare guards against legacy casing.
 UPDATE agent_policies ap
 SET client_id = sub.client_id
 FROM (
   SELECT DISTINCT ON (p.agent_id) p.agent_id, c.id AS client_id
   FROM agent_policies p
-  JOIN clients c ON c.owner_wallet = p.owner_wallet
+  JOIN clients c ON lower(c.owner_wallet) = lower(p.owner_wallet)
   WHERE p.client_id IS NULL
   ORDER BY p.agent_id,
            (p.agent_id = ANY(c.allowed_agent_ids)) DESC,
@@ -170,14 +179,13 @@ FROM (
 ) sub
 WHERE ap.agent_id = sub.agent_id AND ap.client_id IS NULL;
 
--- Partial-run safety: drop rows whose client_id references a client that no
--- longer exists (otherwise VALIDATE CONSTRAINT would fail).
+-- Only rows whose wallet truly has no clients left are orphaned.
 DELETE FROM agent_policies ap
-WHERE ap.client_id IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM clients c WHERE c.id = ap.client_id);
-
--- Only rows whose wallet has no clients left are truly orphaned.
-DELETE FROM agent_policies WHERE client_id IS NULL;
+WHERE ap.client_id IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM clients c
+    WHERE lower(c.owner_wallet) = lower(ap.owner_wallet)
+  );
 
 ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_fkey;
 

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -136,8 +136,10 @@ CREATE TABLE IF NOT EXISTS agent_policies (
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Idempotent migration for pre-#23 deployments: add the column, attach the FK,
--- backfill it from clients.allowed_agent_ids, drop orphans, then enforce NOT NULL.
+-- Idempotent migration for pre-#23 deployments. ensureSchema() runs schema.sql
+-- without an outer transaction, so each step must tolerate resuming from a
+-- half-applied state: the FK is added NOT VALID first, rows are scrubbed, and
+-- the constraint is validated only after the table is consistent.
 ALTER TABLE agent_policies ADD COLUMN IF NOT EXISTS client_id TEXT;
 
 DO $$ BEGIN
@@ -146,24 +148,38 @@ DO $$ BEGIN
   ) THEN
     ALTER TABLE agent_policies
       ADD CONSTRAINT agent_policies_client_id_fkey
-      FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE;
+      FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE
+      NOT VALID;
   END IF;
 END $$;
 
+-- Backfill: prefer a client whose allowed_agent_ids still lists this agent,
+-- otherwise fall back to the most recent client of the same wallet. The
+-- fallback preserves existing allowed_callers configuration when
+-- allowed_agent_ids is out of sync with historical registrations.
 UPDATE agent_policies ap
 SET client_id = sub.client_id
 FROM (
   SELECT DISTINCT ON (p.agent_id) p.agent_id, c.id AS client_id
   FROM agent_policies p
-  JOIN clients c
-    ON c.owner_wallet = p.owner_wallet
-   AND p.agent_id = ANY(c.allowed_agent_ids)
+  JOIN clients c ON c.owner_wallet = p.owner_wallet
   WHERE p.client_id IS NULL
-  ORDER BY p.agent_id, c.created_at DESC
+  ORDER BY p.agent_id,
+           (p.agent_id = ANY(c.allowed_agent_ids)) DESC,
+           c.created_at DESC
 ) sub
 WHERE ap.agent_id = sub.agent_id AND ap.client_id IS NULL;
 
+-- Partial-run safety: drop rows whose client_id references a client that no
+-- longer exists (otherwise VALIDATE CONSTRAINT would fail).
+DELETE FROM agent_policies ap
+WHERE ap.client_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM clients c WHERE c.id = ap.client_id);
+
+-- Only rows whose wallet has no clients left are truly orphaned.
 DELETE FROM agent_policies WHERE client_id IS NULL;
+
+ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_fkey;
 
 ALTER TABLE agent_policies ALTER COLUMN client_id SET NOT NULL;
 

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -167,6 +167,9 @@ DELETE FROM agent_policies WHERE client_id IS NULL;
 
 ALTER TABLE agent_policies ALTER COLUMN client_id SET NOT NULL;
 
+CREATE INDEX IF NOT EXISTS idx_agent_policies_client_id
+  ON agent_policies (client_id);
+
 ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 
 -- agent_policies rows are server-managed (auto-created on WS registration).
@@ -180,11 +183,18 @@ CREATE POLICY agent_policies_select ON agent_policies
   FOR SELECT TO app_authenticated
   USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
--- No INSERT/UPDATE/DELETE policies for app_authenticated — only the server
+-- No INSERT/UPDATE policies for app_authenticated — only the server
 -- (via app_postgraphile) and custom admin tools manage these rows.
 DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
 DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
+
+-- DELETE policy exists solely so ON DELETE CASCADE from clients works when a
+-- user (running as app_authenticated) deletes their own client. The direct
+-- delete mutation is still hidden from GraphQL via COMMENT ON TABLE @omit.
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
+CREATE POLICY agent_policies_delete ON agent_policies
+  FOR DELETE TO app_authenticated
+  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
 -- app_postgraphile bypasses RLS (used by server for auth checks)
 DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -225,10 +225,15 @@ CREATE POLICY agent_policies_select ON agent_policies
   FOR SELECT TO app_authenticated
   USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
 
--- No INSERT/UPDATE policies for app_authenticated — only the server
--- (via app_postgraphile) and custom admin tools manage these rows.
+-- No INSERT policy for app_authenticated. UPDATE is allowed for the same
+-- owner/admin predicate because admin tools (add_caller / remove_caller) run
+-- UPDATE under app_authenticated; direct mutations remain hidden via @omit.
 DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
 DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
+CREATE POLICY agent_policies_update ON agent_policies
+  FOR UPDATE TO app_authenticated
+  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin())
+  WITH CHECK (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
 
 -- DELETE policy exists solely so ON DELETE CASCADE from clients works when a
 -- user (running as app_authenticated) deletes their own client. The direct

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -32,7 +32,9 @@ async function ensureAgentPolicy(
   // Refresh client_id on re-registration so cascade follows the currently
   // registering client. Case-insensitive compare mirrors the lowercase
   // normalization used elsewhere, so a legacy mixed-case row still matches;
-  // the ownership check below still rejects cross-wallet attempts.
+  // the ownership check below still rejects cross-wallet attempts. The
+  // IS DISTINCT FROM guard skips the write when nothing actually changed to
+  // avoid WAL churn on frequent reconnects.
   await sql`
     INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
     VALUES (${agentId}, ${ownerWallet.toLowerCase()}, ${clientId})
@@ -41,6 +43,10 @@ async function ensureAgentPolicy(
           client_id = EXCLUDED.client_id,
           updated_at = now()
       WHERE lower(agent_policies.owner_wallet) = lower(EXCLUDED.owner_wallet)
+        AND (
+          agent_policies.client_id IS DISTINCT FROM EXCLUDED.client_id
+          OR agent_policies.owner_wallet IS DISTINCT FROM EXCLUDED.owner_wallet
+        )
   `;
   const rows = await sql<PolicyRow[]>`
     SELECT owner_wallet, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -27,11 +27,17 @@ async function ensureAgentPolicy(
   sql: Sql,
   agentId: string,
   ownerWallet: string,
+  clientId: string,
 ): Promise<{ ok: true; allowedCallers: string[] } | { ok: false; reason: string }> {
+  // Refresh client_id on re-registration so cascade follows the currently
+  // registering client. The WHERE guards against a different wallet silently
+  // taking over an existing policy — the ownership check below still rejects.
   await sql`
-    INSERT INTO agent_policies (agent_id, owner_wallet)
-    VALUES (${agentId}, ${ownerWallet.toLowerCase()})
-    ON CONFLICT (agent_id) DO NOTHING
+    INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
+    VALUES (${agentId}, ${ownerWallet.toLowerCase()}, ${clientId})
+    ON CONFLICT (agent_id) DO UPDATE
+      SET client_id = EXCLUDED.client_id, updated_at = now()
+      WHERE agent_policies.owner_wallet = EXCLUDED.owner_wallet
   `;
   const rows = await sql<PolicyRow[]>`
     SELECT owner_wallet, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
@@ -99,7 +105,7 @@ async function authenticateAndRegister(
   const clientId = client.id;
   const ownerWallet = client.owner_wallet;
 
-  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet);
+  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet, clientId);
   if (!policyResult.ok) {
     console.log(JSON.stringify({
       event: 'client_rejected',

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -30,14 +30,17 @@ async function ensureAgentPolicy(
   clientId: string,
 ): Promise<{ ok: true; allowedCallers: string[] } | { ok: false; reason: string }> {
   // Refresh client_id on re-registration so cascade follows the currently
-  // registering client. The WHERE guards against a different wallet silently
-  // taking over an existing policy — the ownership check below still rejects.
+  // registering client. Case-insensitive compare mirrors the lowercase
+  // normalization used elsewhere, so a legacy mixed-case row still matches;
+  // the ownership check below still rejects cross-wallet attempts.
   await sql`
     INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
     VALUES (${agentId}, ${ownerWallet.toLowerCase()}, ${clientId})
     ON CONFLICT (agent_id) DO UPDATE
-      SET client_id = EXCLUDED.client_id, updated_at = now()
-      WHERE agent_policies.owner_wallet = EXCLUDED.owner_wallet
+      SET owner_wallet = EXCLUDED.owner_wallet,
+          client_id = EXCLUDED.client_id,
+          updated_at = now()
+      WHERE lower(agent_policies.owner_wallet) = lower(EXCLUDED.owner_wallet)
   `;
   const rows = await sql<PolicyRow[]>`
     SELECT owner_wallet, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}


### PR DESCRIPTION
## Summary

- Ties each `agent_policies` row to the registering `clients.id` via a new `client_id` FK with `ON DELETE CASCADE`, so deleting a client also removes its policies (option **B** from #23).
- WS registration upserts the current `client_id`; the `ON CONFLICT ... WHERE owner_wallet = EXCLUDED.owner_wallet` guard preserves the existing cross-owner reject.
- Idempotent migration backfills `client_id` from `clients.allowed_agent_ids` for existing rows and drops any remaining orphans before enforcing `NOT NULL`.

## Test plan

- [ ] `pnpm -r typecheck` passes locally.
- [ ] Apply schema on a staging DB with orphan rows and verify they are cleaned up.
- [ ] Register an agent via WS, confirm `agent_policies.client_id` matches the client id.
- [ ] Delete the client via `mutate_deleteClientById` and confirm the `agent_policies` row is gone.
- [ ] Re-register the same `agentId` from a second client (same wallet) and confirm `client_id` is updated.
- [ ] Attempt to register the same `agentId` from a different wallet and confirm the WS is rejected with `agent id owned by a different wallet`.

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)