### PR TITLE
Fix OpenClaw gateway connection race and harden task lifecycle

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,11 +13,11 @@
     "cards"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
     "start": "node dist/cli.js",
-    "test": "tsx --test 'src/**/*.test.ts'"
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@vicoop-bridge/protocol": "workspace:*",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,7 +16,8 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
-    "start": "node dist/cli.js"
+    "start": "node dist/cli.js",
+    "test": "tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@vicoop-bridge/protocol": "workspace:*",

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -172,7 +172,6 @@ test('happy path: chat.send → final event → task completes', async () => {
 
 test('concurrent first-connect: shares one WebSocket across parallel handle() calls', async () => {
   let pendingConnectId: string | null = null;
-  const pendingChats: Array<{ sock: WebSocket; id: string; runId: string }> = [];
   const fake = await createFakeGateway({
     autoHandshake: false,
     onRequest: (sock, req) => {
@@ -182,7 +181,25 @@ test('concurrent first-connect: shares one WebSocket across parallel handle() ca
       }
       if (req.method === 'chat.send') {
         const params = req.params as { idempotencyKey: string };
-        pendingChats.push({ sock, id: req.id, runId: `run-${params.idempotencyKey}` });
+        const runId = `run-${params.idempotencyKey}`;
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: 'agent:main:' + params.idempotencyKey,
+                seq: 1,
+                state: 'final',
+                message: { text: 'done ' + params.idempotencyKey },
+              },
+            }),
+          );
+        });
       }
     },
   });
@@ -196,26 +213,7 @@ test('concurrent first-connect: shares one WebSocket across parallel handle() ca
     await new Promise((r) => setTimeout(r, 30));
     assert.equal(fake.connections.length, 1, 'only one WebSocket should be accepted');
     assert.ok(pendingConnectId, 'connect request should have arrived');
-    // Complete handshake. Both handle() calls then send chat.send on the same socket.
-    const sock = fake.connections[0];
-    fake.respond(sock, pendingConnectId!, {});
-    // Wait for both chat.send to arrive, then ack each and emit finals on later ticks
-    // so that handle() has time to register runToTask/taskFinalizers.
-    await new Promise((r) => setTimeout(r, 30));
-    assert.equal(pendingChats.length, 2, 'both chat.send requests should arrive');
-    for (const c of pendingChats) {
-      fake.respond(c.sock, c.id, { runId: c.runId, status: 'started' });
-    }
-    await new Promise((r) => setTimeout(r, 20));
-    for (const c of pendingChats) {
-      fake.emitChat(c.sock, {
-        runId: c.runId,
-        sessionKey: 'agent:main:x',
-        seq: 1,
-        state: 'final',
-        message: { text: c.runId },
-      });
-    }
+    fake.respond(fake.connections[0], pendingConnectId!, {});
     await Promise.all([pA, pB]);
     assert.equal(fake.connections.length, 1, 'no additional WebSocket opened after handshake');
     const finalA = framesA.find((f) => f.type === 'task.complete');
@@ -240,8 +238,7 @@ test('reconnect: after gateway close, next handle() opens a fresh WebSocket', as
             payload: { runId, status: 'started' },
           }),
         );
-        // Space the final well past the ack so handle() can register runToTask.
-        setTimeout(() => {
+        setImmediate(() => {
           sock.send(
             JSON.stringify({
               type: 'event',
@@ -255,7 +252,7 @@ test('reconnect: after gateway close, next handle() opens a fresh WebSocket', as
               },
             }),
           );
-        }, 20);
+        });
       }
     },
   });
@@ -272,6 +269,130 @@ test('reconnect: after gateway close, next handle() opens a fresh WebSocket', as
     assert.equal(fake.connections.length, 2, 'a fresh WebSocket should be opened for the second task');
     assert.ok(framesA.find((f) => f.type === 'task.complete'));
     assert.ok(framesB.find((f) => f.type === 'task.complete'));
+  } finally {
+    await fake.close();
+  }
+});
+
+test('fast terminal event: final arrives on same socket read as ack and is still delivered', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const runId = 'run-fast';
+        // Emit ack and terminal event in the same synchronous burst so both
+        // frames batch into a single socket read on the client. The buffer
+        // in handle() must catch the event even though runToTask has not
+        // been populated yet.
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+        );
+        sock.send(
+          JSON.stringify({
+            type: 'event',
+            event: 'chat',
+            payload: {
+              runId,
+              sessionKey: 'agent:main:ctx-t1',
+              seq: 1,
+              state: 'final',
+              message: { text: 'instant' },
+            },
+          }),
+        );
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete, 'task should complete even with racing ack+final');
+    assert.equal(complete!.status.state, 'completed');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('task timeout: no terminal event triggers task_timeout failure', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        // Ack, then stay silent forever.
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-stall', status: 'started' },
+          }),
+        );
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url, taskTimeoutMs: 150 });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'task must fail on timeout');
+    assert.equal(fail!.error.code, 'task_timeout');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('cancel: issues chat.abort and lets aborted terminal event complete the task as canceled', async () => {
+  let lastChatSendId: string | null = null;
+  let activeSock: WebSocket | null = null;
+  let activeRunId: string | null = null;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        activeSock = sock;
+        lastChatSendId = req.id;
+        activeRunId = `run-${(req.params as { idempotencyKey: string }).idempotencyKey}`;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: activeRunId, status: 'started' },
+          }),
+        );
+      }
+      if (req.method === 'chat.abort') {
+        sock.send(JSON.stringify({ type: 'res', id: req.id, ok: true, payload: {} }));
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId: activeRunId,
+                sessionKey: 'agent:main:ctx-t1',
+                seq: 2,
+                state: 'aborted',
+              },
+            }),
+          );
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    const task = makeTask('t1', 'hi');
+    const pending = backend.handle(task, (f) => frames.push(f));
+    // Wait for the chat.send to land so cancel() can find runToTask.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(lastChatSendId && activeSock);
+    await backend.cancel(task.taskId);
+    await pending;
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.equal(complete!.status.state, 'canceled');
   } finally {
     await fake.close();
   }

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -486,6 +486,26 @@ test('late duplicate chat event for finalized run is dropped, not buffered', asy
   }
 });
 
