### PR TITLE
Add agent_id_available probe for pre-registration availability check

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -483,12 +483,27 @@ CREATE OR REPLACE FUNCTION agent_id_available(agent_id TEXT)
   SET search_path = pg_catalog, public
 AS $$
 BEGIN
+  -- Reject NULL/empty explicitly. Without this, `agent_id = NULL` matches no
+  -- rows and the function would return true, giving a misleading "available"
+  -- signal for an obviously invalid id (PostGraphile surfaces the arg as
+  -- nullable String).
+  IF agent_id_available.agent_id IS NULL OR agent_id_available.agent_id = '' THEN
+    RAISE EXCEPTION 'agent_id must be a non-empty string'
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
   RETURN NOT EXISTS(
     SELECT 1 FROM public.agent_policies ap
     WHERE ap.agent_id = agent_id_available.agent_id
   );
 END;
 $$;
+
+-- Schema setup runs as a superuser, so without an explicit ALTER OWNER the
+-- definer context would be superuser — overkill for reading one table and a
+-- latent escalation surface for future edits. app_postgraphile already has
+-- the RLS-bypass policy on agent_policies, which is exactly (and only) what
+-- this function needs to cross-wallet SELECT.
+ALTER FUNCTION agent_id_available(TEXT) OWNER TO app_postgraphile;
 
 COMMENT ON FUNCTION agent_id_available(TEXT) IS
   'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any wallet (including the caller) already owns it. Never exposes owner_wallet or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -457,6 +457,38 @@ CREATE POLICY agent_policies_postgraphile ON agent_policies
   USING (true)
   WITH CHECK (true);
 
