### PR TITLE
Auto-discover OpenClaw gateway port on connect failure

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import WebSocket, { WebSocketServer } from 'ws';
-import { createOpenclawBackend } from './openclaw.js';
+import { createOpenclawBackend, parseLsofListeningPorts } from './openclaw.js';
 import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
 
 interface ReqFrame {
@@ -606,6 +606,46 @@ test('gateway close mid-run fails in-flight task deterministically', async () =>
     assert.equal(fail!.error.code, 'gateway_closed');
   } finally {
     await fake.close();
+  }
+});
+
+test('parseLsofListeningPorts extracts loopback listen ports and ignores non-loopback', () => {
+  const sample = [
+    'COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME',
+    'openclaw 1234 me    7u  IPv4 0x1111111111111111      0t0  TCP 127.0.0.1:3000 (LISTEN)',
+    'openclaw 1234 me    8u  IPv6 0x2222222222222222      0t0  TCP [::1]:4000 (LISTEN)',
+    'openclaw 1234 me    9u  IPv4 0x3333333333333333      0t0  TCP *:18789 (LISTEN)',
+    'openclaw 1234 me   10u  IPv4 0x4444444444444444      0t0  TCP 192.168.1.10:5000 (LISTEN)',
+    'openclaw 1234 me   11u  IPv4 0x5555555555555555      0t0  TCP 127.0.0.1:6000->127.0.0.1:7000 (ESTABLISHED)',
+  ].join('\n');
+  const ports = parseLsofListeningPorts(sample).sort((a, b) => a - b);
+  assert.deepEqual(ports, [3000, 4000, 18789]);
+});
+
+test('parseLsofListeningPorts returns empty for empty / header-only input', () => {
+  assert.deepEqual(parseLsofListeningPorts(''), []);
+  assert.deepEqual(parseLsofListeningPorts('COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME'), []);
+});
+
+test('discovery fallback: when primary URL is dead and no candidates match, original error propagates', async () => {
+  // Use a deliberately bogus process name so `lsof -c <name>` matches nothing,
+  // forcing the fallback path to exit without candidates and surface the
+  // primary connect failure.
+  const prev = process.env.OPENCLAW_PROCESS_NAME;
+  process.env.OPENCLAW_PROCESS_NAME = '__vicoop_bridge_test_no_such_proc__';
+  try {
+    const backend = createOpenclawBackend({
+      url: 'ws://127.0.0.1:1', // port 1 refuses TCP immediately
+      handshakeTimeoutMs: 1500,
+    });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-disc', 'hi'), (f) => frames.push(f));
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'task must fail when no gateway is reachable');
+    assert.equal(fail!.error.code, 'gateway_closed');
+  } finally {
+    if (prev === undefined) delete process.env.OPENCLAW_PROCESS_NAME;
+    else process.env.OPENCLAW_PROCESS_NAME = prev;
   }
 });
 

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -7,6 +7,7 @@ import {
   createOpenclawBackend,
   listenersToGatewayUrls,
   parseLsofListeningPorts,
+  redactUrl,
 } from './openclaw.js';
 import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
 
@@ -649,6 +650,16 @@ test('listenersToGatewayUrls maps each bind family correctly', () => {
     'ws://127.0.0.1:6000/',
     'ws://[::1]:6000/',
   ]);
+});
+
+test('redactUrl strips query, hash, and userinfo but keeps protocol/host/port/path', () => {
+  assert.equal(
+    redactUrl('wss://user:pass@127.0.0.1:18789/gateway?token=secret#frag'),
+    'wss://127.0.0.1:18789/gateway',
+  );
+  assert.equal(redactUrl('ws://127.0.0.1:3000?token=abc'), 'ws://127.0.0.1:3000/');
+  assert.equal(redactUrl('ws://[::1]:4000/path'), 'ws://[::1]:4000/path');
+  assert.equal(redactUrl('not a url'), '<unparseable-url>');
 });
 
 test('listenersToGatewayUrls preserves template protocol / pathname / search', () => {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -672,6 +672,21 @@ test('listenersToGatewayUrls preserves template protocol / pathname / search', (
   ]);
 });
 