+test('invalid URL: WebSocket constructor throwing does not wedge ensureConnected', async () => {
+  // An invalid URL makes `new WebSocket(url)` throw synchronously. Without
+  // the guard in connect(), _state would stay 'connecting' and every
+  // subsequent handle() call would block forever on the same dead promise.
+  const backend = createOpenclawBackend({
+    url: 'http://not-a-ws-url',
+    handshakeTimeoutMs: 500,
+  });
+  const framesA: UpFrame[] = [];
+  const framesB: UpFrame[] = [];
+  await backend.handle(makeTask('tA', 'a'), (f) => framesA.push(f));
+  // Second call must not hang — it should re-enter ensureConnected() cleanly
+  // and fail the same way.
+  await backend.handle(makeTask('tB', 'b'), (f) => framesB.push(f));
+  const failA = framesA.find((f) => f.type === 'task.fail');
+  const failB = framesB.find((f) => f.type === 'task.fail');
+  assert.ok(failA && failA.error.code === 'gateway_closed');
+  assert.ok(failB && failB.error.code === 'gateway_closed');
+});
+
 test('handshake timeout: gateway accepts TCP but never completes handshake', async () => {
   const fake = await createFakeGateway({
     autoHandshake: false,

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -277,4 +277,37 @@ test('reconnect: after gateway close, next handle() opens a fresh WebSocket', as
   }
 });
 
+test('gateway close mid-run fails in-flight task deterministically', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        // Ack, but never send a terminal event; the close will be the trigger.
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-stuck', status: 'started' },
+          }),
+        );
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    const pending = backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    // Wait for the ack to arrive and handle() to register runToTask/finalizer.
+    await new Promise((r) => setTimeout(r, 50));
+    const sock = await fake.waitForConnection(0);
+    await fake.closeSocket(sock);
+    await pending;
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'task must fail after gateway close');
+    assert.equal(fail!.error.code, 'gateway_closed');
+  } finally {
+    await fake.close();
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -486,6 +486,76 @@ test('late duplicate chat event for finalized run is dropped, not buffered', asy
   }
 });
 
+test('handshake timeout: gateway accepts TCP but never completes handshake', async () => {
+  const fake = await createFakeGateway({
+    autoHandshake: false,
+    // Swallow the connect request so the handshake never resolves.
+    onRequest: () => {},
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url, handshakeTimeoutMs: 100 });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'task must fail when handshake never completes');
+    assert.equal(fail!.error.code, 'gateway_closed');
+    assert.match(fail!.error.message, /handshake timed out/);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('invalid taskTimeoutMs falls back to default instead of firing immediately', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-ok', status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId: 'run-ok',
+                sessionKey: 'x',
+                seq: 1,
+                state: 'final',
+                message: { text: 'ok' },
+              },
+            }),
+          );
+        });
+      }
+    },
+  });
+  try {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    };
+    try {
+      // Invalid timeout — must not cause the task to time out immediately.
+      const backend = createOpenclawBackend({ url: fake.url, taskTimeoutMs: 0 });
+      const frames: UpFrame[] = [];
+      await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+      assert.ok(frames.find((f) => f.type === 'task.complete'));
+      assert.ok(warnings.some((w) => w.includes('invalid taskTimeoutMs')));
+    } finally {
+      console.warn = originalWarn;
+    }
+  } finally {
+    await fake.close();
+  }
+});
+
 test('gateway close mid-run fails in-flight task deterministically', async () => {
   const fake = await createFakeGateway({
     onRequest: (sock, req) => {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -170,4 +170,111 @@ test('happy path: chat.send → final event → task completes', async () => {
   }
 });
 
+test('concurrent first-connect: shares one WebSocket across parallel handle() calls', async () => {
+  let pendingConnectId: string | null = null;
+  const pendingChats: Array<{ sock: WebSocket; id: string; runId: string }> = [];
+  const fake = await createFakeGateway({
+    autoHandshake: false,
+    onRequest: (sock, req) => {
+      if (req.method === 'connect') {
+        pendingConnectId = req.id;
+        return;
+      }
+      if (req.method === 'chat.send') {
+        const params = req.params as { idempotencyKey: string };
+        pendingChats.push({ sock, id: req.id, runId: `run-${params.idempotencyKey}` });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const framesA: UpFrame[] = [];
+    const framesB: UpFrame[] = [];
+    const pA = backend.handle(makeTask('tA', 'a'), (f) => framesA.push(f));
+    const pB = backend.handle(makeTask('tB', 'b'), (f) => framesB.push(f));
+    // Give both handle() calls time to subscribe and reach the connect phase.
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(fake.connections.length, 1, 'only one WebSocket should be accepted');
+    assert.ok(pendingConnectId, 'connect request should have arrived');
+    // Complete handshake. Both handle() calls then send chat.send on the same socket.
+    const sock = fake.connections[0];
+    fake.respond(sock, pendingConnectId!, {});
+    // Wait for both chat.send to arrive, then ack each and emit finals on later ticks
+    // so that handle() has time to register runToTask/taskFinalizers.
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(pendingChats.length, 2, 'both chat.send requests should arrive');
+    for (const c of pendingChats) {
+      fake.respond(c.sock, c.id, { runId: c.runId, status: 'started' });
+    }
+    await new Promise((r) => setTimeout(r, 20));
+    for (const c of pendingChats) {
+      fake.emitChat(c.sock, {
+        runId: c.runId,
+        sessionKey: 'agent:main:x',
+        seq: 1,
+        state: 'final',
+        message: { text: c.runId },
+      });
+    }
+    await Promise.all([pA, pB]);
+    assert.equal(fake.connections.length, 1, 'no additional WebSocket opened after handshake');
+    const finalA = framesA.find((f) => f.type === 'task.complete');
+    const finalB = framesB.find((f) => f.type === 'task.complete');
+    assert.ok(finalA && finalA.status.state === 'completed');
+    assert.ok(finalB && finalB.status.state === 'completed');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('reconnect: after gateway close, next handle() opens a fresh WebSocket', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const runId = `run-${(req.params as { idempotencyKey: string }).idempotencyKey}`;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId, status: 'started' },
+          }),
+        );
+        // Space the final well past the ack so handle() can register runToTask.
+        setTimeout(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: 'agent:main:ctx',
+                seq: 1,
+                state: 'final',
+                message: { text: 'ok' },
+              },
+            }),
+          );
+        }, 20);
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const framesA: UpFrame[] = [];
+    await backend.handle(makeTask('tA', 'a'), (f) => framesA.push(f));
+    const sock0 = await fake.waitForConnection(0);
+    await fake.closeSocket(sock0);
+    // Let the client process the WebSocket close event.
+    await new Promise((r) => setTimeout(r, 20));
+    const framesB: UpFrame[] = [];
+    await backend.handle(makeTask('tB', 'b'), (f) => framesB.push(f));
+    assert.equal(fake.connections.length, 2, 'a fresh WebSocket should be opened for the second task');
+    assert.ok(framesA.find((f) => f.type === 'task.complete'));
+    assert.ok(framesB.find((f) => f.type === 'task.complete'));
+  } finally {
+    await fake.close();
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -398,6 +398,94 @@ test('cancel: issues chat.abort and lets aborted terminal event complete the tas
   }
 });
 