+-- ------------------------------------------------------------
+-- 5a. Agent id availability probe
+-- ------------------------------------------------------------
+-- registerClient() accepts an allowed_agent_ids list but does not verify that
+-- the ids are free — collisions surface only at first WS register
+-- (packages/server/src/ws.ts ensureAgentPolicy → 'agent id owned by a
+-- different wallet'), by which point the CLIENT_TOKEN has already been issued
+-- and rotation is needed. agent_policies_select RLS also hides rows owned by
+-- other wallets, so a non-admin cannot distinguish 'free' from 'taken by
+-- someone else' with a direct query.
+--
+-- This function returns boolean availability only, bypassing RLS via
+-- SECURITY DEFINER so the check is authoritative across all owners. It does
+-- NOT expose owner_wallet or any metadata — callers learn only whether the
+-- id is claimable.
+CREATE OR REPLACE FUNCTION agent_id_available(agent_id TEXT)
+  RETURNS BOOLEAN
+  LANGUAGE plpgsql STABLE
+  SECURITY DEFINER
+  SET search_path = public, pg_temp
+AS $$
+BEGIN
+  RETURN NOT EXISTS(
+    SELECT 1 FROM agent_policies ap
+    WHERE ap.agent_id = agent_id_available.agent_id
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION agent_id_available(TEXT) IS
+  'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any wallet (including the caller) already owns it. Never exposes owner_wallet or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';
+
 -- ============================================================
 -- 6. Caller auth: opaque tokens issued via Google OAuth device flow
 -- ============================================================
@@ -552,6 +584,7 @@ REVOKE EXECUTE ON FUNCTION revoke_client(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION unrevoke_client(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION rotate_client_token(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION agent_id_available(TEXT) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR)
   TO app_authenticated, app_postgraphile;
@@ -562,4 +595,8 @@ GRANT EXECUTE ON FUNCTION unrevoke_client(TEXT)
 GRANT EXECUTE ON FUNCTION rotate_client_token(TEXT)
   TO app_authenticated, app_postgraphile;
 GRANT EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[])
+  TO app_authenticated, app_postgraphile;
+-- Authenticated-only to mitigate enumeration; app_anonymous is deliberately
+-- excluded so probing requires a valid vbc_caller_* token.
+GRANT EXECUTE ON FUNCTION agent_id_available(TEXT)
   TO app_authenticated, app_postgraphile;

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -476,11 +476,15 @@ CREATE OR REPLACE FUNCTION agent_id_available(agent_id TEXT)
   RETURNS BOOLEAN
   LANGUAGE plpgsql STABLE
   SECURITY DEFINER
-  SET search_path = public, pg_temp
+  -- pg_catalog first, public second, and pg_temp is intentionally absent:
+  -- with pg_temp in the path any role that can CREATE TEMP could shadow an
+  -- unqualified reference and hijack a definer-privileged resolution. The
+  -- function schema-qualifies agent_policies for the same reason.
+  SET search_path = pg_catalog, public
 AS $$
 BEGIN
   RETURN NOT EXISTS(
-    SELECT 1 FROM agent_policies ap
+    SELECT 1 FROM public.agent_policies ap
     WHERE ap.agent_id = agent_id_available.agent_id
   );
 END;

--- a/packages/server/src/agent-id-available.test.ts
+++ b/packages/server/src/agent-id-available.test.ts
@@ -60,7 +60,7 @@ test(
 );
 
 test(
-  'authenticated caller from a different wallet still sees taken=true (RLS bypass)',
+  'authenticated caller from a different wallet still sees available=false (RLS bypass)',
   { skip: !hasDb },
   async () => {
     // Guards the SECURITY DEFINER posture: agent_policies_select restricts

--- a/packages/server/src/agent-id-available.test.ts
+++ b/packages/server/src/agent-id-available.test.ts
@@ -1,0 +1,105 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+
+const hasDb = !!process.env.DATABASE_URL;
+
+async function callAvailable(sql: postgres.Sql, agentId: string): Promise<boolean> {
+  const rows = await sql<{ available: boolean }[]>`
+    SELECT agent_id_available(${agentId}) AS available
+  `;
+  return rows[0]!.available;
+}
+
+test(
+  'returns true for an agent_id that no client has registered',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const agentId = `availability-free-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      assert.equal(await callAvailable(sql, agentId), true);
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'returns false once an agent_policies row holds the id',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const agentId = `availability-taken-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const owner = '0x1111111111111111111111111111111111111111';
+      const clients = await sql<{ id: string }[]>`
+        INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
+        VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
+        RETURNING id
+      `;
+      const clientId = clients[0]!.id;
+      try {
+        await sql`
+          INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
+          VALUES (${agentId}, ${owner}, ${clientId})
+        `;
+
+        assert.equal(await callAvailable(sql, agentId), false);
+      } finally {
+        // agent_policies row cascades via ON DELETE CASCADE.
+        await sql`DELETE FROM clients WHERE id = ${clientId}`;
+      }
+
+      // Once cleaned up, the id is free again.
+      assert.equal(await callAvailable(sql, agentId), true);
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'authenticated caller from a different wallet still sees taken=true (RLS bypass)',
+  { skip: !hasDb },
+  async () => {
+    // Guards the SECURITY DEFINER posture: agent_policies_select restricts
+    // SELECT to the owning wallet, so without RLS bypass a different wallet's
+    // direct query would return no rows and the function would wrongly report
+    // the id as available. Exercising app_authenticated with a mismatched
+    // wallet claim proves the bypass is effective.
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const agentId = `availability-cross-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const owner = '0x2222222222222222222222222222222222222222';
+      const other = '0x3333333333333333333333333333333333333333';
+
+      const clients = await sql<{ id: string }[]>`
+        INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
+        VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
+        RETURNING id
+      `;
+      const clientId = clients[0]!.id;
+      try {
+        await sql`
+          INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
+          VALUES (${agentId}, ${owner}, ${clientId})
+        `;
+
+        const available = await sql.begin(async (tx) => {
+          await tx`SET LOCAL ROLE app_authenticated`;
+          await tx`SELECT set_config('jwt.claims.wallet_address', ${other}, true)`;
+          const rows = await tx<{ available: boolean }[]>`
+            SELECT agent_id_available(${agentId}) AS available
+          `;
+          return rows[0]!.available;
+        });
+        assert.equal(available, false);
+      } finally {
+        await sql`DELETE FROM clients WHERE id = ${clientId}`;
+      }
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/agent-id-available.test.ts
+++ b/packages/server/src/agent-id-available.test.ts
@@ -103,3 +103,48 @@ test(
     }
   },
 );
+
+test(
+  'app_anonymous cannot execute agent_id_available (enumeration closed)',
+  { skip: !hasDb },
+  async () => {
+    // GRANTs intentionally exclude app_anonymous so a caller without a
+    // vbc_caller_* token cannot probe the existence of arbitrary agent ids.
+    // Lock this in: if a future edit widens the grant, this test fails.
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      await assert.rejects(
+        () =>
+          sql.begin(async (tx) => {
+            await tx`SET LOCAL ROLE app_anonymous`;
+            await tx`SELECT agent_id_available('any-id')`;
+          }),
+        /permission denied/i,
+      );
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'NULL or empty agent_id is rejected with invalid_parameter_value',
+  { skip: !hasDb },
+  async () => {
+    // Without the explicit guard, ap.agent_id = NULL matches no rows and the
+    // function would return true for a plainly invalid input. Same for ''.
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      await assert.rejects(
+        () => sql`SELECT agent_id_available(${null as unknown as string})`,
+        /non-empty string/,
+      );
+      await assert.rejects(
+        () => sql`SELECT agent_id_available('')`,
+        /non-empty string/,
+      );
+    } finally {
+      await sql.end();
+    }
+  },
+);


### PR DESCRIPTION
## Summary

- Add `agent_id_available(text) returns boolean` SQL function to `packages/server/schema.sql`, exposed via PostGraphile as `Query.agentIdAvailable(agentId)`.
- `SECURITY DEFINER` bypasses the `agent_policies_select` RLS so the probe is authoritative across all owners, but returns **only a boolean** — never `owner_wallet` or other metadata.
- Hardened definer context: `search_path = pg_catalog, public` (no `pg_temp`, schema-qualified `public.agent_policies`) and function ownership explicitly transferred to `app_postgraphile` so the migration-time superuser context doesn't leak into runtime. `app_postgraphile` already carries the RLS-bypass policy on `agent_policies`, which is the minimum required.
- Explicit NULL/empty input guard — raises `invalid_parameter_value` so a plainly invalid id can't be reported as "available".
- Restricted to `app_authenticated` (`vbc_caller_*` token required) to mitigate enumeration. Admin `is_admin()` paths retain full-row visibility unchanged.
- Add DB-gated tests: free id, taken id, cross-wallet authenticated caller (proves RLS bypass works — otherwise a different wallet would see the row as absent and wrongly report `true`), `app_anonymous` permission denied (locks in the enumeration mitigation), NULL/empty input rejection.

## Why

`registerClient()` accepts `allowed_agent_ids` but does not verify the ids are free. A collision with another wallet only surfaces at first WS register (`packages/server/src/ws.ts` `ensureAgentPolicy` → `'agent id owned by a different wallet'`), by which point the `CLIENT_TOKEN` is already issued and rotation/re-issue is needed. Meanwhile `agent_policies_select` RLS hides foreign-owned rows, so a non-admin direct GraphQL query can't tell `'free'` from `'taken by someone else'`. This probe closes that gap cheaply without leaking ownership.

Fixes #41.

## Follow-ups (out of scope)

- IP/caller rate limiting on GraphQL — mentioned in the issue but is a cross-cutting concern beyond this function.
- Wiring the probe into the admin-ui registration flow.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/server typecheck`
- [x] `DATABASE_URL=... pnpm --filter @vicoop-bridge/server exec tsx --test 'src/**/*.test.ts'` — all green locally, including 5 new cases on `agent_id_available`
- [ ] Reviewer sanity-checks the SECURITY DEFINER posture: `search_path = pg_catalog, public` (no `pg_temp`), schema-qualified `public.agent_policies`, owner `app_postgraphile`
- [ ] Reviewer confirms `app_authenticated`-only GRANT matches desired enumeration posture (vs. opening to `app_anonymous`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)