### PR TITLE
Add Google OAuth device flow for A2A caller authentication

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,6 +20,7 @@
     "@vicoop-bridge/protocol": "workspace:*",
     "ai": "^6.0.162",
     "express": "^5.2.1",
+    "google-auth-library": "^10.6.2",
     "hono": "^4.6.11",
     "pg": "^8.20.0",
     "postgraphile": "4",

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -251,7 +251,58 @@ CREATE POLICY agent_policies_postgraphile ON agent_policies
   WITH CHECK (true);
 
 -- ============================================================
--- 6. Grants
+-- 6. Caller auth: opaque tokens issued via Google OAuth device flow
+-- ============================================================
+CREATE TABLE IF NOT EXISTS callers (
+  id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  token_hash      TEXT NOT NULL UNIQUE,
+  principal_id    TEXT NOT NULL,
+  provider        TEXT NOT NULL,
+  email           TEXT,
+  label           TEXT,
+  expires_at      TIMESTAMPTZ NOT NULL,
+  last_used_at    TIMESTAMPTZ,
+  revoked         BOOLEAN NOT NULL DEFAULT false,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS callers_principal_active_idx
+  ON callers(principal_id) WHERE revoked = false;
+
+ALTER TABLE callers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS callers_postgraphile ON callers;
+CREATE POLICY callers_postgraphile ON callers
+  FOR ALL TO app_postgraphile USING (true) WITH CHECK (true);
+
+-- Server-managed only; never expose via GraphQL
+COMMENT ON TABLE callers IS E'@omit';
+
+-- Transient device flow sessions (RFC-8628)
+CREATE TABLE IF NOT EXISTS device_sessions (
+  device_code       TEXT PRIMARY KEY,
+  user_code         TEXT NOT NULL UNIQUE,
+  status            TEXT NOT NULL,
+  principal_id      TEXT,
+  email             TEXT,
+  expires_at        TIMESTAMPTZ NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  approved_at       TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS device_sessions_pending_idx
+  ON device_sessions(user_code) WHERE status = 'pending';
+
+ALTER TABLE device_sessions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS device_sessions_postgraphile ON device_sessions;
+CREATE POLICY device_sessions_postgraphile ON device_sessions
+  FOR ALL TO app_postgraphile USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE device_sessions IS E'@omit';
+
+-- ============================================================
+-- 7. Grants
 -- ============================================================
 GRANT USAGE ON SCHEMA public TO app_postgraphile, app_anonymous, app_authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app_postgraphile;

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -18,6 +18,8 @@ import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
 import { PostgresTaskStore, type ContextAwareTaskStore } from './postgres-task-store.js';
+import { validatePrincipal } from './auth/principal.js';
+import { listCallerTokens, revokeCallerToken } from './auth/caller-token.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -103,15 +105,22 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 - Use \`register_client\` to create a new client — this generates a token and hashes it before storing.
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
+- Use \`list_caller_tokens\` / \`revoke_caller_token\` (admin only) to manage opaque caller tokens issued via Google OAuth device flow.
 - Use \`execute_graphql\` for complex queries and inspection not covered by auto-generated tools.
 
 ## Agent Access Control
 
 Each agent has an access policy (\`agent_policies\` table) with an \`allowed_callers\` list:
 - **Empty \`allowed_callers\`**: Agent is public — anyone can call it via A2A.
-- **Non-empty \`allowed_callers\`**: Agent requires SIWE Bearer authentication, and only listed wallet addresses can call.
+- **Non-empty \`allowed_callers\`**: Agent requires an authenticated Bearer token, and only listed principals can call.
 
-When an agent registers via WebSocket, a default policy (public) is auto-created. Use \`add_caller\` to restrict access to specific wallets. The agent card automatically includes \`securitySchemes\` when callers are configured.
+Supported principal formats in \`allowed_callers\`:
+- \`eth:0x<40 hex>\` — SIWE-authenticated Ethereum address
+- \`google:sub:<sub>\` — specific Google account by stable id
+- \`google:email:<email>\` — Google account by email (pinned to sub on first match)
+- \`google:domain:<domain>\` — any verified Google Workspace account from the domain
+
+When an agent registers via WebSocket, a default policy (public) is auto-created. Use \`add_caller\` to restrict access. The agent card automatically advertises \`securitySchemes\` when callers are configured.
 
 ## Conversation memory
 
@@ -140,14 +149,6 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 }
 
 // ── Custom Tools (token generation, active agents) ───────────────
-
-const ETH_ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
-
-function validateWalletAddress(address: string): string | null {
-  const trimmed = address.trim();
-  if (!ETH_ADDRESS_RE.test(trimmed)) return null;
-  return trimmed.toLowerCase();
-}
 
 function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
   return {
@@ -197,14 +198,22 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
 
     add_caller: tool({
       description:
-        'Add a wallet address to an agent\'s allowed callers. Once any caller is added, the agent requires SIWE authentication.',
+        'Add a principal to an agent\'s allowed callers. Once any caller is added, the agent requires authenticated Bearer token.\n' +
+        'Supported principal formats:\n' +
+        '  eth:0x<40 hex>         Ethereum address (SIWE)\n' +
+        '  0x<40 hex>             Plain wallet, auto-prefixed with eth:\n' +
+        '  google:sub:<sub>       Specific Google account (stable id)\n' +
+        '  google:email:<addr>    Google account by email (pins to sub on first match)\n' +
+        '  google:domain:<d>      Google Workspace domain (any verified account)',
       inputSchema: z.object({
         agent_id: z.string().describe('The agent ID to add the caller to'),
-        wallet_address: z.string().describe('Ethereum wallet address to allow (e.g. 0x1234...)'),
+        principal: z.string().describe('Principal string (see tool description)'),
       }),
-      execute: async ({ agent_id, wallet_address }) => {
-        const wallet = validateWalletAddress(wallet_address);
-        if (!wallet) return { error: 'Invalid wallet address. Expected 0x followed by 40 hex characters.' };
+      execute: async ({ agent_id, principal }) => {
+        const normalized = validatePrincipal(principal);
+        if (!normalized) {
+          return { error: 'Invalid principal format. See tool description for supported formats.' };
+        }
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
@@ -212,10 +221,10 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
           return tx`
             UPDATE agent_policies
-            SET allowed_callers = array_append(allowed_callers, ${wallet}),
+            SET allowed_callers = array_append(allowed_callers, ${normalized}),
                 updated_at = now()
             WHERE agent_id = ${agent_id}
-              AND NOT (${wallet} = ANY(allowed_callers))
+              AND NOT (${normalized} = ANY(allowed_callers))
             RETURNING agent_id, owner_wallet, allowed_callers
           `;
         });
@@ -228,43 +237,64 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
             return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
           });
           if (existing.length === 0) return { error: 'Agent policy not found or not authorized.' };
-          if ((existing[0].allowed_callers as string[]).includes(wallet)) return { agent_id, message: 'Wallet already in allowed callers', allowed_callers: existing[0].allowed_callers };
+          if ((existing[0].allowed_callers as string[]).includes(normalized)) {
+            return { agent_id, message: 'Principal already in allowed callers', allowed_callers: existing[0].allowed_callers };
+          }
           return { error: 'Not authorized to modify this agent policy.' };
         }
         const callers = result[0].allowed_callers as string[];
         registry.updateAllowedCallers(agent_id, callers);
-        return { agent_id, allowed_callers: callers };
+        return { agent_id, principal: normalized, allowed_callers: callers };
       },
     }),
 
     remove_caller: tool({
       description:
-        'Remove a wallet address from an agent\'s allowed callers. If the list becomes empty, the agent becomes public again.',
+        'Remove a principal from an agent\'s allowed callers. If the list becomes empty, the agent becomes public again. ' +
+        'Accepts the same principal formats as add_caller. To remove a legacy plain-0x entry, pass it as-is; ' +
+        'the tool matches both the canonical eth:0x... form and the legacy form.',
       inputSchema: z.object({
         agent_id: z.string().describe('The agent ID to remove the caller from'),
-        wallet_address: z.string().describe('Ethereum wallet address to remove'),
+        principal: z.string().describe('Principal string to remove'),
       }),
-      execute: async ({ agent_id, wallet_address }) => {
-        const wallet = validateWalletAddress(wallet_address);
-        if (!wallet) return { error: 'Invalid wallet address. Expected 0x followed by 40 hex characters.' };
+      execute: async ({ agent_id, principal }) => {
+        const normalized = validatePrincipal(principal);
+        if (!normalized) {
+          return { error: 'Invalid principal format. See add_caller description for supported formats.' };
+        }
+        // Remove both canonical form and, when applicable, the legacy plain-0x form
+        // (pre-principal-prefix data) so stale entries can still be cleaned out.
+        const legacy = normalized.startsWith('eth:') ? normalized.slice(4) : null;
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
           await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
+          if (legacy) {
+            return tx`
+              UPDATE agent_policies
+              SET allowed_callers = array_remove(array_remove(allowed_callers, ${normalized}), ${legacy}),
+                  updated_at = now()
+              WHERE agent_id = ${agent_id}
+                AND (${normalized} = ANY(allowed_callers) OR ${legacy} = ANY(allowed_callers))
+              RETURNING agent_id, owner_wallet, allowed_callers
+            `;
+          }
           return tx`
             UPDATE agent_policies
-            SET allowed_callers = array_remove(allowed_callers, ${wallet}),
+            SET allowed_callers = array_remove(allowed_callers, ${normalized}),
                 updated_at = now()
             WHERE agent_id = ${agent_id}
-              AND ${wallet} = ANY(allowed_callers)
+              AND ${normalized} = ANY(allowed_callers)
             RETURNING agent_id, owner_wallet, allowed_callers
           `;
         });
-        if (result.length === 0) return { error: 'Wallet not found in allowed callers, agent policy not found, or not authorized.' };
+        if (result.length === 0) {
+          return { error: 'Principal not found in allowed callers, agent policy not found, or not authorized.' };
+        }
         const callers = result[0].allowed_callers as string[];
         registry.updateAllowedCallers(agent_id, callers);
-        return { agent_id, allowed_callers: callers };
+        return { agent_id, principal: normalized, allowed_callers: callers };
       },
     }),
 
@@ -292,6 +322,58 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
           allowed_callers: policy.allowed_callers,
           is_public: (policy.allowed_callers as string[]).length === 0,
         };
+      },
+    }),
+
+    list_caller_tokens: tool({
+      description:
+        'List caller tokens (opaque bearer tokens issued via Google OAuth device flow). Admin only. ' +
+        'Filter by principal_id (e.g. "google:1234567890") or email.',
+      inputSchema: z.object({
+        principal_id: z.string().optional().describe('Filter by exact principal_id match'),
+        email: z.string().optional().describe('Filter by exact email match'),
+        include_revoked: z.boolean().optional().describe('Include revoked tokens (default false)'),
+      }),
+      execute: async ({ principal_id, email, include_revoked }) => {
+        if (!isAdmin(walletAddress)) {
+          return { error: 'Admin-only tool. Current wallet is not in ADMIN_WALLET_ADDRESSES.' };
+        }
+        const rows = await listCallerTokens(db, {
+          principalId: principal_id,
+          email,
+          includeRevoked: include_revoked,
+        });
+        return {
+          count: rows.length,
+          tokens: rows.map((r) => ({
+            id: r.id,
+            principal_id: r.principalId,
+            provider: r.provider,
+            email: r.email,
+            label: r.label,
+            expires_at: r.expiresAt.toISOString(),
+            last_used_at: r.lastUsedAt?.toISOString() ?? null,
+            revoked: r.revoked,
+            created_at: r.createdAt.toISOString(),
+          })),
+        };
+      },
+    }),
+
+    revoke_caller_token: tool({
+      description:
+        'Revoke a caller token by id. Admin only. Idempotent — revoking an already-revoked or ' +
+        'nonexistent token is not an error. Effect propagates within ~60s due to the in-memory ' +
+        'verification cache.',
+      inputSchema: z.object({
+        caller_id: z.string().describe('The caller token id (from list_caller_tokens)'),
+      }),
+      execute: async ({ caller_id }) => {
+        if (!isAdmin(walletAddress)) {
+          return { error: 'Admin-only tool. Current wallet is not in ADMIN_WALLET_ADDRESSES.' };
+        }
+        await revokeCallerToken(db, caller_id);
+        return { caller_id, revoked: true };
       },
     }),
   };

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -251,8 +251,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
     remove_caller: tool({
       description:
         'Remove a principal from an agent\'s allowed callers. If the list becomes empty, the agent becomes public again. ' +
-        'Accepts the same principal formats as add_caller. To remove a legacy plain-0x entry, pass it as-is; ' +
-        'the tool matches both the canonical eth:0x... form and the legacy form.',
+        'Accepts the same principal formats as add_caller.',
       inputSchema: z.object({
         agent_id: z.string().describe('The agent ID to remove the caller from'),
         principal: z.string().describe('Principal string to remove'),
@@ -262,24 +261,11 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         if (!normalized) {
           return { error: 'Invalid principal format. See add_caller description for supported formats.' };
         }
-        // Remove both canonical form and, when applicable, the legacy plain-0x form
-        // (pre-principal-prefix data) so stale entries can still be cleaned out.
-        const legacy = normalized.startsWith('eth:') ? normalized.slice(4) : null;
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
           await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
-          if (legacy) {
-            return tx`
-              UPDATE agent_policies
-              SET allowed_callers = array_remove(array_remove(allowed_callers, ${normalized}), ${legacy}),
-                  updated_at = now()
-              WHERE agent_id = ${agent_id}
-                AND (${normalized} = ANY(allowed_callers) OR ${legacy} = ANY(allowed_callers))
-              RETURNING agent_id, owner_wallet, allowed_callers
-            `;
-          }
           return tx`
             UPDATE agent_policies
             SET allowed_callers = array_remove(allowed_callers, ${normalized}),

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,16 +1,24 @@
 import type { Context, Next } from 'hono';
 import type { ClientConnection, Registry } from './registry.js';
+import type { Sql } from './db.js';
 import { verifySiweToken } from './siwe-token.js';
+import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
+import { matchPrincipal, type VerifiedCaller } from './auth/principal.js';
 
 export function getAgentConn(c: Context): ClientConnection {
   return c.get('agentConn') as ClientConnection;
 }
 
+export function getCaller(c: Context): VerifiedCaller | undefined {
+  return c.get('caller') as VerifiedCaller | undefined;
+}
+
 export interface AgentAuthOptions {
+  sql: Sql;
   domain?: string;
 }
 
-export function agentAuthMiddleware(registry: Registry, opts?: AgentAuthOptions) {
+export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
@@ -34,29 +42,36 @@ export function agentAuthMiddleware(registry: Registry, opts?: AgentAuthOptions)
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: 'Authentication required (Bearer SIWE token)' },
+        error: { code: -32001, message: 'Authentication required (Bearer SIWE or caller token)' },
       }, 401);
     }
 