+test('gateway close before ack emits gateway_closed (not gateway_send_failed)', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        // Close the socket before acking so the pending request rejects
+        // due to the close listener.
+        setImmediate(() => sock.close(1000));
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'task must fail');
+    assert.equal(fail!.error.code, 'gateway_closed');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('late duplicate chat event for finalized run is dropped, not buffered', async () => {
+  // After a task terminates, the gateway can still emit late deltas for
+  // the same runId (e.g. a trailing log). Those must not accumulate in
+  // pendingRunEvents — the second task should run normally with no side
+  // effects, and the backend should stay usable across many completions.
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const runId = `run-${(req.params as { idempotencyKey: string }).idempotencyKey}`;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId, status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: 'x',
+                seq: 1,
+                state: 'final',
+                message: { text: 'ok' },
+              },
+            }),
+          );
+          // Late duplicate after the terminal event.
+          setImmediate(() => {
+            sock.send(
+              JSON.stringify({
+                type: 'event',
+                event: 'chat',
+                payload: {
+                  runId,
+                  sessionKey: 'x',
+                  seq: 2,
+                  state: 'delta',
+                  message: { text: 'late' },
+                },
+              }),
+            );
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const framesA: UpFrame[] = [];
+    await backend.handle(makeTask('tA', 'hi'), (f) => framesA.push(f));
+    assert.ok(framesA.find((f) => f.type === 'task.complete'));
+    // Give the late duplicate time to arrive and be dropped.
+    await new Promise((r) => setTimeout(r, 30));
+    const framesB: UpFrame[] = [];
+    await backend.handle(makeTask('tB', 'hi'), (f) => framesB.push(f));
+    assert.ok(framesB.find((f) => f.type === 'task.complete'));
+  } finally {
+    await fake.close();
+  }
+});
+
 test('gateway close mid-run fails in-flight task deterministically', async () => {
   const fake = await createFakeGateway({
     onRequest: (sock, req) => {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1,0 +1,173 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import WebSocket, { WebSocketServer } from 'ws';
+import { createOpenclawBackend } from './openclaw.js';
+import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
+
+interface ReqFrame {
+  type: 'req';
+  id: string;
+  method: string;
+  params?: unknown;
+}
+
+interface FakeGatewayOptions {
+  autoHandshake?: boolean;
+  onConnection?: (sock: WebSocket) => void;
+  onRequest?: (sock: WebSocket, req: ReqFrame) => void;
+}
+
+interface FakeGateway {
+  url: string;
+  connections: WebSocket[];
+  waitForConnection(index?: number): Promise<WebSocket>;
+  respond(sock: WebSocket, id: string, payload: unknown): void;
+  respondError(sock: WebSocket, id: string, error: { code: string; message: string }): void;
+  emitChat(sock: WebSocket, payload: unknown): void;
+  closeSocket(sock: WebSocket): Promise<void>;
+  close(): Promise<void>;
+}
+
+async function createFakeGateway(opts: FakeGatewayOptions = {}): Promise<FakeGateway> {
+  const autoHandshake = opts.autoHandshake ?? true;
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  const connections: WebSocket[] = [];
+  const waiters = new Map<number, Array<() => void>>();
+
+  wss.on('connection', (sock) => {
+    const idx = connections.length;
+    connections.push(sock);
+    sock.send(
+      JSON.stringify({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: `nonce-${idx}` },
+      }),
+    );
+
+    sock.on('message', (raw) => {
+      let frame: ReqFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as ReqFrame;
+      } catch {
+        return;
+      }
+      if (frame.type !== 'req') return;
+      if (frame.method === 'connect' && autoHandshake) {
+        sock.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: {} }));
+        return;
+      }
+      opts.onRequest?.(sock, frame);
+    });
+
+    opts.onConnection?.(sock);
+
+    const list = waiters.get(idx);
+    if (list) {
+      waiters.delete(idx);
+      for (const w of list) w();
+    }
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  const url = `ws://127.0.0.1:${port}`;
+
+  return {
+    url,
+    connections,
+    waitForConnection(index = 0) {
+      if (connections[index]) return Promise.resolve(connections[index]);
+      return new Promise<WebSocket>((resolve) => {
+        const list = waiters.get(index) ?? [];
+        list.push(() => resolve(connections[index]));
+        waiters.set(index, list);
+      });
+    },
+    respond(sock, id, payload) {
+      sock.send(JSON.stringify({ type: 'res', id, ok: true, payload }));
+    },
+    respondError(sock, id, error) {
+      sock.send(JSON.stringify({ type: 'res', id, ok: false, error }));
+    },
+    emitChat(sock, payload) {
+      sock.send(JSON.stringify({ type: 'event', event: 'chat', payload }));
+    },
+    async closeSocket(sock) {
+      await new Promise<void>((resolve) => {
+        if (sock.readyState === WebSocket.CLOSED) return resolve();
+        sock.once('close', () => resolve());
+        sock.close(1000);
+      });
+    },
+    async close() {
+      for (const s of connections) {
+        if (s.readyState !== WebSocket.CLOSED) s.terminate();
+      }
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+function makeTask(taskId: string, text: string): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId,
+    contextId: `ctx-${taskId}`,
+    message: {
+      role: 'user',
+      messageId: `msg-${taskId}`,
+      parts: [{ kind: 'text', text }],
+    },
+  };
+}
+
+test('happy path: chat.send → final event → task completes', async () => {
+  const frames: UpFrame[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-happy', status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId: 'run-happy',
+                sessionKey: 'agent:main:ctx-t1',
+                seq: 1,
+                state: 'final',
+                message: { text: 'hi back' },
+              },
+            }),
+          );
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f));
+    const types = frames.map((f) => f.type);
+    assert.deepEqual(types, ['task.status', 'task.artifact', 'task.complete']);
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.equal(complete!.status.state, 'completed');
+  } finally {
+    await fake.close();
+  }
+});
+
+export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -147,11 +147,18 @@ class GatewayClient {
     }, this.handshakeTimeoutMs);
     this.handshakeTimer.unref?.();
 
