### PR TITLE
Replace root JSON with HTML landing page

### DIFF
--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -68,6 +68,10 @@ function isAdmin(wallet: string): boolean {
   return adminWallets.has(wallet.toLowerCase());
 }
 
+export function getAdminWallets(): string[] {
+  return [...adminWallets];
+}
+
 // ── System Prompt ────────────────────────────────────────────────
 
 function buildSystemPrompt(walletAddress: string, sdl?: string): string {

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -65,6 +65,101 @@ function toSdkAgentCard(
   return card;
 }
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderLandingPage(opts: {
+  adminCard: SdkAgentCard;
+  clients: Array<{ id: string; url: string; card: SdkAgentCard }>;
+}): string {
+  const e = escapeHtml;
+  const clientItems = opts.clients.length
+    ? opts.clients
+        .map(
+          (c) => `
+          <li>
+            <code>${e(c.id)}</code> — ${e(c.card.name)}
+            <span class="muted">v${e(c.card.version)}</span>
+            · <a href="/agents/${e(c.id)}/.well-known/agent-card.json">card</a>
+          </li>`,
+        )
+        .join('')
+    : '<li class="muted">No clients connected.</li>';
+
+  const skillItems = opts.adminCard.skills
+    .map(
+      (s) =>
+        `<li><strong>${e(s.name)}</strong> <span class="muted">— ${e(s.description ?? '')}</span></li>`,
+    )
+    .join('');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>vicoop-bridge</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+      max-width: 720px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      line-height: 1.5;
+    }
+    h1 { margin-bottom: 0.25rem; }
+    h2 {
+      margin-top: 2rem;
+      border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+      padding-bottom: 0.25rem;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.9em;
+      padding: 0.1em 0.3em;
+      background: color-mix(in srgb, currentColor 10%, transparent);
+      border-radius: 3px;
+    }
+    .muted { opacity: 0.7; font-size: 0.9em; }
+    .lede { opacity: 0.8; margin-top: 0; }
+    ul { padding-left: 1.25rem; }
+    li { margin: 0.25rem 0; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <h1>vicoop-bridge</h1>
+  <p class="lede">A2A server for outbound-connected local agents.</p>
+
+  <h2>Admin agent</h2>
+  <p>
+    <strong>${e(opts.adminCard.name)}</strong>
+    <span class="muted">v${e(opts.adminCard.version)}</span>
+  </p>
+  <p>${e(opts.adminCard.description)}</p>
+  <p>Skills:</p>
+  <ul>${skillItems}</ul>
+  <p>Card: <a href="/.well-known/agent-card.json"><code>/.well-known/agent-card.json</code></a></p>
+
+  <h2>Connected clients (${opts.clients.length})</h2>
+  <ul>${clientItems}</ul>
+
+  <h2>Tools</h2>
+  <ul>
+    <li><a href="/admin">Admin UI</a></li>
+    <li><a href="/graphiql">GraphiQL</a></li>
+  </ul>
+</body>
+</html>`;
+}
+
 export function createHttpApp(opts: ServerHttpOptions): Hono {
   const app = new Hono();
 
@@ -117,23 +212,31 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // Root agent card — the server itself is an A2A agent
   app.get('/.well-known/agent-card.json', (c) => c.json(adminCard));
 
-  // Server info
-  app.get('/', (c) =>
-    c.json({
-      name: 'vicoop-bridge',
-      description: 'A2A server for outbound-connected local agents',
-      version: '0.0.0',
-      url: opts.publicUrl,
-      card: adminCard,
-      clients: opts.registry.listAgents().map((a) => ({
-        id: a.agentId,
-        url: opts.publicUrl
-          ? `${opts.publicUrl}/agents/${a.agentId}`
-          : `/agents/${a.agentId}`,
-        card: toSdkAgentCard(a.agentCard, a, opts.publicUrl),
-      })),
-    }),
-  );
+  // Server info — HTML landing for browsers, JSON for API clients
+  app.get('/', (c) => {
+    const clients = opts.registry.listAgents().map((a) => ({
+      id: a.agentId,
+      url: opts.publicUrl
+        ? `${opts.publicUrl}/agents/${a.agentId}`
+        : `/agents/${a.agentId}`,
+      card: toSdkAgentCard(a.agentCard, a, opts.publicUrl),
+    }));
+
+    const accept = c.req.header('accept') ?? '';
+    const wantsJson =
+      accept.includes('application/json') && !accept.includes('text/html');
+    if (wantsJson) {
+      return c.json({
+        name: 'vicoop-bridge',
+        description: 'A2A server for outbound-connected local agents',
+        version: '0.0.0',
+        url: opts.publicUrl,
+        card: adminCard,
+        clients,
+      });
+    }
+    return c.html(renderLandingPage({ adminCard, clients }));
+  });
 
   // Derive SIWE domain early so both admin and agent endpoints use it
   let siweDomain: string | undefined;

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import { Hono, type Context } from 'hono';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { stream } from 'hono/streaming';
+import { html } from 'hono/html';
 import {
   DefaultRequestHandler,
   InMemoryTaskStore,
@@ -16,6 +17,7 @@ import { createAdminTransport, buildAdminAgentCard } from './admin.js';
 import { verifySiweToken } from './siwe-token.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
 import type { Sql } from './db.js';
+import { Landing } from './landing.js';
 
 export interface ServerHttpOptions {
   registry: Registry;
@@ -63,101 +65,6 @@ function toSdkAgentCard(
     card.security = [{ siwe: [] }];
   }
   return card;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function renderLandingPage(opts: {
-  adminCard: SdkAgentCard;
-  clients: Array<{ id: string; url: string; card: SdkAgentCard }>;
-}): string {
-  const e = escapeHtml;
-  const clientItems = opts.clients.length
-    ? opts.clients
-        .map(
-          (c) => `
-          <li>
-            <code>${e(c.id)}</code> — ${e(c.card.name)}
-            <span class="muted">v${e(c.card.version)}</span>
-            · <a href="/agents/${e(c.id)}/.well-known/agent-card.json">card</a>
-          </li>`,
-        )
-        .join('')
-    : '<li class="muted">No clients connected.</li>';
-
-  const skillItems = opts.adminCard.skills
-    .map(
-      (s) =>
-        `<li><strong>${e(s.name)}</strong> <span class="muted">— ${e(s.description ?? '')}</span></li>`,
-    )
-    .join('');
-
-  return `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>vicoop-bridge</title>
-  <style>
-    :root { color-scheme: light dark; }
-    body {
-      font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-      max-width: 720px;
-      margin: 2rem auto;
-      padding: 0 1rem;
-      line-height: 1.5;
-    }
-    h1 { margin-bottom: 0.25rem; }
-    h2 {
-      margin-top: 2rem;
-      border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
-      padding-bottom: 0.25rem;
-    }
-    code {
-      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      font-size: 0.9em;
-      padding: 0.1em 0.3em;
-      background: color-mix(in srgb, currentColor 10%, transparent);
-      border-radius: 3px;
-    }
-    .muted { opacity: 0.7; font-size: 0.9em; }
-    .lede { opacity: 0.8; margin-top: 0; }
-    ul { padding-left: 1.25rem; }
-    li { margin: 0.25rem 0; }
-    a { color: inherit; }
-  </style>
-</head>
-<body>
-  <h1>vicoop-bridge</h1>
-  <p class="lede">A2A server for outbound-connected local agents.</p>
-
-  <h2>Admin agent</h2>
-  <p>
-    <strong>${e(opts.adminCard.name)}</strong>
-    <span class="muted">v${e(opts.adminCard.version)}</span>
-  </p>
-  <p>${e(opts.adminCard.description)}</p>
-  <p>Skills:</p>
-  <ul>${skillItems}</ul>
-  <p>Card: <a href="/.well-known/agent-card.json"><code>/.well-known/agent-card.json</code></a></p>
-
-  <h2>Connected clients (${opts.clients.length})</h2>
-  <ul>${clientItems}</ul>
-
-  <h2>Tools</h2>
-  <ul>
-    <li><a href="/admin">Admin UI</a></li>
-    <li><a href="/graphiql">GraphiQL</a></li>
-  </ul>
-</body>
-</html>`;
 }
 
 export function createHttpApp(opts: ServerHttpOptions): Hono {
@@ -235,7 +142,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         clients,
       });
     }
-    return c.html(renderLandingPage({ adminCard, clients }));
+    return c.html(
+      html`<!DOCTYPE html>${(<Landing adminCard={adminCard} clients={clients} />)}`,
+    );
   });
 
   // Derive SIWE domain early so both admin and agent endpoints use it

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -13,7 +13,7 @@ import type { AgentCard as SdkAgentCard } from '@a2a-js/sdk';
 import type { AgentCard as WireAgentCard } from '@vicoop-bridge/protocol';
 import { ServerAgentExecutor } from './executor.js';
 import type { ClientConnection, Registry } from './registry.js';
-import { createAdminTransport, buildAdminAgentCard } from './admin.js';
+import { createAdminTransport, buildAdminAgentCard, getAdminWallets } from './admin.js';
 import { verifySiweToken } from './siwe-token.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
 import type { Sql } from './db.js';
@@ -143,7 +143,13 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       });
     }
     return c.html(
-      html`<!DOCTYPE html>${(<Landing adminCard={adminCard} clients={clients} />)}`,
+      html`<!DOCTYPE html>${(
+        <Landing
+          adminCard={adminCard}
+          clients={clients}
+          adminWallets={getAdminWallets()}
+        />
+      )}`,
     );
   });
 

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -58,7 +58,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
       <p>Skills:</p>
       <ul>
         {adminCard.skills.map((s) => (
-          <li>
+          <li key={s.id}>
             <strong>{s.name}</strong>{' '}
             <span class="muted">— {s.description ?? ''}</span>
           </li>
@@ -77,7 +77,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
           <li class="muted">No clients connected.</li>
         ) : (
           clients.map((c) => (
-            <li>
+            <li key={c.id}>
               <code>{c.id}</code> — {c.card.name}{' '}
               <span class="muted">v{c.card.version}</span>
               {' · '}
@@ -112,7 +112,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
       ) : (
         <ul>
           {adminWallets.map((w) => (
-            <li>
+            <li key={w}>
               <code>{w}</code>
             </li>
           ))}

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -5,6 +5,7 @@ import type { AgentCard as SdkAgentCard } from '@a2a-js/sdk';
 interface LandingProps {
   adminCard: SdkAgentCard;
   clients: Array<{ id: string; url: string; card: SdkAgentCard }>;
+  adminWallets: string[];
 }
 
 const STYLES = `
@@ -36,7 +37,7 @@ const STYLES = `
   a { color: inherit; }
 `;
 
-export const Landing: FC<LandingProps> = ({ adminCard, clients }) => (
+export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) => (
   <html lang="en">
     <head>
       <meta charset="utf-8" />
@@ -87,14 +88,36 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients }) => (
       </ul>
 
       <h2>Tools</h2>
+      <p class="muted">
+        Both require SIWE (Sign-In with Ethereum) authentication. Non-admin
+        wallets only see clients they own (RLS enforced); admin wallets see
+        everything.
+      </p>
       <ul>
         <li>
-          <a href="/admin">Admin UI</a>
+          <a href="/admin">Admin UI</a> — wallet sign-in via RainbowKit
         </li>
         <li>
-          <a href="/graphiql">GraphiQL</a>
+          <a href="/graphiql">GraphiQL</a> — requires{' '}
+          <code>Authorization: Bearer &lt;SIWE-JWT&gt;</code> header
         </li>
       </ul>
+
+      <h3>Admin wallets</h3>
+      {adminWallets.length === 0 ? (
+        <p class="muted">
+          None configured. Set <code>ADMIN_WALLET_ADDRESSES</code> to grant
+          global access.
+        </p>
+      ) : (
+        <ul>
+          {adminWallets.map((w) => (
+            <li>
+              <code>{w}</code>
+            </li>
+          ))}
+        </ul>
+      )}
     </body>
   </html>
 );

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -81,7 +81,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
               <code>{c.id}</code> — {c.card.name}{' '}
               <span class="muted">v{c.card.version}</span>
               {' · '}
-              <a href={`/agents/${c.id}/.well-known/agent-card.json`}>card</a>
+              <a href={`/agents/${encodeURIComponent(c.id)}/.well-known/agent-card.json`}>card</a>
             </li>
           ))
         )}

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -95,7 +95,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
       </p>
       <ul>
         <li>
