### PR TITLE
Add admin client CRUD mutations (closes #28)

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -54,6 +54,23 @@ AS $$
   );
 $$;
 
+-- Validate and normalize an Ethereum wallet address (0x + 40 hex chars).
+-- Raises invalid_parameter_value if the input does not match. Used by
+-- register_client to reject typo'd or malformed addresses before creating a
+-- client that the intended owner could never access under RLS.
+CREATE OR REPLACE FUNCTION normalize_wallet_address(addr TEXT)
+  RETURNS VARCHAR(42)
+  LANGUAGE plpgsql IMMUTABLE
+AS $$
+BEGIN
+  IF addr IS NULL OR addr !~ '^0x[0-9a-fA-F]{40}$' THEN
+    RAISE EXCEPTION 'invalid wallet address: %', addr
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+  RETURN lower(addr);
+END;
+$$;
+
 -- ============================================================
 -- 3. Clients table
 -- ============================================================
@@ -151,13 +168,17 @@ BEGIN
   v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
 
   IF is_admin() AND register_client.owner_wallet IS NOT NULL THEN
-    v_owner := lower(register_client.owner_wallet);
+    -- Validate the explicit owner_wallet: a typo'd address would create a row
+    -- that the intended owner could never read or update under RLS.
+    v_owner := normalize_wallet_address(register_client.owner_wallet);
   ELSE
-    v_owner := lower(current_wallet_address());
-  END IF;
-
-  IF v_owner IS NULL THEN
-    RAISE EXCEPTION 'current wallet address is not set';
+    IF current_wallet_address() IS NULL THEN
+      RAISE EXCEPTION 'current wallet address is not set';
+    END IF;
+    -- Sanity check: current_wallet_address() comes from the SIWE token claim
+    -- and should already be well-formed. Validate anyway so a compromised or
+    -- buggy auth layer cannot plant malformed rows.
+    v_owner := normalize_wallet_address(current_wallet_address());
   END IF;
 
   INSERT INTO clients AS c (owner_wallet, client_name, token_hash, allowed_agent_ids)

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -20,6 +20,11 @@ DO $$ BEGIN
   GRANT app_authenticated TO app_postgraphile;
 END $$;
 
+-- pgcrypto supplies gen_random_bytes / digest for register_client and
+-- rotate_client_token. gen_random_uuid() is core PG13+ so the clients table
+-- above does not depend on this extension.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- ============================================================
 -- 2. Helper functions
 -- ============================================================
@@ -70,11 +75,13 @@ CREATE POLICY clients_select ON clients
   FOR SELECT TO app_authenticated
   USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
--- Users can insert clients they own
+-- Users can insert clients they own; admins can insert on behalf of any wallet.
+-- The admin branch is needed by register_client() when called with an explicit
+-- owner_wallet argument.
 DROP POLICY IF EXISTS clients_insert ON clients;
 CREATE POLICY clients_insert ON clients
   FOR INSERT TO app_authenticated
-  WITH CHECK (owner_wallet = lower(current_wallet_address()));
+  WITH CHECK (owner_wallet = lower(current_wallet_address()) OR is_admin());
 
 -- Users can update their own clients; admins can update all
 DROP POLICY IF EXISTS clients_update ON clients;
@@ -97,6 +104,186 @@ CREATE POLICY clients_postgraphile ON clients
 
 -- token_hash is never exposed via GraphQL — hide from PostGraphile
 COMMENT ON COLUMN clients.token_hash IS E'@omit';
