### PR TITLE
Add docs/install-client.md onboarding guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ A2A Server + Client for exposing local coding agents (OpenClaw, Claude Code, Cod
 
 Agents connect *outbound* to a public Server via WebSocket, so they can sit behind NAT/firewalls while still being addressable by external A2A clients.
 
-See [`docs/design.md`](./docs/design.md) for the full design.
+Docs:
+
+- [`docs/design.md`](./docs/design.md) — architectural design
+- [`docs/install-client.md`](./docs/install-client.md) — onboarding a new client against a deployed bridge
+- [`docs/remote-testing.md`](./docs/remote-testing.md) — end-to-end testing against a deployed bridge
+- [`docs/local-testing.md`](./docs/local-testing.md) — running both bridge and client from source
 
 ## Client Releases
 
@@ -17,11 +22,9 @@ git tag client-v0.1.0
 git push origin client-v0.1.0
 ```
 
-After extracting the release bundle, run the client with:
-
-```bash
-./bin/vicoop-client --help
-```
+Operators installing from a published release should follow
+[`docs/install-client.md`](./docs/install-client.md) — the one-liner
+installer plus SIWE/registerClient flow for obtaining a client token.
 
 ## Status
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -61,7 +61,7 @@ What you get after extraction:
 
 ```
 $INSTALL_DIR/
-├── bin/vicoop-client        # node wrapper
+├── bin/vicoop-client        # bash wrapper that execs node dist/cli.js
 ├── dist/                    # compiled JS
 ├── cards/openclaw.json      # example agent card
 ├── node_modules/            # pruned prod deps

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -100,17 +100,17 @@ TOKEN=$(a2a-wallet siwe auth \
   --ttl 1h \
   --json | jq -r .token)
 
-# The CLI's token is base64url(JSON({message, signature})). Decode to feed
-# the bridge's exchange endpoint, which wants a plain {message, signature}.
-# GNU base64 uses -d, BSD/macOS base64 uses -D — probe at runtime.
+# The CLI's token is base64url(JSON({message, signature})). Decode and pipe
+# the {message, signature} JSON straight into the exchange endpoint — never
+# write the signed payload to disk where another local user could read it
+# off /tmp before we delete it. GNU base64 uses -d, BSD/macOS uses -D.
 PAD=$(printf '%*s' $(( (4 - ${#TOKEN} % 4) % 4 )) '' | tr ' ' '=')
 if printf '' | base64 -d >/dev/null 2>&1; then B64DEC='base64 -d'; else B64DEC='base64 -D'; fi
-echo "${TOKEN}${PAD}" | tr '_-' '/+' | $B64DEC > /tmp/siwe.json
 
-CALLER_TOKEN=$(curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
-  -H 'Content-Type: application/json' \
-  --data @/tmp/siwe.json | jq -r .access_token)
-rm /tmp/siwe.json
+CALLER_TOKEN=$(echo "${TOKEN}${PAD}" | tr '_-' '/+' | $B64DEC \
+  | curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
+      -H 'Content-Type: application/json' --data-binary @- \
+  | jq -r .access_token)
 
 echo "$CALLER_TOKEN"  # vbc_caller_...
 ```
@@ -317,9 +317,12 @@ Automatic restart on crash is tracked in #18.
 ## Troubleshooting
 
 - **`agent id owned by a different wallet`** (WS register) — your wallet is
-  not the `owner_wallet` on the existing `agent_policies` row. Either pick
-  a fresh `agent_id` (re-register the client) or run from the original
-  owner's wallet.
+  not the `owner_wallet` on the existing `agent_policies` row. Pick a
+  different `agent_id`, amend the existing client's allowlist via
+  `updateClientAllowedAgents` (no token rotation), and restart
+  `vicoop-client` with the new `AGENT_ID`. Re-run Step 3 only if you
+  intentionally want a new client/token; otherwise sign in from the
+  original owner's wallet.
 
 - **`permission denied for function register_client`** (or similar) on
   GraphQL — the caller token was missing, malformed, or expired, so the

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -1,9 +1,13 @@
 # Install vicoop-bridge-client
 
-Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code,
-Codex, ...) to a deployed vicoop-bridge server. The end state is a
-long-running `vicoop-client` process on your host that bridges inbound A2A
+Onboarding guide for connecting a local A2A backend (OpenClaw, with `echo`
+available for testing) to a deployed vicoop-bridge server. The end state is
+a long-running `vicoop-client` process on your host that bridges inbound A2A
 traffic at `POST <bridge>/agents/<your-agent-id>` to your local backend.
+
+Additional backends (Claude Code, Codex, ...) are described in
+`docs/design.md` §5 but are not in the published client bundle yet —
+`packages/client/src/cli.ts` currently only registers `echo` and `openclaw`.
 
 This doc covers the **post-release install path** (the `install.sh`
 one-liner fetching a published `client-v*` bundle). Contrast with:
@@ -24,7 +28,8 @@ one-liner fetching a published `client-v*` bundle). Contrast with:
 ## Prerequisites
 
 - Node.js 20 or newer (`node -v`).
-- `curl`, `tar`, and one of `sha256sum` / `shasum`.
+- `curl`, `tar`, `jq`, and one of `sha256sum` / `shasum`. (`jq` is used by
+  the token-extraction snippets in Steps 2–3.)
 - A reachable bridge URL. The public deployment is
   `https://vicoop-bridge-server.fly.dev`; substitute your own below if you
   run the server yourself.
@@ -67,6 +72,13 @@ The script targets Linux (Fly.io persistent volumes are the original target
 deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
 background.
 
+`install.sh` prints next-step instructions referencing
+`$INSTALL_DIR/card.json` as a placeholder path. The bundle does not ship
+that file — it ships `cards/openclaw.json` as a starting template. The rest
+of this doc points `--card` (and `AGENT_CARD`) at the shipped template
+directly; if you'd rather follow the printed path verbatim, copy the
+template to `$INSTALL_DIR/card.json` first.
+
 ## Step 2 — Obtain a caller token (SIWE)
 
 A caller token (`vbc_caller_*`) is the opaque session token you present to
@@ -90,8 +102,10 @@ TOKEN=$(a2a-wallet siwe auth \
 
 # The CLI's token is base64url(JSON({message, signature})). Decode to feed
 # the bridge's exchange endpoint, which wants a plain {message, signature}.
+# GNU base64 uses -d, BSD/macOS base64 uses -D — probe at runtime.
 PAD=$(printf '%*s' $(( (4 - ${#TOKEN} % 4) % 4 )) '' | tr ' ' '=')
-echo "${TOKEN}${PAD}" | tr '_-' '/+' | base64 -d > /tmp/siwe.json
+if printf '' | base64 -d >/dev/null 2>&1; then B64DEC='base64 -d'; else B64DEC='base64 -D'; fi
+echo "${TOKEN}${PAD}" | tr '_-' '/+' | $B64DEC > /tmp/siwe.json
 
 CALLER_TOKEN=$(curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
   -H 'Content-Type: application/json' \
@@ -138,16 +152,21 @@ CLIENT_TOKEN=$(echo "$REG" | jq -r .data.registerClient.clientWithToken.token)
 
 `allowedAgentIds` is a whitelist — the client may only register as one of
 these agent IDs at WS connect time. Include every ID you plan to run under
-this single token; adding more later requires re-registration.
+this single token if you know them up front; you can also amend the
+allowlist later via the `updateClientAllowedAgents` GraphQL mutation
+(backed by `update_client_allowed_agents()` in `schema.sql`) without
+issuing a new token. Re-registration is only required if you intentionally
+want a new client with a fresh token.
 
 ### Choosing an agent_id
 
 The bridge has no pre-flight API to check whether an `agent_id` is already
 claimed by another wallet (see #41). A collision surfaces only at WS
-register time as `'agent id owned by a different wallet'`, and recovering
-requires issuing a new `CLIENT_TOKEN` with a different `allowedAgentIds` —
-so pick something unlikely to collide. Prefix with your wallet short hash,
-project name, or hostname:
+register time as `'agent id owned by a different wallet'`. Recovering is
+cheap — call `updateClientAllowedAgents` to swap to a different ID without
+rotating the token (issue a new `CLIENT_TOKEN` only if you intentionally
+want a new client). Still, pick something unlikely to collide up front;
+prefix with your wallet short hash, project name, or hostname:
 
 ```sh
 AGENT_ID="openclaw-$(hostname -s)"
@@ -177,8 +196,8 @@ and describe what callers can expect. At minimum you usually want to:
 - Tighten `description` to what this specific instance actually does.
 - Adjust `skills[]` if you've customized the backend.
 
-Schema reference: `packages/protocol/src/agent-card.ts` (validated by the
-client at startup — invalid cards exit with a Zod error).
+Schema reference: `packages/protocol/src/index.ts` (`AgentCard` Zod schema,
+validated by the client at startup — invalid cards exit with a Zod error).
 
 For other backends, write a fresh card:
 
@@ -302,9 +321,13 @@ Automatic restart on crash is tracked in #18.
   a fresh `agent_id` (re-register the client) or run from the original
   owner's wallet.
 
-- **`Authentication required`** on GraphQL — caller token missing or
-  expired. Re-run Step 2. SIWE nonces are single-use; you must re-sign
-  every exchange.
+- **`permission denied for function register_client`** (or similar) on
+  GraphQL — the caller token was missing, malformed, or expired, so the
+  request fell back to the `app_anonymous` Postgres role (see
+  `packages/server/src/postgraphile.ts`) which has no EXECUTE on
+  authenticated functions. Send a valid `Bearer vbc_caller_*` token; if
+  expired, re-run Step 2 to refresh via the SIWE exchange. SIWE nonces are
+  single-use, so every exchange needs a freshly signed message.
 
 - **`SIWE message has already expired`** — the `expirationTime` was in the
   past when the bridge verified it. Increase `--ttl` or check host clock
@@ -321,11 +344,14 @@ Automatic restart on crash is tracked in #18.
 
 ## What's next
 
-- **Bind more agents to the same token**: re-register with
-  `allowedAgentIds: ["openclaw-a", "openclaw-b", ...]` and run one
-  `vicoop-client` per id.
-- **Different backends**: pass `--backend claude-cli` or `--backend codex`
-  with a matching card. See `docs/design.md` §5.
+- **Bind more agents to the same token**: amend the existing client's
+  allowlist via the `updateClientAllowedAgents` GraphQL mutation (e.g. to
+  `["openclaw-a", "openclaw-b", ...]`) and run one `vicoop-client` per id.
+  No token rotation needed.
+- **Different backends**: in the published bundle today, pass
+  `--backend openclaw` or `--backend echo` with a matching card.
+  `claude-cli` / `codex` are described in `docs/design.md` §5 but are not
+  shipped yet.
 - **Audit/revoke access**: the admin agent exposes `list_caller_tokens`,
   `list_callers`, and `revoke_caller_token` tools; see the tool list in
   `packages/server/src/admin.ts`.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -191,11 +191,19 @@ this probe and your WS register; if another wallet claims the id in
 between, Step 5 emits `'agent id owned by a different wallet'` and you can
 fall back to the recovery path in "Troubleshooting".
 
-Even with the probe, prefer names unlikely to collide across operators:
+Even with the probe, prefer names unlikely to collide across operators.
+Pick one:
 
 ```sh
+# By hostname
 AGENT_ID="openclaw-$(hostname | cut -d. -f1)"
-AGENT_ID="openclaw-$(printf '%s' "${WALLET#0x}" | cut -c1-6)"   # first 6 hex chars of your EOA
+
+# By wallet prefix — derive WALLET from a2a-wallet status (same format used
+# later for add_caller); strip the 0x and take the first 6 hex chars
+WALLET=$(a2a-wallet status | awk '/Address/{print tolower($2)}')
+AGENT_ID="openclaw-$(printf '%s' "${WALLET#0x}" | cut -c1-6)"
+
+# Random
 AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
 ```
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -267,7 +267,15 @@ All flags also accept env vars, which is usually cleaner for long-running
 services:
 
 ```sh
-SERVER_URL="wss://${BRIDGE_URL#https://}" \
+# The client appends /connect to SERVER_URL, so it must be a bare origin
+# (scheme+host+port only, no path). Derive via URL parsing and map the
+# scheme to its WS counterpart.
+SERVER_URL=$(BRIDGE_URL="$BRIDGE_URL" node -p '
+  const u = new URL(process.env.BRIDGE_URL);
+  (u.protocol === "https:" ? "wss:" : "ws:") + "//" + u.host
+')
+
+SERVER_URL="$SERVER_URL" \
 SERVER_TOKEN="$CLIENT_TOKEN" \
 AGENT_ID="$AGENT_ID" \
 AGENT_CARD="$INSTALL_DIR/cards/openclaw.json" \
@@ -351,7 +359,9 @@ Put `SERVER_URL=...`, `SERVER_TOKEN=...`, etc. in
 ### Tmux (interactive hosts)
 
 ```sh
-tmux new -d -s vbc 'sh -c "set -a; . \"$HOME/.config/vicoop-client.env\"; set +a; exec \"$INSTALL_DIR/bin/vicoop-client\""'
+# Swap the hardcoded path if you installed elsewhere. The inner sh is
+# spawned fresh by tmux, so don't rely on $INSTALL_DIR being exported here.
+tmux new -d -s vbc 'sh -c "set -a; . \"$HOME/.config/vicoop-client.env\"; set +a; exec \"$HOME/vicoop-bridge-client/bin/vicoop-client\""'
 tmux attach -t vbc   # to watch logs
 ```
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -168,13 +168,30 @@ want a new client with a fresh token.
 
 ### Choosing an agent_id
 
-The bridge has no pre-flight API to check whether an `agent_id` is already
-claimed by another wallet (see #41). A collision surfaces only at WS
-register time as `'agent id owned by a different wallet'`. Recovering is
-cheap — call `updateClientAllowedAgents` to swap to a different ID without
-rotating the token (issue a new `CLIENT_TOKEN` only if you intentionally
-want a new client). Still, pick something unlikely to collide up front;
-prefix with your wallet short hash, project name, or hostname:
+Before calling `registerClient`, probe the id with the
+`agentIdAvailable(agentId)` GraphQL query. It's a `SECURITY DEFINER`
+function (`packages/server/schema.sql`) that returns a plain boolean
+across every owner — no `owner_wallet` leaks — and raises
+`invalid_parameter_value` on empty input. Requires your caller token.
+
+```sh
+AGENT_ID=openclaw-local    # or one of the patterns below
+
+AVAILABLE=$(curl -sX POST "$BRIDGE_URL/graphql" \
+  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"query\":\"{agentIdAvailable(agentId:\\\"$AGENT_ID\\\")}\"}" \
+  | jq -r .data.agentIdAvailable)
+[ "$AVAILABLE" = "true" ] || { echo "agent_id '$AGENT_ID' is taken"; exit 1; }
+```
+
+`true` means no `agent_policies` row exists for that id yet, so your first
+WS register in Step 5 will claim ownership. `false` means another wallet
+already owns it — pick a different id. A small race window exists between
+this probe and your WS register; if another wallet claims the id in
+between, Step 5 emits `'agent id owned by a different wallet'` and you can
+fall back to the recovery path in "Troubleshooting".
+
+Even with the probe, prefer names unlikely to collide across operators:
 
 ```sh
 AGENT_ID="openclaw-$(hostname | cut -d. -f1)"
@@ -182,7 +199,10 @@ AGENT_ID="openclaw-$(printf '%s' "${WALLET#0x}" | cut -c1-6)"   # first 6 hex ch
 AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
 ```
 
-You *can* check whether you already own a given ID (helpful on reinstalls):
+On reinstalls, `agentIdAvailable` reports `false` for an id you yourself
+already registered. To distinguish "mine" from "somebody else's", also
+query `agentPolicyByAgentId` — RLS returns a non-null row only when *you*
+are the owner:
 
 ```sh
 curl -sX POST "$BRIDGE_URL/graphql" \
@@ -190,9 +210,9 @@ curl -sX POST "$BRIDGE_URL/graphql" \
   -d "{\"query\":\"{agentPolicyByAgentId(agentId:\\\"$AGENT_ID\\\"){agentId ownerWallet}}\"}" | jq .
 ```
 
-A non-null response means *you* own it (re-registration will replace the
-bound client). A null response means either "unclaimed" or "owned by
-someone else" — RLS on `agent_policies` hides the difference.
+A non-null response means you own it and a reinstall will reuse the
+existing policy; null after `agentIdAvailable=false` means someone else
+owns it.
 
 ## Step 4 — Prepare the agent card
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -1,0 +1,331 @@
+# Install vicoop-bridge-client
+
+Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code,
+Codex, ...) to a deployed vicoop-bridge server. The end state is a
+long-running `vicoop-client` process on your host that bridges inbound A2A
+traffic at `POST <bridge>/agents/<your-agent-id>` to your local backend.
+
+This doc covers the **post-release install path** (the `install.sh`
+one-liner fetching a published `client-v*` bundle). Contrast with:
+
+- [`local-testing.md`](./local-testing.md) — running both bridge and client
+  from source against a local Postgres, using `psql` for setup.
+- [`remote-testing.md`](./remote-testing.md) — end-to-end verification of a
+  deployed bridge using the echo backend. Covers the raw-curl SIWE path
+  that the "alternative" sections here link to.
+
+## Audience
+
+- A human operator (or an agent acting on their behalf) standing up a
+  brand-new client that will connect to a bridge they do not operate.
+- The operator has an Ethereum EOA they control; that wallet becomes the
+  owner of the resulting agent policy and must sign SIWE to obtain tokens.
+
+## Prerequisites
+
+- Node.js 20 or newer (`node -v`).
+- `curl`, `tar`, and one of `sha256sum` / `shasum`.
+- A reachable bridge URL. The public deployment is
+  `https://vicoop-bridge-server.fly.dev`; substitute your own below if you
+  run the server yourself.
+- An operator EOA. Either:
+  - [`a2a-wallet`](https://github.com/planetarium/a2a-x402-wallet) CLI with a
+    local wallet imported — this is the shortest path, used throughout.
+  - Or the raw-curl path from `remote-testing.md` §1-2 if you prefer
+    scripting SIWE yourself.
+- For the OpenClaw backend specifically: an OpenClaw gateway running
+  locally at `ws://127.0.0.1:18789` (override via `OPENCLAW_GATEWAY_URL`).
+
+## Step 1 — Install the client bundle
+
+The one-liner downloads the latest `client-v*` release, verifies its
+`.sha256`, and extracts into `$INSTALL_DIR`:
+
+```sh
+INSTALL_DIR="$HOME/vicoop-bridge-client" \
+  curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh | sh
+```
+
+| Env | Default | Purpose |
+|---|---|---|
+| `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
+| `VERSION` | latest `client-v*` | Pin a specific tag, e.g. `client-v0.1.1`. |
+| `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
+
+What you get after extraction:
+
+```
+$INSTALL_DIR/
+├── bin/vicoop-client        # node wrapper
+├── dist/                    # compiled JS
+├── cards/openclaw.json      # example agent card
+├── node_modules/            # pruned prod deps
+└── package.json
+```
+
+The script targets Linux (Fly.io persistent volumes are the original target
+deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
+background.
+
+## Step 2 — Obtain a caller token (SIWE)
+
+A caller token (`vbc_caller_*`) is the opaque session token you present to
+the bridge's admin endpoints. It is minted by signing a SIWE message at
+`POST /auth/siwe/exchange` (see `packages/server/src/auth/siwe-exchange.ts`
+for the exchange, `schema.sql` `used_siwe_nonces` for single-use-nonce
+enforcement). TTL equals the SIWE `expirationTime`, capped at 7 days.
+
+### Using `a2a-wallet`
+
+```sh
+export BRIDGE_URL=https://vicoop-bridge-server.fly.dev
+
+# Generate, sign, and encode a SIWE token in one step with your local wallet.
+TOKEN=$(a2a-wallet siwe auth \
+  --wallet <wallet-name> \
+  --domain "${BRIDGE_URL#https://}" \
+  --uri "$BRIDGE_URL" \
+  --ttl 1h \
+  --json | jq -r .token)
+
+# The CLI's token is base64url(JSON({message, signature})). Decode to feed
+# the bridge's exchange endpoint, which wants a plain {message, signature}.
+PAD=$(printf '%*s' $(( (4 - ${#TOKEN} % 4) % 4 )) '' | tr ' ' '=')
+echo "${TOKEN}${PAD}" | tr '_-' '/+' | base64 -d > /tmp/siwe.json
+
+CALLER_TOKEN=$(curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/siwe.json | jq -r .access_token)
+rm /tmp/siwe.json
+
+echo "$CALLER_TOKEN"  # vbc_caller_...
+```
+
+Replace `<wallet-name>` with the label from `a2a-wallet wallet list`. The
+default wallet is used if you omit `--wallet`.
+
+The `a2a-wallet siwe` subcommand is marked deprecated (its tokens are
+CLI-wallet-scoped and not shareable with a Web UI) but is the correct tool
+here — the bridge's exchange endpoint explicitly wants a wallet-signed
+SIWE message.
+
+### Alternative: raw curl
+
+If you'd rather not depend on `a2a-wallet`, follow
+[`remote-testing.md` §1 (SIWE exchange)](./remote-testing.md) — it builds
+the SIWE message in Node with `viem` + `siwe` and POSTs to the same
+endpoint. The resulting `CALLER_TOKEN` is interchangeable with the one
+produced above.
+
+## Step 3 — Register the client
+
+Call the `registerClient` GraphQL mutation with your caller token. This
+creates a `clients` row scoped to your wallet and issues a raw
+`CLIENT_TOKEN` (64-hex). **Save it immediately — it is unrecoverable.**
+
+```sh
+AGENT_ID=openclaw-local     # see "Choosing an agent_id" below
+CLIENT_NAME="openclaw on $(hostname -s)"
+
+REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
+  -H "Authorization: Bearer $CALLER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerWallet allowedAgentIds}}}\"}")
+
+echo "$REG" | jq .
+CLIENT_TOKEN=$(echo "$REG" | jq -r .data.registerClient.clientWithToken.token)
+```
+
+`allowedAgentIds` is a whitelist — the client may only register as one of
+these agent IDs at WS connect time. Include every ID you plan to run under
+this single token; adding more later requires re-registration.
+
+### Choosing an agent_id
+
+The bridge has no pre-flight API to check whether an `agent_id` is already
+claimed by another wallet (see #41). A collision surfaces only at WS
+register time as `'agent id owned by a different wallet'`, and recovering
+requires issuing a new `CLIENT_TOKEN` with a different `allowedAgentIds` —
+so pick something unlikely to collide. Prefix with your wallet short hash,
+project name, or hostname:
+
+```sh
+AGENT_ID="openclaw-$(hostname -s)"
+AGENT_ID="openclaw-${WALLET:2:6}"      # first 6 hex chars of your EOA
+AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
+```
+
+You *can* check whether you already own a given ID (helpful on reinstalls):
+
+```sh
+curl -sX POST "$BRIDGE_URL/graphql" \
+  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"query\":\"{agentPolicyByAgentId(agentId:\\\"$AGENT_ID\\\"){agentId ownerWallet}}\"}" | jq .
+```
+
+A non-null response means *you* own it (re-registration will replace the
+bound client). A null response means either "unclaimed" or "owned by
+someone else" — RLS on `agent_policies` hides the difference.
+
+## Step 4 — Prepare the agent card
+
+The bundle ships `$INSTALL_DIR/cards/openclaw.json` as a starting template.
+Agent cards are published at `GET <bridge>/agents/<agent_id>/.well-known/agent-card.json`
+and describe what callers can expect. At minimum you usually want to:
+
+- Rename `name` to something meaningful (it defaults to `openclaw`).
+- Tighten `description` to what this specific instance actually does.
+- Adjust `skills[]` if you've customized the backend.
+
+Schema reference: `packages/protocol/src/agent-card.ts` (validated by the
+client at startup — invalid cards exit with a Zod error).
+
+For other backends, write a fresh card:
+
+```sh
+cat > "$INSTALL_DIR/cards/my-agent.json" <<'JSON'
+{
+  "name": "my-agent",
+  "description": "...",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": { "streaming": false },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    { "id": "chat", "name": "chat", "description": "...", "tags": ["chat"] }
+  ]
+}
+JSON
+```
+
+## Step 5 — Run the client
+
+All flags also accept env vars, which is usually cleaner for long-running
+services:
+
+```sh
+SERVER_URL="wss://${BRIDGE_URL#https://}" \
+SERVER_TOKEN="$CLIENT_TOKEN" \
+AGENT_ID="$AGENT_ID" \
+AGENT_CARD="$INSTALL_DIR/cards/openclaw.json" \
+BACKEND=openclaw \
+  "$INSTALL_DIR/bin/vicoop-client"
+```
+
+On success you'll see a `[client] connected` log. After that:
+
+- The bridge auto-creates an `agent_policies` row owned by your wallet with
+  empty `allowed_callers` — meaning **publicly callable** until you restrict it.
+- `POST $BRIDGE_URL/agents/$AGENT_ID` with a JSON-RPC `message/send` payload
+  reaches your backend and the reply is returned inline.
+
+### OpenClaw-specific env
+
+The OpenClaw backend connects outbound to a local OpenClaw gateway over a
+second WS. Override if yours isn't on the default:
+
+| Env | Default | |
+|---|---|---|
+| `OPENCLAW_GATEWAY_URL` | `ws://127.0.0.1:18789` | Local gateway endpoint |
+| `OPENCLAW_GATEWAY_TOKEN` | *(none)* | If your gateway requires auth |
+| `OPENCLAW_AGENT` | `main` | Agent name inside OpenClaw |
+| `OPENCLAW_TASK_TIMEOUT_MS` | backend default | Per-task timeout |
+
+### Restrict who can call your agent
+
+By default the policy has empty `allowed_callers`, which the dispatcher
+treats as "public". To lock it down, use the admin agent's `add_caller`
+tool — this is the same flow as
+[`remote-testing.md` §5](./remote-testing.md). Example for gating to your
+own wallet only:
+
+```sh
+WALLET_PRINCIPAL="eth:$(a2a-wallet status | awk '/Address/{print tolower($2)}')"
+
+curl -sX POST "$BRIDGE_URL/" \
+  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"message/send\",\"params\":{\"message\":{\"messageId\":\"ac\",\"role\":\"user\",\"kind\":\"message\",\"parts\":[{\"kind\":\"text\",\"text\":\"Use add_caller to add '${WALLET_PRINCIPAL}' to agent '${AGENT_ID}'.\"}]}}}" \
+  | jq -r '.result.status.message.parts[0].text'
+```
+
+The change hot-reloads via `registry.updateAllowedCallers` — no client
+restart needed.
+
+## Step 6 — Run persistently
+
+`vicoop-client` does not daemonize. Pick whichever supervisor fits your host.
+
+### macOS — `launchd`
+
+Create `~/Library/LaunchAgents/com.local.vicoop-client.plist` with
+`KeepAlive=true`, point `ProgramArguments` at
+`$INSTALL_DIR/bin/vicoop-client`, and put your env into
+`EnvironmentVariables`. Load with `launchctl load -w <plist>`.
+
+### Linux — systemd user unit
+
+```ini
+# ~/.config/systemd/user/vicoop-client.service
+[Unit]
+Description=vicoop-bridge-client
+After=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.config/vicoop-client.env
+ExecStart=%h/vicoop-bridge-client/bin/vicoop-client
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target
+```
+
+Put `SERVER_URL=...`, `SERVER_TOKEN=...`, etc. in
+`~/.config/vicoop-client.env` (mode `0600`), then
+`systemctl --user enable --now vicoop-client`.
+
+### Tmux (interactive hosts)
+
+```sh
+tmux new -d -s vbc "env $(cat ~/.config/vicoop-client.env | xargs) $INSTALL_DIR/bin/vicoop-client"
+tmux attach -t vbc   # to watch logs
+```
+
+Automatic restart on crash is tracked in #18.
+
+## Troubleshooting
+
+- **`agent id owned by a different wallet`** (WS register) — your wallet is
+  not the `owner_wallet` on the existing `agent_policies` row. Either pick
+  a fresh `agent_id` (re-register the client) or run from the original
+  owner's wallet.
+
+- **`Authentication required`** on GraphQL — caller token missing or
+  expired. Re-run Step 2. SIWE nonces are single-use; you must re-sign
+  every exchange.
+
+- **`SIWE message has already expired`** — the `expirationTime` was in the
+  past when the bridge verified it. Increase `--ttl` or check host clock
+  skew.
+
+- **Client reconnects but `/agents/:id` returns 404** — the
+  `agent_policies` row exists but no WS session is live. Check the client
+  log; the row is re-used on reconnect but dispatch requires an active
+  session.
+
+- **Lost the `CLIENT_TOKEN`** — it's unrecoverable. Re-run Step 3 to issue
+  a new one. The old `clients` row (and any cascading `agent_policies`)
+  can be cleaned up via the admin agent's CRUD mutations (#29).
+
+## What's next
+
+- **Bind more agents to the same token**: re-register with
+  `allowedAgentIds: ["openclaw-a", "openclaw-b", ...]` and run one
+  `vicoop-client` per id.
+- **Different backends**: pass `--backend claude-cli` or `--backend codex`
+  with a matching card. See `docs/design.md` §5.
+- **Audit/revoke access**: the admin agent exposes `list_caller_tokens`,
+  `list_callers`, and `revoke_caller_token` tools; see the tool list in
+  `packages/server/src/admin.ts`.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -28,8 +28,10 @@ one-liner fetching a published `client-v*` bundle). Contrast with:
 ## Prerequisites
 
 - Node.js 20 or newer (`node -v`).
-- `curl`, `tar`, `jq`, and one of `sha256sum` / `shasum`. (`jq` is used by
-  the token-extraction snippets in Steps 2–3.)
+- `curl`, `tar`, `jq`, `base64` (usually part of `coreutils` / `busybox`),
+  and one of `sha256sum` / `shasum`. `jq` is used by the token-extraction
+  snippets in Steps 2–3; `base64` is used for the SIWE-token decode in
+  Step 2.
 - A reachable bridge URL. The public deployment is
   `https://vicoop-bridge-server.fly.dev`; substitute your own below if you
   run the server yourself.
@@ -99,10 +101,15 @@ enforcement). TTL equals the SIWE `expirationTime`, capped at 7 days.
 ```sh
 export BRIDGE_URL=https://vicoop-bridge-server.fly.dev
 
+# The server compares the SIWE `domain` field against PUBLIC_URL's hostname
+# exactly, so derive the bare hostname via URL parsing — a naïve
+# ${BRIDGE_URL#https://} breaks on http:// or trailing paths/slashes.
+BRIDGE_HOSTNAME=$(BRIDGE_URL="$BRIDGE_URL" node -p 'new URL(process.env.BRIDGE_URL).hostname')
+
 # Generate, sign, and encode a SIWE token in one step with your local wallet.
 TOKEN=$(a2a-wallet siwe auth \
   --wallet <wallet-name> \
-  --domain "${BRIDGE_URL#https://}" \
+  --domain "$BRIDGE_HOSTNAME" \
   --uri "$BRIDGE_URL" \
   --ttl 1h \
   --json | jq -r .token)
@@ -381,9 +388,15 @@ Automatic restart on crash is tracked in #18.
   log; the row is re-used on reconnect but dispatch requires an active
   session.
 
-- **Lost the `CLIENT_TOKEN`** — it's unrecoverable. Re-run Step 3 to issue
-  a new one. The old `clients` row (and any cascading `agent_policies`)
-  can be cleaned up via the admin agent's CRUD mutations (#29).
+- **Lost the `CLIENT_TOKEN`** — the raw value is unrecoverable, but you
+  don't need to create a new client identity. Rotate the token in place
+  via the `rotateClientToken` GraphQL mutation (backed by
+  `rotate_client_token()` in `schema.sql`): it mints a fresh raw token for
+  the existing `clients` row and invalidates the old hash, so your
+  `allowedAgentIds` and `agent_policies` carry over. Re-run Step 3 only if
+  you intentionally want a new client identity; in that case the old
+  `clients` row (and cascading `agent_policies`) can be cleaned up via
+  the admin agent's CRUD mutations (#29).
 
 ## What's next
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -49,9 +49,13 @@ The one-liner downloads the latest `client-v*` release, verifies its
 `.sha256`, and extracts into `$INSTALL_DIR`:
 
 ```sh
-INSTALL_DIR="$HOME/vicoop-bridge-client" \
-  curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh \
+  | INSTALL_DIR="$HOME/vicoop-bridge-client" sh
 ```
+
+The env assignment has to sit on the `sh` side of the pipe — prefixing the
+`curl` call would scope `INSTALL_DIR` to curl's process only, and `install.sh`
+would still default to `/data/vicoop-bridge-client`.
 
 | Env | Default | Purpose |
 |---|---|---|

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -72,12 +72,19 @@ The script targets Linux (Fly.io persistent volumes are the original target
 deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
 background.
 
-`install.sh` prints next-step instructions referencing
-`$INSTALL_DIR/card.json` as a placeholder path. The bundle does not ship
-that file — it ships `cards/openclaw.json` as a starting template. The rest
-of this doc points `--card` (and `AGENT_CARD`) at the shipped template
-directly; if you'd rather follow the printed path verbatim, copy the
-template to `$INSTALL_DIR/card.json` first.
+`install.sh` prints next-step instructions, but parts of that output are
+outdated and should be ignored in favor of Steps 2-3 below:
+
+- It references `$INSTALL_DIR/card.json` as the card path — the bundle does
+  not ship that file; it ships `cards/openclaw.json` as a starting
+  template. This doc points `--card` (and `AGENT_CARD`) at the shipped
+  template directly; if you'd rather keep the printed path, copy the
+  template to `$INSTALL_DIR/card.json` first.
+- It suggests obtaining a token via a `register_client` tool on the admin
+  agent. Today the flow goes through the PostGraphile-exposed
+  `registerClient` GraphQL mutation (Step 3), gated by a SIWE caller token
+  (Step 2). The admin A2A agent itself does not carry a
+  `register_client` tool with that name.
 
 ## Step 2 — Obtain a caller token (SIWE)
 
@@ -139,7 +146,8 @@ creates a `clients` row scoped to your wallet and issues a raw
 
 ```sh
 AGENT_ID=openclaw-local     # see "Choosing an agent_id" below
-CLIENT_NAME="openclaw on $(hostname -s)"
+HOSTNAME=$(hostname)
+CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 
 REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
   -H "Authorization: Bearer $CALLER_TOKEN" \
@@ -169,8 +177,8 @@ want a new client). Still, pick something unlikely to collide up front;
 prefix with your wallet short hash, project name, or hostname:
 
 ```sh
-AGENT_ID="openclaw-$(hostname -s)"
-AGENT_ID="openclaw-${WALLET:2:6}"      # first 6 hex chars of your EOA
+AGENT_ID="openclaw-$(hostname | cut -d. -f1)"
+AGENT_ID="openclaw-$(printf '%s' "${WALLET#0x}" | cut -c1-6)"   # first 6 hex chars of your EOA
 AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
 ```
 
@@ -232,7 +240,7 @@ BACKEND=openclaw \
   "$INSTALL_DIR/bin/vicoop-client"
 ```
 
-On success you'll see a `[client] connected` log. After that:
+On success you'll see a `[client] connected, sending hello` log. After that:
 
 - The bridge auto-creates an `agent_policies` row owned by your wallet with
   empty `allowed_callers` — meaning **publicly callable** until you restrict it.
@@ -308,9 +316,13 @@ Put `SERVER_URL=...`, `SERVER_TOKEN=...`, etc. in
 ### Tmux (interactive hosts)
 
 ```sh
-tmux new -d -s vbc "env $(cat ~/.config/vicoop-client.env | xargs) $INSTALL_DIR/bin/vicoop-client"
+tmux new -d -s vbc 'sh -c "set -a; . \"$HOME/.config/vicoop-client.env\"; set +a; exec \"$INSTALL_DIR/bin/vicoop-client\""'
 tmux attach -t vbc   # to watch logs
 ```
+
+Using `set -a` + `.` keeps secrets out of the process-listing line and
+tolerates quoted values / comment lines in the env file, which the
+`env $(xargs)` pattern does not.
 
 Automatic restart on crash is tracked in #18.
 


### PR DESCRIPTION
## Summary

- New `docs/install-client.md` walking an operator (or an agent acting on their behalf) from a fresh host to a connected `vicoop-client` against a deployed bridge.
- Covers the pieces that were scattered across `remote-testing.md` + PR #21 + chat knowledge: `install.sh` one-liner, SIWE → caller-token exchange via `a2a-wallet` (with raw-curl pointer to `remote-testing.md` §1-2 as alternative), `registerClient` mutation, `agent_id` collision caveats (linked to #41), card preparation, env-driven startup, persistent-run recipes (launchd / systemd / tmux), troubleshooting.
- README grows a full docs index so this, `remote-testing.md`, and `local-testing.md` are discoverable; the old "release bundle → `vicoop-client --help`" paragraph is replaced with a pointer into the new guide.

## Why a new file instead of expanding remote-testing.md

`remote-testing.md` is written as a verification procedure (echo backend, Anvil wallet, cleanup at the end). Operators standing up a real backend need different framing: install-from-release, operator wallet, choosing an `agent_id`, persistent supervision. Kept the two docs separate and cross-linked — the SIWE-signing-by-hand recipe lives in remote-testing.md and this doc links to it rather than duplicating.

## Test plan

- [ ] Reviewer runs the `install.sh` + SIWE + `registerClient` blocks verbatim against the deployed bridge and confirms a caller token + client token are issued (we already verified this end-to-end in the install session that produced this doc).
- [ ] Reviewer spot-checks code references (`packages/server/src/auth/siwe-exchange.ts`, `packages/server/src/admin.ts`, `packages/protocol/src/agent-card.ts`) — all current as of `main`.
- [ ] Reviewer skims the troubleshooting section for accuracy vs. actual error strings emitted by `ws.ts` / GraphQL.

## Related

- #17 / #21 — `install.sh` one-liner
- #41 — `agent_id` pre-flight availability API (referenced from the "Choosing an agent_id" section)
- #18 — restart auto-recovery (referenced from the persistent-run section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)