### PR TITLE
Trigger server deploy on admin-ui changes

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'packages/server/**'
       - 'packages/protocol/**'
+      - 'packages/admin-ui/**'
       - 'pnpm-lock.yaml'
 
 jobs:


### PR DESCRIPTION
## Summary

- `packages/server/Dockerfile`이 admin-ui 번들(`packages/admin-ui/**`)을 빌드해서 이미지에 포함시키지만, `.github/workflows/deploy-server.yml`의 path 필터에는 빠져 있어 admin UI만 고친 PR이 main에 머지되어도 Fly 배포가 안 돌았다.
- path 필터에 `packages/admin-ui/**` 추가.

Closes #26

## Test plan

- [x] YAML 구문 유효 (`.github/workflows/deploy-server.yml` 단일 라인 추가)
- [ ] 이 PR 머지 후 admin-ui 단독 수정 PR을 main에 올릴 때 "Deploy Server" 워크플로가 실행되는지 실제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)