+
+-- Block the auto-generated create mutation: token_hash cannot be supplied via
+-- GraphQL (it is @omit) so PostGraphile's createClient would fail at runtime.
+-- Clients must be created through register_client() which generates the token.
+COMMENT ON TABLE clients IS E'@omit create';
+
+-- ------------------------------------------------------------
+-- 3a. Client CRUD mutations (exposed by PostGraphile)
+-- ------------------------------------------------------------
+-- Token-carrying return type for register / rotate.
+-- Wrapped in DO so the migration is idempotent.
+DO $$ BEGIN
+  CREATE TYPE client_with_token AS (
+    id                TEXT,
+    owner_wallet      VARCHAR(42),
+    client_name       TEXT,
+    allowed_agent_ids TEXT[],
+    revoked           BOOLEAN,
+    created_at        TIMESTAMPTZ,
+    token             TEXT
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Register a new client. Admins may pass an explicit owner_wallet to create on
+-- behalf of another wallet; non-admins own the client themselves regardless of
+-- what they pass. Returns the raw bearer token — shown only once.
+-- Arg names match clients column names, so the body qualifies them with
+-- `register_client.*` to disambiguate from columns in enclosing SQL scopes.
+CREATE OR REPLACE FUNCTION register_client(
+  client_name       TEXT,
+  allowed_agent_ids TEXT[],
+  owner_wallet      VARCHAR(42) DEFAULT NULL
+) RETURNS client_with_token
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+AS $$
+DECLARE
+  v_raw_token  TEXT;
+  v_token_hash TEXT;
+  v_owner      VARCHAR(42);
+  v_row        client_with_token;
+BEGIN
+  v_raw_token  := encode(gen_random_bytes(32), 'hex');
+  v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
+
+  IF is_admin() AND register_client.owner_wallet IS NOT NULL THEN
+    v_owner := lower(register_client.owner_wallet);
+  ELSE
+    v_owner := lower(current_wallet_address());
+  END IF;
+
+  IF v_owner IS NULL THEN
+    RAISE EXCEPTION 'current wallet address is not set';
+  END IF;
+
+  INSERT INTO clients AS c (owner_wallet, client_name, token_hash, allowed_agent_ids)
+  VALUES (
+    v_owner,
+    register_client.client_name,
+    v_token_hash,
+    COALESCE(register_client.allowed_agent_ids, '{}')
+  )
+  RETURNING c.id, c.owner_wallet, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  INTO v_row;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION register_client(TEXT, TEXT[], VARCHAR) IS
+  'Register a new client. Admins may pass ownerWallet to create on behalf of another wallet; non-admins always own the resulting client. Returns the raw bearer token — shown only once.';
+
+-- Mark a client as revoked. Does not delete the row so history is preserved.
+-- RLS authorizes the update (owner or admin).
+CREATE OR REPLACE FUNCTION revoke_client(client_id TEXT)
+RETURNS clients
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+AS $$
+DECLARE
+  v_row clients;
+BEGIN
+  UPDATE clients AS c SET revoked = TRUE
+  WHERE c.id = revoke_client.client_id
+  RETURNING c.* INTO v_row;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'client not found or not authorized: %', revoke_client.client_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION revoke_client(TEXT) IS
+  'Set revoked=true on a client. Active WebSocket sessions keep running until they reconnect; registry sync is out of scope here.';
+
+-- Clear the revoked flag.
+CREATE OR REPLACE FUNCTION unrevoke_client(client_id TEXT)
+RETURNS clients
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+AS $$
+DECLARE
+  v_row clients;
+BEGIN
+  UPDATE clients AS c SET revoked = FALSE
+  WHERE c.id = unrevoke_client.client_id
+  RETURNING c.* INTO v_row;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'client not found or not authorized: %', unrevoke_client.client_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION unrevoke_client(TEXT) IS
+  'Clear the revoked flag on a client.';
+
+-- Issue a new bearer token for an existing client, replacing token_hash.
+-- Returns the raw token — shown only once.
+CREATE OR REPLACE FUNCTION rotate_client_token(client_id TEXT)
+RETURNS client_with_token
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+AS $$
+DECLARE
+  v_raw_token  TEXT;
+  v_token_hash TEXT;
+  v_row        client_with_token;
+BEGIN
+  v_raw_token  := encode(gen_random_bytes(32), 'hex');
+  v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
+
+  UPDATE clients AS c
+  SET token_hash = v_token_hash
+  WHERE c.id = rotate_client_token.client_id
+  RETURNING c.id, c.owner_wallet, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  INTO v_row;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'client not found or not authorized: %', rotate_client_token.client_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION rotate_client_token(TEXT) IS
+  'Issue a new bearer token for a client. Returns the raw token — shown only once. Previous tokens are immediately invalidated for new connections.';
+
+-- Replace the allowed_agent_ids list on a client.
+CREATE OR REPLACE FUNCTION update_client_allowed_agents(
+  client_id         TEXT,
+  allowed_agent_ids TEXT[]
+) RETURNS clients
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+AS $$
+DECLARE
+  v_row clients;
+BEGIN
+  UPDATE clients AS c
+  SET allowed_agent_ids = COALESCE(update_client_allowed_agents.allowed_agent_ids, '{}')
+  WHERE c.id = update_client_allowed_agents.client_id
+  RETURNING c.* INTO v_row;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'client not found or not authorized: %', update_client_allowed_agents.client_id;
+  END IF;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) IS
+  'Replace the allowed_agent_ids list on a client.';
 
 -- ============================================================
 -- 4. Infra schema (not exposed via PostGraphile / GraphQL)