-          <a href="/admin">Admin UI</a> — wallet sign-in via RainbowKit
+          <a href="/admin/">Admin UI</a> — wallet sign-in via RainbowKit
         </li>
         <li>
           <a href="/graphiql">GraphiQL</a> — requires{' '}

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -1,0 +1,100 @@
+import type { FC } from 'hono/jsx';
+import { raw } from 'hono/html';
+import type { AgentCard as SdkAgentCard } from '@a2a-js/sdk';
+
+interface LandingProps {
+  adminCard: SdkAgentCard;
+  clients: Array<{ id: string; url: string; card: SdkAgentCard }>;
+}
+
+const STYLES = `
+  :root { color-scheme: light dark; }
+  body {
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+    max-width: 720px;
+    margin: 2rem auto;
+    padding: 0 1rem;
+    line-height: 1.5;
+  }
+  h1 { margin-bottom: 0.25rem; }
+  h2 {
+    margin-top: 2rem;
+    border-bottom: 1px solid color-mix(in srgb, currentColor 20%, transparent);
+    padding-bottom: 0.25rem;
+  }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.9em;
+    padding: 0.1em 0.3em;
+    background: color-mix(in srgb, currentColor 10%, transparent);
+    border-radius: 3px;
+  }
+  .muted { opacity: 0.7; font-size: 0.9em; }
+  .lede { opacity: 0.8; margin-top: 0; }
+  ul { padding-left: 1.25rem; }
+  li { margin: 0.25rem 0; }
+  a { color: inherit; }
+`;
+
+export const Landing: FC<LandingProps> = ({ adminCard, clients }) => (
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <title>vicoop-bridge</title>
+      <style>{raw(STYLES)}</style>
+    </head>
+    <body>
+      <h1>vicoop-bridge</h1>
+      <p class="lede">A2A server for outbound-connected local agents.</p>
+
+      <h2>Admin agent</h2>
+      <p>
+        <strong>{adminCard.name}</strong>{' '}
+        <span class="muted">v{adminCard.version}</span>
+      </p>
+      <p>{adminCard.description}</p>
+      <p>Skills:</p>
+      <ul>
+        {adminCard.skills.map((s) => (
+          <li>
+            <strong>{s.name}</strong>{' '}
+            <span class="muted">— {s.description ?? ''}</span>
+          </li>
+        ))}
+      </ul>
+      <p>
+        Card:{' '}
+        <a href="/.well-known/agent-card.json">
+          <code>/.well-known/agent-card.json</code>
+        </a>
+      </p>
+
+      <h2>Connected clients ({clients.length})</h2>
+      <ul>
+        {clients.length === 0 ? (
+          <li class="muted">No clients connected.</li>
+        ) : (
+          clients.map((c) => (
+            <li>
+              <code>{c.id}</code> — {c.card.name}{' '}
+              <span class="muted">v{c.card.version}</span>
+              {' · '}
+              <a href={`/agents/${c.id}/.well-known/agent-card.json`}>card</a>
+            </li>
+          ))
+        )}
+      </ul>
+
+      <h2>Tools</h2>
+      <ul>
+        <li>
+          <a href="/admin">Admin UI</a>
+        </li>
+        <li>
+          <a href="/graphiql">GraphiQL</a>
+        </li>
+      </ul>
+    </body>
+  </html>
+);

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- `GET /`는 이제 브라우저에 HTML 랜딩을 보여준다 — 서버 소개, admin 에이전트 카드 요약 + skills, 연결된 client 목록 (각 card 링크), `/admin` · `/graphiql` 바로가기.
- `Accept: application/json`가 명시된 API 요청에는 기존 JSON 응답을 그대로 반환 (content-negotiation).
- 표준 A2A discovery 경로 `/.well-known/agent-card.json`은 변경 없음.

Closes #22

## Test plan

- [x] `pnpm --filter @vicoop-bridge/server typecheck` 통과
- [x] 로컬 풀 스택(Postgres + PostGraphile + admin-ui) 기동 후 확인
  - [x] `GET /` with `Accept: text/html` → HTML 랜딩
  - [x] `GET /` with `Accept: application/json` → 기존 JSON
  - [x] `GET /` with no `Accept` 헤더 → HTML (기본)
  - [x] `GET /.well-known/agent-card.json` → admin card JSON
  - [x] `GET /admin/` → admin UI SPA 정상 로드
  - [x] HTML 이스케이프 동작 (`Weather <Bot>` → `Weather &lt;Bot&gt;`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)