### PR TITLE
Add logEvent helper and broaden agent-id log coverage

### DIFF
--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -3,6 +3,7 @@ import type { ClientConnection, Registry } from './registry.js';
 import type { Sql } from './db.js';
 import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
 import { matchPrincipal, type VerifiedCaller } from './auth/principal.js';
+import { logEvent } from './log.js';
 
 export function getAgentConn(c: Context): ClientConnection {
   return c.get('agentConn') as ClientConnection;
@@ -26,6 +27,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
     if (!conn) {
+      logEvent('agent_request_rejected', { agentId, reason: 'agent_not_connected' });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -42,6 +44,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken) {
+      logEvent('agent_request_rejected', { agentId, reason: 'missing_bearer' });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -53,6 +56,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     }
 
     if (!bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+      logEvent('agent_request_rejected', { agentId, reason: 'bad_token_prefix' });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -67,6 +71,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     try {
       caller = await verifyCallerToken(opts.sql, bearerToken);
     } catch (err) {
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'invalid_token',
+        detail: (err as Error).message,
+      });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -76,6 +85,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
 
     const allowed = conn.allowedCallers.some((entry) => matchPrincipal(entry, caller));
     if (!allowed) {
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'caller_not_authorized',
+        principalId: caller.principalId,
+      });
       return c.json({
         jsonrpc: '2.0',
         id: null,

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -1,5 +1,6 @@
 import type { AgentExecutor, ExecutionEventBus, RequestContext } from '@a2a-js/sdk/server';
 import type { Registry } from './registry.js';
+import { logEvent } from './log.js';
 
 export class ServerAgentExecutor implements AgentExecutor {
   constructor(
@@ -33,13 +34,7 @@ export class ServerAgentExecutor implements AgentExecutor {
     });
 
     if (!sent) {
-      console.log(JSON.stringify({
-        event: 'task_unreachable',
-        agentId: this.agentId,
-        taskId,
-        contextId,
-        ts: new Date().toISOString(),
-      }));
+      logEvent('task_unreachable', { agentId: this.agentId, taskId, contextId });
       bus.publish({
         kind: 'status-update',
         taskId,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -22,6 +22,7 @@ import { mountSiweExchange } from './auth/siwe-exchange.js';
 import type { GoogleConfig } from './auth/google-oauth.js';
 import type { Sql } from './db.js';
 import { Landing } from './landing.js';
+import { logEvent } from './log.js';
 
 export interface ServerHttpOptions {
   registry: Registry;
@@ -322,6 +323,10 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
+    logEvent('agent_request', {
+      agentId: conn.agentId,
+      hasAuth: !!c.req.header('Authorization'),
+    });
 
     const rawBody = await c.req.text();
     const transport = getTransport(conn);

--- a/packages/server/src/log.ts
+++ b/packages/server/src/log.ts
@@ -1,0 +1,3 @@
+export function logEvent(event: string, fields: Record<string, unknown> = {}): void {
+  console.log(JSON.stringify({ event, ts: new Date().toISOString(), ...fields }));
+}

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -4,6 +4,7 @@ import { parseUpFrame, PROTOCOL_VERSION, type Part, type TaskStatus } from '@vic
 import type { Registry } from './registry.js';
 import type { Sql } from './db.js';
 import { hashToken } from './token.js';
+import { logEvent } from './log.js';
 
 interface ClientRow {
   id: string;
@@ -92,23 +93,16 @@ async function authenticateAndRegister(
   const hash = hashToken(frame.token);
   const client = await lookupByTokenHash(opts.db, hash);
   if (!client) {
-    console.log(JSON.stringify({
-      event: 'client_rejected',
-      reason: 'bad token',
-      agentId: frame.agentId,
-      ts: new Date().toISOString(),
-    }));
+    logEvent('client_rejected', { reason: 'bad token', agentId: frame.agentId });
     return { ok: false, code: 4005, reason: 'bad token' };
   }
   if (!client.allowed_agent_ids.includes(frame.agentId)) {
-    console.log(JSON.stringify({
-      event: 'client_rejected',
+    logEvent('client_rejected', {
       reason: 'agent not allowed',
       agentId: frame.agentId,
       clientId: client.id,
       allowed: client.allowed_agent_ids,
-      ts: new Date().toISOString(),
-    }));
+    });
     return { ok: false, code: 4008, reason: 'agent id not authorized for this client' };
   }
   const clientId = client.id;
@@ -116,13 +110,11 @@ async function authenticateAndRegister(
 
   const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet, clientId);
   if (!policyResult.ok) {
-    console.log(JSON.stringify({
-      event: 'client_rejected',
+    logEvent('client_rejected', {
       reason: policyResult.reason,
       agentId: frame.agentId,
       clientId,
-      ts: new Date().toISOString(),
-    }));
+    });
     return { ok: false, code: 4010, reason: policyResult.reason };
   }
 
@@ -136,13 +128,11 @@ async function authenticateAndRegister(
     connectedAt: Date.now(),
   });
   if (!result.ok) {
-    console.log(JSON.stringify({
-      event: 'client_rejected',
+    logEvent('client_rejected', {
       reason: result.reason,
       agentId: frame.agentId,
       clientId,
-      ts: new Date().toISOString(),
-    }));
+    });
     return { ok: false, code: 4006, reason: result.reason };
   }
 
@@ -204,13 +194,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         agentId = frame.agentId;
         authed = true;
         clearTimeout(helloTimeout);
-        console.log(JSON.stringify({
-          event: 'client_connected',
+        logEvent('client_connected', {
           agentId,
           clientId: result.clientId,
           name: frame.agentCard.name,
-          ts: new Date().toISOString(),
-        }));
+        });
       }).catch((err) => {
         console.error('[server] auth error:', err);
         ws.close(1011, 'internal error');
@@ -261,6 +249,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         });
         b.eventBus.finished();
         opts.registry.unbindTask(frame.taskId);
+        logEvent('task_completed', {
+          agentId: b.agentId,
+          taskId: frame.taskId,
+          state: frame.status.state,
+        });
         break;
       }
       case 'task.fail': {
@@ -286,6 +279,12 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         });
         b.eventBus.finished();
         opts.registry.unbindTask(frame.taskId);
+        logEvent('task_failed_by_client', {
+          agentId: b.agentId,
+          taskId: frame.taskId,
+          errorCode: frame.error.code,
+          errorMessage: frame.error.message,
+        });
         break;
       }
       case 'pong':
@@ -299,7 +298,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   ws.on('close', () => {
     clearTimeout(helloTimeout);
     if (agentId) {
-      console.log(JSON.stringify({ event: 'client_disconnected', agentId, ts: new Date().toISOString() }));
+      logEvent('client_disconnected', { agentId });
       opts.registry.unregisterAgent(agentId, ws);
     }
   });


### PR DESCRIPTION
> Stacked on top of #45. Will rebase onto main once #45 lands.

## Summary
- Introduces `packages/server/src/log.ts` with a tiny `logEvent(event, fields)` helper that stamps `event`/`ts` and merges callers' fields. Keeps the existing console-based JSON-line format so existing log consumers (e.g. `fly logs | grep`) keep working; gives us one place to swap to a real logger later.
- Migrates the existing 6 log sites to the helper (`client_connected`, `client_disconnected`, 4× `client_rejected`, `task_unreachable`).
- Adds 5 new log points, all carrying `agentId` so they're greppable by agent:
  - `agent_request` — entry to `POST /agents/:id` (after `agentAuthMiddleware` passes)
  - `agent_request_rejected` — each reject path in `agent-auth.ts` (`reason`: `agent_not_connected` | `missing_bearer` | `bad_token_prefix` | `invalid_token` | `caller_not_authorized`)
  - `task_completed` / `task_failed_by_client` — when the connected ws client publishes a terminal frame

## Why
Today, `fly logs -a vicoop-bridge-server | grep <agentId>` only surfaces ws connection lifecycle events. There's no trace of an A2A HTTP request actually arriving, no trace of why agent-auth rejected one, and no trace of how the worker side reported the task back. That made the original \"task created with status: failed\" investigation harder than it needed to be.

## Test plan
- [ ] Send a message to a connected agent → expect `agent_request` then `task_completed` (or `task_failed_by_client`) with the same `agentId`.
- [ ] Send a message to an unknown agent id → expect `agent_request_rejected reason=agent_not_connected`.
- [ ] Send with no/invalid `Authorization` header → expect `agent_request_rejected` with `missing_bearer` / `bad_token_prefix` / `invalid_token` as appropriate.
- [ ] Send with a valid caller token that isn't in `allowed_callers` → expect `agent_request_rejected reason=caller_not_authorized` with `principalId`.
- [ ] Confirm existing `client_connected` / `client_disconnected` / `client_rejected` lines still appear with the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)