-    let walletAddress: string;
+    let caller: VerifiedCaller;
     try {
-      walletAddress = await verifySiweToken(bearerToken, { domain: opts?.domain });
+      if (bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+        caller = await verifyCallerToken(opts.sql, bearerToken);
+      } else {
+        const wallet = await verifySiweToken(bearerToken, { domain: opts.domain });
+        caller = { principalId: `eth:${wallet.toLowerCase()}` };
+      }
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: `Invalid SIWE token: ${(err as Error).message}` },
+        error: { code: -32001, message: `Invalid bearer token: ${(err as Error).message}` },
       }, 401);
     }
 
-    if (!conn.allowedCallers.includes(walletAddress.toLowerCase())) {
+    const allowed = conn.allowedCallers.some((entry) => matchPrincipal(entry, caller));
+    if (!allowed) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: 'Wallet not authorized for this agent' },
+        error: { code: -32001, message: 'Caller not authorized for this agent' },
       }, 403);
     }
 
+    c.set('caller', caller);
     return next();
   };
 }

--- a/packages/server/src/auth/caller-token.test.ts
+++ b/packages/server/src/auth/caller-token.test.ts
@@ -1,0 +1,175 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+import {
+  CALLER_TOKEN_PREFIX,
+  generateCallerToken,
+  hashCallerToken,
+  issueCallerToken,
+  verifyCallerToken,
+  revokeCallerToken,
+  listCallerTokens,
+} from './caller-token.js';
+
+// ---------- Pure unit tests (always run) ----------
+
+test('generateCallerToken has vbc_caller_ prefix', () => {
+  const t = generateCallerToken();
+  assert.ok(t.startsWith(CALLER_TOKEN_PREFIX));
+});
+
+test('generateCallerToken produces base64url (no +/= chars) with 32 bytes of entropy', () => {
+  const t = generateCallerToken();
+  const body = t.slice(CALLER_TOKEN_PREFIX.length);
+  // 32 bytes -> 43 chars in unpadded base64url
+  assert.equal(body.length, 43);
+  assert.match(body, /^[A-Za-z0-9_-]+$/);
+});
+
+test('generateCallerToken produces distinct tokens', () => {
+  const a = generateCallerToken();
+  const b = generateCallerToken();
+  assert.notEqual(a, b);
+});
+
+test('hashCallerToken is deterministic', () => {
+  const t = 'vbc_caller_abc';
+  assert.equal(hashCallerToken(t), hashCallerToken(t));
+});
+
+test('hashCallerToken returns 64-char sha256 hex', () => {
+  const h = hashCallerToken('vbc_caller_abc');
+  assert.equal(h.length, 64);
+  assert.match(h, /^[0-9a-f]+$/);
+});
+
+test('different tokens produce different hashes', () => {
+  assert.notEqual(hashCallerToken('a'), hashCallerToken('b'));
+});
+
+// ---------- DB-gated tests ----------
+
+const hasDb = !!process.env.DATABASE_URL;
+
+test('verifyCallerToken rejects bad prefix without hitting DB', async () => {
+  // We pass a dummy sql stub that would throw if actually used.
+  const sqlStub = (() => {
+    throw new Error('should not touch DB');
+  }) as unknown as Parameters<typeof verifyCallerToken>[0];
+  await assert.rejects(
+    () => verifyCallerToken(sqlStub, 'not-a-caller-token'),
+    /Invalid caller token format/,
+  );
+});
+
+test(
+  'issue and verify roundtrip',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const issued = await issueCallerToken(sql, {
+        principalId: `google:test-${Date.now()}`,
+        provider: 'google',
+        email: 'alice@example.com',
+        label: 'test',
+      });
+      assert.ok(issued.rawToken.startsWith(CALLER_TOKEN_PREFIX));
+      assert.ok(issued.callerId);
+      assert.ok(issued.expiresAt instanceof Date);
+      assert.ok(issued.expiresAt.getTime() > Date.now());
+
+      const caller = await verifyCallerToken(sql, issued.rawToken);
+      assert.match(caller.principalId, /^google:test-/);
+      assert.equal(caller.email, 'alice@example.com');
+      assert.equal(caller.emailVerified, true);
+
+      // Cleanup
+      await sql`DELETE FROM callers WHERE id = ${issued.callerId}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'verifyCallerToken throws on revoked token',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const issued = await issueCallerToken(sql, {
+        principalId: `google:revoke-${Date.now()}`,
+        provider: 'google',
+        email: 'bob@example.com',
+      });
+
+      await revokeCallerToken(sql, issued.callerId);
+
+      // Revocation is idempotent
+      await revokeCallerToken(sql, issued.callerId);
+
+      // The caller token shouldn't be cached (we never verified before
+      // revoking), so this should hit the DB and see revoked=true.
+      // Use a fresh token string variant to sidestep any prior cache.
+      await assert.rejects(
+        () => verifyCallerToken(sql, issued.rawToken),
+        /Caller token revoked/,
+      );
+
+      await sql`DELETE FROM callers WHERE id = ${issued.callerId}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'verifyCallerToken throws on expired token',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      // Issue with a 1ms TTL so it's immediately in the past.
+      const issued = await issueCallerToken(sql, {
+        principalId: `google:expired-${Date.now()}`,
+        provider: 'google',
+        ttlMs: 1,
+      });
+      // Ensure clock moves past expiry.
+      await new Promise((r) => setTimeout(r, 10));
+      await assert.rejects(
+        () => verifyCallerToken(sql, issued.rawToken),
+        /Caller token expired/,
+      );
+      await sql`DELETE FROM callers WHERE id = ${issued.callerId}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'listCallerTokens filters by principalId and hides revoked by default',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const principalId = `google:list-${Date.now()}`;
+      const a = await issueCallerToken(sql, { principalId, provider: 'google' });
+      const b = await issueCallerToken(sql, { principalId, provider: 'google' });
+      await revokeCallerToken(sql, b.callerId);
+
+      const listed = await listCallerTokens(sql, { principalId });
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0]!.id, a.callerId);
+
+      const listedAll = await listCallerTokens(sql, { principalId, includeRevoked: true });
+      assert.equal(listedAll.length, 2);
+
+      await sql`DELETE FROM callers WHERE id IN (${a.callerId}, ${b.callerId})`;
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/auth/caller-token.ts
+++ b/packages/server/src/auth/caller-token.ts
@@ -1,0 +1,239 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { Sql } from '../db.js';
+import type { VerifiedCaller } from './principal.js';
+
+// Bridge-issued opaque token for A2A caller auth.
+// Wire format: 'vbc_caller_' + 43-char base64url (32 bytes of entropy).
+
+export const CALLER_TOKEN_PREFIX = 'vbc_caller_';
+
+export interface IssueCallerTokenInput {
+  principalId: string;        // 'google:<sub>'
+  provider: 'google';
+  email?: string;
+  label?: string;
+  ttlMs?: number;             // default 90 days
+}
+
+export interface IssuedCallerToken {
+  rawToken: string;           // shown once to the user
+  callerId: string;
+  expiresAt: Date;
+}
+
+const DEFAULT_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+
+// In-memory verification cache. Mirrors pattern in siwe-token.ts.
+// Keyed by raw token. Values hold the VerifiedCaller plus an `expiresAt`
+// (ms epoch) bounded to `now + CACHE_MAX_ENTRY_TTL_MS` so revocations
+// take effect within ~60s without us having to do explicit invalidation.
+interface VerifyCacheEntry {
+  caller: VerifiedCaller;
+  expiresAt: number;
+}
+
+const verifyCache = new Map<string, VerifyCacheEntry>();
+const CACHE_EVICT_INTERVAL_MS = 60_000;
+const VERIFY_CACHE_MAX_ENTRIES = 10_000;
+const CACHE_MAX_ENTRY_TTL_MS = 60_000;
+let lastEvict = Date.now();
+
+function evictExpired(): void {
+  const now = Date.now();
+  if (now - lastEvict < CACHE_EVICT_INTERVAL_MS && verifyCache.size <= VERIFY_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  lastEvict = now;
+  for (const [key, entry] of verifyCache) {
+    if (entry.expiresAt <= now) verifyCache.delete(key);
+  }
+  while (verifyCache.size > VERIFY_CACHE_MAX_ENTRIES) {
+    const oldest = verifyCache.keys().next().value;
+    if (oldest === undefined) break;
+    verifyCache.delete(oldest);
+  }
+}
+
+// Generate a new unguessable opaque token string. Does not touch DB.
+export function generateCallerToken(): string {
+  return CALLER_TOKEN_PREFIX + randomBytes(32).toString('base64url');
+}
+
+// sha256 hex of the raw token, for DB lookup.
+export function hashCallerToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+// Issue a new token and persist to `callers`. Returns raw token (one-time).
+export async function issueCallerToken(
+  sql: Sql,
+  input: IssueCallerTokenInput,
+): Promise<IssuedCallerToken> {
+  const rawToken = generateCallerToken();
+  const tokenHash = hashCallerToken(rawToken);
+  const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS;
+  const expiresAt = new Date(Date.now() + ttlMs);
+
+  const rows = await sql<{ id: string; expires_at: Date }[]>`
+    INSERT INTO callers (token_hash, principal_id, provider, email, label, expires_at)
+    VALUES (
+      ${tokenHash},
+      ${input.principalId},
+      ${input.provider},
+      ${input.email ?? null},
+      ${input.label ?? null},
+      ${expiresAt}
+    )
+    RETURNING id, expires_at
+  `;
+
+  const row = rows[0];
+  if (!row) {
+    throw new Error('Failed to insert caller token');
+  }
+
+  return {
+    rawToken,
+    callerId: row.id,
+    expiresAt: row.expires_at,
+  };
+}
+
+// Verify a raw token. Checks revoked + expires_at. Updates last_used_at.
+// Throws on any failure. Returns VerifiedCaller with principal and metadata.
+export async function verifyCallerToken(
+  sql: Sql,
+  rawToken: string,
+): Promise<VerifiedCaller> {
+  if (!rawToken.startsWith(CALLER_TOKEN_PREFIX)) {
+    throw new Error('Invalid caller token format');
+  }
+
+  evictExpired();
+
+  const now = Date.now();
+  const cached = verifyCache.get(rawToken);
+  if (cached && cached.expiresAt > now) {
+    // Deliberately do not touch last_used_at on cache hits to avoid
+    // write amplification.
+    return cached.caller;
+  }
+
+  const tokenHash = hashCallerToken(rawToken);
+  const rows = await sql<
+    {
+      id: string;
+      principal_id: string;
+      email: string | null;
+      expires_at: Date;
+      revoked: boolean;
+    }[]
+  >`
+    SELECT id, principal_id, email, expires_at, revoked
+    FROM callers
+    WHERE token_hash = ${tokenHash}
+    LIMIT 1
+  `;
+
+  const row = rows[0];
+  if (!row) {
+    throw new Error('Caller token not found');
+  }
+  if (row.revoked) {
+    throw new Error('Caller token revoked');
+  }
+  if (row.expires_at.getTime() <= now) {
+    throw new Error('Caller token expired');
+  }
+
+  // Stamp last_used_at. Awaited for test determinism; the write is cheap
+  // and only happens on cache misses (so at most once per 60s per token).
+  await sql`UPDATE callers SET last_used_at = now() WHERE id = ${row.id}`;
+
+  // email_verified inference: we only persist email at issue time when the
+  // upstream provider (google-oauth) has already validated it, so a non-null
+  // email here is known-verified.
+  const caller: VerifiedCaller = {
+    principalId: row.principal_id,
+    email: row.email ?? undefined,
+    emailVerified: row.email ? true : undefined,
+  };
+
+  const cacheExpiresAt = Math.min(row.expires_at.getTime(), now + CACHE_MAX_ENTRY_TTL_MS);
+  verifyCache.set(rawToken, { caller, expiresAt: cacheExpiresAt });
+
+  return caller;
+}
+
+// Mark a caller token as revoked. Idempotent.
+// NOTE: We intentionally do not invalidate the in-memory LRU here. Cache
+// entries are bounded to `now + 60s` at insert time, so revocations take
+// effect within ~60s without requiring us to track id → token mappings.
+export async function revokeCallerToken(sql: Sql, callerId: string): Promise<void> {
+  await sql`UPDATE callers SET revoked = true WHERE id = ${callerId}`;
+}
+
+export interface CallerTokenRow {
+  id: string;
+  principalId: string;
+  provider: string;
+  email: string | null;
+  label: string | null;
+  expiresAt: Date;
+  lastUsedAt: Date | null;
+  revoked: boolean;
+  createdAt: Date;
+}
+
+interface RawCallerRow {
+  id: string;
+  principal_id: string;
+  provider: string;
+  email: string | null;
+  label: string | null;
+  expires_at: Date;
+  last_used_at: Date | null;
+  revoked: boolean;
+  created_at: Date;
+}
+
+// List tokens with optional filters. Used by admin tools.
+export async function listCallerTokens(
+  sql: Sql,
+  filter: { principalId?: string; email?: string; includeRevoked?: boolean },
+): Promise<CallerTokenRow[]> {
+  const conditions: ReturnType<Sql>[] = [];
+  if (filter.principalId) {
+    conditions.push(sql`principal_id = ${filter.principalId}`);
+  }
+  if (filter.email) {
+    conditions.push(sql`email = ${filter.email}`);
+  }
+  if (!filter.includeRevoked) {
+    conditions.push(sql`revoked = false`);
+  }
+
+  const where =
+    conditions.length > 0
+      ? sql`WHERE ${conditions.reduce((a, b) => sql`${a} AND ${b}`)}`
+      : sql``;
+
+  const rows = await sql<RawCallerRow[]>`
+    SELECT id, principal_id, provider, email, label, expires_at, last_used_at, revoked, created_at
+    FROM callers
+    ${where}
+    ORDER BY created_at DESC
+  `;
+
+  return rows.map((r) => ({
+    id: r.id,
+    principalId: r.principal_id,
+    provider: r.provider,
+    email: r.email,
+    label: r.label,
+    expiresAt: r.expires_at,
+    lastUsedAt: r.last_used_at,
+    revoked: r.revoked,
+    createdAt: r.created_at,
+  }));
+}

--- a/packages/server/src/auth/device-flow.test.ts
+++ b/packages/server/src/auth/device-flow.test.ts
@@ -1,0 +1,215 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import postgres from 'postgres';
+import { generateUserCode, mountDeviceFlow } from './device-flow.js';
+import { CALLER_TOKEN_PREFIX } from './caller-token.js';
+
+// ---------- Pure unit tests (always run) ----------
+
+test('generateUserCode has the shape XXXX-XXXX', () => {
+  const code = generateUserCode();
+  assert.equal(code.length, 9);
+  assert.equal(code[4], '-');
+  assert.match(code, /^[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}$/);
+});
+
+test('generateUserCode only uses Crockford Base32 alphabet', () => {
+  const allowed = new Set('0123456789ABCDEFGHJKMNPQRSTVWXYZ');
+  for (let i = 0; i < 50; i++) {
+    const code = generateUserCode();
+    for (const ch of code.replace('-', '')) {
+      assert.ok(allowed.has(ch), `unexpected char ${ch} in ${code}`);
+    }
+  }
+});
+
+test('generateUserCode produces distinct codes (10 unique in 10 tries)', () => {
+  const codes = new Set<string>();
+  for (let i = 0; i < 10; i++) codes.add(generateUserCode());
+  assert.equal(codes.size, 10);
+});
+
+// ---------- DB-gated integration tests ----------
+
+const hasDb = !!process.env.DATABASE_URL;
+
+function buildApp(sql: postgres.Sql) {
+  const app = new Hono();
+  mountDeviceFlow(app, {
+    sql,
+    publicUrl: 'https://example.test',
+    // Drop slow_down window so sequential polls in tests don't trigger it.
+    minPollIntervalMs: 0,
+  });
+  return app;
+}
+
+test(
+  'POST /oauth/device/code returns expected shape and inserts DB row',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const res = await app.request('/oauth/device/code', { method: 'POST' });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Record<string, unknown>;
+
+      assert.equal(typeof body.device_code, 'string');
+      assert.equal((body.device_code as string).length, 43);
+      assert.equal(typeof body.user_code, 'string');
+      assert.match(body.user_code as string, /^[0-9A-HJKMNP-TV-Z]{4}-[0-9A-HJKMNP-TV-Z]{4}$/);
+      assert.equal(body.verification_uri, 'https://example.test/oauth/device');
+      assert.equal(
+        body.verification_uri_complete,
+        `https://example.test/oauth/device?user_code=${encodeURIComponent(body.user_code as string)}`,
+      );
+      assert.equal(typeof body.expires_in, 'number');
+      assert.equal(body.interval, 5);
+
+      const rows = await sql<
+        { device_code: string; user_code: string; status: string }[]
+      >`SELECT device_code, user_code, status FROM device_sessions WHERE device_code = ${body.device_code as string}`;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]!.status, 'pending');
+      assert.equal(rows[0]!.user_code, body.user_code);
+
+      await sql`DELETE FROM device_sessions WHERE device_code = ${body.device_code as string}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /oauth/token without device_code returns invalid_request',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const form = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      });
+      const res = await app.request('/oauth/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'invalid_request');
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /oauth/token with wrong grant_type returns unsupported_grant_type',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const form = new URLSearchParams({
+        grant_type: 'authorization_code',
+        device_code: 'whatever',
+      });
+      const res = await app.request('/oauth/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'unsupported_grant_type');
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /oauth/token on pending session returns authorization_pending',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+
+      const issueRes = await app.request('/oauth/device/code', { method: 'POST' });
+      const issued = (await issueRes.json()) as { device_code: string };
+
+      const form = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: issued.device_code,
+      });
+      const res = await app.request('/oauth/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'authorization_pending');
+
+      await sql`DELETE FROM device_sessions WHERE device_code = ${issued.device_code}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /oauth/token on approved session returns access_token and deletes row',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+
+      const issueRes = await app.request('/oauth/device/code', { method: 'POST' });
+      const issued = (await issueRes.json()) as { device_code: string };
+
+      const principalId = `google:device-${Date.now()}`;
+      const email = 'device-flow@example.com';
+      await sql`
+        UPDATE device_sessions
+        SET status = 'approved',
+            principal_id = ${principalId},
+            email = ${email},
+            approved_at = now()
+        WHERE device_code = ${issued.device_code}
+      `;
+
+      const form = new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: issued.device_code,
+      });
+      const res = await app.request('/oauth/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(typeof body.access_token, 'string');
+      assert.ok((body.access_token as string).startsWith(CALLER_TOKEN_PREFIX));
+      assert.equal(body.token_type, 'Bearer');
+      assert.equal(typeof body.expires_in, 'number');
+      assert.ok((body.expires_in as number) > 0);
+
+      const remaining = await sql`
+        SELECT 1 FROM device_sessions WHERE device_code = ${issued.device_code}
+      `;
+      assert.equal(remaining.length, 0);
+
+      // Cleanup the caller row we just issued.
+      await sql`DELETE FROM callers WHERE principal_id = ${principalId}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -1,0 +1,232 @@
+// RFC-8628 OAuth 2.0 Device Authorization Grant endpoints for vicoop-bridge.
+// Exposes POST /oauth/device/code and POST /oauth/token. The UI approval path
+// (that sets status='approved' and fills principal_id/email) is implemented
+// separately in device-ui.ts.
+
+import { randomBytes, randomInt } from 'node:crypto';
+import type { Hono, Context } from 'hono';
+import type { Sql } from '../db.js';
+import { issueCallerToken } from './caller-token.js';
+
+export interface DeviceFlowOptions {
+  sql: Sql;
+  publicUrl: string;
+  sessionTtlMs?: number;
+  tokenTtlMs?: number;
+  pollIntervalSeconds?: number;
+  minPollIntervalMs?: number;
+}
+
+const DEFAULT_SESSION_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_TOKEN_TTL_MS = 90 * 24 * 60 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_SECONDS = 5;
+const DEFAULT_MIN_POLL_INTERVAL_MS = 5000;
+const DEVICE_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+// Crockford Base32: no I, L, O, U — reduces ambiguity when users type codes.
+const CROCKFORD_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const USER_CODE_LENGTH = 8;
+const USER_CODE_HYPHEN_AT = 4;
+const MAX_USER_CODE_RETRIES = 5;
+
+interface DeviceSessionRow {
+  device_code: string;
+  user_code: string;
+  status: string;
+  principal_id: string | null;
+  email: string | null;
+  expires_at: Date;
+}
+
+// Generate an 8-char Crockford Base32 user code with a hyphen at position 4:
+// e.g. "WDJB-MJHT". Uses crypto.randomInt so each char is independently uniform.
+export function generateUserCode(): string {
+  let out = '';
+  for (let i = 0; i < USER_CODE_LENGTH; i++) {
+    if (i === USER_CODE_HYPHEN_AT) out += '-';
+    out += CROCKFORD_ALPHABET[randomInt(0, CROCKFORD_ALPHABET.length)];
+  }
+  return out;
+}
+
+// 32 bytes of entropy → 43 chars of unpadded base64url. Matches caller-token's format.
+function generateDeviceCode(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+// Parse RFC-6749 form-encoded bodies, falling back to JSON. Both shapes are
+// accepted for ergonomics; CLI callers typically send form, JS SDKs send JSON.
+async function readBody(c: Context): Promise<Record<string, unknown>> {
+  const contentType = c.req.header('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    try {
+      return (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+  try {
+    const parsed = await c.req.parseBody();
+    return parsed as Record<string, unknown>;
+  } catch {
+    // Fall back to JSON for clients that mislabel content-type.
+    try {
+      return (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return {};
+    }
+  }
+}
+
+export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
+  const sql = opts.sql;
+  const sessionTtlMs = opts.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
+  const tokenTtlMs = opts.tokenTtlMs ?? DEFAULT_TOKEN_TTL_MS;
+  const pollIntervalSeconds = opts.pollIntervalSeconds ?? DEFAULT_POLL_INTERVAL_SECONDS;
+  const minPollIntervalMs = opts.minPollIntervalMs ?? DEFAULT_MIN_POLL_INTERVAL_MS;
+
+  // Per-device last-poll timestamp for slow_down enforcement. Kept in-memory
+  // to avoid schema churn; bounded via prune() (see below).
+  const lastPoll = new Map<string, number>();
+
+  function prunePollMap(): void {
+    const cutoff = Date.now() - sessionTtlMs;
+    for (const [k, v] of lastPoll) {
+      if (v < cutoff) lastPoll.delete(k);
+    }
+  }
+
+  app.post('/oauth/device/code', async (c) => {
+    // Body is deliberately ignored — we don't do external client registration yet.
+    const deviceCode = generateDeviceCode();
+    const expiresAt = new Date(Date.now() + sessionTtlMs);
+
+    let userCode: string | null = null;
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < MAX_USER_CODE_RETRIES; attempt++) {
+      const candidate = generateUserCode();
+      try {
+        await sql`
+          INSERT INTO device_sessions (device_code, user_code, status, expires_at)
+          VALUES (${deviceCode}, ${candidate}, 'pending', ${expiresAt})
+        `;
+        userCode = candidate;
+        break;
+      } catch (err) {
+        lastErr = err;
+        // Collision on user_code unique index — retry with a new code.
+        continue;
+      }
+    }
+
+    if (!userCode) {
+      // Surface a 500 without leaking the raw DB error.
+      console.error('[device-flow] failed to allocate user_code', lastErr);
+      return c.json({ error: 'server_error' }, 500);
+    }
+
+    prunePollMap();
+
+    const verificationUri = `${opts.publicUrl}/oauth/device`;
+    const verificationUriComplete = `${verificationUri}?user_code=${encodeURIComponent(userCode)}`;
+
+    return c.json({
+      device_code: deviceCode,
+      user_code: userCode,
+      verification_uri: verificationUri,
+      verification_uri_complete: verificationUriComplete,
+      expires_in: Math.floor(sessionTtlMs / 1000),
+      interval: pollIntervalSeconds,
+    });
+  });
+
+  app.post('/oauth/token', async (c) => {
+    const body = await readBody(c);
+    const grantType = typeof body.grant_type === 'string' ? body.grant_type : undefined;
+    const deviceCode = typeof body.device_code === 'string' ? body.device_code : undefined;
+
+    if (grantType !== DEVICE_CODE_GRANT_TYPE) {
+      return c.json({ error: 'unsupported_grant_type' }, 400);
+    }
+    if (!deviceCode) {
+      return c.json({ error: 'invalid_request' }, 400);
+    }
+
+    // Slow-down enforcement *before* DB lookup to bound load from noisy pollers.
+    const now = Date.now();
+    const prev = lastPoll.get(deviceCode);
+    if (prev !== undefined && now - prev < minPollIntervalMs) {
+      return c.json({ error: 'slow_down' }, 400);
+    }
+    lastPoll.set(deviceCode, now);
+
+    const rows = await sql<DeviceSessionRow[]>`
+      SELECT device_code, user_code, status, principal_id, email, expires_at
+      FROM device_sessions
+      WHERE device_code = ${deviceCode}
+      LIMIT 1
+    `;
+    const row = rows[0];
+    if (!row) {
+      lastPoll.delete(deviceCode);
+      return c.json({ error: 'expired_token' }, 400);
+    }
+
+    if (row.expires_at.getTime() <= Date.now()) {
+      // Best-effort status bump for observability; ignore failures.
+      await sql`
+        UPDATE device_sessions SET status = 'expired'
+        WHERE device_code = ${deviceCode} AND status <> 'expired'
+      `;
+      lastPoll.delete(deviceCode);
+      return c.json({ error: 'expired_token' }, 400);
+    }
+
+    if (row.status === 'pending') {
+      return c.json({ error: 'authorization_pending' }, 400);
+    }
+
+    if (row.status === 'expired') {
+      lastPoll.delete(deviceCode);
+      return c.json({ error: 'expired_token' }, 400);
+    }
+
+    if (row.status === 'approved') {
+      if (!row.principal_id) {
+        // Defensive: approved rows must have principal_id. Treat as expired.
+        lastPoll.delete(deviceCode);
+        return c.json({ error: 'expired_token' }, 400);
+      }
+
+      // Issue the caller token and delete the session atomically. The transaction
+      // object from postgres.js is type-compatible with Sql, so issueCallerToken
+      // participates in the same tx.
+      const issued = await sql.begin(async (tx) => {
+        const i = await issueCallerToken(tx as unknown as Sql, {
+          principalId: row.principal_id!,
+          provider: 'google',
+          email: row.email ?? undefined,
+          ttlMs: tokenTtlMs,
+        });
+        await tx`DELETE FROM device_sessions WHERE device_code = ${deviceCode}`;
+        return i;
+      });
+
+      lastPoll.delete(deviceCode);
+      prunePollMap();
+
+      const expiresInSec = Math.max(
+        0,
+        Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
+      );
+      return c.json({
+        access_token: issued.rawToken,
+        token_type: 'Bearer',
+        expires_in: expiresInSec,
+      });
+    }
+
+    // Unknown status — conservative fallback.
+    return c.json({ error: 'expired_token' }, 400);
+  });
+}

--- a/packages/server/src/auth/device-ui.test.ts
+++ b/packages/server/src/auth/device-ui.test.ts
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __test__ } from './device-ui.js';
+
+const { buildState, verifyState, escapeHtml, normalizeUserCode } = __test__;
+
+describe('escapeHtml', () => {
+  it('escapes the five significant HTML characters', () => {
+    assert.equal(escapeHtml('&'), '&amp;');
+    assert.equal(escapeHtml('<'), '&lt;');
+    assert.equal(escapeHtml('>'), '&gt;');
+    assert.equal(escapeHtml('"'), '&quot;');
+    assert.equal(escapeHtml("'"), '&#39;');
+  });
+
+  it('neutralizes a classic XSS script payload', () => {
+    const out = escapeHtml('<script>alert("x")</script>');
+    assert.ok(!out.includes('<script>'), `still contains <script>: ${out}`);
+    assert.ok(!out.includes('</script>'), `still contains </script>: ${out}`);
+    assert.ok(out.includes('&lt;script&gt;'));
+    assert.ok(out.includes('&quot;'));
+  });
+
+  it('neutralizes quoted attribute injections', () => {
+    const out = escapeHtml(`" onerror="alert(1)`);
+    assert.ok(!out.includes('"'), `raw quote left intact: ${out}`);
+    assert.ok(out.startsWith('&quot;'));
+  });
+
+  it('handles ampersand ordering (does not double-escape)', () => {
+    // Must escape '&' first so e.g. '&lt;' doesn't get turned into '&amp;lt;'
+    // When passed literal text with '<' the single pass should produce '&lt;', not '&amp;lt;'.
+    assert.equal(escapeHtml('<'), '&lt;');
+    assert.equal(escapeHtml('&<'), '&amp;&lt;');
+  });
+});
+
+describe('normalizeUserCode', () => {
+  it('uppercases and inserts hyphen at position 4 when 8 chars', () => {
+    assert.equal(normalizeUserCode('wdjbmjht'), 'WDJB-MJHT');
+    assert.equal(normalizeUserCode('WDJB-MJHT'), 'WDJB-MJHT');
+    assert.equal(normalizeUserCode('  wdjb mjht  '), 'WDJB-MJHT');
+    assert.equal(normalizeUserCode('wdjb-mjht'), 'WDJB-MJHT');
+  });
+
+  it('leaves non-8-char input uppercased but without forced hyphen', () => {
+    assert.equal(normalizeUserCode('abc'), 'ABC');
+    assert.equal(normalizeUserCode('abcdefghi'), 'ABCDEFGHI');
+  });
+});
+
+describe('state build/parse round-trip', () => {
+  const secret = 'test-secret-xyzzy';
+  const deviceCode = 'device_abc123_!@#';
+
+  it('builds a state that verifies back to the original device_code', () => {
+    const state = buildState(secret, deviceCode);
+    assert.match(state, /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    const decoded = verifyState(secret, state);
+    assert.equal(decoded, deviceCode);
+  });
+
+  it('binds to the secret — wrong secret rejects', () => {
+    const state = buildState(secret, deviceCode);
+    assert.equal(verifyState('different-secret', state), null);
+  });
+
+  it('rejects a state whose HMAC was bit-flipped', () => {
+    const state = buildState(secret, deviceCode);
+    const dot = state.indexOf('.');
+    const macB64 = state.slice(0, dot);
+    const rest = state.slice(dot);
+
+    // Decode, flip the first bit, re-encode — same length, bad HMAC.
+    const macBytes = Buffer.from(macB64, 'base64url');
+    macBytes[0] = (macBytes[0]! ^ 0x01) & 0xff;
+    const tampered = macBytes.toString('base64url') + rest;
+
+    assert.equal(verifyState(secret, tampered), null);
+  });
+
+  it('rejects a state whose device_code portion was swapped (HMAC mismatch)', () => {
+    const state = buildState(secret, deviceCode);
+    const dot = state.indexOf('.');
+    const macPart = state.slice(0, dot);
+    const otherDc = Buffer.from('other_device_code', 'utf8').toString('base64url');
+    const tampered = `${macPart}.${otherDc}`;
+    assert.equal(verifyState(secret, tampered), null);
+  });
+
+  it('rejects malformed states', () => {
+    assert.equal(verifyState(secret, ''), null);
+    assert.equal(verifyState(secret, 'no-dot-here'), null);
+    assert.equal(verifyState(secret, '.foo'), null);
+    assert.equal(verifyState(secret, 'foo.'), null);
+  });
+
+  it('rejects a truncated HMAC (length mismatch short-circuit)', () => {
+    const state = buildState(secret, deviceCode);
+    const dot = state.indexOf('.');
+    const shortMac = state.slice(0, dot).slice(0, 8);
+    const tampered = `${shortMac}${state.slice(dot)}`;
+    assert.equal(verifyState(secret, tampered), null);
+  });
+});

--- a/packages/server/src/auth/device-ui.ts
+++ b/packages/server/src/auth/device-ui.ts
@@ -1,0 +1,322 @@
+// Browser-facing Device Authorization flow: a user enters a user_code printed
+// by a CLI, signs in with Google via our OAuth client, and the callback marks
+// the underlying device_code session as approved.
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Hono } from 'hono';
+
+import {
+  buildAuthorizeUrl,
+  exchangeCode,
+  type GoogleConfig,
+} from './google-oauth.js';
+import type { Sql } from '../db.js';
+
+export interface DeviceUiOptions {
+  sql: Sql;
+  google: GoogleConfig;
+  stateSecret: string;
+  publicUrl: string;
+}
+
+// ---- small helpers ----------------------------------------------------------
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    switch (c) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return c;
+    }
+  });
+}
+
+function page(title: string, body: string): string {
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>
+<style>
+  body { font-family: system-ui, sans-serif; background: #0b0b0b; color: #e5e5e5;
+         display: flex; align-items: center; justify-content: center;
+         min-height: 100vh; margin: 0; padding: 2rem; }
+  .card { max-width: 28rem; width: 100%; background: #1a1a1a;
+          border: 1px solid #2a2a2a; border-radius: 0.75rem; padding: 2rem; }
+  h1 { margin: 0 0 1rem 0; font-size: 1.25rem; }
+  .code { font-family: ui-monospace, monospace; font-size: 1.5rem;
+          letter-spacing: 0.1em; background: #0b0b0b; padding: 0.75rem 1rem;
+          border-radius: 0.5rem; display: inline-block; margin: 0.5rem 0 1rem; }
+  .btn { display: inline-block; background: #3b82f6; color: white;
+         padding: 0.75rem 1.25rem; border-radius: 0.5rem;
+         text-decoration: none; font-weight: 600; }
+  .btn:hover { background: #2563eb; }
+  input { background: #0b0b0b; color: #e5e5e5; border: 1px solid #2a2a2a;
+          padding: 0.5rem 0.75rem; border-radius: 0.375rem; width: 100%;
+          box-sizing: border-box; margin-bottom: 0.75rem; font-size: 1rem; }
+  p { color: #a3a3a3; line-height: 1.5; }
+  .error { color: #f87171; }
+</style></head><body><div class="card">${body}</div></body></html>`;
+}
+
+function b64urlEncode(buf: Buffer): string {
+  return buf.toString('base64url');
+}
+
+function b64urlDecode(s: string): Buffer {
+  return Buffer.from(s, 'base64url');
+}
+
+function hmacOf(secret: string, deviceCode: string): Buffer {
+  return createHmac('sha256', secret).update(deviceCode).digest();
+}
+
+// state = base64url(HMAC) + '.' + base64url(device_code)
+function buildState(secret: string, deviceCode: string): string {
+  const mac = hmacOf(secret, deviceCode);
+  return `${b64urlEncode(mac)}.${b64urlEncode(Buffer.from(deviceCode, 'utf8'))}`;
+}
+
+// Returns the decoded device_code on success, or null on any failure.
+// Uses timingSafeEqual with equal-length buffers.
+function verifyState(secret: string, state: string): string | null {
+  if (typeof state !== 'string' || state.length === 0) return null;
+  const dot = state.indexOf('.');
+  if (dot < 0) return null;
+  const macPart = state.slice(0, dot);
+  const dcPart = state.slice(dot + 1);
+  if (!macPart || !dcPart) return null;
+
+  let presented: Buffer;
+  let deviceCodeBuf: Buffer;
+  try {
+    presented = b64urlDecode(macPart);
+    deviceCodeBuf = b64urlDecode(dcPart);
+  } catch {
+    return null;
+  }
+  const deviceCode = deviceCodeBuf.toString('utf8');
+  if (deviceCode.length === 0) return null;
+
+  const expected = hmacOf(secret, deviceCode);
+  if (presented.length !== expected.length) return null;
+  if (!timingSafeEqual(presented, expected)) return null;
+  return deviceCode;
+}
+
+// Normalize "wdjb mjht" / "wdjb-mjht" / "WDJBMJHT" → "WDJB-MJHT"
+function normalizeUserCode(raw: string): string {
+  const cleaned = raw.toUpperCase().replace(/[\s-]+/g, '');
+  if (cleaned.length === 8) {
+    return `${cleaned.slice(0, 4)}-${cleaned.slice(4)}`;
+  }
+  return cleaned;
+}
+
+// ---- route handlers --------------------------------------------------------
+
+interface DeviceRow {
+  device_code: string;
+  user_code: string;
+  status: string;
+  expires_at: Date;
+}
+
+export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
+  app.get('/oauth/device', async (c) => {
+    const raw = c.req.query('user_code');
+    if (!raw || raw.trim() === '') {
+      const body = `
+        <h1>Enter device code</h1>
+        <form method="GET">
+          <input name="user_code" placeholder="Enter code (e.g. WDJB-MJHT)" autofocus>
+          <button class="btn" type="submit">Continue</button>
+        </form>
+      `;
+      return c.html(page('Device authorization', body));
+    }
+
+    const normalized = normalizeUserCode(raw);
+    const rows = await opts.sql<DeviceRow[]>`
+      SELECT device_code, user_code, status, expires_at
+      FROM device_sessions
+      WHERE user_code = ${normalized}
+        AND status = 'pending'
+        AND expires_at > now()
+      LIMIT 1
+    `;
+
+    if (rows.length === 0) {
+      const body = `
+        <h1 class="error">Invalid or expired code</h1>
+        <p>The code you entered is not recognized or has expired.</p>
+        <p><a class="btn" href="/oauth/device">Try again</a></p>
+      `;
+      return c.html(page('Invalid code', body), 400);
+    }
+
+    const safeCode = escapeHtml(normalized);
+    const href = `/oauth/google/start?user_code=${encodeURIComponent(normalized)}`;
+    const body = `
+      <h1>Authorize device</h1>
+      <div class="code">${safeCode}</div>
+      <p>You'll be asked to sign in to Google to authorize device <strong>${safeCode}</strong>.</p>
+      <p><a class="btn" href="${escapeHtml(href)}">Continue with Google</a></p>
+    `;
+    return c.html(page('Authorize device', body));
+  });
+
+  app.get('/oauth/google/start', async (c) => {
+    const raw = c.req.query('user_code');
+    if (!raw) {
+      return c.html(
+        page(
+          'Invalid code',
+          `<h1 class="error">Invalid or expired code</h1><p><a class="btn" href="/oauth/device">Back</a></p>`,
+        ),
+        400,
+      );
+    }
+    const normalized = normalizeUserCode(raw);
+    const rows = await opts.sql<{ device_code: string }[]>`
+      SELECT device_code
+      FROM device_sessions
+      WHERE user_code = ${normalized}
+        AND status = 'pending'
+        AND expires_at > now()
+      LIMIT 1
+    `;
+    const row = rows[0];
+    if (!row) {
+      return c.html(
+        page(
+          'Invalid code',
+          `<h1 class="error">Invalid or expired code</h1><p><a class="btn" href="/oauth/device">Back</a></p>`,
+        ),
+        400,
+      );
+    }
+
+    const state = buildState(opts.stateSecret, row.device_code);
+    const url = buildAuthorizeUrl(opts.google, state);
+    return c.redirect(url, 302);
+  });
+
+  app.get('/oauth/google/callback', async (c) => {
+    const error = c.req.query('error');
+    if (error) {
+      const body = `
+        <h1 class="error">Authorization denied</h1>
+        <p>${escapeHtml(error)}</p>
+        <p>You may close this window.</p>
+      `;
+      return c.html(page('Authorization denied', body));
+    }
+
+    const state = c.req.query('state') ?? '';
+    const deviceCode = verifyState(opts.stateSecret, state);
+    if (!deviceCode) {
+      return c.html(
+        page(
+          'Invalid state',
+          `<h1 class="error">Invalid state</h1><p>The authorization request could not be verified.</p>`,
+        ),
+        400,
+      );
+    }
+
+    const code = c.req.query('code');
+    if (!code) {
+      return c.html(
+        page(
+          'Invalid request',
+          `<h1 class="error">Invalid request</h1><p>Missing authorization code.</p>`,
+        ),
+        400,
+      );
+    }
+
+    const rows = await opts.sql<{ status: string; expires_at: Date }[]>`
+      SELECT status, expires_at
+      FROM device_sessions
+      WHERE device_code = ${deviceCode}
+      LIMIT 1
+    `;
+    const row = rows[0];
+    if (!row) {
+      return c.html(
+        page(
+          'Session expired',
+          `<h1 class="error">Session expired</h1><p>Your device session was not found.</p>`,
+        ),
+        400,
+      );
+    }
+    if (row.status !== 'pending' || row.expires_at.getTime() <= Date.now()) {
+      return c.html(
+        page(
+          'Session expired',
+          `<h1 class="error">Session expired or already completed</h1><p>You may close this window.</p>`,
+        ),
+        400,
+      );
+    }
+
+    let user;
+    try {
+      user = await exchangeCode(opts.google, code);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'unknown error';
+      const body = `
+        <h1 class="error">Google verification failed</h1>
+        <p>${escapeHtml(msg)}</p>
+      `;
+      return c.html(page('Verification failed', body), 400);
+    }
+
+    const principalId = `google:${user.sub}`;
+    const updated = await opts.sql`
+      UPDATE device_sessions
+      SET status = 'approved',
+          principal_id = ${principalId},
+          email = ${user.email},
+          approved_at = now()
+      WHERE device_code = ${deviceCode}
+        AND status = 'pending'
+    `;
+
+    // postgres.js returns a result with a `count` field for non-SELECT.
+    const affected = (updated as unknown as { count?: number }).count ?? 0;
+    if (affected === 0) {
+      return c.html(
+        page(
+          'No longer pending',
+          `<h1 class="error">Session was no longer pending</h1><p>You may close this window.</p>`,
+        ),
+        400,
+      );
+    }
+
+    const body = `
+      <h1>Approved</h1>
+      <p>Approved as <strong>${escapeHtml(user.email)}</strong>.</p>
+      <p>You may close this window.</p>
+    `;
+    return c.html(page('Approved', body));
+  });
+}
+
+// Test-only exports. Not part of the public API.
+export const __test__ = {
+  buildState,
+  verifyState,
+  escapeHtml,
+  normalizeUserCode,
+  page,
+};