+test('listenersToGatewayUrls preserves template userinfo when credentials are embedded', () => {
+  assert.deepEqual(
+    listenersToGatewayUrls(
+      [{ host: '127.0.0.1', port: 3000 }],
+      'ws://user:pass@127.0.0.1:18789/',
+    ),
+    ['ws://user:pass@127.0.0.1:3000/'],
+  );
+  // Username-only (no password) is preserved without a trailing colon.
+  assert.deepEqual(
+    listenersToGatewayUrls([{ host: '[::1]', port: 3000 }], 'ws://user@127.0.0.1:18789/'),
+    ['ws://user@[::1]:3000/'],
+  );
+});
+
 test('discovery fallback: when primary URL is dead and no candidates match, original error propagates', async () => {
   const backend = createOpenclawBackend({
     url: 'ws://127.0.0.1:1', // port 1 refuses TCP immediately
@@ -749,6 +764,26 @@ test('discovery fallback: primary URL dead, discovered candidate completes hands
   } finally {
     await real.close();
   }
+});
+
+test('discovery runs when configured URL uses a wildcard bind address (0.0.0.0 / ::)', async () => {
+  // Users sometimes copy a local bind URL (ws://0.0.0.0:<port>) into config.
+  // Those should be treated as local for the purpose of allowing discovery.
+  let discoverCalls = 0;
+  const backend = createOpenclawBackend({
+    url: 'ws://0.0.0.0:1', // wildcard bind, port 1 refuses TCP
+    handshakeTimeoutMs: 1500,
+    discoverGatewayUrls: async () => {
+      discoverCalls++;
+      return [];
+    },
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-wild', 'hi'), (f) => frames.push(f));
+  assert.equal(discoverCalls, 1, 'discover must run for wildcard bind URLs');
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail!.error.code, 'gateway_closed');
 });
 
 test('discovery skipped when configured URL is remote (non-loopback)', async () => {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -687,6 +687,20 @@ test('listenersToGatewayUrls preserves template userinfo when credentials are em
   );
 });
 
+test('listenersToGatewayUrls keeps percent-encoded userinfo intact for reserved chars', () => {
+  // `@` in a username and `:` in a password must remain percent-encoded in
+  // the rebuilt candidate, otherwise the authority component parses wrong.
+  const tpl = 'ws://alice%40admin:p%3Ass@127.0.0.1:18789/gateway';
+  const [candidate] = listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }], tpl);
+  // Round-trip through URL to confirm the reserved chars decode back to the
+  // intended literals.
+  const parsed = new URL(candidate);
+  assert.equal(parsed.username, 'alice%40admin');
+  assert.equal(parsed.password, 'p%3Ass');
+  assert.equal(parsed.host, '127.0.0.1:3000');
+  assert.equal(parsed.pathname, '/gateway');
+});
+
 test('discovery fallback: when primary URL is dead and no candidates match, original error propagates', async () => {
   const backend = createOpenclawBackend({
     url: 'ws://127.0.0.1:1', // port 1 refuses TCP immediately
@@ -764,6 +778,30 @@ test('discovery fallback: primary URL dead, discovered candidate completes hands
   } finally {
     await real.close();
   }
+});
+
+test('discovery: when all candidates fail, the original primary connect error is surfaced', async () => {
+  // Candidates are all dead loopback ports. The final task.fail message must
+  // match the primary URL's connect error, not whichever candidate happened
+  // to fail last — the operator configured the primary URL, that's what
+  // diagnostics should point at.
+  const backend = createOpenclawBackend({
+    url: 'ws://127.0.0.1:1', // dead primary
+    handshakeTimeoutMs: 1500,
+    discoverGatewayUrls: async () => ['ws://127.0.0.1:2', 'ws://127.0.0.1:3'],
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-allfail', 'hi'), (f) => frames.push(f));
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail!.error.code, 'gateway_closed');
+  // Primary URL was 127.0.0.1:1. The error message from connect ECONNREFUSED
+  // mentions the port that failed. The surfaced error must reference port 1
+  // (the configured primary), not 3 (the last candidate).
+  assert.ok(
+    /127\.0\.0\.1:1\b/.test(fail!.error.message),
+    `expected primary URL error (port 1), got: ${fail!.error.message}`,
+  );
 });
 
 test('discovery errors are swallowed so the primary connect failure still propagates', async () => {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -3,7 +3,11 @@ import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import WebSocket, { WebSocketServer } from 'ws';
-import { createOpenclawBackend, parseLsofListeningPorts } from './openclaw.js';
+import {
+  createOpenclawBackend,
+  listenersToGatewayUrls,
+  parseLsofListeningPorts,
+} from './openclaw.js';
 import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
 
 interface ReqFrame {
@@ -609,7 +613,7 @@ test('gateway close mid-run fails in-flight task deterministically', async () =>
   }
 });
 
-test('parseLsofListeningPorts extracts loopback listen ports and ignores non-loopback', () => {
+test('parseLsofListeningPorts extracts loopback/wildcard listeners and preserves host', () => {
   const sample = [
     'COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME',
     'openclaw 1234 me    7u  IPv4 0x1111111111111111      0t0  TCP 127.0.0.1:3000 (LISTEN)',
@@ -618,8 +622,12 @@ test('parseLsofListeningPorts extracts loopback listen ports and ignores non-loo
     'openclaw 1234 me   10u  IPv4 0x4444444444444444      0t0  TCP 192.168.1.10:5000 (LISTEN)',
     'openclaw 1234 me   11u  IPv4 0x5555555555555555      0t0  TCP 127.0.0.1:6000->127.0.0.1:7000 (ESTABLISHED)',
   ].join('\n');
-  const ports = parseLsofListeningPorts(sample).sort((a, b) => a - b);
-  assert.deepEqual(ports, [3000, 4000, 18789]);
+  const listeners = parseLsofListeningPorts(sample).sort((a, b) => a.port - b.port);
+  assert.deepEqual(listeners, [
+    { host: '127.0.0.1', port: 3000 },
+    { host: '[::1]', port: 4000 },
+    { host: '*', port: 18789 },
+  ]);
 });
 
 test('parseLsofListeningPorts returns empty for empty / header-only input', () => {
@@ -627,26 +635,117 @@ test('parseLsofListeningPorts returns empty for empty / header-only input', () =
   assert.deepEqual(parseLsofListeningPorts('COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME'), []);
 });
 
+test('listenersToGatewayUrls expands wildcard binds to both IPv4 and IPv6 loopback', () => {
+  assert.deepEqual(listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }]), ['ws://127.0.0.1:3000']);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '[::1]', port: 4000 }]), ['ws://[::1]:4000']);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '*', port: 5000 }]), ['ws://127.0.0.1:5000']);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '0.0.0.0', port: 5000 }]), ['ws://127.0.0.1:5000']);
+  // IPv6 wildcard expands to both families so a v6-only-bound gateway still
+  // gets probed via [::1] and a dual-stack gateway is reachable via 127.0.0.1.
+  assert.deepEqual(listenersToGatewayUrls([{ host: '[::]', port: 6000 }]).sort(), [
+    'ws://127.0.0.1:6000',
+    'ws://[::1]:6000',
+  ]);
+});
+
 test('discovery fallback: when primary URL is dead and no candidates match, original error propagates', async () => {
-  // Use a deliberately bogus process name so `lsof -c <name>` matches nothing,
-  // forcing the fallback path to exit without candidates and surface the
-  // primary connect failure.
-  const prev = process.env.OPENCLAW_PROCESS_NAME;
-  process.env.OPENCLAW_PROCESS_NAME = '__vicoop_bridge_test_no_such_proc__';
+  const backend = createOpenclawBackend({
+    url: 'ws://127.0.0.1:1', // port 1 refuses TCP immediately
+    handshakeTimeoutMs: 1500,
+    discoverGatewayUrls: async () => [],
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-disc', 'hi'), (f) => frames.push(f));
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail, 'task must fail when no gateway is reachable');
+  assert.equal(fail!.error.code, 'gateway_closed');
+});
+
+test('discovery fallback: primary URL dead, discovered candidate completes handshake, task succeeds', async () => {
+  let runCounter = 0;
+  const real = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const runId = `run-disc-${++runCounter}`;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId, status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: `agent:main:ctx-td${runCounter}`,
+                seq: 1,
+                state: 'final',
+                message: { text: `discovered-${runCounter}` },
+              },
+            }),
+          );
+        });
+      }
+    },
+  });
+  let discoverCalls = 0;
   try {
     const backend = createOpenclawBackend({
-      url: 'ws://127.0.0.1:1', // port 1 refuses TCP immediately
+      url: 'ws://127.0.0.1:1', // dead
       handshakeTimeoutMs: 1500,
+      discoverGatewayUrls: async () => {
+        discoverCalls++;
+        return [real.url];
+      },
     });
     const frames: UpFrame[] = [];
-    await backend.handle(makeTask('t-disc', 'hi'), (f) => frames.push(f));
-    const fail = frames.find((f) => f.type === 'task.fail');
-    assert.ok(fail, 'task must fail when no gateway is reachable');
-    assert.equal(fail!.error.code, 'gateway_closed');
+    await backend.handle(makeTask('td1', 'hi'), (f) => frames.push(f));
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete, 'task must complete via discovered URL');
+    assert.equal(complete!.status.state, 'completed');
+    assert.equal(discoverCalls, 1, 'discover should be invoked once on primary failure');
+
+    // Cache check: close the socket to force a reconnect, then send a second
+    // task. ensureConnected() should try the discovered URL directly without
+    // invoking discover again.
+    const sock = await real.waitForConnection(0);
+    await real.closeSocket(sock);
+    // Let the client process the WebSocket close event.
+    await new Promise((r) => setTimeout(r, 20));
+    const frames2: UpFrame[] = [];
+    await backend.handle(makeTask('td2', 'hi2'), (f) => frames2.push(f));
+    const complete2 = frames2.find((f) => f.type === 'task.complete');
+    assert.ok(complete2, 'second task must complete on reconnect');
+    assert.equal(discoverCalls, 1, 'discover must not re-run when primary (discovered) URL works');
   } finally {
-    if (prev === undefined) delete process.env.OPENCLAW_PROCESS_NAME;
-    else process.env.OPENCLAW_PROCESS_NAME = prev;
+    await real.close();
   }
