### PR TITLE
Log task_unreachable when agent client is not connected

### DIFF
--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -33,6 +33,13 @@ export class ServerAgentExecutor implements AgentExecutor {
     });
 
     if (!sent) {
+      console.log(JSON.stringify({
+        event: 'task_unreachable',
+        agentId: this.agentId,
+        taskId,
+        contextId,
+        ts: new Date().toISOString(),
+      }));
       bus.publish({
         kind: 'status-update',
         taskId,


### PR DESCRIPTION
## Summary
- When a message arrives for an agent with no connected WebSocket client, `ServerAgentExecutor` immediately publishes a `failed` status with `\"client not connected\"` and finishes the bus, but emits no server log.
- That made the failure invisible in `fly logs` (no `message/send` trace, no `client_rejected`, nothing) and forced operators to deduce the cause from the *absence* of a prior `client_connected` event for that agentId.
- Adds a structured `task_unreachable` log line on the unreachable path in `packages/server/src/executor.ts` so this state is greppable.

## Test plan
- [ ] Send a message to an agentId that has no live ws client and confirm a `{\"event\":\"task_unreachable\",\"agentId\":...,\"taskId\":...}` line appears in server logs alongside the existing `failed` task status returned to the caller.
- [ ] Send a message to a connected agent and confirm no `task_unreachable` line is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)