--- a/packages/server/src/auth/google-oauth.test.ts
+++ b/packages/server/src/auth/google-oauth.test.ts
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildAuthorizeUrl, exchangeCode, type GoogleConfig } from './google-oauth.js';
+
+const cfg: GoogleConfig = {
+  clientId: 'test-client-id.apps.googleusercontent.com',
+  clientSecret: 'test-client-secret',
+  redirectUri: 'https://bridge.example.com/oauth/google/callback',
+};
+
+describe('buildAuthorizeUrl', () => {
+  it('builds a URL pointing at accounts.google.com with required params', () => {
+    const url = new URL(buildAuthorizeUrl(cfg, 'state-abc'));
+
+    assert.equal(url.host, 'accounts.google.com');
+    assert.equal(url.searchParams.get('client_id'), cfg.clientId);
+    assert.equal(url.searchParams.get('redirect_uri'), cfg.redirectUri);
+    assert.equal(url.searchParams.get('response_type'), 'code');
+    assert.equal(url.searchParams.get('state'), 'state-abc');
+  });
+
+  it('requests openid, email, and profile scopes', () => {
+    const url = new URL(buildAuthorizeUrl(cfg, 'state-xyz'));
+    const scope = url.searchParams.get('scope') ?? '';
+    const scopes = scope.split(/\s+/);
+    assert.ok(scopes.includes('openid'), `expected 'openid' scope, got: ${scope}`);
+    assert.ok(scopes.includes('email'), `expected 'email' scope, got: ${scope}`);
+    assert.ok(scopes.includes('profile'), `expected 'profile' scope, got: ${scope}`);
+  });
+
+  it('passes state through verbatim and uses prompt=select_account', () => {
+    const oddState = 'v1.abc:def/ghi+jkl=mno';
+    const url = new URL(buildAuthorizeUrl(cfg, oddState));
+    assert.equal(url.searchParams.get('state'), oddState);
+    assert.equal(url.searchParams.get('prompt'), 'select_account');
+  });
+});
+
+describe('exchangeCode', () => {
+  it('throws on invalid code (cannot exchange with Google)', async (t) => {
+    if (process.env.SKIP_NETWORK_TESTS === '1') {
+      t.skip('SKIP_NETWORK_TESTS=1 set');
+      return;
+    }
+
+    let threw = false;
+    try {
+      await exchangeCode(cfg, 'not-a-real-code');
+    } catch (err) {
+      threw = true;
+      assert.ok(err instanceof Error);
+      // Must not leak the raw code back in the error message.
+      assert.ok(
+        !String(err.message).includes('not-a-real-code'),
+        `error message leaked raw code: ${err.message}`,
+      );
+    }
+    assert.ok(threw, 'expected exchangeCode to throw for invalid code');
+  });
+});