-    const ws = new WebSocket(this.url);
-    this.ws = ws;
-    ws.on('message', (raw) => this.handleMessage(raw));
-    ws.on('close', () => this.onClosed(new Error('gateway websocket closed')));
-    ws.on('error', (err) => this.onClosed(err as Error));
+    try {
+      const ws = new WebSocket(this.url);
+      this.ws = ws;
+      ws.on('message', (raw) => this.handleMessage(raw));
+      ws.on('close', () => this.onClosed(new Error('gateway websocket closed')));
+      ws.on('error', (err) => this.onClosed(err as Error));
+    } catch (err) {
+      // `new WebSocket(url)` can throw synchronously for things like an
+      // invalid URL. Without this guard, _state would stay 'connecting'
+      // and the handshake timer would fire later against a dead promise.
+      this.onClosed(err as Error);
+    }
 
     return this.readyPromise;
   }
@@ -393,6 +400,7 @@ export function createOpenclawBackend(
   const recentlyFinalizedRuns = new Set<string>();
   const MAX_FINALIZED_RUNS = 512;
   const MAX_BUFFERED_EVENTS_PER_RUN = 64;
+  const MAX_PENDING_RUN_KEYS = 256;
 
   function markRunFinalized(runId: string): void {
     if (recentlyFinalizedRuns.has(runId)) return;
@@ -446,11 +454,20 @@ export function createOpenclawBackend(
             // drop without buffering so memory stays bounded.
             if (recentlyFinalizedRuns.has(p.runId)) return;
             // Event arrived before handle() finished registering the runId.
-            // Buffer until the handler catches up and drains it.
-            const buf = pendingRunEvents.get(p.runId) ?? [];
+            // Buffer until the handler catches up and drains it. Evict the
+            // oldest unknown runId when the map grows past the cap so a
+            // noisy/misbehaving gateway can't inflate memory indefinitely.
+            let buf = pendingRunEvents.get(p.runId);
+            if (!buf) {
+              if (pendingRunEvents.size >= MAX_PENDING_RUN_KEYS) {
+                const oldest = pendingRunEvents.keys().next().value;
+                if (oldest !== undefined) pendingRunEvents.delete(oldest);
+              }
+              buf = [];
+              pendingRunEvents.set(p.runId, buf);
+            }
             if (buf.length >= MAX_BUFFERED_EVENTS_PER_RUN) buf.shift();
             buf.push(p);
-            pendingRunEvents.set(p.runId, buf);
             return;
           }
           taskFinalizers.get(binding.taskId)?.(p);

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -330,10 +330,30 @@ export function createOpenclawBackend(
   const runToTask = new Map<string, { taskId: string; sessionKey: string }>();
   const taskFinalizers = new Map<string, (evt: FinalizerEvent) => void>();
   const pendingRunEvents = new Map<string, ChatEventPayload[]>();
+  // Bounded memory of recently-finalized runIds. Any chat event carrying one
+  // of these is dropped instead of buffered in pendingRunEvents, so late or
+  // duplicate deltas from OpenClaw cannot accumulate forever after the task
+  // has already emitted its terminal frame.
+  const recentlyFinalizedRuns = new Set<string>();
+  const MAX_FINALIZED_RUNS = 512;
+  const MAX_BUFFERED_EVENTS_PER_RUN = 64;
+
+  function markRunFinalized(runId: string): void {
+    if (recentlyFinalizedRuns.has(runId)) return;
+    recentlyFinalizedRuns.add(runId);
+    if (recentlyFinalizedRuns.size > MAX_FINALIZED_RUNS) {
+      const oldest = recentlyFinalizedRuns.values().next().value;
+      if (oldest !== undefined) recentlyFinalizedRuns.delete(oldest);
+    }
+  }
 
   function handleGatewayClose(c: GatewayClient, err: Error): void {
     console.error('[openclaw] connection error:', err.message);
     if (current === c) current = null;
+    // Drop any orphaned event buffers and finalization memory — runIds are
+    // scoped to a single gateway session, so a reconnect starts clean.
+    pendingRunEvents.clear();
+    recentlyFinalizedRuns.clear();
     // Fail every in-flight task that was running on this client so handle()
     // does not hang forever waiting for a terminal event that can never come.
     if (taskFinalizers.size === 0) return;
@@ -366,9 +386,13 @@ export function createOpenclawBackend(
           }
           const binding = runToTask.get(p.runId);
           if (!binding) {
+            // Late or duplicate event for a run whose task already finalized:
+            // drop without buffering so memory stays bounded.
+            if (recentlyFinalizedRuns.has(p.runId)) return;
             // Event arrived before handle() finished registering the runId.
             // Buffer until the handler catches up and drains it.
             const buf = pendingRunEvents.get(p.runId) ?? [];
+            if (buf.length >= MAX_BUFFERED_EVENTS_PER_RUN) buf.shift();
             buf.push(p);
             pendingRunEvents.set(p.runId, buf);
             return;
@@ -442,10 +466,18 @@ export function createOpenclawBackend(
             ...(thinking ? { thinking } : {}),
           });
         } catch (err) {
+          // A close between send and ack rejects the pending request AND
+          // resolves `settled` via the close listener. Since we bail out
+          // here without awaiting `settled`, surface the gateway-closed
+          // cause directly so the caller gets a precise error code.
+          const closed = gw.state === 'closed';
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: { code: 'gateway_send_failed', message: (err as Error).message },
+            error: {
+              code: closed ? 'gateway_closed' : 'gateway_send_failed',
+              message: (err as Error).message,
+            },
           });
           return;
         }
@@ -531,6 +563,7 @@ export function createOpenclawBackend(
         if (runId) {
           runToTask.delete(runId);
           pendingRunEvents.delete(runId);
+          markRunFinalized(runId);
         }
       }
     },

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -110,10 +110,12 @@ class GatewayClient {
   private readyReject: ((err: Error) => void) | null = null;
   private nonce: string | null = null;
   private identity: DeviceIdentity;
+  private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     private readonly url: string,
     private readonly token?: string,
+    private readonly handshakeTimeoutMs: number = 10_000,
   ) {
     this.identity = generateDeviceIdentity();
   }
@@ -134,6 +136,16 @@ class GatewayClient {
       this.readyResolve = resolve;
       this.readyReject = reject;
     });
+
+    // Bound the handshake so a gateway that accepts the TCP connection but
+    // never finishes the challenge/connect exchange cannot wedge every
+    // subsequent ensureConnected() caller.
+    this.handshakeTimer = setTimeout(() => {
+      if (this._state === 'connecting') {
+        this.abortWith(new Error(`gateway handshake timed out after ${this.handshakeTimeoutMs}ms`));
+      }
+    }, this.handshakeTimeoutMs);
+    this.handshakeTimer.unref?.();
 
     const ws = new WebSocket(this.url);
     this.ws = ws;
@@ -165,7 +177,15 @@ class GatewayClient {
         resolve: (v) => resolve(v as T),
         reject,
       });