@@ -258,3 +445,18 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_postg
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_authenticated;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_postgraphile;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_authenticated;
+
+-- Default PUBLIC has EXECUTE on newly created functions, but ignoreRBAC=false
+-- in PostGraphile only exposes functions whose EXECUTE privilege is granted to
+-- the connecting role. Grant explicitly so these mutations show up in the
+-- GraphQL schema.
+GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR)
+  TO app_authenticated, app_postgraphile;
+GRANT EXECUTE ON FUNCTION revoke_client(TEXT)
+  TO app_authenticated, app_postgraphile;
+GRANT EXECUTE ON FUNCTION unrevoke_client(TEXT)
+  TO app_authenticated, app_postgraphile;
+GRANT EXECUTE ON FUNCTION rotate_client_token(TEXT)
+  TO app_authenticated, app_postgraphile;
+GRANT EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[])
+  TO app_authenticated, app_postgraphile;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -20,9 +20,8 @@ DO $$ BEGIN
   GRANT app_authenticated TO app_postgraphile;
 END $$;
 
--- pgcrypto supplies gen_random_bytes / digest for register_client and
--- rotate_client_token. gen_random_uuid() is core PG13+ so the clients table
--- above does not depend on this extension.
+-- pgcrypto supplies gen_random_bytes and digest, used by register_client and
+-- rotate_client_token for token generation.
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ============================================================
@@ -467,10 +466,17 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_authe
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_postgraphile;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO app_authenticated;
 