--- a/packages/server/src/auth/google-oauth.ts
+++ b/packages/server/src/auth/google-oauth.ts
@@ -1,0 +1,92 @@
+// Google OAuth 2.0 (web server flow) used internally to authenticate device flow sessions.
+// Callers never see Google endpoints directly — bridge-server is their OAuth AS.
+
+import { OAuth2Client } from 'google-auth-library';
+
+export interface GoogleConfig {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;      // `${PUBLIC_URL}/oauth/google/callback`
+}
+
+export interface GoogleUserInfo {
+  sub: string;              // stable, unique Google account id
+  email: string;
+  emailVerified: boolean;
+  hostedDomain?: string;    // 'hd' claim for Workspace accounts
+}
+
+// Build a Google OAuth authorize URL. The `state` param is already HMAC-signed
+// by the caller (device-ui.ts); this function does not add any additional binding.
+export function buildAuthorizeUrl(cfg: GoogleConfig, state: string): string {
+  const client = new OAuth2Client(cfg.clientId, cfg.clientSecret, cfg.redirectUri);
+  return client.generateAuthUrl({
+    access_type: 'online',
+    scope: ['openid', 'email', 'profile'],
+    state,
+    // Force account chooser so users on shared machines can pick the right identity.
+    prompt: 'select_account',
+  });
+}
+
+// Exchange an authorization code for an id_token. Verifies aud, iss, exp, and
+// email_verified. Throws on any mismatch.
+export async function exchangeCode(
+  cfg: GoogleConfig,
+  code: string,
+): Promise<GoogleUserInfo> {
+  // Fresh client per call — keeps this stateless and avoids token leakage across requests.
+  const client = new OAuth2Client(cfg.clientId, cfg.clientSecret, cfg.redirectUri);
+
+  let idToken: string | null | undefined;
+  try {
+    const { tokens } = await client.getToken(code);
+    idToken = tokens.id_token;
+  } catch {
+    // Don't leak raw code or upstream error text.
+    throw new Error('Google token exchange failed');
+  }
+
+  if (!idToken) {
+    throw new Error('Google response missing id_token');
+  }
+
+  let payload;
+  try {
+    // verifyIdToken validates signature (JWKS), aud, iss (accounts.google.com),
+    // and exp automatically.
+    const ticket = await client.verifyIdToken({
+      idToken,
+      audience: cfg.clientId,
+    });
+    payload = ticket.getPayload();
+  } catch {
+    throw new Error('Google id_token verification failed');
+  }
+
+  if (!payload) {
+    throw new Error('Google id_token payload missing');
+  }
+
+  const sub = payload.sub;
+  const email = payload.email;
+  const emailVerified = payload.email_verified;
+  const hd = payload.hd;
+
+  if (!sub || typeof sub !== 'string') {
+    throw new Error('Google id_token missing sub claim');
+  }
+  if (!email || typeof email !== 'string') {
+    throw new Error('Google id_token missing email claim');
+  }
+  if (emailVerified !== true) {
+    throw new Error('Google account email is not verified');
+  }
+
+  return {
+    sub,
+    email,
+    emailVerified: true,
+    hostedDomain: typeof hd === 'string' && hd.length > 0 ? hd : undefined,
+  };
+}