+});
+
+test('discovery skipped when configured URL is remote (non-loopback)', async () => {
+  let discoverCalls = 0;
+  const backend = createOpenclawBackend({
+    // Non-loopback host that cannot connect quickly. Using .invalid TLD keeps
+    // DNS resolution local/fast-failing on most platforms, but we also bound
+    // the handshake to avoid a long hang.
+    url: 'ws://gateway.invalid:9999',
+    handshakeTimeoutMs: 1500,
+    discoverGatewayUrls: async () => {
+      discoverCalls++;
+      return ['ws://127.0.0.1:18789'];
+    },
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-remote', 'hi'), (f) => frames.push(f));
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail, 'task must fail when remote gateway is unreachable');
+  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(discoverCalls, 0, 'discover must not be invoked for non-loopback URLs');
 });
 
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -635,16 +635,29 @@ test('parseLsofListeningPorts returns empty for empty / header-only input', () =
   assert.deepEqual(parseLsofListeningPorts('COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME'), []);
 });
 
-test('listenersToGatewayUrls expands wildcard binds to both IPv4 and IPv6 loopback', () => {
-  assert.deepEqual(listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }]), ['ws://127.0.0.1:3000']);
-  assert.deepEqual(listenersToGatewayUrls([{ host: '[::1]', port: 4000 }]), ['ws://[::1]:4000']);
-  assert.deepEqual(listenersToGatewayUrls([{ host: '*', port: 5000 }]), ['ws://127.0.0.1:5000']);
-  assert.deepEqual(listenersToGatewayUrls([{ host: '0.0.0.0', port: 5000 }]), ['ws://127.0.0.1:5000']);
-  // IPv6 wildcard expands to both families so a v6-only-bound gateway still
-  // gets probed via [::1] and a dual-stack gateway is reachable via 127.0.0.1.
-  assert.deepEqual(listenersToGatewayUrls([{ host: '[::]', port: 6000 }]).sort(), [
-    'ws://127.0.0.1:6000',
-    'ws://[::1]:6000',
+test('listenersToGatewayUrls maps each bind family correctly', () => {
+  const tpl = 'ws://127.0.0.1:18789/';
+  // IPv4 loopback and IPv4 wildcards stay on IPv4 loopback.
+  assert.deepEqual(listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }], tpl), ['ws://127.0.0.1:3000/']);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '*', port: 5000 }], tpl), ['ws://127.0.0.1:5000/']);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '0.0.0.0', port: 5000 }], tpl), ['ws://127.0.0.1:5000/']);
+  // IPv6 loopback stays on IPv6.
+  assert.deepEqual(listenersToGatewayUrls([{ host: '[::1]', port: 4000 }], tpl), ['ws://[::1]:4000/']);
+  // Only the IPv6 wildcard expands to both families — a dual-stack listener
+  // is reachable via either 127.0.0.1 or [::1].
+  assert.deepEqual(listenersToGatewayUrls([{ host: '[::]', port: 6000 }], tpl).sort(), [
+    'ws://127.0.0.1:6000/',
+    'ws://[::1]:6000/',
+  ]);
+});
+
+test('listenersToGatewayUrls preserves template protocol / pathname / search', () => {
+  const tpl = 'wss://127.0.0.1:18789/gateway?token=abc#frag';
+  assert.deepEqual(listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }], tpl), [
+    'wss://127.0.0.1:3000/gateway?token=abc#frag',
+  ]);
+  assert.deepEqual(listenersToGatewayUrls([{ host: '[::1]', port: 3000 }], tpl), [
+    'wss://[::1]:3000/gateway?token=abc#frag',
   ]);
 });
 

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -766,6 +766,27 @@ test('discovery fallback: primary URL dead, discovered candidate completes hands
   }
 });
 