--- Default PUBLIC has EXECUTE on newly created functions, but ignoreRBAC=false
--- in PostGraphile only exposes functions whose EXECUTE privilege is granted to
--- the connecting role. Grant explicitly so these mutations show up in the
--- GraphQL schema.
+-- Restrict the client lifecycle mutations to authenticated callers. Postgres
+-- grants EXECUTE to PUBLIC by default, which would let app_anonymous invoke
+-- these via GraphQL (they'd fail inside, but we want them off the anonymous
+-- surface entirely). Revoke PUBLIC and grant back only to the authenticated
+-- role and to app_postgraphile (used for introspection).
+REVOKE EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION revoke_client(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION unrevoke_client(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION rotate_client_token(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) FROM PUBLIC;
+
 GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR)
   TO app_authenticated, app_postgraphile;
 GRANT EXECUTE ON FUNCTION revoke_client(TEXT)

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -13,7 +13,6 @@ import {
 } from '@a2a-js/sdk/server';
 import type { AgentCard as SdkAgentCard } from '@a2a-js/sdk';
 import type { Sql } from './db.js';
-import { hashToken, generateToken } from './token.js';
 import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
@@ -95,12 +94,17 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 - **allowed_agent_ids**: List of agent IDs this client is authorized to register
 - **revoked**: Whether this client has been revoked
 - **created_at**: When it was created
-- **token_hash**: Not exposed via GraphQL — use register_client tool to create tokens
+- **token_hash**: Not exposed via GraphQL — use \`mutate_registerClient\` or \`mutate_rotateClientToken\` to obtain tokens
 
 ## Tool Usage
 
-- Use \`query_*\` and \`mutate_*\` tools for standard CRUD operations on clients. Use \`query_*\` tools to inspect agent policies. RLS enforces ownership.
-- Use \`register_client\` to create a new client — this generates a token and hashes it before storing.
+- Use \`query_*\` tools to read clients and agent policies. RLS enforces ownership (admins see all).
+- Client lifecycle mutations are exposed as custom GraphQL functions:
+  - \`mutate_registerClient(clientName, allowedAgentIds, ownerWallet?)\` — creates a new client and returns the raw bearer token (shown only once). Admins may pass \`ownerWallet\` to create on behalf of another wallet; non-admins always own the resulting client.
+  - \`mutate_revokeClient(clientId)\` / \`mutate_unrevokeClient(clientId)\` — toggle the \`revoked\` flag. Existing WebSocket sessions stay connected until they reconnect.
+  - \`mutate_rotateClientToken(clientId)\` — issues a new bearer token and invalidates the previous one. Returns the raw token once.
+  - \`mutate_updateClientAllowedAgents(clientId, allowedAgentIds)\` — replaces the agent allowlist.
+- Do NOT use the auto-generated \`mutate_updateClientById\` or \`mutate_deleteClientById\` for revoke/token rotation — always prefer the semantic mutations above.
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
 - Use \`execute_graphql\` for complex queries and inspection not covered by auto-generated tools.
@@ -119,7 +123,8 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 
 ## Important rules
 
-- When registering a client, always warn the user that the token is shown only once.
+- When registering a client or rotating a token, always warn the user that the raw token is shown only once.
+- When registering on behalf of another wallet (admin only), echo back the chosen \`ownerWallet\` so the user can confirm.
 - When adding a caller, explain that the agent will require SIWE authentication from that point on.
 - Present data clearly in tables or lists.
 - If asked about something outside client management, politely explain your scope.
@@ -151,33 +156,6 @@ function validateWalletAddress(address: string): string | null {
 
 function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
   return {
-    register_client: tool({
-      description:
-        'Register a new client owned by the current wallet. Generates a bearer token (shown only once) and stores its hash.',
-      inputSchema: z.object({
-        client_name: z.string().describe('Human-readable client name'),
-        allowed_agent_ids: z
-          .array(z.string())
-          .describe('List of agent IDs this client is authorized to register'),
-      }),
-      execute: async ({ client_name, allowed_agent_ids }) => {
-        const rawToken = generateToken();
-        const tokenHash = hashToken(rawToken);
-        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
-        const result = await db.begin(async (tx) => {
-          await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
-          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
-          return tx`
-            INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
-            VALUES (${walletAddress.toLowerCase()}, ${client_name}, ${tokenHash}, ${allowed_agent_ids})
-            RETURNING id, owner_wallet, client_name, allowed_agent_ids, created_at
-          `;
-        });
-        return { ...result[0], token: rawToken };
-      },
-    }),
-
     list_active_agents: tool({
       description: 'List currently connected agents with their client identity and connection time. Non-admin users only see their own agents.',
       inputSchema: z.object({}),

--- a/packages/server/src/token.ts
+++ b/packages/server/src/token.ts
@@ -1,9 +1,5 @@
-import { createHash, randomBytes } from 'node:crypto';
+import { createHash } from 'node:crypto';
 
 export function hashToken(token: string): string {
   return createHash('sha256').update(token).digest('hex');
-}
-
-export function generateToken(): string {
-  return randomBytes(32).toString('hex');
 }


### PR DESCRIPTION
## Summary

Exposes five custom PostGraphile mutations so the admin agent can manage clients semantically — including on behalf of other owners — without relying on the Node-side \`register_client\` tool.

- \`registerClient(clientName, allowedAgentIds, ownerWallet?)\` — admins may pass \`ownerWallet\` to create on behalf of another wallet; non-admins always own the resulting client. Returns the raw bearer token once.
- \`revokeClient(clientId)\` / \`unrevokeClient(clientId)\` — toggle the \`revoked\` flag.
- \`rotateClientToken(clientId)\` — issue a fresh bearer token, invalidating the previous one. Returns the raw token once.
- \`updateClientAllowedAgents(clientId, allowedAgentIds)\` — replace the agent-id allowlist.

All five are SECURITY INVOKER SQL functions, so RLS still authorizes the update/insert. The \`clients\` INSERT policy is relaxed to allow admins (needed for \`registerClient\` with an explicit \`ownerWallet\`). The auto-generated \`createClient\` is blocked via \`@omit create\` since \`token_hash\` (also \`@omit\`) cannot be supplied through GraphQL.

The admin agent now uses auto-generated \`mutate_*\` tools (\`schema-tools.ts\` already introspects PostGraphile mutations), so the bespoke \`register_client\` custom tool and \`generateToken\` helper are removed.

## Notes

- **pgcrypto** is added to \`schema.sql\` for \`gen_random_bytes\` + \`digest('sha256')\`. \`gen_random_uuid()\` is core PG13+ so the existing clients table does not depend on it.
- **Registry sync on revoke/rotate is out of scope** per issue #28 — active WS sessions reflect the change on their next reconnect. \`ws.ts\` performs the token lookup on connect; existing sockets remain connected until they disconnect naturally.
- Argument names match clients column names for a clean GraphQL surface (\`clientName\`, \`ownerWallet\`). The bodies qualify references with \`register_client.*\` / \`revoke_client.*\` / etc., so PL/pgSQL never gets ambiguity errors.
- PostGraphile v4 uses \`formatInsideUnderscores(lodash.camelCase)\` which preserves leading underscores — verified in \`graphile-build/node8plus/utils.js\`. Hence the qualifier-based approach rather than \`_\` prefix.

## Test plan

Schema was applied and exercised against a scratch PostgreSQL 16 instance. Verified:

- [x] \`schema.sql\` applies cleanly on a fresh DB.
- [x] \`schema.sql\` re-applies idempotently (no errors on second run).
- [x] Admin can \`registerClient\` for another wallet; \`ownerWallet\` is honored.
- [x] Non-admin passing \`ownerWallet\` — spoof param ignored, caller becomes owner.
- [x] Admin can \`revokeClient\` / \`unrevokeClient\` — flag toggles.
- [x] Owner can \`rotateClientToken\` — new token returned, \`token_hash\` updated.
- [x] Owner can \`updateClientAllowedAgents\` — list replaced.
- [x] Non-owner/non-admin cannot revoke — raises \`client not found or not authorized\` (RLS blocks the UPDATE).
- [x] \`pnpm --filter @vicoop-bridge/server typecheck\` passes.
- [x] \`pnpm --filter @vicoop-bridge/server build\` passes.

## Follow-ups (not in this PR)

- Force-disconnect active WS sessions on revoke/rotate — \`registry.ts\` would need a targeted \`closeByClientId\` helper. Deferred per the issue.
- Admin UI wiring for the new mutations — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)