--- a/packages/server/src/auth/principal.test.ts
+++ b/packages/server/src/auth/principal.test.ts
@@ -1,0 +1,331 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parsePrincipal, validatePrincipal, matchPrincipal } from './principal.js';
+
+// ---------- parsePrincipal ----------
+
+test('parsePrincipal: eth lowercase address', () => {
+  assert.deepEqual(
+    parsePrincipal('eth:0xaabbccddeeff00112233445566778899aabbccdd'),
+    { kind: 'eth', address: '0xaabbccddeeff00112233445566778899aabbccdd' },
+  );
+});
+
+test('parsePrincipal: eth mixed-case normalizes to lowercase', () => {
+  assert.deepEqual(
+    parsePrincipal('eth:0xAaBbCcDdEeFf00112233445566778899AaBbCcDd'),
+    { kind: 'eth', address: '0xaabbccddeeff00112233445566778899aabbccdd' },
+  );
+});
+
+test('parsePrincipal: eth invalid length', () => {
+  assert.equal(parsePrincipal('eth:0xabc'), null);
+});
+
+test('parsePrincipal: eth invalid non-hex', () => {
+  assert.equal(parsePrincipal('eth:0xgggggggggggggggggggggggggggggggggggggggg'), null);
+});
+
+test('parsePrincipal: eth missing 0x prefix', () => {
+  assert.equal(parsePrincipal('eth:aabbccddeeff00112233445566778899aabbccdd'), null);
+});
+
+test('parsePrincipal: google:sub valid', () => {
+  assert.deepEqual(
+    parsePrincipal('google:sub:1234567890'),
+    { kind: 'google-sub', sub: '1234567890' },
+  );
+});
+
+test('parsePrincipal: google:sub opaque string preserved', () => {
+  assert.deepEqual(
+    parsePrincipal('google:sub:abc-XYZ_123'),
+    { kind: 'google-sub', sub: 'abc-XYZ_123' },
+  );
+});
+
+test('parsePrincipal: google:sub empty', () => {
+  assert.equal(parsePrincipal('google:sub:'), null);
+});
+
+test('parsePrincipal: google:email valid lowercase', () => {
+  assert.deepEqual(
+    parsePrincipal('google:email:alice@example.com'),
+    { kind: 'google-email', email: 'alice@example.com' },
+  );
+});
+
+test('parsePrincipal: google:email normalizes to lowercase', () => {
+  assert.deepEqual(
+    parsePrincipal('google:email:Alice@Example.COM'),
+    { kind: 'google-email', email: 'alice@example.com' },
+  );
+});
+
+test('parsePrincipal: google:email missing @', () => {
+  assert.equal(parsePrincipal('google:email:noatsign'), null);
+});
+
+test('parsePrincipal: google:email two @', () => {
+  assert.equal(parsePrincipal('google:email:a@b@c'), null);
+});
+
+test('parsePrincipal: google:email empty local', () => {
+  assert.equal(parsePrincipal('google:email:@example.com'), null);
+});
+
+test('parsePrincipal: google:email empty domain', () => {
+  assert.equal(parsePrincipal('google:email:alice@'), null);
+});
+
+test('parsePrincipal: google:domain valid', () => {
+  assert.deepEqual(
+    parsePrincipal('google:domain:example.com'),
+    { kind: 'google-domain', domain: 'example.com' },
+  );
+});
+
+test('parsePrincipal: google:domain uppercase normalized', () => {
+  assert.deepEqual(
+    parsePrincipal('google:domain:Example.COM'),
+    { kind: 'google-domain', domain: 'example.com' },
+  );
+});
+
+test('parsePrincipal: google:domain no dot', () => {
+  assert.equal(parsePrincipal('google:domain:localhost'), null);
+});
+
+test('parsePrincipal: google:domain empty', () => {
+  assert.equal(parsePrincipal('google:domain:'), null);
+});
+
+test('parsePrincipal: google:domain invalid chars', () => {
+  assert.equal(parsePrincipal('google:domain:foo_bar.com'), null);
+});
+
+test('parsePrincipal: unknown prefix', () => {
+  assert.equal(parsePrincipal('facebook:123'), null);
+});
+
+test('parsePrincipal: empty string', () => {
+  assert.equal(parsePrincipal(''), null);
+});
+
+test('parsePrincipal: plain 0x address (no prefix) is not valid', () => {
+  assert.equal(parsePrincipal('0xaabbccddeeff00112233445566778899aabbccdd'), null);
+});
+
+// ---------- validatePrincipal ----------
+
+test('validatePrincipal: plain 0x auto-prefix', () => {
+  assert.equal(
+    validatePrincipal('0xaabbccddeeff00112233445566778899aabbccdd'),
+    'eth:0xaabbccddeeff00112233445566778899aabbccdd',
+  );
+});
+
+test('validatePrincipal: plain 0x uppercase normalized', () => {
+  assert.equal(
+    validatePrincipal('0xAABBCCDDEEFF00112233445566778899AABBCCDD'),
+    'eth:0xaabbccddeeff00112233445566778899aabbccdd',
+  );
+});
+
+test('validatePrincipal: trims whitespace', () => {
+  assert.equal(
+    validatePrincipal('   0xaabbccddeeff00112233445566778899aabbccdd  '),
+    'eth:0xaabbccddeeff00112233445566778899aabbccdd',
+  );
+});
+
+test('validatePrincipal: eth: prefixed, mixed case normalizes', () => {
+  assert.equal(
+    validatePrincipal('eth:0xAABBccddEEFF00112233445566778899aabbccdd'),
+    'eth:0xaabbccddeeff00112233445566778899aabbccdd',
+  );
+});
+
+test('validatePrincipal: google:sub normalizes (sub opaque)', () => {
+  assert.equal(
+    validatePrincipal('google:sub:1234567890'),
+    'google:sub:1234567890',
+  );
+});
+
+test('validatePrincipal: google:email normalizes to lowercase', () => {
+  assert.equal(
+    validatePrincipal('google:email:Alice@Example.COM'),
+    'google:email:alice@example.com',
+  );
+});
+
+test('validatePrincipal: google:domain normalizes to lowercase', () => {
+  assert.equal(
+    validatePrincipal('google:domain:Example.COM'),
+    'google:domain:example.com',
+  );
+});
+
+test('validatePrincipal: empty string', () => {
+  assert.equal(validatePrincipal(''), null);
+});
+
+test('validatePrincipal: only whitespace', () => {
+  assert.equal(validatePrincipal('   '), null);
+});
+
+test('validatePrincipal: malformed eth', () => {
+  assert.equal(validatePrincipal('eth:0xnotvalid'), null);
+});
+
+test('validatePrincipal: unknown prefix', () => {
+  assert.equal(validatePrincipal('facebook:123'), null);
+});
+
+test('validatePrincipal: malformed email', () => {
+  assert.equal(validatePrincipal('google:email:notanemail'), null);
+});
+
+// ---------- matchPrincipal ----------
+
+test('matchPrincipal: eth exact match with mixed case on both sides', () => {
+  const caller = {
+    principalId: 'eth:0xAABBCCDDEEFF00112233445566778899AABBCCDD',
+  };
+  assert.equal(
+    matchPrincipal('eth:0xaabbccddeeff00112233445566778899aabbccdd', caller),
+    true,
+  );
+});
+
+test('matchPrincipal: eth mismatch', () => {
+  const caller = {
+    principalId: 'eth:0x1111111111111111111111111111111111111111',
+  };
+  assert.equal(
+    matchPrincipal('eth:0xaabbccddeeff00112233445566778899aabbccdd', caller),
+    false,
+  );
+});
+
+test('matchPrincipal: eth entry but caller is google', () => {
+  const caller = { principalId: 'google:1234567890' };
+  assert.equal(
+    matchPrincipal('eth:0xaabbccddeeff00112233445566778899aabbccdd', caller),
+    false,
+  );
+});
+
+test('matchPrincipal: google:sub hit', () => {
+  const caller = { principalId: 'google:1234567890' };
+  assert.equal(matchPrincipal('google:sub:1234567890', caller), true);
+});
+
+test('matchPrincipal: google:sub miss (different sub)', () => {
+  const caller = { principalId: 'google:9999999999' };
+  assert.equal(matchPrincipal('google:sub:1234567890', caller), false);
+});
+
+test('matchPrincipal: google:sub miss (eth caller)', () => {
+  const caller = { principalId: 'eth:0xaabbccddeeff00112233445566778899aabbccdd' };
+  assert.equal(matchPrincipal('google:sub:1234567890', caller), false);
+});
+
+test('matchPrincipal: google:email hit', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'Alice@Example.com',
+    emailVerified: true,
+  };
+  assert.equal(matchPrincipal('google:email:alice@example.com', caller), true);
+});
+
+test('matchPrincipal: google:email miss when emailVerified=false', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@example.com',
+    emailVerified: false,
+  };
+  assert.equal(matchPrincipal('google:email:alice@example.com', caller), false);
+});
+
+test('matchPrincipal: google:email miss when emailVerified undefined', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@example.com',
+  };
+  assert.equal(matchPrincipal('google:email:alice@example.com', caller), false);
+});
+
+test('matchPrincipal: google:email miss on different email', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'bob@example.com',
+    emailVerified: true,
+  };
+  assert.equal(matchPrincipal('google:email:alice@example.com', caller), false);
+});
+
+test('matchPrincipal: google:domain hit via hostedDomain', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@example.com',
+    emailVerified: true,
+    hostedDomain: 'Example.com',
+  };
+  assert.equal(matchPrincipal('google:domain:example.com', caller), true);
+});
+
+test('matchPrincipal: google:domain hit via email suffix when hostedDomain missing', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@Example.COM',
+    emailVerified: true,
+  };
+  assert.equal(matchPrincipal('google:domain:example.com', caller), true);
+});
+
+test('matchPrincipal: google:domain miss when emailVerified=false', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@example.com',
+    emailVerified: false,
+    hostedDomain: 'example.com',
+  };
+  assert.equal(matchPrincipal('google:domain:example.com', caller), false);
+});
+
+test('matchPrincipal: google:domain miss when domain differs', () => {
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@other.com',
+    emailVerified: true,
+    hostedDomain: 'other.com',
+  };
+  assert.equal(matchPrincipal('google:domain:example.com', caller), false);
+});
+
+test('matchPrincipal: google:domain miss when email suffix is a subdomain (not exact)', () => {
+  // alice@mail.example.com ends with "@mail.example.com", which does not end
+  // with "@example.com" literally — so this should not match.
+  const caller = {
+    principalId: 'google:1234567890',
+    email: 'alice@mail.example.com',
+    emailVerified: true,
+  };
+  assert.equal(matchPrincipal('google:domain:example.com', caller), false);
+});
+
+test('matchPrincipal: unparseable entry returns false', () => {
+  const caller = { principalId: 'eth:0xaabbccddeeff00112233445566778899aabbccdd' };
+  assert.equal(matchPrincipal('garbage', caller), false);
+});
+
+test('matchPrincipal: legacy plain 0x entry matches eth principal (backward compat)', () => {
+  const caller = { principalId: 'eth:0xaabbccddeeff00112233445566778899aabbccdd' };
+  assert.equal(
+    matchPrincipal('0xAABBCCDDEEFF00112233445566778899AABBCCDD', caller),
+    true,
+  );
+});