-      this.ws!.send(JSON.stringify(frame));
+      try {
+        this.ws!.send(JSON.stringify(frame));
+      } catch (err) {
+        // Synchronous send failure (socket transitioned out of OPEN between
+        // the readyState check and ws.send). Clean up the pending entry so
+        // it cannot linger and be double-rejected later by onClosed().
+        this.pending.delete(id);
+        reject(err as Error);
+      }
     });
   }
 
@@ -203,6 +223,10 @@ class GatewayClient {
     if (this._state === 'closed') return;
     const wasConnecting = this._state === 'connecting';
     this._state = 'closed';
+    if (this.handshakeTimer) {
+      clearTimeout(this.handshakeTimer);
+      this.handshakeTimer = null;
+    }
     for (const p of this.pending.values()) p.reject(err);
     this.pending.clear();
     if (wasConnecting) this.readyReject?.(err);
@@ -269,6 +293,10 @@ class GatewayClient {
       await this.request('connect', params);
       if (this._state === 'connecting') {
         this._state = 'ready';
+        if (this.handshakeTimer) {
+          clearTimeout(this.handshakeTimer);
+          this.handshakeTimer = null;
+        }
         this.readyResolve?.();
       }
     } catch (err) {
@@ -307,9 +335,29 @@ export interface OpenclawBackendOptions {
   debug?: boolean;
   /** Max time (ms) to wait for a terminal chat event after chat.send ack. Default 600000 (10min). */
   taskTimeoutMs?: number;
+  /** Max time (ms) to wait for the gateway handshake to complete. Default 10000. */
+  handshakeTimeoutMs?: number;
 }
 
 const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10 * 1000;
+
+function resolveTimeout(
+  explicit: number | undefined,
+  envName: string,
+  fallback: number,
+  label: string,
+): number {
+  const envRaw = process.env[envName];
+  const envNum = envRaw !== undefined ? Number(envRaw) : undefined;
+  const requested = explicit ?? envNum;
+  if (requested === undefined) return fallback;
+  if (!Number.isFinite(requested) || requested <= 0) {
+    console.warn(`[openclaw] invalid ${label} "${requested}", falling back to ${fallback}ms`);
+    return fallback;
+  }
+  return requested;
+}
 
 export function createOpenclawBackend(
   opts: OpenclawBackendOptions = {},
@@ -320,10 +368,18 @@ export function createOpenclawBackend(
   const thinking = opts.thinking ?? process.env.OPENCLAW_THINKING;
   const sessionPrefix = opts.sessionKeyPrefix ?? 'agent';
   const debug = opts.debug ?? process.env.OPENCLAW_DEBUG === '1';
-  const envTimeout = process.env.OPENCLAW_TASK_TIMEOUT_MS
-    ? Number(process.env.OPENCLAW_TASK_TIMEOUT_MS)
-    : undefined;
-  const taskTimeoutMs = opts.taskTimeoutMs ?? (Number.isFinite(envTimeout) ? (envTimeout as number) : DEFAULT_TASK_TIMEOUT_MS);
+  const taskTimeoutMs = resolveTimeout(
+    opts.taskTimeoutMs,
+    'OPENCLAW_TASK_TIMEOUT_MS',
+    DEFAULT_TASK_TIMEOUT_MS,
+    'taskTimeoutMs',
+  );
+  const handshakeTimeoutMs = resolveTimeout(
+    opts.handshakeTimeoutMs,
+    'OPENCLAW_HANDSHAKE_TIMEOUT_MS',
+    DEFAULT_HANDSHAKE_TIMEOUT_MS,
+    'handshakeTimeoutMs',
+  );
 
   let current: GatewayClient | null = null;
   let connecting: Promise<GatewayClient> | null = null;
@@ -372,7 +428,7 @@ export function createOpenclawBackend(
   async function ensureConnected(): Promise<GatewayClient> {
     if (current && current.state === 'ready') return current;
     if (connecting) return connecting;
-    const c = new GatewayClient(url, token);
+    const c = new GatewayClient(url, token, handshakeTimeoutMs);
     connecting = (async () => {
       try {
         await c.connect();
@@ -416,7 +472,17 @@ export function createOpenclawBackend(
     name: 'openclaw',
 
     async handle(task, emit) {
-      const gw = await ensureConnected();
+      let gw: GatewayClient;
+      try {
+        gw = await ensureConnected();
+      } catch (err) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: { code: 'gateway_closed', message: (err as Error).message },
+        });
+        return;
+      }
       const sessionKey = `${sessionPrefix}:${agent}:${task.contextId}`;
       const text = task.message.parts
         .map((p) => (p.kind === 'text' ? p.text : ''))

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -305,7 +305,11 @@ export interface OpenclawBackendOptions {
   thinking?: string;
   sessionKeyPrefix?: string;
   debug?: boolean;
+  /** Max time (ms) to wait for a terminal chat event after chat.send ack. Default 600000 (10min). */
+  taskTimeoutMs?: number;
 }
+
+const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
 
 export function createOpenclawBackend(
   opts: OpenclawBackendOptions = {},
@@ -316,11 +320,16 @@ export function createOpenclawBackend(
   const thinking = opts.thinking ?? process.env.OPENCLAW_THINKING;
   const sessionPrefix = opts.sessionKeyPrefix ?? 'agent';
   const debug = opts.debug ?? process.env.OPENCLAW_DEBUG === '1';
+  const envTimeout = process.env.OPENCLAW_TASK_TIMEOUT_MS
+    ? Number(process.env.OPENCLAW_TASK_TIMEOUT_MS)
+    : undefined;
+  const taskTimeoutMs = opts.taskTimeoutMs ?? (Number.isFinite(envTimeout) ? (envTimeout as number) : DEFAULT_TASK_TIMEOUT_MS);
 
   let current: GatewayClient | null = null;
   let connecting: Promise<GatewayClient> | null = null;
   const runToTask = new Map<string, { taskId: string; sessionKey: string }>();
   const taskFinalizers = new Map<string, (evt: FinalizerEvent) => void>();
+  const pendingRunEvents = new Map<string, ChatEventPayload[]>();
 
   function handleGatewayClose(c: GatewayClient, err: Error): void {
     console.error('[openclaw] connection error:', err.message);
@@ -356,7 +365,14 @@ export function createOpenclawBackend(
             console.log('[openclaw] chat event:', JSON.stringify(p).slice(0, 500));
           }
           const binding = runToTask.get(p.runId);
-          if (!binding) return;
+          if (!binding) {
+            // Event arrived before handle() finished registering the runId.
+            // Buffer until the handler catches up and drains it.
+            const buf = pendingRunEvents.get(p.runId) ?? [];
+            buf.push(p);
+            pendingRunEvents.set(p.runId, buf);
+            return;
+          }
           taskFinalizers.get(binding.taskId)?.(p);
         });
         c.onClose((err) => handleGatewayClose(c, err));
@@ -389,91 +405,134 @@ export function createOpenclawBackend(
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
 
-      const idempotencyKey = task.taskId;
-      let ack: ChatSendAck;
-      try {
-        ack = await gw.request<ChatSendAck>('chat.send', {
-          sessionKey,
-          message: text,
-          idempotencyKey,
-          ...(thinking ? { thinking } : {}),
-        });
-      } catch (err) {
-        emit({
-          type: 'task.fail',
-          taskId: task.taskId,
-          error: { code: 'gateway_send_failed', message: (err as Error).message },
-        });
-        return;
-      }
-
-      const runId = ack.runId;
-      runToTask.set(runId, { taskId: task.taskId, sessionKey });
-
-      const settled = await new Promise<FinalizerEvent>((resolve) => {
-        taskFinalizers.set(task.taskId, (evt) => {
-          if (evt.state === 'final' || evt.state === 'error' || evt.state === 'aborted') {
-            resolve(evt);
-          }
-        });
+      // Register the finalizer BEFORE sending chat.send so that:
+      //   1. a gateway close between send and ack still fails this task,
+      //   2. a fast terminal event arriving before runId is known is buffered.
+      let resolveSettled!: (evt: FinalizerEvent) => void;
+      const settled = new Promise<FinalizerEvent>((r) => {
+        resolveSettled = r;
       });
+      const finalizer = (evt: FinalizerEvent) => {
+        if (evt.state === 'final' || evt.state === 'error' || evt.state === 'aborted') {
+          resolveSettled(evt);
+        }
+      };
+      taskFinalizers.set(task.taskId, finalizer);
 
-      taskFinalizers.delete(task.taskId);
-      runToTask.delete(runId);
+      let runId: string | null = null;
+      const timer = setTimeout(() => {
+        resolveSettled({
+          runId: runId ?? '',
+          sessionKey,
+          seq: -1,
+          state: 'error',
+          errorMessage: `task timed out after ${taskTimeoutMs}ms`,
+          cause: 'timeout',
+        });
+      }, taskTimeoutMs);
+      timer.unref?.();
 
-      if (settled.cause === 'gateway_closed') {
+      try {
+        let ack: ChatSendAck;
+        try {
+          ack = await gw.request<ChatSendAck>('chat.send', {
+            sessionKey,
+            message: text,
+            idempotencyKey: task.taskId,
+            ...(thinking ? { thinking } : {}),
+          });
+        } catch (err) {
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: { code: 'gateway_send_failed', message: (err as Error).message },
+          });
+          return;
+        }
+
+        runId = ack.runId;
+        runToTask.set(runId, { taskId: task.taskId, sessionKey });
+        // Drain any events that raced ahead of registration.
+        const buffered = pendingRunEvents.get(runId);
+        if (buffered) {
+          pendingRunEvents.delete(runId);
+          for (const p of buffered) finalizer(p);
+        }
+
+        const result = await settled;
+
+        if (result.cause === 'timeout') {
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: {
+              code: 'task_timeout',
+              message: result.errorMessage ?? 'task timed out',
+            },
+          });
+          return;
+        }
+        if (result.cause === 'gateway_closed') {
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: {
+              code: 'gateway_closed',
+              message: result.errorMessage ?? 'gateway closed',
+            },
+          });
+          return;
+        }
+        if (result.state === 'error') {
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: {
+              code: 'gateway_chat_error',
+              message: result.errorMessage ?? 'unknown gateway error',
+            },
+          });
+          return;
+        }
+        if (result.state === 'aborted') {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+
+        const text2 = extractFinalText(result.message);
+        const parts: Part[] = [{ kind: 'text', text: text2 }];
+        const artifactId = randomUUID();
         emit({
-          type: 'task.fail',
+          type: 'task.artifact',
           taskId: task.taskId,
-          error: {
-            code: 'gateway_closed',
-            message: settled.errorMessage ?? 'gateway closed',
-          },
+          artifact: { artifactId, name: 'openclaw-result', parts },
+          lastChunk: true,
         });
-        return;
-      }
-      if (settled.state === 'error') {
-        emit({
-          type: 'task.fail',
-          taskId: task.taskId,
-          error: {
-            code: 'gateway_chat_error',
-            message: settled.errorMessage ?? 'unknown gateway error',
-          },
-        });
-        return;
-      }
-      if (settled.state === 'aborted') {
         emit({
           type: 'task.complete',
           taskId: task.taskId,
-          status: { state: 'canceled', timestamp: new Date().toISOString() },
-        });
-        return;
-      }
-
-      const text2 = extractFinalText(settled.message);
-      const parts: Part[] = [{ kind: 'text', text: text2 }];
-      const artifactId = randomUUID();
-      emit({
-        type: 'task.artifact',
-        taskId: task.taskId,
-        artifact: { artifactId, name: 'openclaw-result', parts },
-        lastChunk: true,
-      });
-      emit({
-        type: 'task.complete',
-        taskId: task.taskId,
-        status: {
-          state: 'completed',
-          timestamp: new Date().toISOString(),
-          message: {
-            role: 'agent',
-            messageId: randomUUID(),
-            parts,
+          status: {
+            state: 'completed',
+            timestamp: new Date().toISOString(),
+            message: {
+              role: 'agent',
+              messageId: randomUUID(),
+              parts,
+            },
           },
-        },
-      });
+        });
+      } finally {
+        clearTimeout(timer);
+        taskFinalizers.delete(task.taskId);
+        if (runId) {
+          runToTask.delete(runId);
+          pendingRunEvents.delete(runId);
+        }
+      }
     },
 
     async cancel(taskId) {

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -93,15 +93,17 @@ interface ChatSendAck {
 
 type EventHandler = (evt: EventFrame) => void;
 
+type ClientState = 'idle' | 'connecting' | 'ready' | 'closed';
+
 class GatewayClient {
   private ws: WebSocket | null = null;
   private pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
   private eventHandlers = new Set<EventHandler>();
-  private ready: Promise<void> | null = null;
+  private _state: ClientState = 'idle';
+  private readyPromise: Promise<void> | null = null;
   private readyResolve: (() => void) | null = null;
   private readyReject: ((err: Error) => void) | null = null;
   private nonce: string | null = null;
-  private stopped = false;
   private identity: DeviceIdentity;
 
   constructor(
@@ -112,69 +114,30 @@ class GatewayClient {
     this.identity = generateDeviceIdentity();
   }
 
+  get state(): ClientState {
+    return this._state;
+  }
+
   connect(): Promise<void> {
-    if (this.ready) return this.ready;
-    this.ready = new Promise<void>((resolve, reject) => {
+    if (this._state === 'ready') return Promise.resolve();
+    if (this._state === 'connecting') return this.readyPromise!;
+    if (this._state === 'closed') {
+      return Promise.reject(new Error('gateway client closed'));
+    }
+
+    this._state = 'connecting';
+    this.readyPromise = new Promise<void>((resolve, reject) => {
       this.readyResolve = resolve;
       this.readyReject = reject;
     });
 
     const ws = new WebSocket(this.url);
     this.ws = ws;
+    ws.on('message', (raw) => this.handleMessage(raw));
+    ws.on('close', () => this.onClosed(new Error('gateway websocket closed')));
+    ws.on('error', (err) => this.onClosed(err as Error));
 
-    ws.on('message', (raw) => {
-      let frame: Frame;
-      try {
-        frame = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8')) as Frame;
-      } catch {
-        return;
-      }
-      if (frame.type === 'event' && frame.event === 'connect.challenge') {
-        const p = frame.payload as { nonce?: string } | undefined;
-        this.nonce = p?.nonce?.trim() ?? null;
-        if (!this.nonce) {
-          this.fail(new Error('gateway sent empty connect nonce'));
-          return;
-        }
-        this.sendConnect();
-        return;
-      }
-      if (frame.type === 'res') {
-        const pending = this.pending.get(frame.id);
-        if (!pending) return;
-        this.pending.delete(frame.id);
-        if (frame.ok) pending.resolve(frame.payload);
-        else pending.reject(new Error(frame.error?.message ?? 'gateway error'));
-        return;
-      }
-      if (frame.type === 'event') {
-        for (const h of this.eventHandlers) h(frame);
-      }
-    });
-
-    ws.on('close', () => {
-      const err = new Error('gateway websocket closed');
-      for (const p of this.pending.values()) p.reject(err);
-      this.pending.clear();
-      if (this.readyReject && this.ready) {
-        this.readyReject(err);
-      }
-      this.ws = null;
-      this.ready = null;
-      if (!this.stopped) this.onError?.(err);
-    });
-
-    ws.on('error', (err) => {
-      this.onError?.(err as Error);
-      if (this.readyReject) this.readyReject(err as Error);
-    });
-
-    return this.ready;
-  }
-
-  stop(): void {
-    this.stopped = true;
-    this.ws?.close();
+    return this.readyPromise;
   }
 
   onEvent(handler: EventHandler): () => void {
@@ -197,10 +160,52 @@ class GatewayClient {
     });
   }
 
-  private fail(err: Error) {
-    this.readyReject?.(err);
+  private handleMessage(raw: WebSocket.RawData | string): void {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8')) as Frame;
+    } catch {
+      return;
+    }
+    if (frame.type === 'event' && frame.event === 'connect.challenge') {
+      const p = frame.payload as { nonce?: string } | undefined;
+      this.nonce = p?.nonce?.trim() ?? null;
+      if (!this.nonce) {
+        this.abortWith(new Error('gateway sent empty connect nonce'));
+        return;
+      }
+      void this.sendConnect();
+      return;
+    }
+    if (frame.type === 'res') {
+      const pending = this.pending.get(frame.id);
+      if (!pending) return;
+      this.pending.delete(frame.id);
+      if (frame.ok) pending.resolve(frame.payload);
+      else pending.reject(new Error(frame.error?.message ?? 'gateway error'));
+      return;
+    }
+    if (frame.type === 'event') {
+      for (const h of this.eventHandlers) h(frame);
+    }
+  }
+
+  private onClosed(err: Error): void {
+    if (this._state === 'closed') return;
+    const wasConnecting = this._state === 'connecting';
+    this._state = 'closed';
+    for (const p of this.pending.values()) p.reject(err);
+    this.pending.clear();
+    if (wasConnecting) this.readyReject?.(err);
+    this.readyResolve = null;
+    this.readyReject = null;
+    this.ws = null;
     this.onError?.(err);
+  }
+
+  private abortWith(err: Error): void {
     this.ws?.close();
+    this.onClosed(err);
   }
 
   private async sendConnect(): Promise<void> {
@@ -244,9 +249,12 @@ class GatewayClient {
         },
       };
       await this.request('connect', params);
-      this.readyResolve?.();
+      if (this._state === 'connecting') {
+        this._state = 'ready';
+        this.readyResolve?.();
+      }
     } catch (err) {
-      this.fail(err as Error);
+      this.abortWith(err as Error);
     }
   }
 }
@@ -291,32 +299,40 @@ export function createOpenclawBackend(
   const sessionPrefix = opts.sessionKeyPrefix ?? 'agent';
   const debug = opts.debug ?? process.env.OPENCLAW_DEBUG === '1';
 
-  let client: GatewayClient | null = null;
+  let current: GatewayClient | null = null;
+  let connecting: Promise<GatewayClient> | null = null;
   const runToTask = new Map<string, { taskId: string; sessionKey: string }>();
   const taskFinalizers = new Map<string, (evt: ChatEventPayload) => void>();
 
   async function ensureConnected(): Promise<GatewayClient> {
-    if (client) return client;
-    client = new GatewayClient(url, token, (err) => {
+    if (current && current.state === 'ready') return current;
+    if (connecting) return connecting;
+    const c = new GatewayClient(url, token, (err) => {
       console.error('[openclaw] connection error:', err.message);
-      client = null;
+      if (current === c) current = null;
     });
-    await client.connect();
-    console.log(`[openclaw] connected ${url}`);
-
-    client.onEvent((evt) => {
-      if (evt.event !== 'chat') return;
-      const p = evt.payload as ChatEventPayload | undefined;
-      if (!p?.runId) return;
-      if (debug) {
-        console.log('[openclaw] chat event:', JSON.stringify(p).slice(0, 500));
+    connecting = (async () => {
+      try {
+        await c.connect();
+        console.log(`[openclaw] connected ${url}`);
+        c.onEvent((evt) => {
+          if (evt.event !== 'chat') return;
+          const p = evt.payload as ChatEventPayload | undefined;
+          if (!p?.runId) return;
+          if (debug) {
+            console.log('[openclaw] chat event:', JSON.stringify(p).slice(0, 500));
+          }
+          const binding = runToTask.get(p.runId);
+          if (!binding) return;
+          taskFinalizers.get(binding.taskId)?.(p);
+        });
+        current = c;
+        return c;
+      } finally {
+        connecting = null;
       }
-      const binding = runToTask.get(p.runId);
-      if (!binding) return;
-      const finalizer = taskFinalizers.get(binding.taskId);
-      finalizer?.(p);
-    });
-    return client;
+    })();
+    return connecting;
   }
 
   return {
@@ -414,10 +430,10 @@ export function createOpenclawBackend(
 
     async cancel(taskId) {
       const entry = [...runToTask.entries()].find(([, v]) => v.taskId === taskId);
-      if (!entry || !client) return;
+      if (!entry || !current) return;
       const [runId, binding] = entry;
       try {
-        await client.request('chat.abort', { sessionKey: binding.sessionKey, runId });
+        await current.request('chat.abort', { sessionKey: binding.sessionKey, runId });
       } catch (err) {
         console.error('[openclaw] abort failed:', (err as Error).message);
       }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -86,6 +86,10 @@ interface ChatEventPayload {
   stopReason?: string;
 }
 
+type FinalizerCause = 'gateway_closed' | 'timeout';
+
+type FinalizerEvent = ChatEventPayload & { cause?: FinalizerCause };
+
 interface ChatSendAck {
   runId: string;
   status: 'started' | 'in_flight';
@@ -99,6 +103,7 @@ class GatewayClient {
   private ws: WebSocket | null = null;
   private pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
   private eventHandlers = new Set<EventHandler>();
+  private closeListeners = new Set<(err: Error) => void>();
   private _state: ClientState = 'idle';
   private readyPromise: Promise<void> | null = null;
   private readyResolve: (() => void) | null = null;
@@ -109,7 +114,6 @@ class GatewayClient {
   constructor(
     private readonly url: string,
     private readonly token?: string,
-    private readonly onError?: (err: Error) => void,
   ) {
     this.identity = generateDeviceIdentity();
   }
@@ -143,6 +147,11 @@ class GatewayClient {
   onEvent(handler: EventHandler): () => void {
     this.eventHandlers.add(handler);
     return () => this.eventHandlers.delete(handler);
+  }
+
+  onClose(listener: (err: Error) => void): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
   }
 
   async request<T = unknown>(method: string, params?: unknown): Promise<T> {
@@ -200,7 +209,16 @@ class GatewayClient {
     this.readyResolve = null;
     this.readyReject = null;
     this.ws = null;
-    this.onError?.(err);
+    const listeners = Array.from(this.closeListeners);
+    this.closeListeners.clear();
+    this.eventHandlers.clear();
+    for (const l of listeners) {
+      try {
+        l(err);
+      } catch (listenerErr) {
+        console.error('[openclaw] close listener threw:', (listenerErr as Error).message);
+      }
+    }
   }
 
   private abortWith(err: Error): void {
@@ -302,15 +320,30 @@ export function createOpenclawBackend(
   let current: GatewayClient | null = null;
   let connecting: Promise<GatewayClient> | null = null;
   const runToTask = new Map<string, { taskId: string; sessionKey: string }>();
-  const taskFinalizers = new Map<string, (evt: ChatEventPayload) => void>();
+  const taskFinalizers = new Map<string, (evt: FinalizerEvent) => void>();
+
+  function handleGatewayClose(c: GatewayClient, err: Error): void {
+    console.error('[openclaw] connection error:', err.message);
+    if (current === c) current = null;
+    // Fail every in-flight task that was running on this client so handle()
+    // does not hang forever waiting for a terminal event that can never come.
+    if (taskFinalizers.size === 0) return;
+    for (const fin of Array.from(taskFinalizers.values())) {
+      fin({
+        runId: '',
+        sessionKey: '',
+        seq: -1,
+        state: 'error',
+        errorMessage: `gateway closed: ${err.message}`,
+        cause: 'gateway_closed',
+      });
+    }
+  }
 
   async function ensureConnected(): Promise<GatewayClient> {
     if (current && current.state === 'ready') return current;
     if (connecting) return connecting;
-    const c = new GatewayClient(url, token, (err) => {
-      console.error('[openclaw] connection error:', err.message);
-      if (current === c) current = null;
-    });
+    const c = new GatewayClient(url, token);
     connecting = (async () => {
       try {
         await c.connect();
@@ -326,8 +359,12 @@ export function createOpenclawBackend(
           if (!binding) return;
           taskFinalizers.get(binding.taskId)?.(p);
         });
+        c.onClose((err) => handleGatewayClose(c, err));
         current = c;
         return c;
+      } catch (err) {
+        // connect() itself failed: nothing is registered yet, just propagate.
+        throw err;
       } finally {
         connecting = null;
       }
@@ -373,7 +410,7 @@ export function createOpenclawBackend(
       const runId = ack.runId;
       runToTask.set(runId, { taskId: task.taskId, sessionKey });
 
-      const settled = await new Promise<ChatEventPayload>((resolve) => {
+      const settled = await new Promise<FinalizerEvent>((resolve) => {
         taskFinalizers.set(task.taskId, (evt) => {
           if (evt.state === 'final' || evt.state === 'error' || evt.state === 'aborted') {
             resolve(evt);
@@ -384,6 +421,17 @@ export function createOpenclawBackend(
       taskFinalizers.delete(task.taskId);
       runToTask.delete(runId);
 
+      if (settled.cause === 'gateway_closed') {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'gateway_closed',
+            message: settled.errorMessage ?? 'gateway closed',
+          },
+        });
+        return;
+      }
       if (settled.state === 'error') {
         emit({
           type: 'task.fail',

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -4,6 +4,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- Fix the connection-state race in the OpenClaw backend by introducing an explicit `idle/connecting/ready/closed` state machine on `GatewayClient` and a single-flight `ensureConnected()`, so concurrent tasks during the first connect no longer fail with `gateway not connected` (#35).
- Propagate WebSocket close/error through a new `onClose` listener on `GatewayClient` and surface it as a deterministic `gateway_closed` `task.fail` for every in-flight A2A task, instead of hanging forever waiting on a terminal event that can never arrive (#36).
- Harden `handle()` with a per-runId event buffer, finalizer-before-ack registration, a configurable task timeout (`taskTimeoutMs`, 10 min default), and `try/finally` cleanup of `runToTask` / `taskFinalizers` / `pendingRunEvents`. Introduces distinct `task_timeout` and `gateway_closed` error codes (#36).

## Test plan
- [x] `pnpm --filter @vicoop-bridge/client test` — 7 tests pass (happy path, concurrent first-connect, reconnect, fast terminal event race, task timeout, cancel, gateway close mid-run).
- [x] `pnpm -r typecheck` clean across the workspace.
- [x] `pnpm -r build` clean across the workspace.

Closes #35
Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)