### PR TITLE
Unify SIWE onto caller-token issuance model

### DIFF
--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -225,6 +225,9 @@ const PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf
 
 const account = privateKeyToAccount(PRIVATE_KEY);
 console.error(`# wallet: ${account.address}`);
+// Fresh nonce per invocation: `/auth/siwe/exchange` enforces single-use per
+// (principal, nonce), so a fixed literal would cause the second run to fail.
+const nonce = crypto.randomUUID().replace(/-/g, '');
 const msg = new SiweMessage({
   domain: DOMAIN,
   address: account.address,
@@ -232,7 +235,7 @@ const msg = new SiweMessage({
   uri: URI,
   version: '1',
   chainId: 1,
-  nonce: 'testnonce0123456789abcdef',
+  nonce,
   issuedAt: new Date().toISOString(),
   expirationTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
 });

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,7 +1,10 @@
 # Local E2E testing
 
-Walkthroughs for exercising the A2A caller auth paths (SIWE, opaque token via
-Google OAuth device flow) end-to-end against a local server + echo client.
+Walkthroughs for exercising the A2A caller auth paths end-to-end against a
+local server + echo client. After #31 all paths converge on opaque caller
+tokens (`vbc_caller_*`); they differ only in how the token is **issued**:
+direct DB insert (Path A — smoke test), Google device flow (Path B), or SIWE
+exchange (Path C).
 
 ## Prerequisites
 
@@ -199,11 +202,13 @@ Other entry formats:
 - `google:domain:<your_workspace_domain>` — any verified account from the domain
   (matches either `hd` claim or `@domain` email suffix)
 
-## SIWE regression check (programmatic)
+## Path C — SIWE exchange (programmatic)
 
-Runs SIWE without a browser by signing a SIWE message with a test EOA key using
-`viem` + `siwe`. Useful for verifying the SIWE path wasn't broken by auth
-refactors.
+Raw SIWE bearers are no longer accepted on `/agents/:id`, `POST /`, or admin
+GraphQL (see #31). SIWE is now an **issuance method**: sign a message, POST it
+to `/auth/siwe/exchange`, receive an opaque `vbc_caller_*` token, and use that
+token on every subsequent request. This section signs programmatically with a
+test EOA and walks the full exchange.
 
 ```bash
 # Script uses a well-known Anvil test key — safe because it has no real balance.
@@ -211,13 +216,15 @@ cat > /tmp/gen-siwe.mjs <<'JS'
 import { SiweMessage } from 'siwe';
 import { privateKeyToAccount } from 'viem/accounts';
 
+// Must match the server's PUBLIC_URL hostname — the exchange endpoint enforces
+// domain match against siweDomain derived from PUBLIC_URL.
 const DOMAIN = process.env.SIWE_DOMAIN ?? 'localhost';
 const URI = process.env.SIWE_URI ?? 'http://localhost:8787';
 // Anvil account #0 — public test key, DO NOT use for anything real.
 const PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
 
 const account = privateKeyToAccount(PRIVATE_KEY);
-console.log(`# wallet: ${account.address}`);
+console.error(`# wallet: ${account.address}`);
 const msg = new SiweMessage({
   domain: DOMAIN,
   address: account.address,
@@ -231,43 +238,57 @@ const msg = new SiweMessage({
 });
 const message = msg.prepareMessage();
 const signature = await account.signMessage({ message });
-const token = Buffer.from(JSON.stringify({ message, signature })).toString('base64url');
-console.log(token);
+// Emit JSON to stdout so it can be piped directly into the exchange endpoint.
+console.log(JSON.stringify({ message, signature }));
 JS
 
 # Run from packages/admin-ui — it's the only workspace with viem resolvable.
 cp /tmp/gen-siwe.mjs packages/admin-ui/
-(cd packages/admin-ui && node gen-siwe.mjs)
+(cd packages/admin-ui && node gen-siwe.mjs) > /tmp/siwe.json
 
-# Grant the wallet, restart client, call the agent.
+# Exchange SIWE → opaque caller token.
+TOKEN=$(curl -sX POST http://localhost:8787/auth/siwe/exchange \
+  -H "Content-Type: application/json" \
+  --data @/tmp/siwe.json | jq -r .access_token)
+echo "$TOKEN"   # vbc_caller_...
+
+# Confirm the callers row landed with provider='siwe'.
 psql vicoop_bridge_dev -c \
-  "UPDATE agent_policies SET allowed_callers = ARRAY['eth:<wallet_lower>'] WHERE agent_id='echo-agent';"
+  "SELECT principal_id, provider, expires_at FROM callers ORDER BY created_at DESC LIMIT 1;"
+# principal_id should be eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 (Anvil #0, lowercased)
+# provider should be 'siwe'
+
+# Grant the wallet, restart client, call the agent with the opaque token.
+psql vicoop_bridge_dev -c \
+  "UPDATE agent_policies SET allowed_callers = ARRAY['eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'] WHERE agent_id='echo-agent';"
 # ...restart client...
 
-SIWE_TOKEN="<token from script>"
 curl -s -X POST http://localhost:8787/agents/echo-agent \
-  -H "Authorization: Bearer $SIWE_TOKEN" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"m","role":"user","kind":"message","parts":[{"kind":"text","text":"siwe test"}]}}}'
 ```
 
 Verified scenarios:
-- canonical `eth:0x...` entry matches SIWE token
-- legacy plain `0x...` entry (no prefix, for DBs predating the principal format)
-  also matches via `validatePrincipal` auto-prefix in `matchPrincipal`
-- mixed policy (`[eth:0x..., google:sub:...]`) — both token types match
-  against their own entry type
-- malformed bearer → 401 `Failed to decode SIWE token`
+- exchange issues an opaque token tied to `eth:<addr>` with `provider='siwe'`
+- that opaque token matches canonical `eth:0x...` entries in `allowed_callers`
+- mixed policy (`[eth:0x..., google:sub:...]`) — both opaque tokens match
+  against their own principal
+- raw SIWE bearer on `/agents/:id` → 401 `Invalid bearer token: expected vbc_caller_* prefix`
+- expired SIWE message on exchange → 401 `invalid_grant`
+- domain mismatch on exchange → 401 `invalid_grant`
+- admin UI / admin GraphQL: same opaque token grants `wallet_address` claim and
+  (if wallet in `ADMIN_WALLET_ADDRESSES`) admin scope
 
 ## Unit tests with live DB
 
-9 DB-gated cases live in the auth module tests (caller-token, device-flow)
-and skip without `DATABASE_URL`. To run the full suite:
+DB-gated cases in the auth module tests (caller-token, device-flow,
+siwe-exchange) skip without `DATABASE_URL`. To run the full suite:
 
 ```bash
 DATABASE_URL="postgres://$USER@localhost:5432/vicoop_bridge_dev" \
-  ./node_modules/.bin/tsx --test packages/server/src/auth/*.test.ts
-# expect: pass 86 / skipped 0
+  pnpm --filter @vicoop-bridge/server exec tsx --test src/auth/*.test.ts
+# expect: pass 90 / skipped 0
 ```
 
 ## Gotchas

--- a/packages/admin-ui/src/components/wallet-auth.tsx
+++ b/packages/admin-ui/src/components/wallet-auth.tsx
@@ -21,6 +21,10 @@ export function WalletAuth() {
     setError(null);
 
     try {
+      // Share a single base timestamp between issuedAt and expirationTime so
+      // their difference is exactly 7 days. Two separate Date reads can drift
+      // a few ms apart and push `expires - issued` over the server's cap.
+      const now = Date.now();
       const siweMessage = new SiweMessage({
         domain: window.location.hostname,
         address,
@@ -29,8 +33,8 @@ export function WalletAuth() {
         version: '1',
         chainId,
         nonce: crypto.randomUUID().replace(/-/g, ''),
-        issuedAt: new Date().toISOString(),
-        expirationTime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        issuedAt: new Date(now).toISOString(),
+        expirationTime: new Date(now + 7 * 24 * 60 * 60 * 1000).toISOString(),
       });
 
       const message = siweMessage.prepareMessage();

--- a/packages/admin-ui/src/components/wallet-auth.tsx
+++ b/packages/admin-ui/src/components/wallet-auth.tsx
@@ -3,7 +3,7 @@ import { useAccount, useSignMessage, useDisconnect } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthToken, setToken } from '../lib/auth-token';
-import { encodeSiweToken } from '../lib/siwe-token';
+import { exchangeSiweForCallerToken } from '../lib/siwe-exchange';
 
 export function WalletAuth() {
   const { address, isConnected, chainId } = useAccount();
@@ -35,7 +35,8 @@ export function WalletAuth() {
 
       const message = siweMessage.prepareMessage();
       const signature = await signMessageAsync({ message });
-      setToken(encodeSiweToken(message, signature));
+      const accessToken = await exchangeSiweForCallerToken(message, signature);
+      setToken(accessToken);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.toLowerCase().includes('user rejected')) {

--- a/packages/admin-ui/src/lib/siwe-exchange.ts
+++ b/packages/admin-ui/src/lib/siwe-exchange.ts
@@ -1,0 +1,34 @@
+// Exchanges a signed SIWE (message, signature) pair for a bridge-issued
+// opaque caller token (`vbc_caller_*`). The returned token is the only
+// credential subsequently presented to the bridge — admin GraphQL, A2A
+// /agents/:id, and the root admin agent all accept opaque tokens and no
+// longer accept raw SIWE bearers (see issue #31).
+
+interface ExchangeResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+export async function exchangeSiweForCallerToken(
+  message: string,
+  signature: string,
+): Promise<string> {
+  const res = await fetch('/auth/siwe/exchange', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ message, signature }),
+  });
+  if (!res.ok) {
+    let description = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error_description?: string; error?: string };
+      description = body.error_description ?? body.error ?? description;
+    } catch {
+      // ignore: non-JSON body
+    }
+    throw new Error(`SIWE exchange failed: ${description}`);
+  }
+  const body = (await res.json()) as ExchangeResponse;
+  return body.access_token;
+}

--- a/packages/admin-ui/src/lib/siwe-exchange.ts
+++ b/packages/admin-ui/src/lib/siwe-exchange.ts
@@ -4,11 +4,7 @@
 // /agents/:id, and the root admin agent all accept opaque tokens and no
 // longer accept raw SIWE bearers (see issue #31).
 
-interface ExchangeResponse {
-  access_token: string;
-  token_type: string;
-  expires_in: number;
-}
+const CALLER_TOKEN_PREFIX = 'vbc_caller_';
 
 export async function exchangeSiweForCallerToken(
   message: string,
@@ -29,6 +25,22 @@ export async function exchangeSiweForCallerToken(
     }
     throw new Error(`SIWE exchange failed: ${description}`);
   }
-  const body = (await res.json()) as ExchangeResponse;
-  return body.access_token;
+
+  // Validate the 2xx body shape: a misconfigured proxy / redirected HTML page
+  // could respond 200 with junk, which we'd otherwise silently persist as
+  // the auth token.
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    throw new Error('SIWE exchange returned a non-JSON response');
+  }
+  const payload = body as { access_token?: unknown; token_type?: unknown };
+  if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(CALLER_TOKEN_PREFIX)) {
+    throw new Error('SIWE exchange response missing or malformed access_token');
+  }
+  if (typeof payload.token_type === 'string' && payload.token_type.toLowerCase() !== 'bearer') {
+    throw new Error(`SIWE exchange returned unsupported token_type: ${payload.token_type}`);
+  }
+  return payload.access_token;
 }

--- a/packages/admin-ui/src/lib/siwe-token.ts
+++ b/packages/admin-ui/src/lib/siwe-token.ts
@@ -1,5 +1,0 @@
-export function encodeSiweToken(message: string, signature: string): string {
-  const json = JSON.stringify({ message, signature });
-  const base64 = btoa(unescape(encodeURIComponent(json)));
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/pg": "^8.20.0",
-    "@types/ws": "^8.5.13"
+    "@types/ws": "^8.5.13",
+    "ethers": "^6.16.0"
   }
 }

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -508,6 +508,31 @@ CREATE POLICY device_sessions_postgraphile ON device_sessions
 
 COMMENT ON TABLE device_sessions IS E'@omit';
 
+-- Consumed SIWE nonces, scoped per (principal_id, nonce). Prevents replay of a
+-- captured (message, signature) at POST /auth/siwe/exchange: without this, an
+-- attacker who intercepted a valid SIWE could mint fresh vbc_caller_* tokens
+-- until SIWE expirationTime, defeating per-token revocation. The per-principal
+-- scoping means a bogus signature (→ wrong recovered principal) can only burn
+-- its own nonce, not a legitimate signer's.
+CREATE TABLE IF NOT EXISTS used_siwe_nonces (
+  principal_id    TEXT NOT NULL,
+  nonce           TEXT NOT NULL,
+  expires_at      TIMESTAMPTZ NOT NULL,
+  used_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (principal_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS used_siwe_nonces_expires_idx
+  ON used_siwe_nonces(expires_at);
+
+ALTER TABLE used_siwe_nonces ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS used_siwe_nonces_postgraphile ON used_siwe_nonces;
+CREATE POLICY used_siwe_nonces_postgraphile ON used_siwe_nonces
+  FOR ALL TO app_postgraphile USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE used_siwe_nonces IS E'@omit';
+
 -- ============================================================
 -- 7. Grants
 -- ============================================================

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -109,7 +109,7 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 - Do NOT use the auto-generated \`mutate_updateClientById\` or \`mutate_deleteClientById\` for revoke/token rotation — always prefer the semantic mutations above.
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
-- Use \`list_caller_tokens\` / \`revoke_caller_token\` (admin only) to manage opaque caller tokens issued via Google OAuth device flow.
+- Use \`list_caller_tokens\` / \`revoke_caller_token\` (admin only) to manage opaque caller tokens. Issued via either Google OAuth device flow (provider=google) or SIWE exchange (provider=siwe).
 - Use \`execute_graphql\` for complex queries and inspection not covered by auto-generated tools.
 
 ## Agent Access Control
@@ -134,7 +134,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 
 - When registering a client or rotating a token, always warn the user that the raw token is shown only once.
 - When registering on behalf of another wallet (admin only), echo back the chosen \`ownerWallet\` so the user can confirm.
-- When adding a caller, explain that the agent will require SIWE authentication from that point on.
+- When adding a caller, explain that the agent will require an authenticated bearer token from that point on (either SIWE-exchanged or Google-device-flow-issued, depending on the principal format).
 - Present data clearly in tables or lists.
 - If asked about something outside client management, politely explain your scope.
 
@@ -473,7 +473,7 @@ export function buildAdminAgentCard(publicUrl?: string): SdkAgentCard {
   return {
     name: 'Vicoop Bridge Server Admin',
     description:
-      'Manages client registration, revocation, and access control for Vicoop Bridge Server. Clients are WebSocket services that bridge local A2A agents to the server. Each client is scoped to an owner wallet and an explicit agent ID allowlist. Requires SIWE authentication.',
+      'Manages client registration, revocation, and access control for Vicoop Bridge Server. Clients are WebSocket services that bridge local A2A agents to the server. Each client is scoped to an owner wallet and an explicit agent ID allowlist. Requires a bridge-issued opaque caller token (vbc_caller_*) tied to a wallet principal; obtain one by signing a SIWE message at POST /auth/siwe/exchange.',
     version: '0.1.0',
     protocolVersion: '0.3.0',
     url,

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,7 +1,6 @@
 import type { Context, Next } from 'hono';
 import type { ClientConnection, Registry } from './registry.js';
 import type { Sql } from './db.js';
-import { verifySiweToken } from './siwe-token.js';
 import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
 import { matchPrincipal, type VerifiedCaller } from './auth/principal.js';
 
@@ -15,7 +14,6 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
 
 export interface AgentAuthOptions {
   sql: Sql;
-  domain?: string;
 }
 
 export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
@@ -42,18 +40,27 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: 'Authentication required (Bearer SIWE or caller token)' },
+        error: {
+          code: -32001,
+          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token)`,
+        },
+      }, 401);
+    }
+
+    if (!bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32001,
+          message: `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via /auth/siwe/exchange (SIWE) or /oauth/token (device flow).`,
+        },
       }, 401);
     }
 
     let caller: VerifiedCaller;
     try {
-      if (bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
-        caller = await verifyCallerToken(opts.sql, bearerToken);
-      } else {
-        const wallet = await verifySiweToken(bearerToken, { domain: opts.domain });
-        caller = { principalId: `eth:${wallet.toLowerCase()}` };
-      }
+      caller = await verifyCallerToken(opts.sql, bearerToken);
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -14,9 +14,14 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
 
 export interface AgentAuthOptions {
   sql: Sql;
+  deviceFlowEnabled?: boolean;
 }
 
 export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
+  const acquisitionHint = opts.deviceFlowEnabled
+    ? '/auth/siwe/exchange (SIWE) or /oauth/token (device flow)'
+    : '/auth/siwe/exchange (SIWE)';
+
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
@@ -53,7 +58,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         id: null,
         error: {
           code: -32001,
-          message: `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via /auth/siwe/exchange (SIWE) or /oauth/token (device flow).`,
+          message: `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
         },
       }, 401);
     }

--- a/packages/server/src/auth/caller-token.ts
+++ b/packages/server/src/auth/caller-token.ts
@@ -7,9 +7,13 @@ import type { VerifiedCaller } from './principal.js';
 
 export const CALLER_TOKEN_PREFIX = 'vbc_caller_';
 
+// Provider label persisted on the `callers` row. Expands as new issuance
+// methods are added (e.g. passkey, ssh-agent). Not enforced by schema.
+export type CallerProvider = 'google' | 'siwe';
+
 export interface IssueCallerTokenInput {
-  principalId: string;        // 'google:<sub>'
-  provider: 'google';
+  principalId: string;        // 'google:<sub>' | 'eth:0x<addr>'
+  provider: CallerProvider;
   email?: string;
   label?: string;
   ttlMs?: number;             // default 90 days

--- a/packages/server/src/auth/siwe-exchange.test.ts
+++ b/packages/server/src/auth/siwe-exchange.test.ts
@@ -177,7 +177,7 @@ test(
       // Craft a SIWE where expirationTime - issuedAt stays under the 7-day cap
       // (so the per-message TTL check passes) but issuedAt is far in the future,
       // which would otherwise let the caller token's absolute lifetime exceed
-      // the 7-day max. verifySiweToken's issuedAt-vs-now check must reject it.
+      // the 7-day max. verifySiweMessage's issuedAt-vs-now check must reject it.
       const wallet = Wallet.createRandom();
       const issued = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
       const expires = new Date(Date.now() + (365 + 3) * 24 * 60 * 60 * 1000).toISOString();

--- a/packages/server/src/auth/siwe-exchange.test.ts
+++ b/packages/server/src/auth/siwe-exchange.test.ts
@@ -168,6 +168,52 @@ test(
 );
 
 test(
+  'SIWE with issuedAt far in the future is rejected with 401',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      // Craft a SIWE where expirationTime - issuedAt stays under the 7-day cap
+      // (so the per-message TTL check passes) but issuedAt is far in the future,
+      // which would otherwise let the caller token's absolute lifetime exceed
+      // the 7-day max. verifySiweToken's issuedAt-vs-now check must reject it.
+      const wallet = Wallet.createRandom();
+      const issued = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+      const expires = new Date(Date.now() + (365 + 3) * 24 * 60 * 60 * 1000).toISOString();
+      const siwe = new SiweMessage({
+        domain: TEST_DOMAIN,
+        address: wallet.address,
+        statement: 'Future.',
+        uri: `https://${TEST_DOMAIN}`,
+        version: '1',
+        chainId: 1,
+        nonce: 'futurefuture0123456789abcdef',
+        issuedAt: issued,
+        expirationTime: expires,
+      });
+      const message = siwe.prepareMessage();
+      const signature = await wallet.signMessage(message);
+
+      const res = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      assert.equal(res.status, 401);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'invalid_grant');
+      assert.match(String(body.error_description), /issuedAt is in the future/);
+
+      const rows = await sql`SELECT count(*)::int AS n FROM callers WHERE principal_id = ${`eth:${wallet.address.toLowerCase()}`}`;
+      assert.equal((rows[0] as { n: number }).n, 0);
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
   'exchanging twice for the same SIWE yields two distinct tokens tied to same principal',
   { skip: !hasDb },
   async () => {

--- a/packages/server/src/auth/siwe-exchange.test.ts
+++ b/packages/server/src/auth/siwe-exchange.test.ts
@@ -1,0 +1,205 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import postgres from 'postgres';
+import { SiweMessage } from 'siwe';
+import { Wallet } from 'ethers';
+import { mountSiweExchange } from './siwe-exchange.js';
+import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './caller-token.js';
+
+const TEST_DOMAIN = 'example.test';
+
+interface SignedSiwe {
+  message: string;
+  signature: string;
+  address: string;
+}
+
+async function buildSignedSiwe(opts?: {
+  domain?: string;
+  expirationSecondsFromNow?: number;
+}): Promise<SignedSiwe> {
+  const wallet = Wallet.createRandom();
+  const expSecs = opts?.expirationSecondsFromNow ?? 300;
+  const siwe = new SiweMessage({
+    domain: opts?.domain ?? TEST_DOMAIN,
+    address: wallet.address,
+    statement: 'Test.',
+    uri: `https://${opts?.domain ?? TEST_DOMAIN}`,
+    version: '1',
+    chainId: 1,
+    nonce: 'abcdef1234567890abcdef1234567890',
+    issuedAt: new Date().toISOString(),
+    expirationTime: new Date(Date.now() + expSecs * 1000).toISOString(),
+  });
+  const message = siwe.prepareMessage();
+  const signature = await wallet.signMessage(message);
+  return { message, signature, address: wallet.address };
+}
+
+function buildApp(sql: postgres.Sql): Hono {
+  const app = new Hono();
+  mountSiweExchange(app, { sql, domain: TEST_DOMAIN });
+  return app;
+}
+
+const hasDb = !!process.env.DATABASE_URL;
+
+test(
+  'happy path: valid SIWE returns opaque caller token bound to eth:<addr>',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const { message, signature, address } = await buildSignedSiwe();
+
+      const res = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as Record<string, unknown>;
+
+      assert.equal(typeof body.access_token, 'string');
+      assert.ok((body.access_token as string).startsWith(CALLER_TOKEN_PREFIX));
+      assert.equal(body.token_type, 'Bearer');
+      assert.equal(typeof body.expires_in, 'number');
+      assert.ok((body.expires_in as number) > 0);
+
+      const caller = await verifyCallerToken(sql, body.access_token as string);
+      assert.equal(caller.principalId, `eth:${address.toLowerCase()}`);
+
+      const rows = await sql<
+        { provider: string; principal_id: string }[]
+      >`SELECT provider, principal_id FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]!.provider, 'siwe');
+
+      await sql`DELETE FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'expired SIWE is rejected with 401',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      // SIWE with expirationTime already in the past.
+      const wallet = Wallet.createRandom();
+      const past = new Date(Date.now() - 60_000).toISOString();
+      const issued = new Date(Date.now() - 120_000).toISOString();
+      const siwe = new SiweMessage({
+        domain: TEST_DOMAIN,
+        address: wallet.address,
+        statement: 'Test.',
+        uri: `https://${TEST_DOMAIN}`,
+        version: '1',
+        chainId: 1,
+        nonce: 'abcdef1234567890abcdef1234567890',
+        issuedAt: issued,
+        expirationTime: past,
+      });
+      const message = siwe.prepareMessage();
+      const signature = await wallet.signMessage(message);
+
+      const res = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      assert.equal(res.status, 401);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'invalid_grant');
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'domain mismatch is rejected with 401',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const { message, signature } = await buildSignedSiwe({ domain: 'malicious.example' });
+
+      const res = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      assert.equal(res.status, 401);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'invalid_grant');
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'missing message or signature returns 400 invalid_request',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const res = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message: 'x' }),
+      });
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as Record<string, unknown>;
+      assert.equal(body.error, 'invalid_request');
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'exchanging twice for the same SIWE yields two distinct tokens tied to same principal',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const app = buildApp(sql);
+      const { message, signature, address } = await buildSignedSiwe();
+
+      const resA = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      const bodyA = (await resA.json()) as { access_token: string };
+
+      const resB = await app.request('/auth/siwe/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message, signature }),
+      });
+      const bodyB = (await resB.json()) as { access_token: string };
+
+      assert.notEqual(bodyA.access_token, bodyB.access_token);
+
+      const callerA = await verifyCallerToken(sql, bodyA.access_token);
+      const callerB = await verifyCallerToken(sql, bodyB.access_token);
+      assert.equal(callerA.principalId, `eth:${address.toLowerCase()}`);
+      assert.equal(callerB.principalId, callerA.principalId);
+
+      await sql`DELETE FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/auth/siwe-exchange.test.ts
+++ b/packages/server/src/auth/siwe-exchange.test.ts
@@ -214,36 +214,49 @@ test(
 );
 
 test(
-  'exchanging twice for the same SIWE yields two distinct tokens tied to same principal',
+  'replaying the same SIWE is rejected on the second exchange',
   { skip: !hasDb },
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
     try {
       const app = buildApp(sql);
       const { message, signature, address } = await buildSignedSiwe();
+      const principalId = `eth:${address.toLowerCase()}`;
 
       const resA = await app.request('/auth/siwe/exchange', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ message, signature }),
       });
+      assert.equal(resA.status, 200);
       const bodyA = (await resA.json()) as { access_token: string };
 
+      // Second attempt with the same (message, signature) must be rejected:
+      // the nonce has been consumed. Without this guard, an attacker who
+      // intercepted the SIWE could mint fresh tokens after the first one
+      // was revoked, defeating per-token revocation.
       const resB = await app.request('/auth/siwe/exchange', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ message, signature }),
       });
-      const bodyB = (await resB.json()) as { access_token: string };
+      assert.equal(resB.status, 401);
+      const bodyB = (await resB.json()) as Record<string, unknown>;
+      assert.equal(bodyB.error, 'invalid_grant');
+      assert.match(String(bodyB.error_description), /nonce/i);
 
-      assert.notEqual(bodyA.access_token, bodyB.access_token);
+      // The first token must still be valid — replay protection doesn't
+      // invalidate legitimately issued tokens.
+      const caller = await verifyCallerToken(sql, bodyA.access_token);
+      assert.equal(caller.principalId, principalId);
 
-      const callerA = await verifyCallerToken(sql, bodyA.access_token);
-      const callerB = await verifyCallerToken(sql, bodyB.access_token);
-      assert.equal(callerA.principalId, `eth:${address.toLowerCase()}`);
-      assert.equal(callerB.principalId, callerA.principalId);
+      const callerRows = await sql<
+        { n: number }[]
+      >`SELECT count(*)::int AS n FROM callers WHERE principal_id = ${principalId}`;
+      assert.equal(callerRows[0]!.n, 1);
 
-      await sql`DELETE FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+      await sql`DELETE FROM callers WHERE principal_id = ${principalId}`;
+      await sql`DELETE FROM used_siwe_nonces WHERE principal_id = ${principalId}`;
     } finally {
       await sql.end();
     }

--- a/packages/server/src/auth/siwe-exchange.test.ts
+++ b/packages/server/src/auth/siwe-exchange.test.ts
@@ -71,13 +71,15 @@ test(
       const caller = await verifyCallerToken(sql, body.access_token as string);
       assert.equal(caller.principalId, `eth:${address.toLowerCase()}`);
 
+      const principalId = `eth:${address.toLowerCase()}`;
       const rows = await sql<
         { provider: string; principal_id: string }[]
-      >`SELECT provider, principal_id FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+      >`SELECT provider, principal_id FROM callers WHERE principal_id = ${principalId}`;
       assert.equal(rows.length, 1);
       assert.equal(rows[0]!.provider, 'siwe');
 
-      await sql`DELETE FROM callers WHERE principal_id = ${`eth:${address.toLowerCase()}`}`;
+      await sql`DELETE FROM callers WHERE principal_id = ${principalId}`;
+      await sql`DELETE FROM used_siwe_nonces WHERE principal_id = ${principalId}`;
     } finally {
       await sql.end();
     }

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -48,11 +48,15 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
 
     let walletAddress: string;
     let expiresAtMs: number;
+    let nonce: string;
     try {
       walletAddress = await verifySiweMessage(message, signature, { domain: opts.domain });
-      // Re-parse only to read expirationTime for TTL; verifySiweMessage
-      // already validated it exists and is a valid date.
-      expiresAtMs = new Date(new SiweMessage(message).expirationTime!).getTime();
+      // Re-parse only to read expirationTime + nonce; verifySiweMessage
+      // already validated expirationTime exists and is a valid date, and
+      // siwe itself enforces a well-formed nonce on construction.
+      const parsed = new SiweMessage(message);
+      expiresAtMs = new Date(parsed.expirationTime!).getTime();
+      nonce = parsed.nonce;
     } catch (err) {
       return c.json(
         { error: 'invalid_grant', error_description: (err as Error).message },
@@ -61,9 +65,9 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
     }
 
     // Clamp against the SIWE max TTL as a defense-in-depth measure alongside
-    // verifySiweToken's issuedAt check. Without clamping, a SIWE verified with
-    // a relaxed skew could still mint a caller token whose absolute lifetime
-    // (relative to now) exceeds MAX_TOKEN_TTL_MS.
+    // verifySiweMessage's issuedAt check. Without clamping, a SIWE verified
+    // with a relaxed skew could still mint a caller token whose absolute
+    // lifetime (relative to now) exceeds MAX_TOKEN_TTL_MS.
     const ttlMs = Math.min(MAX_TOKEN_TTL_MS, Math.max(0, expiresAtMs - Date.now()));
     if (ttlMs <= 0) {
       return c.json(
@@ -72,8 +76,32 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
       );
     }
 
+    const principalId = `eth:${walletAddress.toLowerCase()}`;
+
+    // Single-use nonce enforcement. Without this, an attacker who intercepted
+    // a valid SIWE (message, signature) could mint fresh vbc_caller_* tokens
+    // until the SIWE expirationTime, defeating per-token revocation. The
+    // primary key is (principal_id, nonce) — a bogus signature producing a
+    // different recovered address only burns its own nonce row, so a valid
+    // signer's nonce cannot be pre-burned by an attacker.
+    const nonceInsert = await opts.sql`
+      INSERT INTO used_siwe_nonces (principal_id, nonce, expires_at)
+      VALUES (${principalId}, ${nonce}, ${new Date(expiresAtMs)})
+      ON CONFLICT DO NOTHING
+      RETURNING principal_id
+    `;
+    if (nonceInsert.length === 0) {
+      return c.json(
+        {
+          error: 'invalid_grant',
+          error_description: 'SIWE nonce already used — sign a fresh message',
+        },
+        401,
+      );
+    }
+
     const issued = await issueCallerToken(opts.sql, {
-      principalId: `eth:${walletAddress.toLowerCase()}`,
+      principalId,
       provider: 'siwe',
       ttlMs,
     });

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -1,0 +1,92 @@
+// POST /auth/siwe/exchange — issues an opaque caller token in exchange for a
+// verified SIWE (message, signature) pair.
+//
+// This unifies SIWE with the bridge's opaque token model: after exchange, the
+// SIWE signature is never presented to the server again. The caller presents
+// the opaque `vbc_caller_*` token on subsequent requests (admin GraphQL, A2A
+// /agents/:id, root POST /). Revocation, audit (`last_used_at`, `label`), and
+// admin tooling (`list_caller_tokens` / `revoke_caller_token`) all apply.
+//
+// TTL is inherited from the SIWE message's `expirationTime` rather than the
+// 90-day caller-token default; SIWE messages cap at 7 days by convention.
+//
+// See issue #31 for the design rationale.
+
+import type { Hono } from 'hono';
+import { SiweMessage } from 'siwe';
+import type { Sql } from '../db.js';
+import { verifySiweToken, encodeSiweToken } from '../siwe-token.js';
+import { issueCallerToken } from './caller-token.js';
+
+export interface SiweExchangeOptions {
+  sql: Sql;
+  domain?: string;
+}
+
+interface ExchangeBody {
+  message?: unknown;
+  signature?: unknown;
+}
+
+export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
+  app.post('/auth/siwe/exchange', async (c) => {
+    let body: ExchangeBody;
+    try {
+      body = (await c.req.json()) as ExchangeBody;
+    } catch {
+      return c.json({ error: 'invalid_request', error_description: 'Body must be JSON' }, 400);
+    }
+
+    const message = typeof body.message === 'string' ? body.message : undefined;
+    const signature = typeof body.signature === 'string' ? body.signature : undefined;
+    if (!message || !signature) {
+      return c.json(
+        { error: 'invalid_request', error_description: 'message and signature are required' },
+        400,
+      );
+    }
+
+    let walletAddress: string;
+    let expiresAtMs: number;
+    try {
+      // verifySiweToken expects the base64url-packed form used as a bearer
+      // today. Encode here so we share exactly one verification path (sig,
+      // domain, TTL cap, exp/iat sanity) with the existing agent-auth flow.
+      const packed = encodeSiweToken(message, signature);
+      walletAddress = await verifySiweToken(packed, { domain: opts.domain });
+      // Parse again only to read expirationTime for TTL — verifySiweToken
+      // already validated it exists and is a valid date.
+      const parsed = new SiweMessage(message);
+      expiresAtMs = new Date(parsed.expirationTime!).getTime();
+    } catch (err) {
+      return c.json(
+        { error: 'invalid_grant', error_description: (err as Error).message },
+        401,
+      );
+    }
+
+    const ttlMs = Math.max(0, expiresAtMs - Date.now());
+    if (ttlMs <= 0) {
+      return c.json(
+        { error: 'invalid_grant', error_description: 'SIWE message has already expired' },
+        401,
+      );
+    }
+
+    const issued = await issueCallerToken(opts.sql, {
+      principalId: `eth:${walletAddress.toLowerCase()}`,
+      provider: 'siwe',
+      ttlMs,
+    });
+
+    const expiresInSec = Math.max(
+      0,
+      Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
+    );
+    return c.json({
+      access_token: issued.rawToken,
+      token_type: 'Bearer',
+      expires_in: expiresInSec,
+    });
+  });
+}

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -15,7 +15,7 @@
 import type { Hono } from 'hono';
 import { SiweMessage } from 'siwe';
 import type { Sql } from '../db.js';
-import { verifySiweToken, encodeSiweToken, MAX_TOKEN_TTL_MS } from '../siwe-token.js';
+import { MAX_TOKEN_TTL_MS, verifySiweMessage } from '../siwe-token.js';
 import { issueCallerToken } from './caller-token.js';
 
 export interface SiweExchangeOptions {
@@ -49,15 +49,10 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
     let walletAddress: string;
     let expiresAtMs: number;
     try {
-      // verifySiweToken expects the base64url-packed form used as a bearer
-      // today. Encode here so we share exactly one verification path (sig,
-      // domain, TTL cap, exp/iat sanity) with the existing agent-auth flow.
-      const packed = encodeSiweToken(message, signature);
-      walletAddress = await verifySiweToken(packed, { domain: opts.domain });
-      // Parse again only to read expirationTime for TTL — verifySiweToken
+      walletAddress = await verifySiweMessage(message, signature, { domain: opts.domain });
+      // Re-parse only to read expirationTime for TTL; verifySiweMessage
       // already validated it exists and is a valid date.
-      const parsed = new SiweMessage(message);
-      expiresAtMs = new Date(parsed.expirationTime!).getTime();
+      expiresAtMs = new Date(new SiweMessage(message).expirationTime!).getTime();
     } catch (err) {
       return c.json(
         { error: 'invalid_grant', error_description: (err as Error).message },

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -15,7 +15,7 @@
 import type { Hono } from 'hono';
 import { SiweMessage } from 'siwe';
 import type { Sql } from '../db.js';
-import { verifySiweToken, encodeSiweToken } from '../siwe-token.js';
+import { verifySiweToken, encodeSiweToken, MAX_TOKEN_TTL_MS } from '../siwe-token.js';
 import { issueCallerToken } from './caller-token.js';
 
 export interface SiweExchangeOptions {
@@ -65,7 +65,11 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
       );
     }
 
-    const ttlMs = Math.max(0, expiresAtMs - Date.now());
+    // Clamp against the SIWE max TTL as a defense-in-depth measure alongside
+    // verifySiweToken's issuedAt check. Without clamping, a SIWE verified with
+    // a relaxed skew could still mint a caller token whose absolute lifetime
+    // (relative to now) exceeds MAX_TOKEN_TTL_MS.
+    const ttlMs = Math.min(MAX_TOKEN_TTL_MS, Math.max(0, expiresAtMs - Date.now()));
     if (ttlMs <= 0) {
       return c.json(
         { error: 'invalid_grant', error_description: 'SIWE message has already expired' },

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -78,42 +78,55 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
 
     const principalId = `eth:${walletAddress.toLowerCase()}`;
 
-    // Single-use nonce enforcement. Without this, an attacker who intercepted
-    // a valid SIWE (message, signature) could mint fresh vbc_caller_* tokens
-    // until the SIWE expirationTime, defeating per-token revocation. The
-    // primary key is (principal_id, nonce) — a bogus signature producing a
-    // different recovered address only burns its own nonce row, so a valid
-    // signer's nonce cannot be pre-burned by an attacker.
-    const nonceInsert = await opts.sql`
-      INSERT INTO used_siwe_nonces (principal_id, nonce, expires_at)
-      VALUES (${principalId}, ${nonce}, ${new Date(expiresAtMs)})
-      ON CONFLICT DO NOTHING
-      RETURNING principal_id
-    `;
-    if (nonceInsert.length === 0) {
+    // Nonce consumption and caller-token issuance must be atomic. If
+    // issueCallerToken throws (DB error, connection drop, serialization
+    // failure), an un-wrapped nonce insert would stay committed and the
+    // caller would have to re-sign a fresh SIWE even though no token was
+    // minted. Single-use nonce enforcement still holds — ON CONFLICT DO
+    // NOTHING returns an empty RETURNING on replay, which we map to 401.
+    try {
+      return await opts.sql.begin(async (tx) => {
+        const nonceInsert = await tx`
+          INSERT INTO used_siwe_nonces (principal_id, nonce, expires_at)
+          VALUES (${principalId}, ${nonce}, ${new Date(expiresAtMs)})
+          ON CONFLICT DO NOTHING
+          RETURNING principal_id
+        `;
+        if (nonceInsert.length === 0) {
+          return c.json(
+            {
+              error: 'invalid_grant',
+              error_description: 'SIWE nonce already used — sign a fresh message',
+            },
+            401,
+          );
+        }
+
+        const issued = await issueCallerToken(tx as unknown as typeof opts.sql, {
+          principalId,
+          provider: 'siwe',
+          ttlMs,
+        });
+
+        const expiresInSec = Math.max(
+          0,
+          Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
+        );
+        return c.json({
+          access_token: issued.rawToken,
+          token_type: 'Bearer',
+          expires_in: expiresInSec,
+        });
+      });
+    } catch (err) {
+      console.error('[siwe-exchange] transaction failed:', err);
       return c.json(
         {
-          error: 'invalid_grant',
-          error_description: 'SIWE nonce already used — sign a fresh message',
+          error: 'server_error',
+          error_description: 'Failed to exchange SIWE message',
         },
-        401,
+        500,
       );
     }
-
-    const issued = await issueCallerToken(opts.sql, {
-      principalId,
-      provider: 'siwe',
-      ttlMs,
-    });
-
-    const expiresInSec = Math.max(
-      0,
-      Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
-    );
-    return c.json({
-      access_token: issued.rawToken,
-      token_type: 'Bearer',
-      expires_in: expiresInSec,
-    });
   });
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -43,7 +43,7 @@ async function main() {
   // Runtime DB connection (used for client token lookup)
   const db = createDb(databaseUrl!);
 
-  await startPostGraphile(databaseUrl!);
+  await startPostGraphile(databaseUrl!, db);
   await startServer({
     port,
     publicUrl,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -31,11 +31,17 @@ export interface ServerHttpOptions {
   deviceFlowStateSecret?: string;
 }
 
+interface AgentCardOptions {
+  publicUrl: string | undefined;
+  deviceFlowEnabled: boolean;
+}
+
 function toSdkAgentCard(
   wire: WireAgentCard,
   conn: ClientConnection,
-  publicUrl: string | undefined,
+  opts: AgentCardOptions,
 ): SdkAgentCard {
+  const { publicUrl, deviceFlowEnabled } = opts;
   const url = publicUrl
     ? `${publicUrl}/agents/${conn.agentId}`
     : `/agents/${conn.agentId}`;
@@ -60,22 +66,37 @@ function toSdkAgentCard(
     })),
   };
   if (conn.allowedCallers.length > 0) {
-    card.securitySchemes = {
-      bridge: {
-        type: 'oauth2',
-        description:
-          'Bridge-issued opaque bearer token. Acquire via /oauth/token (Google device flow) or /auth/siwe/exchange (SIWE).',
-        flows: {
-          deviceAuthorization: {
-            deviceAuthorizationUrl: publicUrl
-              ? `${publicUrl}/oauth/device/code`
-              : '/oauth/device/code',
-            tokenUrl: publicUrl ? `${publicUrl}/oauth/token` : '/oauth/token',
-            scopes: {},
+    // The device-flow scheme only matches a real endpoint when Google OAuth is
+    // configured on this deployment (mountDeviceFlow call below). Advertising
+    // it unconditionally would point clients at a 404.
+    if (deviceFlowEnabled) {
+      card.securitySchemes = {
+        bridge: {
+          type: 'oauth2',
+          description:
+            'Bridge-issued opaque bearer token. Acquire via /oauth/token (Google device flow) or /auth/siwe/exchange (SIWE).',
+          flows: {
+            deviceAuthorization: {
+              deviceAuthorizationUrl: publicUrl
+                ? `${publicUrl}/oauth/device/code`
+                : '/oauth/device/code',
+              tokenUrl: publicUrl ? `${publicUrl}/oauth/token` : '/oauth/token',
+              scopes: {},
+            },
           },
+        } as unknown as NonNullable<SdkAgentCard['securitySchemes']>[string],
+      };
+    } else {
+      card.securitySchemes = {
+        bridge: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'Opaque',
+          description:
+            'Bridge-issued opaque bearer token (vbc_caller_*). Acquire via POST /auth/siwe/exchange by signing a SIWE message.',
         },
-      } as unknown as NonNullable<SdkAgentCard['securitySchemes']>[string],
-    };
+      };
+    }
     card.security = [{ bridge: [] }];
   }
   return card;
@@ -86,6 +107,16 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   const taskStore = new InMemoryTaskStore();
   const transports = new Map<string, JsonRpcTransportHandler>();
+
+  // Device flow endpoints (/oauth/device/code, /oauth/token) are only mounted
+  // when Google OAuth is fully configured. Surface this to the agent card and
+  // the agent-auth error hint so SIWE-only deployments don't point callers at
+  // non-existent endpoints.
+  const deviceFlowEnabled = Boolean(opts.google && opts.publicUrl);
+  const agentCardOpts: AgentCardOptions = {
+    publicUrl: opts.publicUrl,
+    deviceFlowEnabled,
+  };
 
   // Built-in admin agent at root
   const adminTransport = createAdminTransport({
@@ -99,7 +130,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     // Rebuild transport when security state changes (allowedCallers toggled)
     const cached = transports.get(conn.agentId);
     if (cached) return cached;
-    const card = toSdkAgentCard(conn.agentCard, conn, opts.publicUrl);
+    const card = toSdkAgentCard(conn.agentCard, conn, agentCardOpts);
     const executor = new ServerAgentExecutor(conn.agentId, opts.registry);
     const handler = new DefaultRequestHandler(card, taskStore, executor);
     const transport = new JsonRpcTransportHandler(handler);
@@ -140,7 +171,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       url: opts.publicUrl
         ? `${opts.publicUrl}/agents/${a.agentId}`
         : `/agents/${a.agentId}`,
-      card: toSdkAgentCard(a.agentCard, a, opts.publicUrl),
+      card: toSdkAgentCard(a.agentCard, a, agentCardOpts),
     }));
 
     const accept = c.req.header('accept') ?? '';
@@ -285,7 +316,10 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  const authMw = agentAuthMiddleware(opts.registry, { sql: opts.db });
+  const authMw = agentAuthMiddleware(opts.registry, {
+    sql: opts.db,
+    deviceFlowEnabled,
+  });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
 

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -312,7 +312,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     const id = c.req.param('id');
     const conn = opts.registry.getAgent(id);
     if (!conn) return c.json({ error: 'agent not connected' }, 404);
-    return c.json(toSdkAgentCard(conn.agentCard, conn, opts.publicUrl));
+    return c.json(toSdkAgentCard(conn.agentCard, conn, agentCardOpts));
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -14,10 +14,11 @@ import type { AgentCard as WireAgentCard } from '@vicoop-bridge/protocol';
 import { ServerAgentExecutor } from './executor.js';
 import type { ClientConnection, Registry } from './registry.js';
 import { createAdminTransport, buildAdminAgentCard, getAdminWallets } from './admin.js';
-import { verifySiweToken } from './siwe-token.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
+import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
 import { mountDeviceFlow } from './auth/device-flow.js';
 import { mountDeviceUi } from './auth/device-ui.js';
+import { mountSiweExchange } from './auth/siwe-exchange.js';
 import type { GoogleConfig } from './auth/google-oauth.js';
 import type { Sql } from './db.js';
 import { Landing } from './landing.js';
@@ -60,15 +61,10 @@ function toSdkAgentCard(
   };
   if (conn.allowedCallers.length > 0) {
     card.securitySchemes = {
-      siwe: {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'SIWE',
-        description: 'Sign-In with Ethereum (EIP-4361) bearer token',
-      },
       bridge: {
         type: 'oauth2',
-        description: 'Bridge-issued opaque bearer token obtained via Google OAuth device flow',
+        description:
+          'Bridge-issued opaque bearer token. Acquire via /oauth/token (Google device flow) or /auth/siwe/exchange (SIWE).',
         flows: {
           deviceAuthorization: {
             deviceAuthorizationUrl: publicUrl
@@ -80,7 +76,7 @@ function toSdkAgentCard(
         },
       } as unknown as NonNullable<SdkAgentCard['securitySchemes']>[string],
     };
-    card.security = [{ siwe: [] }, { bridge: [] }];
+    card.security = [{ bridge: [] }];
   }
   return card;
 }
@@ -181,26 +177,48 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     }
   }
 
-  // Root POST — admin agent A2A endpoint (SIWE auth)
+  // SIWE → opaque caller token exchange. Admin UI and any wallet-based client
+  // signs a SIWE message once, then presents the returned vbc_caller_* token
+  // on all subsequent requests.
+  mountSiweExchange(app, { sql: opts.db, domain: siweDomain });
+
+  // Root POST — admin agent A2A endpoint. Requires opaque caller token with
+  // an `eth:*` principal (admin agent is wallet-based; Google-only callers
+  // can still call /agents/:id but have no admin GraphQL access under the
+  // current owner_wallet schema).
   app.post('/', async (c) => {
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
-    if (!bearerToken) {
+    if (!bearerToken || !bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: 'Authentication required (Bearer SIWE token)' },
+        error: {
+          code: -32001,
+          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token). Acquire via /auth/siwe/exchange.`,
+        },
       }, 401);
     }
 
     let walletAddress: string;
     try {
-      walletAddress = await verifySiweToken(bearerToken, { domain: siweDomain });
+      const caller = await verifyCallerToken(opts.db, bearerToken);
+      if (!caller.principalId.startsWith('eth:')) {
+        return c.json({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32001,
+            message: 'Admin agent requires a wallet-based caller token (eth:*). Sign in via SIWE.',
+          },
+        }, 403);
+      }
+      walletAddress = caller.principalId.slice('eth:'.length);
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: `Invalid SIWE token: ${(err as Error).message}` },
+        error: { code: -32001, message: `Invalid caller token: ${(err as Error).message}` },
       }, 401);
     }
 
@@ -267,7 +285,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
-  const authMw = agentAuthMiddleware(opts.registry, { sql: opts.db, domain: siweDomain });
+  const authMw = agentAuthMiddleware(opts.registry, { sql: opts.db });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,13 +5,18 @@ import { attachWsServer } from './ws.js';
 import type { Sql } from './db.js';
 import type { GoogleConfig } from './auth/google-oauth.js';
 
-const DEVICE_SESSION_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1h
+const TRANSIENT_CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1h
 
-async function cleanupExpiredDeviceSessions(db: Sql): Promise<void> {
+async function cleanupExpiredTransients(db: Sql): Promise<void> {
   try {
     await db`DELETE FROM device_sessions WHERE expires_at <= now()`;
   } catch (err) {
     console.error('[server] device_sessions cleanup failed:', err);
+  }
+  try {
+    await db`DELETE FROM used_siwe_nonces WHERE expires_at <= now()`;
+  } catch (err) {
+    console.error('[server] used_siwe_nonces cleanup failed:', err);
   }
 }
 
@@ -45,11 +50,12 @@ export async function startServer(opts: ServerOptions) {
     registry,
   });
 
-  // Cleanup expired device_sessions on startup and periodically.
-  void cleanupExpiredDeviceSessions(opts.db);
+  // Cleanup expired transient rows (device_sessions, used_siwe_nonces) on
+  // startup and periodically.
+  void cleanupExpiredTransients(opts.db);
   const cleanupTimer = setInterval(
-    () => void cleanupExpiredDeviceSessions(opts.db),
-    DEVICE_SESSION_CLEANUP_INTERVAL_MS,
+    () => void cleanupExpiredTransients(opts.db),
+    TRANSIENT_CLEANUP_INTERVAL_MS,
   );
   cleanupTimer.unref();
 

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -101,8 +101,9 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
           <a href="/admin/">Admin UI</a> — wallet sign-in via RainbowKit
         </li>
         <li>
-          <a href="/graphiql">GraphiQL</a> — requires{' '}
-          <code>Authorization: Bearer vbc_caller_*</code> header
+          <a href="/graphiql">GraphiQL</a> — loads anonymously; include{' '}
+          <code>Authorization: Bearer vbc_caller_*</code> header for
+          authenticated queries (RLS filters rows otherwise)
         </li>
       </ul>
 

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -89,9 +89,12 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
 
       <h2>Tools</h2>
       <p class="muted">
-        Both require SIWE (Sign-In with Ethereum) authentication. Non-admin
-        wallets only see clients they own (RLS enforced); admin wallets see
-        everything.
+        Both accept a bridge-issued opaque caller token
+        (<code>vbc_caller_*</code>) on the{' '}
+        <code>Authorization: Bearer ...</code> header. Wallet-based clients
+        obtain one by signing a SIWE message and exchanging it at{' '}
+        <code>POST /auth/siwe/exchange</code>. Non-admin wallets only see
+        clients they own (RLS enforced); admin wallets see everything.
       </p>
       <ul>
         <li>
@@ -99,7 +102,7 @@ export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) 
         </li>
         <li>
           <a href="/graphiql">GraphiQL</a> — requires{' '}
-          <code>Authorization: Bearer &lt;SIWE-JWT&gt;</code> header
+          <code>Authorization: Bearer vbc_caller_*</code> header
         </li>
       </ul>
 

--- a/packages/server/src/postgraphile.ts
+++ b/packages/server/src/postgraphile.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import { postgraphile } from 'postgraphile';
 import { Pool } from 'pg';
-import { verifySiweToken } from './siwe-token.js';
 import type { IncomingMessage } from 'node:http';
+import type { Sql } from './db.js';
+import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
 
 const ADMIN_WALLET_ADDRESSES = (process.env.ADMIN_WALLET_ADDRESSES ?? '')
   .split(',')
@@ -10,7 +11,7 @@ const ADMIN_WALLET_ADDRESSES = (process.env.ADMIN_WALLET_ADDRESSES ?? '')
   .filter(Boolean)
   .join(',');
 
-export async function startPostGraphile(databaseUrl: string): Promise<void> {
+export async function startPostGraphile(databaseUrl: string, sql: Sql): Promise<void> {
   const port = Number(process.env.POSTGRAPHILE_PORT ?? 5433);
 
   const pool = new Pool({
@@ -40,15 +41,24 @@ export async function startPostGraphile(databaseUrl: string): Promise<void> {
         const auth = req.headers.authorization;
         if (auth?.startsWith('Bearer ')) {
           const token = auth.slice(7);
-          try {
-            const address = await verifySiweToken(token);
-            return {
-              role: 'app_authenticated',
-              'jwt.claims.wallet_address': address,
-              'app.admin_addresses': ADMIN_WALLET_ADDRESSES,
-            };
-          } catch {
-            // fall through to anonymous
+          // Opaque caller tokens are the only accepted admin GraphQL credential
+          // as of #31. Wallet-based callers (eth:* principals) get RLS-gated
+          // access; Google-only callers have no owner_wallet so their queries
+          // fall through to anonymous.
+          if (token.startsWith(CALLER_TOKEN_PREFIX)) {
+            try {
+              const caller = await verifyCallerToken(sql, token);
+              if (caller.principalId.startsWith('eth:')) {
+                const walletAddress = caller.principalId.slice('eth:'.length);
+                return {
+                  role: 'app_authenticated',
+                  'jwt.claims.wallet_address': walletAddress,
+                  'app.admin_addresses': ADMIN_WALLET_ADDRESSES,
+                };
+              }
+            } catch {
+              // fall through to anonymous
+            }
           }
         }
         return { role: 'app_anonymous' };

--- a/packages/server/src/siwe-token.ts
+++ b/packages/server/src/siwe-token.ts
@@ -5,7 +5,13 @@ export interface SiweToken {
   signature: string;
 }
 
-const MAX_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Tolerance for clock skew between signer and server when validating `issuedAt`.
+// Without this, a SIWE message with `issuedAt` set in the future could pass the
+// `expirationTime - issuedAt <= MAX_TOKEN_TTL_MS` cap while still having an
+// effective lifetime (relative to now) far greater than the intended 7-day max.
+export const ISSUED_AT_SKEW_MS = 2 * 60 * 1000;
 
 export function encodeSiweToken(message: string, signature: string): string {
   const json = JSON.stringify({ message, signature });
@@ -75,8 +81,14 @@ export async function verifySiweToken(token: string, opts?: { domain?: string })
   if (Number.isNaN(issued) || Number.isNaN(expires)) {
     throw new Error('SIWE token has invalid date format');
   }
+  if (expires <= issued) {
+    throw new Error('SIWE token expirationTime must be after issuedAt');
+  }
   if (expires - issued > MAX_TOKEN_TTL_MS) {
     throw new Error('SIWE token TTL exceeds maximum allowed duration');
+  }
+  if (issued > Date.now() + ISSUED_AT_SKEW_MS) {
+    throw new Error('SIWE token issuedAt is in the future');
   }
 
   const result = await siweMessage.verify({ signature });

--- a/packages/server/src/siwe-token.ts
+++ b/packages/server/src/siwe-token.ts
@@ -8,6 +8,14 @@ export const MAX_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 // effective lifetime (relative to now) far greater than the intended 7-day max.
 const ISSUED_AT_SKEW_MS = 2 * 60 * 1000;
 
+// Clients often compute issuedAt and expirationTime from separate time reads
+// (`new Date().toISOString()` followed by `new Date(Date.now() + 7d)`), so
+// `expires - issued` can land a handful of milliseconds over a nominal 7-day
+// target. Allow a small slop here so honest clients aiming for exactly 7 days
+// aren't rejected by sub-millisecond scheduling jitter. 1 second is far below
+// the granularity of anything that would meaningfully extend the cap.
+const TTL_CAP_SLOP_MS = 1000;
+
 // Verify a SIWE (message, signature) pair and return the recovered wallet
 // address. Throws on any failure (malformed fields, TTL over cap, future
 // issuedAt, signature mismatch, domain mismatch).
@@ -32,7 +40,7 @@ export async function verifySiweMessage(
   if (expires <= issued) {
     throw new Error('SIWE message expirationTime must be after issuedAt');
   }
-  if (expires - issued > MAX_TOKEN_TTL_MS) {
+  if (expires - issued > MAX_TOKEN_TTL_MS + TTL_CAP_SLOP_MS) {
     throw new Error('SIWE message TTL exceeds maximum allowed duration');
   }
   if (issued > Date.now() + ISSUED_AT_SKEW_MS) {

--- a/packages/server/src/siwe-token.ts
+++ b/packages/server/src/siwe-token.ts
@@ -7,6 +7,11 @@ export interface SiweToken {
 
 const MAX_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
+export function encodeSiweToken(message: string, signature: string): string {
+  const json = JSON.stringify({ message, signature });
+  return Buffer.from(json, 'utf-8').toString('base64url');
+}
+
 export function decodeSiweToken(token: string): SiweToken {
   try {
     let base64 = token.replace(/-/g, '+').replace(/_/g, '/');

--- a/packages/server/src/siwe-token.ts
+++ b/packages/server/src/siwe-token.ts
@@ -1,94 +1,42 @@
 import { SiweMessage } from 'siwe';
 
-export interface SiweToken {
-  message: string;
-  signature: string;
-}
-
 export const MAX_TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 // Tolerance for clock skew between signer and server when validating `issuedAt`.
 // Without this, a SIWE message with `issuedAt` set in the future could pass the
 // `expirationTime - issuedAt <= MAX_TOKEN_TTL_MS` cap while still having an
 // effective lifetime (relative to now) far greater than the intended 7-day max.
-export const ISSUED_AT_SKEW_MS = 2 * 60 * 1000;
+const ISSUED_AT_SKEW_MS = 2 * 60 * 1000;
 
-export function encodeSiweToken(message: string, signature: string): string {
-  const json = JSON.stringify({ message, signature });
-  return Buffer.from(json, 'utf-8').toString('base64url');
-}
-
-export function decodeSiweToken(token: string): SiweToken {
-  try {
-    let base64 = token.replace(/-/g, '+').replace(/_/g, '/');
-    const padLength = (4 - (base64.length % 4)) % 4;
-    base64 += '='.repeat(padLength);
-    const json = Buffer.from(base64, 'base64').toString('utf-8');
-    const parsed = JSON.parse(json);
-    if (typeof parsed.message !== 'string' || typeof parsed.signature !== 'string') {
-      throw new Error('Invalid SIWE token structure');
-    }
-    return parsed as SiweToken;
-  } catch {
-    throw new Error('Failed to decode SIWE token');
-  }
-}
-
-interface VerifyCacheEntry {
-  address: string;
-  expiresAt: number;
-}
-
-const verifyCache = new Map<string, VerifyCacheEntry>();
-const CACHE_EVICT_INTERVAL_MS = 60_000;
-const VERIFY_CACHE_MAX_ENTRIES = 10_000;
-let lastEvict = Date.now();
-
-function evictExpired() {
-  const now = Date.now();
-  if (now - lastEvict < CACHE_EVICT_INTERVAL_MS && verifyCache.size <= VERIFY_CACHE_MAX_ENTRIES) return;
-  lastEvict = now;
-  for (const [key, entry] of verifyCache) {
-    if (entry.expiresAt <= now) verifyCache.delete(key);
-  }
-  while (verifyCache.size > VERIFY_CACHE_MAX_ENTRIES) {
-    const oldest = verifyCache.keys().next().value;
-    if (oldest === undefined) break;
-    verifyCache.delete(oldest);
-  }
-}
-
-export async function verifySiweToken(token: string, opts?: { domain?: string }): Promise<string> {
-  evictExpired();
-
-  const cacheKey = opts?.domain ? `${token}\0${opts.domain.toLowerCase()}` : token;
-  const cached = verifyCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.address;
-  }
-
-  const { message, signature } = decodeSiweToken(token);
+// Verify a SIWE (message, signature) pair and return the recovered wallet
+// address. Throws on any failure (malformed fields, TTL over cap, future
+// issuedAt, signature mismatch, domain mismatch).
+export async function verifySiweMessage(
+  message: string,
+  signature: string,
+  opts?: { domain?: string },
+): Promise<string> {
   const siweMessage = new SiweMessage(message);
 
   if (!siweMessage.expirationTime) {
-    throw new Error('SIWE token must have an expirationTime');
+    throw new Error('SIWE message must have an expirationTime');
   }
   if (!siweMessage.issuedAt) {
-    throw new Error('SIWE token must have an issuedAt');
+    throw new Error('SIWE message must have an issuedAt');
   }
   const issued = new Date(siweMessage.issuedAt).getTime();
   const expires = new Date(siweMessage.expirationTime).getTime();
   if (Number.isNaN(issued) || Number.isNaN(expires)) {
-    throw new Error('SIWE token has invalid date format');
+    throw new Error('SIWE message has invalid date format');
   }
   if (expires <= issued) {
-    throw new Error('SIWE token expirationTime must be after issuedAt');
+    throw new Error('SIWE message expirationTime must be after issuedAt');
   }
   if (expires - issued > MAX_TOKEN_TTL_MS) {
-    throw new Error('SIWE token TTL exceeds maximum allowed duration');
+    throw new Error('SIWE message TTL exceeds maximum allowed duration');
   }
   if (issued > Date.now() + ISSUED_AT_SKEW_MS) {
-    throw new Error('SIWE token issuedAt is in the future');
+    throw new Error('SIWE message issuedAt is in the future');
   }
 
   const result = await siweMessage.verify({ signature });
@@ -100,6 +48,5 @@ export async function verifySiweToken(token: string, opts?: { domain?: string })
     throw new Error(`SIWE domain mismatch: expected ${opts.domain}, got ${siweMessage.domain}`);
   }
 
-  verifyCache.set(cacheKey, { address: siweMessage.address, expiresAt: expires });
   return siweMessage.address;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 0.3.13(express@5.2.1)
       '@rainbow-me/rainbowkit':
         specifier: ^2
-        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
       '@tanstack/react-query':
         specifier: ^5
         version: 5.99.0(react@19.2.5)
@@ -49,10 +49,10 @@ importers:
         version: 2.3.2(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       viem:
         specifier: ^2
-        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: ^2
-        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
@@ -155,6 +155,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
 packages:
 
@@ -4253,16 +4256,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -4310,15 +4313,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -4512,11 +4515,11 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -4780,7 +4783,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
+  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@vanilla-extract/css': 1.17.3
@@ -4792,8 +4795,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.6.2(@types/react@19.2.14)(react@19.2.5)
       ua-parser-js: 1.0.41
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -4810,24 +4813,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -4856,12 +4859,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
@@ -4896,12 +4899,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -4933,10 +4936,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -4968,16 +4971,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5017,21 +5020,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5137,9 +5140,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -5147,10 +5150,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -5898,19 +5901,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -5951,11 +5954,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.99.0
@@ -5966,7 +5969,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -5980,7 +5983,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -6010,7 +6013,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -6024,7 +6027,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -6058,18 +6061,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6192,16 +6195,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6228,16 +6231,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6326,7 +6329,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -6335,9 +6338,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -6366,7 +6369,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -6375,9 +6378,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -6406,7 +6409,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -6424,7 +6427,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6450,7 +6453,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -6468,7 +6471,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6508,10 +6511,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.0.8(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 3.25.76
+      zod: 4.3.6
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -8095,28 +8098,43 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.17(typescript@5.9.3)(zod@4.3.6):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.1
-      '@noble/curves': 1.8.1
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
-      '@adraffy/ens-normalize': 1.10.1
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -8246,21 +8264,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -8950,15 +8968,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.7(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -9001,6 +9019,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.17(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -9016,14 +9051,14 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:


### PR DESCRIPTION
Closes #31.

## Summary

- Introduce `POST /auth/siwe/exchange`. Wallet-based clients sign a SIWE message once, swap it for a bridge-issued opaque caller token (`vbc_caller_*`), and present that token on every subsequent request.
- Raw SIWE bearers are no longer accepted on `/agents/:id`, `POST /`, or admin GraphQL.
- SIWE is now one of two issuance methods alongside the Google device flow — both produce rows in `callers` so admin tooling (`list_caller_tokens` / `revoke_caller_token`), audit (`last_used_at`, `label`), and immediate revocation all apply uniformly.

## Why

PR #30 added opaque caller tokens for Google OAuth while leaving SIWE as a direct bearer credential. The two paths were structurally asymmetric (no revocation / no audit / no admin tooling for SIWE) and the asymmetry would compound as more IdPs get added. Issue #31 proposed treating every caller credential as two-step (issuance → usage) so the runtime stays on a single verification path.

## Changes

- `packages/server/src/auth/siwe-exchange.ts` — new endpoint. TTL inherited from SIWE `expirationTime` (≤ 7d) instead of the 90d caller-token default.
- `packages/server/src/agent-auth.ts` — requires `vbc_caller_*` prefix; SIWE branch removed.
- `packages/server/src/http.tsx` — root `POST /` now requires an opaque token bound to an `eth:*` principal (admin agent stays wallet-gated). Agent Card `securitySchemes` collapses to a single `bridge` scheme documenting both acquisition paths.
- `packages/server/src/postgraphile.ts` — `pgSettings` verifies opaque tokens. `eth:*` principals get `jwt.claims.wallet_address`; anything else falls through to anonymous (Google-only callers have no `owner_wallet` so RLS would deny anyway).
- `packages/server/src/auth/caller-token.ts` — `provider` type widened to `'google' | 'siwe'`. No schema constraint change (column is plain `TEXT`).
- `packages/admin-ui/src/components/wallet-auth.tsx` — after `signMessageAsync`, POSTs to `/auth/siwe/exchange` and stores the returned opaque token instead of packing the SIWE bearer.
- `docs/local-testing.md` — raw-SIWE walkthrough replaced by "Path C — SIWE exchange" reflecting the new two-step flow.

## Test plan

- [x] `pnpm typecheck` — all packages pass
- [x] `DATABASE_URL=… tsx --test packages/server/src/auth/*.test.ts` — 90/90 pass
- [x] New `siwe-exchange.test.ts` covers: happy path → token bound to `eth:<addr>` with `provider='siwe'`; expired SIWE → 401 `invalid_grant`; domain mismatch → 401; missing message/signature → 400 `invalid_request`; two exchanges → two distinct tokens, same principal
- [x] `pnpm --filter @vicoop-bridge/admin-ui build` — clean build
- [x] Local E2E per `docs/local-testing.md` Path A (opaque-via-DB-insert) — no bearer 401, bad prefix 401, unknown opaque 401, valid opaque → echo 200
- [x] Local E2E Path C (SIWE exchange) — exchange 200 with `expires_in` inherited from SIWE exp; `callers` row has `provider='siwe'`, `principal_id=eth:<lower>`; opaque token on `/agents/:id` → 200 echo; raw packed SIWE bearer → 401 `expected vbc_caller_* prefix`; expired SIWE → 401 `invalid_grant`; domain mismatch → 401 `invalid_grant`
- [x] Admin GraphQL via PostGraphile proxy — anonymous → null (RLS denies), non-admin SIWE opaque → only own row (totalCount=1), admin SIWE opaque → both rows (totalCount=2), wrong-prefix bearer → anonymous, revoked opaque → anonymous
- [ ] Path B (Google OAuth device flow) — deferred; requires browser-based Google consent, not scripted. No code paths in this PR touch the device flow.
- [ ] Manual admin-ui browser smoke — RainbowKit connect → MetaMask sign → observe `vbc_caller_*` in `localStorage['vicoop-admin-auth-token']`. The GraphQL-side of this is covered above; remaining human-only step is the wallet UI itself.

## Migration notes

- No deploy yet, so no live SIWE sessions to preserve.
- After this lands, raw SIWE bearers on any endpoint return 401 — clients must go through `/auth/siwe/exchange`.
- SIWE-issued tokens inherit the SIWE `expirationTime` (≤ 7d), matching current session UX.

## Non-goals

- `owner_wallet` → `owner_principal` schema generalization (separate effort)
- Refresh token support — expiry still means re-exchange / re-device-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)