--- a/packages/server/src/auth/principal.test.ts
+++ b/packages/server/src/auth/principal.test.ts
@@ -321,11 +321,3 @@ test('matchPrincipal: unparseable entry returns false', () => {
   const caller = { principalId: 'eth:0xaabbccddeeff00112233445566778899aabbccdd' };
   assert.equal(matchPrincipal('garbage', caller), false);
 });
-
-test('matchPrincipal: legacy plain 0x entry matches eth principal (backward compat)', () => {
-  const caller = { principalId: 'eth:0xaabbccddeeff00112233445566778899aabbccdd' };
-  assert.equal(
-    matchPrincipal('0xAABBCCDDEEFF00112233445566778899AABBCCDD', caller),
-    true,
-  );
-});

--- a/packages/server/src/auth/principal.ts
+++ b/packages/server/src/auth/principal.ts
@@ -94,13 +94,8 @@ export function validatePrincipal(raw: string): Principal | null {
 
 // Returns true if the verified caller satisfies the given allowed_callers entry.
 // google:domain:* requires emailVerified=true.
-//
-// Backward compat: accepts legacy plain `0x<40 hex>` entries (pre-principal-prefix
-// data) by normalizing through validatePrincipal before parsing.
 export function matchPrincipal(entry: Principal, caller: VerifiedCaller): boolean {
-  const normalized = validatePrincipal(entry);
-  if (!normalized) return false;
-  const parsed = parsePrincipal(normalized);
+  const parsed = parsePrincipal(entry);
   if (!parsed) return false;
 
   switch (parsed.kind) {

--- a/packages/server/src/auth/principal.ts
+++ b/packages/server/src/auth/principal.ts
@@ -1,0 +1,135 @@
+// Principal string parsing and matching for agent_policies.allowed_callers.
+//
+// Format:
+//   eth:0x<40 hex>              SIWE-authenticated Ethereum address
+//   google:sub:<sub>            Specific Google account (stable numeric id)
+//   google:email:<email>        Google account by email; pinned to sub on first match
+//   google:domain:<domain>      Any verified Google Workspace account from <domain>
+
+export type Principal = string;
+
+export type ParsedPrincipal =
+  | { kind: 'eth'; address: string }
+  | { kind: 'google-sub'; sub: string }
+  | { kind: 'google-email'; email: string }
+  | { kind: 'google-domain'; domain: string };
+
+export interface VerifiedCaller {
+  principalId: string;       // e.g. 'google:<sub>' | 'eth:0x...'
+  email?: string;
+  emailVerified?: boolean;
+  hostedDomain?: string;
+}
+
+const ETH_ADDR_RE = /^0x[0-9a-f]{40}$/i;
+const DOMAIN_RE = /^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/;
+
+// Parse a stored principal string. Returns null for invalid input.
+export function parsePrincipal(s: string): ParsedPrincipal | null {
+  if (typeof s !== 'string' || s.length === 0) return null;
+
+  if (s.startsWith('eth:')) {
+    const addr = s.slice(4);
+    if (!ETH_ADDR_RE.test(addr)) return null;
+    return { kind: 'eth', address: addr.toLowerCase() };
+  }
+
+  if (s.startsWith('google:sub:')) {
+    const sub = s.slice('google:sub:'.length);
+    if (sub.length === 0) return null;
+    return { kind: 'google-sub', sub };
+  }
+
+  if (s.startsWith('google:email:')) {
+    const email = s.slice('google:email:'.length);
+    if (email.length === 0) return null;
+    const atIdx = email.indexOf('@');
+    if (atIdx === -1) return null;
+    // Exactly one '@'
+    if (email.indexOf('@', atIdx + 1) !== -1) return null;
+    const local = email.slice(0, atIdx);
+    const domain = email.slice(atIdx + 1);
+    if (local.length === 0 || domain.length === 0) return null;
+    return { kind: 'google-email', email: email.toLowerCase() };
+  }
+
+  if (s.startsWith('google:domain:')) {
+    const domain = s.slice('google:domain:'.length);
+    if (domain.length === 0) return null;
+    const lower = domain.toLowerCase();
+    if (!DOMAIN_RE.test(lower)) return null;
+    return { kind: 'google-domain', domain: lower };
+  }
+
+  return null;
+}
+
+// Validate user-supplied principal string (from admin tool input). Normalizes
+// case where appropriate. Plain '0x<40 hex>' is auto-prefixed with 'eth:'.
+// Returns null if invalid.
+export function validatePrincipal(raw: string): Principal | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+
+  // Plain Ethereum address => auto-prefix
+  if (ETH_ADDR_RE.test(trimmed)) {
+    return 'eth:' + trimmed.toLowerCase();
+  }
+
+  const parsed = parsePrincipal(trimmed);
+  if (!parsed) return null;
+
+  switch (parsed.kind) {
+    case 'eth':
+      return 'eth:' + parsed.address;
+    case 'google-sub':
+      return 'google:sub:' + parsed.sub;
+    case 'google-email':
+      return 'google:email:' + parsed.email;
+    case 'google-domain':
+      return 'google:domain:' + parsed.domain;
+  }
+}
+
+// Returns true if the verified caller satisfies the given allowed_callers entry.
+// google:domain:* requires emailVerified=true.
+//
+// Backward compat: accepts legacy plain `0x<40 hex>` entries (pre-principal-prefix
+// data) by normalizing through validatePrincipal before parsing.
+export function matchPrincipal(entry: Principal, caller: VerifiedCaller): boolean {
+  const normalized = validatePrincipal(entry);
+  if (!normalized) return false;
+  const parsed = parsePrincipal(normalized);
+  if (!parsed) return false;
+
+  switch (parsed.kind) {
+    case 'eth': {
+      if (!caller.principalId.startsWith('eth:')) return false;
+      const callerAddr = caller.principalId.slice(4).toLowerCase();
+      return callerAddr === parsed.address;
+    }
+    case 'google-sub': {
+      return caller.principalId === 'google:' + parsed.sub;
+    }
+    case 'google-email': {
+      if (caller.emailVerified !== true) return false;
+      if (!caller.email) return false;
+      return caller.email.toLowerCase() === parsed.email;
+    }
+    case 'google-domain': {
+      if (caller.emailVerified !== true) return false;
+      const target = parsed.domain;
+      if (caller.hostedDomain && caller.hostedDomain.toLowerCase() === target) {
+        return true;
+      }
+      if (caller.email) {
+        const suffix = '@' + target;
+        if (caller.email.toLowerCase().endsWith(suffix)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -8,6 +8,10 @@ const databaseUrl = process.env.DATABASE_URL;
 const dbSetupUrl = process.env.DB_SETUP_URL;
 const publicUrl = process.env.PUBLIC_URL;
 
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const deviceFlowStateSecret = process.env.DEVICE_FLOW_STATE_SECRET;
+
 if (!databaseUrl) {
   console.error('DATABASE_URL env var required');
   process.exit(1);
@@ -15,6 +19,17 @@ if (!databaseUrl) {
 
 if (!process.env.ANTHROPIC_API_KEY) {
   console.error('ANTHROPIC_API_KEY env var required');
+  process.exit(1);
+}
+
+// Google OAuth device flow is optional. If any Google config is partially
+// provided we fail fast to surface misconfiguration.
+const googleConfigured = !!(googleClientId || googleClientSecret || deviceFlowStateSecret);
+if (googleConfigured && (!googleClientId || !googleClientSecret || !deviceFlowStateSecret || !publicUrl)) {
+  console.error(
+    'Google OAuth device flow requires GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, ' +
+      'DEVICE_FLOW_STATE_SECRET, and PUBLIC_URL to all be set.',
+  );
   process.exit(1);
 }
 
@@ -29,7 +44,19 @@ async function main() {
   const db = createDb(databaseUrl!);
 
   await startPostGraphile(databaseUrl!);
-  await startServer({ port, publicUrl, db });
+  await startServer({
+    port,
+    publicUrl,
+    db,
+    google: googleConfigured
+      ? {
+          clientId: googleClientId!,
+          clientSecret: googleClientSecret!,
+          redirectUri: `${publicUrl}/oauth/google/callback`,
+        }
+      : undefined,
+    deviceFlowStateSecret,
+  });
 }
 
 main().catch((err) => {

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -16,6 +16,9 @@ import type { ClientConnection, Registry } from './registry.js';
 import { createAdminTransport, buildAdminAgentCard, getAdminWallets } from './admin.js';
 import { verifySiweToken } from './siwe-token.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
+import { mountDeviceFlow } from './auth/device-flow.js';
+import { mountDeviceUi } from './auth/device-ui.js';
+import type { GoogleConfig } from './auth/google-oauth.js';
 import type { Sql } from './db.js';
 import { Landing } from './landing.js';
 
@@ -23,6 +26,8 @@ export interface ServerHttpOptions {
   registry: Registry;
   publicUrl?: string;
   db: Sql;
+  google?: GoogleConfig;     // absent = device flow endpoints disabled
+  deviceFlowStateSecret?: string;
 }
 
 function toSdkAgentCard(
@@ -61,8 +66,21 @@ function toSdkAgentCard(
         bearerFormat: 'SIWE',
         description: 'Sign-In with Ethereum (EIP-4361) bearer token',
       },
+      bridge: {
+        type: 'oauth2',
+        description: 'Bridge-issued opaque bearer token obtained via Google OAuth device flow',
+        flows: {
+          deviceAuthorization: {
+            deviceAuthorizationUrl: publicUrl
+              ? `${publicUrl}/oauth/device/code`
+              : '/oauth/device/code',
+            tokenUrl: publicUrl ? `${publicUrl}/oauth/token` : '/oauth/token',
+            scopes: {},
+          },
+        },
+      } as unknown as NonNullable<SdkAgentCard['securitySchemes']>[string],
     };
-    card.security = [{ siwe: [] }];
+    card.security = [{ siwe: [] }, { bridge: [] }];
   }
   return card;
 }
@@ -201,6 +219,20 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     return handleTransportResult(result, c);
   });
 
+  // Device flow endpoints (RFC-8628) — optional: only mounted when Google config is provided
+  if (opts.google && opts.publicUrl) {
+    if (!opts.deviceFlowStateSecret) {
+      throw new Error('deviceFlowStateSecret is required when google OAuth is configured');
+    }
+    mountDeviceFlow(app, { sql: opts.db, publicUrl: opts.publicUrl });
+    mountDeviceUi(app, {
+      sql: opts.db,
+      google: opts.google,
+      stateSecret: opts.deviceFlowStateSecret,
+      publicUrl: opts.publicUrl,
+    });
+  }
+
   // PostGraphile proxy — forward /graphql and /graphiql to internal PostGraphile server
   const postgraphileUrl = `http://localhost:${process.env.POSTGRAPHILE_PORT ?? 5433}`;
 
@@ -235,7 +267,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  const authMw = agentAuthMiddleware(opts.registry, { domain: siweDomain });
+  const authMw = agentAuthMiddleware(opts.registry, { sql: opts.db, domain: siweDomain });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,12 +3,25 @@ import { Registry } from './registry.js';
 import { createHttpApp } from './http.js';
 import { attachWsServer } from './ws.js';
 import type { Sql } from './db.js';
+import type { GoogleConfig } from './auth/google-oauth.js';
+
+const DEVICE_SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1h
+
+async function cleanupExpiredDeviceSessions(db: Sql): Promise<void> {
+  try {
+    await db`DELETE FROM device_sessions WHERE expires_at <= now()`;
+  } catch (err) {
+    console.error('[server] device_sessions cleanup failed:', err);
+  }
+}
 
 export interface ServerOptions {
   port: number;
   host?: string;
   publicUrl?: string;
   db: Sql;
+  google?: GoogleConfig;
+  deviceFlowStateSecret?: string;
 }
 
 export async function startServer(opts: ServerOptions) {
@@ -17,6 +30,8 @@ export async function startServer(opts: ServerOptions) {
     registry,
     publicUrl: opts.publicUrl,
     db: opts.db,
+    google: opts.google,
+    deviceFlowStateSecret: opts.deviceFlowStateSecret,
   });
 
   const server = serve({
@@ -29,6 +44,14 @@ export async function startServer(opts: ServerOptions) {
     db: opts.db,
     registry,
   });
+
+  // Cleanup expired device_sessions on startup and periodically.
+  void cleanupExpiredDeviceSessions(opts.db);
+  const cleanupTimer = setInterval(
+    () => void cleanupExpiredDeviceSessions(opts.db),
+    DEVICE_SESSION_CLEANUP_INTERVAL_MS,
+  );
+  cleanupTimer.unref();
 
   console.log(`[server] listening on :${opts.port}`);
   return { registry, server };

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -95,11 +95,10 @@ export class Registry {
   }
 
   updateAllowedCallers(agentId: string, callers: string[]): void {
-    const normalized = callers.map((c) => c.toLowerCase());
     const conn = this.agents.get(agentId);
-    if (conn) conn.allowedCallers = normalized;
+    if (conn) conn.allowedCallers = callers;
     for (const listener of this.callerChangeListeners) {
-      listener(agentId, normalized);
+      listener(agentId, callers);
     }
   }
 

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -57,7 +57,7 @@ async function ensureAgentPolicy(
   if (rows[0].owner_wallet.toLowerCase() !== ownerWallet.toLowerCase()) {
     return { ok: false, reason: 'agent id owned by a different wallet' };
   }
-  return { ok: true, allowedCallers: rows[0].allowed_callers.map((a) => a.toLowerCase()) };
+  return { ok: true, allowedCallers: rows[0].allowed_callers };
 }
 
 export interface ServerWsOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 0.3.13(express@5.2.1)
       '@rainbow-me/rainbowkit':
         specifier: ^2
-        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
       '@tanstack/react-query':
         specifier: ^5
         version: 5.99.0(react@19.2.5)
@@ -49,10 +49,10 @@ importers:
         version: 2.3.2(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       viem:
         specifier: ^2
-        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       wagmi:
         specifier: ^2
-        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
@@ -118,6 +118,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      google-auth-library:
+        specifier: ^10.6.2
+        version: 10.6.2
       hono:
         specifier: ^4.6.11
         version: 4.12.12
@@ -1781,6 +1784,10 @@ packages:
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ai@6.0.162:
     resolution: {integrity: sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA==}
     engines: {node: '>=18'}
@@ -1847,6 +1854,9 @@ packages:
 
   big.js@6.2.2:
     resolution: {integrity: sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -2034,6 +2044,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -2311,6 +2325,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   filter-obj@1.1.0:
     resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
     engines: {node: '>=0.10.0'}
@@ -2344,6 +2362,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2359,6 +2381,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -2386,6 +2416,14 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -2471,6 +2509,10 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -2589,6 +2631,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
   json-rpc-engine@6.1.0:
     resolution: {integrity: sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==}
@@ -2961,6 +3006,11 @@ packages:
   node-addon-api@2.0.2:
     resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -2972,6 +3022,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -3871,6 +3925,10 @@ packages:
       typescript:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webextension-polyfill@0.10.0:
     resolution: {integrity: sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g==}
 
@@ -4195,16 +4253,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -4252,15 +4310,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -4454,11 +4512,11 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -4722,7 +4780,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
+  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@vanilla-extract/css': 1.17.3
@@ -4734,8 +4792,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.6.2(@types/react@19.2.14)(react@19.2.5)
       ua-parser-js: 1.0.41
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -4752,24 +4810,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4798,12 +4856,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
@@ -4838,12 +4896,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -4875,10 +4933,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -4910,16 +4968,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4959,21 +5017,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5079,9 +5137,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -5089,10 +5147,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -5840,19 +5898,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5893,11 +5951,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.99.0
@@ -5908,7 +5966,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -5922,7 +5980,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -5952,7 +6010,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -5966,7 +6024,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -6000,18 +6058,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6134,16 +6192,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6170,16 +6228,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6268,7 +6326,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -6277,9 +6335,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -6308,7 +6366,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -6317,9 +6375,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -6348,7 +6406,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -6366,7 +6424,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6392,7 +6450,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -6410,7 +6468,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6450,10 +6508,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@4.3.6):
+  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 4.3.6
+      zod: 3.25.76
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -6476,6 +6534,8 @@ snapshots:
       negotiator: 1.0.0
 
   aes-js@4.0.0-beta.5: {}
+
+  agent-base@7.1.4: {}
 
   ai@6.0.162(zod@3.25.76):
     dependencies:
@@ -6538,6 +6598,8 @@ snapshots:
   baseline-browser-mapping@2.10.19: {}
 
   big.js@6.2.2: {}
+
+  bignumber.js@9.3.1: {}
 
   bn.js@5.2.3: {}
 
@@ -6723,6 +6785,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       typescript: 5.9.3
+
+  data-uri-to-buffer@4.0.1: {}
 
   date-fns@2.30.0:
     dependencies:
@@ -7045,6 +7109,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   filter-obj@1.1.0: {}
 
   finalhandler@1.3.2:
@@ -7089,6 +7158,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
@@ -7097,6 +7170,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -7127,6 +7216,19 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -7258,6 +7360,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -7350,6 +7459,10 @@ snapshots:
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
 
   json-rpc-engine@6.1.0:
     dependencies:
@@ -7900,11 +8013,19 @@ snapshots:
 
   node-addon-api@2.0.2: {}
 
+  node-domexception@1.0.0: {}
+
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4: {}
 
@@ -7974,43 +8095,28 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.17(typescript@5.9.3)(zod@4.3.6):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - zod
-
-  ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
+  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
+  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.10.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -8140,21 +8246,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)):
+  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -8844,15 +8950,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@4.3.6)
+      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -8895,23 +9001,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.14.17(typescript@5.9.3)(zod@4.3.6)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -8927,14 +9016,14 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
+  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8971,6 +9060,8 @@ snapshots:
       - uploadthing
       - utf-8-validate
       - zod
+
+  web-streams-polyfill@3.3.3: {}
 
   webextension-polyfill@0.10.0: {}
 


### PR DESCRIPTION
## Summary

Adds a second A2A caller authentication path alongside SIWE: bridge-issued opaque bearer tokens (`vbc_caller_*`) obtained via RFC-8628 device flow, where Google acts as the upstream identity provider.

Callers never see Google endpoints directly — the bridge-server is their OAuth authorization server. This keeps Google as a swappable IdP slot and gives the server full control over token lifetime, revocation, and labelling without hitting Google on every request.

## Design

```
Caller process → POST /oauth/device/code → {device_code, user_code, verification_uri}
Human browser → /oauth/device?user_code=… → redirect to Google → callback → approved
Caller process polls POST /oauth/token → opaque vbc_caller_… token
Caller process → POST /agents/:id with Authorization: Bearer vbc_caller_…
```

`allowed_callers` values now accept a principal vocabulary:
- `eth:0x<40 hex>` — SIWE
- `google:sub:<sub>` — specific Google account
- `google:email:<addr>` — Google email (pinned to sub on first match)
- `google:domain:<d>` — any verified Google Workspace account from the domain

Device flow is only mounted when `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `DEVICE_FLOW_STATE_SECRET`, and `PUBLIC_URL` are all set; the server fails fast on partial config.

## What's included

- `auth/principal.ts` — principal parse / validate / match, with emailVerified checks for `google:*` entries. Admin input still accepts plain 0x (auto-prefixed to `eth:` by `validatePrincipal`).
- `auth/caller-token.ts` — opaque token lifecycle (issue / verify / revoke / list), sha256-hashed storage, LRU verify cache bounded to 60 s so revocations propagate without explicit invalidation.
- `auth/google-oauth.ts` — Google id_token exchange/verification via `google-auth-library`; rejects `email_verified=false`; `prompt=select_account` forces account chooser.
- `auth/device-flow.ts` — `POST /oauth/device/code` and `POST /oauth/token` per RFC-8628, `slow_down` enforcement, transactional caller-token-issue + device-session-delete.
- `auth/device-ui.ts` — `/oauth/device`, `/oauth/google/start`, `/oauth/google/callback` browser pages; HMAC-signed `state`; all user-visible strings HTML-escaped.
- `agent-auth.ts` — dispatches SIWE vs opaque by bearer prefix; principal-based matching.
- `admin.ts` — `add_caller`/`remove_caller` generalized to accept all principal formats; new admin-only `list_caller_tokens` and `revoke_caller_token` tools.
- Agent Card `securitySchemes` advertises both `siwe` and `bridge` (oauth2 deviceAuthorization).
- DB: new `callers` and `device_sessions` tables, both marked `@omit` in PostGraphile.
- Cleanup job for expired `device_sessions` on startup + hourly.

## Test plan

- [x] Unit tests: 85 pass (all green with live Postgres, 9 tests exercise DB)
- [x] Typecheck clean
- [x] Full build clean
- [x] Security review via `security-review` skill: no HIGH/MEDIUM findings at ≥8 confidence
- [x] **E2E verified locally**:
  - Opaque token dispatch (manual DB insert → A2A call): 4/4 scenarios pass (no Bearer → 401, invalid token → 401, unlisted principal → 403, matching principal → 200 echo)
  - Real Google device flow end-to-end: `/oauth/device/code` → browser Google login → `/oauth/token` → `/agents/:id` with issued opaque token → 200 echo
  - SIWE regression: canonical `eth:` entry matches, SIWE + Google entries coexist in one policy, malformed bearer → 401

## Follow-ups (not in this PR)

- Per-user "list/revoke my tokens" UI for callers (currently admin-only)
- Refresh token support (current model: 90-day opaque, re-auth via device flow on expiry)
- Additional IdPs (GitHub, Okta) — plug into the `google:` / principal-prefix pattern

## Config

New env vars (all optional, must be set as a group or not at all):
- `GOOGLE_CLIENT_ID`
- `GOOGLE_CLIENT_SECRET`
- `DEVICE_FLOW_STATE_SECRET` (HMAC key for OAuth state param)

Google Cloud Console setup:
- OAuth 2.0 Client (Web application)
- Authorized redirect URI: `{PUBLIC_URL}/oauth/google/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)