+test('discovery errors are swallowed so the primary connect failure still propagates', async () => {
+  const backend = createOpenclawBackend({
+    url: 'ws://127.0.0.1:1', // dead
+    handshakeTimeoutMs: 1500,
+    discoverGatewayUrls: async () => {
+      throw new Error('boom: discovery exploded');
+    },
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-boom', 'hi'), (f) => frames.push(f));
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail, 'task must fail even when discovery itself throws');
+  assert.equal(fail!.error.code, 'gateway_closed');
+  // The message should be the original connect error, not "boom: discovery
+  // exploded" — discovery failures are best-effort and must not mask it.
+  assert.ok(
+    !/boom: discovery exploded/.test(fail!.error.message),
+    `expected primary connect error, got: ${fail!.error.message}`,
+  );
+});
+
 test('discovery runs when configured URL uses a wildcard bind address (0.0.0.0 / ::)', async () => {
   // Users sometimes copy a local bind URL (ws://0.0.0.0:<port>) into config.
   // Those should be treated as local for the purpose of allowing discovery.

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -692,8 +692,8 @@ test('listenersToGatewayUrls keeps percent-encoded userinfo intact for reserved 
   // the rebuilt candidate, otherwise the authority component parses wrong.
   const tpl = 'ws://alice%40admin:p%3Ass@127.0.0.1:18789/gateway';
   const [candidate] = listenersToGatewayUrls([{ host: '127.0.0.1', port: 3000 }], tpl);
-  // Round-trip through URL to confirm the reserved chars decode back to the
-  // intended literals.
+  // Round-trip through URL to confirm the encoded userinfo is preserved in
+  // URL.username / URL.password for these reserved characters.
   const parsed = new URL(candidate);
   assert.equal(parsed.username, 'alice%40admin');
   assert.equal(parsed.password, 'p%3Ass');

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -825,6 +825,27 @@ test('discovery errors are swallowed so the primary connect failure still propag
   );
 });
 
+test('discovery error logging is defensive against non-Error rejections', async () => {
+  // Reject with `null` — reading `.message` on it would throw TypeError and
+  // could mask the primary connect failure. errorMessage() must render it as
+  // a string without throwing, so the primary error still surfaces.
+  const backend = createOpenclawBackend({
+    url: 'ws://127.0.0.1:1',
+    handshakeTimeoutMs: 1500,
+    debug: true, // exercise the debug log path
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    discoverGatewayUrls: (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw null as unknown;
+    }) as () => Promise<string[]>,
+  });
+  const frames: UpFrame[] = [];
+  await backend.handle(makeTask('t-null', 'hi'), (f) => frames.push(f));
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.ok(fail, 'task must fail, not hang, on a null discovery rejection');
+  assert.equal(fail!.error.code, 'gateway_closed');
+});
+
 test('discovery runs when configured URL uses a wildcard bind address (0.0.0.0 / ::)', async () => {
   // Users sometimes copy a local bind URL (ws://0.0.0.0:<port>) into config.
   // Those should be treated as local for the purpose of allowing discovery.

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -285,7 +285,7 @@ class GatewayClient {
         client: {
           id: clientId,
           displayName: 'vicoop-bridge-client',
-          version: '0.0.0',
+          version: '0.2.0',
           platform: process.platform,
           mode: clientMode,
         },

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -348,6 +348,11 @@ export interface OpenclawBackendOptions {
   taskTimeoutMs?: number;
   /** Max time (ms) to wait for the gateway handshake to complete. Default 10000. */
   handshakeTimeoutMs?: number;
+  /**
+   * Override the default process-based port discovery used on connect
+   * failure. Returns candidate ws:// URLs to try. Primarily for testing.
+   */
+  discoverGatewayUrls?: () => Promise<string[]>;
 }
 
 const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
@@ -356,10 +361,17 @@ const DEFAULT_DISCOVERY_PROCESS_NAME = 'openclaw';
 const DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS = 3_000;
 const DISCOVERY_LSOF_TIMEOUT_MS = 2_000;
 
-// Parses `lsof -nP -iTCP -sTCP:LISTEN` output and returns listening TCP ports
-// bound to loopback or wildcard. Exported for unit testing.
-export function parseLsofListeningPorts(output: string): number[] {
-  const ports = new Set<number>();
+export interface DiscoveredListener {
+  host: string;
+  port: number;
+}
+
+// Parses `lsof -nP -iTCP -sTCP:LISTEN` output and returns listeners bound to
+// loopback or wildcard. The original bind host is preserved so callers can
+// distinguish IPv4/IPv6/wildcard binds. Exported for unit testing.
+export function parseLsofListeningPorts(output: string): DiscoveredListener[] {
+  const out: DiscoveredListener[] = [];
+  const seen = new Set<string>();
   for (const line of output.split('\n')) {
     // NAME column (last) for LISTEN rows looks like "127.0.0.1:3000 (LISTEN)"
     // or "*:18789 (LISTEN)" or "[::1]:3000 (LISTEN)".
@@ -374,9 +386,33 @@ export function parseLsofListeningPorts(output: string): number[] {
       host === '[::]';
     if (!loopback) continue;
     const port = Number(m[2]);
-    if (Number.isFinite(port) && port > 0) ports.add(port);
+    if (!Number.isFinite(port) || port <= 0) continue;
+    const key = `${host}:${port}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ host, port });
   }
-  return Array.from(ports);
+  return out;
+}
+
+// Expand a bind host into one or more ws:// URLs. Wildcard binds are expanded
+// to both IPv4 and IPv6 loopback so a dual-stack gateway is reachable either
+// way.
+export function listenersToGatewayUrls(listeners: DiscoveredListener[]): string[] {
+  const urls = new Set<string>();
+  for (const { host, port } of listeners) {
+    if (host === '127.0.0.1' || host === '0.0.0.0' || host === '*') {
+      urls.add(`ws://127.0.0.1:${port}`);
+    } else if (host === '[::1]') {
+      urls.add(`ws://[::1]:${port}`);
+    } else if (host === '[::]') {
+      // IPv6 wildcard — try both families; Node dual-stack defaults accept
+      // v4-mapped connections, but we probe v6 loopback too for safety.
+      urls.add(`ws://127.0.0.1:${port}`);
+      urls.add(`ws://[::1]:${port}`);
+    }
+  }
+  return Array.from(urls);
 }
 
 async function discoverLocalGatewayUrls(processName: string): Promise<string[]> {
@@ -387,7 +423,7 @@ async function discoverLocalGatewayUrls(processName: string): Promise<string[]> 
       ['-nP', '-iTCP', '-sTCP:LISTEN', '-c', processName],
       { timeout: DISCOVERY_LSOF_TIMEOUT_MS },
     );
-    return parseLsofListeningPorts(stdout).map((port) => `ws://127.0.0.1:${port}`);
+    return listenersToGatewayUrls(parseLsofListeningPorts(stdout));
   } catch {
     return [];
   }
@@ -400,6 +436,19 @@ function sameGatewayUrl(a: string, b: string): boolean {
     return ua.hostname === ub.hostname && ua.port === ub.port;
   } catch {
     return a === b;
+  }
+}
+
+// Discovery is only attempted when the configured URL targets the local
+// machine. A remote gateway that's temporarily unreachable must not silently
+// fall back to a local OpenClaw process — that would route tasks to the wrong
+// place.
+function isLoopbackUrl(u: string): boolean {
+  try {
+    const h = new URL(u).hostname; // WHATWG URL strips brackets for IPv6
+    return h === '127.0.0.1' || h === 'localhost' || h === '::1';
+  } catch {
+    return false;
   }
 }
 
@@ -490,6 +539,8 @@ export function createOpenclawBackend(
   let resolvedUrl = url;
   const discoveryProcessName =
     process.env.OPENCLAW_PROCESS_NAME ?? DEFAULT_DISCOVERY_PROCESS_NAME;
+  const discover =
+    opts.discoverGatewayUrls ?? (() => discoverLocalGatewayUrls(discoveryProcessName));
 
   async function connectAt(candidateUrl: string, hsTimeoutMs: number): Promise<GatewayClient> {
     const c = new GatewayClient(candidateUrl, token, hsTimeoutMs);
@@ -538,8 +589,11 @@ export function createOpenclawBackend(
       // Fall back to process-based discovery: locate any OpenClaw-named
       // process listening on loopback and try its port(s). Keeps the common
       // "gateway moved to a different port" case self-healing without any
-      // OpenClaw-side cooperation.
-      const candidates = await discoverLocalGatewayUrls(discoveryProcessName);
+      // OpenClaw-side cooperation. Skip when the configured URL is remote —
+      // a remote gateway outage must not silently reroute tasks to a local
+      // process.
+      if (!isLoopbackUrl(resolvedUrl)) throw primaryErr;
+      const candidates = await discover();
       const alternates = candidates.filter((u) => !sameGatewayUrl(u, resolvedUrl));
       if (alternates.length === 0) throw primaryErr;
       console.warn(

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -438,7 +438,10 @@ async function discoverLocalGatewayUrls(processName: string, template: string): 
   try {
     const { stdout } = await execFileP(
       'lsof',
-      ['-nP', '-iTCP', '-sTCP:LISTEN', '-c', processName],
+      // `-a` AND-s the selectors below; without it lsof OR-s them and returns
+      // every LISTEN socket on the host plus every file handle owned by the
+      // target process, which produces false candidates and extra latency.
+      ['-nP', '-a', '-iTCP', '-sTCP:LISTEN', '-c', processName],
       { timeout: DISCOVERY_LSOF_TIMEOUT_MS },
     );
     return listenersToGatewayUrls(parseLsofListeningPorts(stdout), template);

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -1,7 +1,11 @@
 import { createHash, generateKeyPairSync, randomUUID, sign as cryptoSign } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import WebSocket from 'ws';
 import type { Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+
+const execFileP = promisify(execFile);
 
 const GATEWAY_PROTOCOL_VERSION = 3;
 
@@ -348,6 +352,56 @@ export interface OpenclawBackendOptions {
 
 const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10 * 1000;
+const DEFAULT_DISCOVERY_PROCESS_NAME = 'openclaw';
+const DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS = 3_000;
+const DISCOVERY_LSOF_TIMEOUT_MS = 2_000;
+
+// Parses `lsof -nP -iTCP -sTCP:LISTEN` output and returns listening TCP ports
+// bound to loopback or wildcard. Exported for unit testing.
+export function parseLsofListeningPorts(output: string): number[] {
+  const ports = new Set<number>();
+  for (const line of output.split('\n')) {
+    // NAME column (last) for LISTEN rows looks like "127.0.0.1:3000 (LISTEN)"
+    // or "*:18789 (LISTEN)" or "[::1]:3000 (LISTEN)".
+    const m = line.match(/\s(\S+):(\d+)\s+\(LISTEN\)/);
+    if (!m) continue;
+    const host = m[1];
+    const loopback =
+      host === '127.0.0.1' ||
+      host === '[::1]' ||
+      host === '*' ||
+      host === '0.0.0.0' ||
+      host === '[::]';
+    if (!loopback) continue;
+    const port = Number(m[2]);
+    if (Number.isFinite(port) && port > 0) ports.add(port);
+  }
+  return Array.from(ports);
+}
+
+async function discoverLocalGatewayUrls(processName: string): Promise<string[]> {
+  if (process.platform === 'win32') return [];
+  try {
+    const { stdout } = await execFileP(
+      'lsof',
+      ['-nP', '-iTCP', '-sTCP:LISTEN', '-c', processName],
+      { timeout: DISCOVERY_LSOF_TIMEOUT_MS },
+    );
+    return parseLsofListeningPorts(stdout).map((port) => `ws://127.0.0.1:${port}`);
+  } catch {
+    return [];
+  }
+}
+
+function sameGatewayUrl(a: string, b: string): boolean {
+  try {
+    const ua = new URL(a);
+    const ub = new URL(b);
+    return ua.hostname === ub.hostname && ua.port === ub.port;
+  } catch {
+    return a === b;
+  }
+}
 
 function resolveTimeout(
   explicit: number | undefined,
@@ -433,51 +487,88 @@ export function createOpenclawBackend(
     }
   }
 
+  let resolvedUrl = url;
+  const discoveryProcessName =
+    process.env.OPENCLAW_PROCESS_NAME ?? DEFAULT_DISCOVERY_PROCESS_NAME;
+
+  async function connectAt(candidateUrl: string, hsTimeoutMs: number): Promise<GatewayClient> {
+    const c = new GatewayClient(candidateUrl, token, hsTimeoutMs);
+    await c.connect();
+    c.onEvent((evt) => {
+      if (evt.event !== 'chat') return;
+      const p = evt.payload as ChatEventPayload | undefined;
+      if (!p?.runId) return;
+      if (debug) {
+        console.log('[openclaw] chat event:', JSON.stringify(p).slice(0, 500));
+      }
+      const binding = runToTask.get(p.runId);
+      if (!binding) {
+        // Late or duplicate event for a run whose task already finalized:
+        // drop without buffering so memory stays bounded.
+        if (recentlyFinalizedRuns.has(p.runId)) return;
+        // Event arrived before handle() finished registering the runId.
+        // Buffer until the handler catches up and drains it. Evict the
+        // oldest unknown runId when the map grows past the cap so a
+        // noisy/misbehaving gateway can't inflate memory indefinitely.
+        let buf = pendingRunEvents.get(p.runId);
+        if (!buf) {
+          if (pendingRunEvents.size >= MAX_PENDING_RUN_KEYS) {
+            const oldest = pendingRunEvents.keys().next().value;
+            if (oldest !== undefined) pendingRunEvents.delete(oldest);
+          }
+          buf = [];
+          pendingRunEvents.set(p.runId, buf);
+        }
+        if (buf.length >= MAX_BUFFERED_EVENTS_PER_RUN) buf.shift();
+        buf.push(p);
+        return;
+      }
+      taskFinalizers.get(binding.taskId)?.(p);
+    });
+    c.onClose((err) => handleGatewayClose(c, err));
+    return c;
+  }
+
+  async function tryConnectWithDiscovery(): Promise<GatewayClient> {
+    try {
+      const c = await connectAt(resolvedUrl, handshakeTimeoutMs);
+      console.log(`[openclaw] connected ${resolvedUrl}`);
+      return c;
+    } catch (primaryErr) {
+      // Fall back to process-based discovery: locate any OpenClaw-named
+      // process listening on loopback and try its port(s). Keeps the common
+      // "gateway moved to a different port" case self-healing without any
+      // OpenClaw-side cooperation.
+      const candidates = await discoverLocalGatewayUrls(discoveryProcessName);
+      const alternates = candidates.filter((u) => !sameGatewayUrl(u, resolvedUrl));
+      if (alternates.length === 0) throw primaryErr;
+      console.warn(
+        `[openclaw] connect to ${resolvedUrl} failed (${(primaryErr as Error).message}); trying ${alternates.length} discovered candidate(s)`,
+      );
+      const probeTimeout = Math.min(handshakeTimeoutMs, DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS);
+      let lastErr: Error = primaryErr as Error;
+      for (const alt of alternates) {
+        try {
+          const c = await connectAt(alt, probeTimeout);
+          console.log(`[openclaw] auto-discovered gateway at ${alt} (was ${resolvedUrl})`);
+          resolvedUrl = alt;
+          return c;
+        } catch (err) {
+          lastErr = err as Error;
+        }
+      }
+      throw lastErr;
+    }
+  }
+
   async function ensureConnected(): Promise<GatewayClient> {
     if (current && current.state === 'ready') return current;
     if (connecting) return connecting;
-    const c = new GatewayClient(url, token, handshakeTimeoutMs);
     connecting = (async () => {
       try {
-        await c.connect();
-        console.log(`[openclaw] connected ${url}`);
-        c.onEvent((evt) => {
-          if (evt.event !== 'chat') return;
-          const p = evt.payload as ChatEventPayload | undefined;
-          if (!p?.runId) return;
-          if (debug) {
-            console.log('[openclaw] chat event:', JSON.stringify(p).slice(0, 500));
-          }
-          const binding = runToTask.get(p.runId);
-          if (!binding) {
-            // Late or duplicate event for a run whose task already finalized:
-            // drop without buffering so memory stays bounded.
-            if (recentlyFinalizedRuns.has(p.runId)) return;
-            // Event arrived before handle() finished registering the runId.
-            // Buffer until the handler catches up and drains it. Evict the
-            // oldest unknown runId when the map grows past the cap so a
-            // noisy/misbehaving gateway can't inflate memory indefinitely.
-            let buf = pendingRunEvents.get(p.runId);
-            if (!buf) {
-              if (pendingRunEvents.size >= MAX_PENDING_RUN_KEYS) {
-                const oldest = pendingRunEvents.keys().next().value;
-                if (oldest !== undefined) pendingRunEvents.delete(oldest);
-              }
-              buf = [];
-              pendingRunEvents.set(p.runId, buf);
-            }
-            if (buf.length >= MAX_BUFFERED_EVENTS_PER_RUN) buf.shift();
-            buf.push(p);
-            return;
-          }
-          taskFinalizers.get(binding.taskId)?.(p);
-        });
-        c.onClose((err) => handleGatewayClose(c, err));
+        const c = await tryConnectWithDiscovery();
         current = c;
         return c;
-      } catch (err) {
-        // connect() itself failed: nothing is registered yet, just propagate.
-        throw err;
       } finally {
         connecting = null;
       }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -400,8 +400,15 @@ function buildCandidateUrl(template: URL, host: '127.0.0.1' | '::1', port: numbe
   // and hash are all preserved while only host+port get swapped. Preserving
   // user-info matters when the configured URL carries credentials
   // (ws://user:pass@host:port) — dropping them would make the retry fail even
-  // on the right port. Avoids WHATWG URL hostname-setter quirks when swapping
-  // between address families.
+  // on the right port.
+  //
+  // Why not just clone the URL and set `.hostname`? Node's WHATWG URL setter
+  // silently refuses to swap an IPv4 hostname for `::1` (and vice versa),
+  // leaving the original host in place — so that approach would quietly lose
+  // the v6 candidate. Reconstructing via string interpolation is safe
+  // because `template.username` / `template.password` are exposed in their
+  // already-percent-encoded form by the URL parser, so special characters
+  // (e.g. `@`, `:`) in credentials round-trip correctly.
   const h = host === '::1' ? '[::1]' : host;
   const userInfo =
     template.username !== '' || template.password !== ''
@@ -458,10 +465,19 @@ async function discoverLocalGatewayUrls(processName: string, template: string): 
 }
 
 function sameGatewayUrl(a: string, b: string): boolean {
+  // Used to avoid re-trying the already-failed primary URL. Compare enough
+  // components that a candidate which only differs in protocol or pathname
+  // (e.g. `wss://` vs `ws://`, or a different WebSocket path) is still tried,
+  // since those changes can be the exact reason the primary failed.
   try {
     const ua = new URL(a);
     const ub = new URL(b);
-    return ua.hostname === ub.hostname && ua.port === ub.port;
+    return (
+      ua.protocol === ub.protocol &&
+      ua.hostname === ub.hostname &&
+      ua.port === ub.port &&
+      ua.pathname === ub.pathname
+    );
   } catch {
     return a === b;
   }
@@ -659,7 +675,6 @@ export function createOpenclawBackend(
         `[openclaw] connect to ${redactUrl(resolvedUrl)} failed (${(primaryErr as Error).message}); trying ${alternates.length} discovered candidate(s)`,
       );
       const probeTimeout = Math.min(handshakeTimeoutMs, DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS);
-      let lastErr: Error = primaryErr as Error;
       for (const alt of alternates) {
         try {
           const c = await connectAt(alt, probeTimeout);
@@ -668,11 +683,19 @@ export function createOpenclawBackend(
           );
           resolvedUrl = alt;
           return c;
-        } catch (err) {
-          lastErr = err as Error;
+        } catch (candidateErr) {
+          if (debug) {
+            console.warn(
+              `[openclaw] discovered candidate ${redactUrl(alt)} failed: ${(candidateErr as Error).message}`,
+            );
+          }
         }
       }
-      throw lastErr;
+      // Surface the original connect failure instead of the last candidate's
+      // error — that's what the operator actually configured, and the
+      // candidate errors are downstream noise whose identity depends on scan
+      // order and false positives.
+      throw primaryErr;
     }
   }
 

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -489,6 +489,20 @@ function sameGatewayUrl(a: string, b: string): boolean {
   }
 }
 
+// Defensive error-to-string: catch clauses receive `unknown`, so a rejection
+// with `null`, a plain object, or a primitive would crash the logging path
+// that tries to read `.message`. Always return a string suitable for logs
+// without throwing.
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable>';
+  }
+}
+
 // Strip query, hash, and user-info from a gateway URL before logging so
 // credentials embedded in a token query param (or userinfo) don't leak into
 // stdout. Keeps protocol + host + port + pathname, which is what operators
@@ -672,13 +686,13 @@ export function createOpenclawBackend(
         candidates = await discover();
       } catch (discoverErr) {
         if (debug) {
-          console.warn(`[openclaw] discover() threw, treating as empty: ${(discoverErr as Error).message}`);
+          console.warn(`[openclaw] discover() threw, treating as empty: ${errorMessage(discoverErr)}`);
         }
       }
       const alternates = candidates.filter((u) => !sameGatewayUrl(u, resolvedUrl));
       if (alternates.length === 0) throw primaryErr;
       console.warn(
-        `[openclaw] connect to ${redactUrl(resolvedUrl)} failed (${(primaryErr as Error).message}); trying ${alternates.length} discovered candidate(s)`,
+        `[openclaw] connect to ${redactUrl(resolvedUrl)} failed (${errorMessage(primaryErr)}); trying ${alternates.length} discovered candidate(s)`,
       );
       const probeTimeout = Math.min(handshakeTimeoutMs, DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS);
       for (const alt of alternates) {
@@ -692,7 +706,7 @@ export function createOpenclawBackend(
         } catch (candidateErr) {
           if (debug) {
             console.warn(
-              `[openclaw] discovered candidate ${redactUrl(alt)} failed: ${(candidateErr as Error).message}`,
+              `[openclaw] discovered candidate ${redactUrl(alt)} failed: ${errorMessage(candidateErr)}`,
             );
           }
         }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -457,6 +457,19 @@ function sameGatewayUrl(a: string, b: string): boolean {
   }
 }
 
+// Strip query, hash, and user-info from a gateway URL before logging so
+// credentials embedded in a token query param (or userinfo) don't leak into
+// stdout. Keeps protocol + host + port + pathname, which is what operators
+// actually need to diagnose a connect failure. Exported for unit testing.
+export function redactUrl(u: string): string {
+  try {
+    const p = new URL(u);
+    return `${p.protocol}//${p.host}${p.pathname}`;
+  } catch {
+    return '<unparseable-url>';
+  }
+}
+
 // Discovery is only attempted when the configured URL targets the local
 // machine. A remote gateway that's temporarily unreachable must not silently
 // fall back to a local OpenClaw process — that would route tasks to the wrong
@@ -602,7 +615,7 @@ export function createOpenclawBackend(
   async function tryConnectWithDiscovery(): Promise<GatewayClient> {
     try {
       const c = await connectAt(resolvedUrl, handshakeTimeoutMs);
-      console.log(`[openclaw] connected ${resolvedUrl}`);
+      console.log(`[openclaw] connected ${redactUrl(resolvedUrl)}`);
       return c;
     } catch (primaryErr) {
       // Fall back to process-based discovery: locate any OpenClaw-named
@@ -616,14 +629,16 @@ export function createOpenclawBackend(
       const alternates = candidates.filter((u) => !sameGatewayUrl(u, resolvedUrl));
       if (alternates.length === 0) throw primaryErr;
       console.warn(
-        `[openclaw] connect to ${resolvedUrl} failed (${(primaryErr as Error).message}); trying ${alternates.length} discovered candidate(s)`,
+        `[openclaw] connect to ${redactUrl(resolvedUrl)} failed (${(primaryErr as Error).message}); trying ${alternates.length} discovered candidate(s)`,
       );
       const probeTimeout = Math.min(handshakeTimeoutMs, DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS);
       let lastErr: Error = primaryErr as Error;
       for (const alt of alternates) {
         try {
           const c = await connectAt(alt, probeTimeout);
-          console.log(`[openclaw] auto-discovered gateway at ${alt} (was ${resolvedUrl})`);
+          console.log(
+            `[openclaw] auto-discovered gateway at ${redactUrl(alt)} (was ${redactUrl(resolvedUrl)})`,
+          );
           resolvedUrl = alt;
           return c;
         } catch (err) {

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -642,7 +642,17 @@ export function createOpenclawBackend(
       // a remote gateway outage must not silently reroute tasks to a local
       // process.
       if (!isLoopbackUrl(resolvedUrl)) throw primaryErr;
-      const candidates = await discover();
+      // Discovery is best-effort. An injected discoverGatewayUrls that throws
+      // must not mask the original connect error, so treat any rejection as
+      // "no candidates" and fall through to surface the primary failure.
+      let candidates: string[] = [];
+      try {
+        candidates = await discover();
+      } catch (discoverErr) {
+        if (debug) {
+          console.warn(`[openclaw] discover() threw, treating as empty: ${(discoverErr as Error).message}`);
+        }
+      }
       const alternates = candidates.filter((u) => !sameGatewayUrl(u, resolvedUrl));
       if (alternates.length === 0) throw primaryErr;
       console.warn(

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -396,11 +396,18 @@ export function parseLsofListeningPorts(output: string): DiscoveredListener[] {
 }
 
 function buildCandidateUrl(template: URL, host: '127.0.0.1' | '::1', port: number): string {
-  // Reconstruct from parts so protocol (ws/wss), pathname, search, and hash
-  // are all preserved while only host+port get swapped. Avoids WHATWG URL
-  // hostname-setter quirks when swapping between address families.
+  // Reconstruct from parts so protocol (ws/wss), user-info, pathname, search,
+  // and hash are all preserved while only host+port get swapped. Preserving
+  // user-info matters when the configured URL carries credentials
+  // (ws://user:pass@host:port) — dropping them would make the retry fail even
+  // on the right port. Avoids WHATWG URL hostname-setter quirks when swapping
+  // between address families.
   const h = host === '::1' ? '[::1]' : host;
-  return `${template.protocol}//${h}:${port}${template.pathname}${template.search}${template.hash}`;
+  const userInfo =
+    template.username !== '' || template.password !== ''
+      ? `${template.username}${template.password !== '' ? `:${template.password}` : ''}@`
+      : '';
+  return `${template.protocol}//${userInfo}${h}:${port}${template.pathname}${template.search}${template.hash}`;
 }
 
 // Expand a bind host + port into ws:// candidate URLs derived from `template`
@@ -476,11 +483,18 @@ export function redactUrl(u: string): string {
 // Discovery is only attempted when the configured URL targets the local
 // machine. A remote gateway that's temporarily unreachable must not silently
 // fall back to a local OpenClaw process — that would route tasks to the wrong
-// place.
+// place. Wildcard binds (`0.0.0.0`, `::`) count as local too, since users may
+// copy a local bind address like `ws://0.0.0.0:<port>` into config.
 function isLoopbackUrl(u: string): boolean {
   try {
     const h = new URL(u).hostname; // WHATWG URL strips brackets for IPv6
-    return h === '127.0.0.1' || h === 'localhost' || h === '::1';
+    return (
+      h === '127.0.0.1' ||
+      h === '0.0.0.0' ||
+      h === 'localhost' ||
+      h === '::1' ||
+      h === '::'
+    );
   } catch {
     return false;
   }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -350,7 +350,8 @@ export interface OpenclawBackendOptions {
   handshakeTimeoutMs?: number;
   /**
    * Override the default process-based port discovery used on connect
-   * failure. Returns candidate ws:// URLs to try. Primarily for testing.
+   * failure. Returns candidate WebSocket URLs (ws:// or wss://) to try.
+   * Primarily for testing.
    */
   discoverGatewayUrls?: () => Promise<string[]>;
 }
@@ -465,10 +466,12 @@ async function discoverLocalGatewayUrls(processName: string, template: string): 
 }
 
 function sameGatewayUrl(a: string, b: string): boolean {
-  // Used to avoid re-trying the already-failed primary URL. Compare enough
-  // components that a candidate which only differs in protocol or pathname
-  // (e.g. `wss://` vs `ws://`, or a different WebSocket path) is still tried,
-  // since those changes can be the exact reason the primary failed.
+  // Used to avoid re-trying the already-failed primary URL. Err on the side
+  // of "different → try it": if any of protocol, host, port, pathname,
+  // search, or user-info differs, treat the candidate as distinct. That way
+  // an injected discover returning the same host/port with (say) a different
+  // token query or path still gets attempted — the primary may have failed
+  // precisely because of that component.
   try {
     const ua = new URL(a);
     const ub = new URL(b);
@@ -476,7 +479,10 @@ function sameGatewayUrl(a: string, b: string): boolean {
       ua.protocol === ub.protocol &&
       ua.hostname === ub.hostname &&
       ua.port === ub.port &&
-      ua.pathname === ub.pathname
+      ua.pathname === ub.pathname &&
+      ua.search === ub.search &&
+      ua.username === ub.username &&
+      ua.password === ub.password
     );
   } catch {
     return a === b;

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -395,27 +395,45 @@ export function parseLsofListeningPorts(output: string): DiscoveredListener[] {
   return out;
 }
 
-// Expand a bind host into one or more ws:// URLs. Wildcard binds are expanded
-// to both IPv4 and IPv6 loopback so a dual-stack gateway is reachable either
-// way.
-export function listenersToGatewayUrls(listeners: DiscoveredListener[]): string[] {
+function buildCandidateUrl(template: URL, host: '127.0.0.1' | '::1', port: number): string {
+  // Reconstruct from parts so protocol (ws/wss), pathname, search, and hash
+  // are all preserved while only host+port get swapped. Avoids WHATWG URL
+  // hostname-setter quirks when swapping between address families.
+  const h = host === '::1' ? '[::1]' : host;
+  return `${template.protocol}//${h}:${port}${template.pathname}${template.search}${template.hash}`;
+}
+
+// Expand a bind host + port into ws:// candidate URLs derived from `template`
+// (preserves scheme/path/search/hash — only host+port change). IPv4 binds
+// (`127.0.0.1`, `0.0.0.0`, `*`) map to IPv4 loopback; `[::1]` stays on IPv6
+// loopback. The IPv6 wildcard (`[::]`) is the only bind that expands to both
+// families, since a dual-stack listener is reachable via either 127.0.0.1 or
+// [::1] depending on how the client connects.
+export function listenersToGatewayUrls(
+  listeners: DiscoveredListener[],
+  template: string,
+): string[] {
+  let tpl: URL;
+  try {
+    tpl = new URL(template);
+  } catch {
+    return [];
+  }
   const urls = new Set<string>();
   for (const { host, port } of listeners) {
     if (host === '127.0.0.1' || host === '0.0.0.0' || host === '*') {
-      urls.add(`ws://127.0.0.1:${port}`);
+      urls.add(buildCandidateUrl(tpl, '127.0.0.1', port));
     } else if (host === '[::1]') {
-      urls.add(`ws://[::1]:${port}`);
+      urls.add(buildCandidateUrl(tpl, '::1', port));
     } else if (host === '[::]') {
-      // IPv6 wildcard — try both families; Node dual-stack defaults accept
-      // v4-mapped connections, but we probe v6 loopback too for safety.
-      urls.add(`ws://127.0.0.1:${port}`);
-      urls.add(`ws://[::1]:${port}`);
+      urls.add(buildCandidateUrl(tpl, '127.0.0.1', port));
+      urls.add(buildCandidateUrl(tpl, '::1', port));
     }
   }
   return Array.from(urls);
 }
 
-async function discoverLocalGatewayUrls(processName: string): Promise<string[]> {
+async function discoverLocalGatewayUrls(processName: string, template: string): Promise<string[]> {
   if (process.platform === 'win32') return [];
   try {
     const { stdout } = await execFileP(
@@ -423,7 +441,7 @@ async function discoverLocalGatewayUrls(processName: string): Promise<string[]> 
       ['-nP', '-iTCP', '-sTCP:LISTEN', '-c', processName],
       { timeout: DISCOVERY_LSOF_TIMEOUT_MS },
     );
-    return listenersToGatewayUrls(parseLsofListeningPorts(stdout));
+    return listenersToGatewayUrls(parseLsofListeningPorts(stdout), template);
   } catch {
     return [];
   }
@@ -540,7 +558,8 @@ export function createOpenclawBackend(
   const discoveryProcessName =
     process.env.OPENCLAW_PROCESS_NAME ?? DEFAULT_DISCOVERY_PROCESS_NAME;
   const discover =
-    opts.discoverGatewayUrls ?? (() => discoverLocalGatewayUrls(discoveryProcessName));
+    opts.discoverGatewayUrls ??
+    (() => discoverLocalGatewayUrls(discoveryProcessName, resolvedUrl));
 
   async function connectAt(candidateUrl: string, hsTimeoutMs: number): Promise<GatewayClient> {
     const c = new GatewayClient(candidateUrl, token, hsTimeoutMs);


### PR DESCRIPTION
## Summary
- When the configured OpenClaw gateway URL fails to connect, fall back to process-based port discovery (`lsof -c openclaw`) and retry each loopback listen port with a short handshake timeout. First candidate that completes the challenge becomes the resolved URL and is cached for subsequent reconnects.
- Self-heals the common "gateway moved to a different port" case without requiring any OpenClaw-side cooperation.
- Client-side change only. Core implementation lives in `packages/client/src/backends/openclaw.ts` (plus matching tests in `openclaw.test.ts`). The `Backend` interface, CLI, and other backends are untouched.
- **Version bump**: `packages/client/package.json` and the OpenClaw handshake client-identity version are both bumped `0.0.0 → 0.2.0` in preparation for the `client-v0.2.0` release tag after merge.

## Behavior
- Happy path is unchanged: `opts.url` → `OPENCLAW_GATEWAY_URL` → `ws://127.0.0.1:18789` is tried first with the configured `handshakeTimeoutMs`.
- On failure (loopback URLs only): run `lsof -nP -a -iTCP -sTCP:LISTEN -c <name>` (2s timeout), parse loopback/wildcard listen ports, retry each with `min(handshakeTimeoutMs, 3s)`. Non-loopback URLs skip discovery so a remote gateway outage cannot reroute tasks to a local process. Windows is skipped; missing `lsof` or a throwing injected discovery is treated as "no candidates".
- Process name defaults to `openclaw`, overridable via `OPENCLAW_PROCESS_NAME`.
- On success, the discovered URL replaces the resolved URL for future reconnects within the same backend instance.
- Candidate URL construction preserves the configured template's protocol (ws/wss), pathname, query, hash, and user-info — only host+port are swapped.
- When all candidates fail, the original primary connect error is surfaced (not the last candidate's), so diagnostics point at what the operator actually configured.
- Logs use `redactUrl()` so credentials embedded in query strings or user-info never reach stdout.

## Test plan
- [x] 25 unit tests covering: `parseLsofListeningPorts`, `listenersToGatewayUrls` (template preservation, userinfo round-trip with encoded reserved chars), `redactUrl`, discovery happy path + `resolvedUrl` caching, all-candidates-fail surfacing primary error, discovery errors swallowed, remote URL skips discovery, wildcard-bind URL triggers discovery
- [x] `pnpm typecheck` clean
- [ ] manual: start OpenClaw on a non-default port, confirm client auto-discovers and connects (end-to-end path requires a real OpenClaw process for `lsof` to find)

🤖 Generated with [Claude Code](https://claude.com/claude-code)