### PR TITLE
Support non-text A2A parts in openclaw backend

### DIFF
--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -1,16 +1,16 @@
 {
   "name": "openclaw",
-  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted.",
+  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text and inline image attachments.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": { "streaming": false },
-  "defaultInputModes": ["text/plain"],
+  "defaultInputModes": ["text/plain", "image/png", "image/jpeg", "image/gif", "image/webp"],
   "defaultOutputModes": ["text/plain"],
   "skills": [
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text.",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image parts (file.bytes with image/* mimeType).",
       "tags": ["chat", "assistant"]
     }
   ]

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -6,6 +6,7 @@ import WebSocket, { WebSocketServer } from 'ws';
 import {
   createOpenclawBackend,
   listenersToGatewayUrls,
+  mapPartsToChatInput,
   parseLsofListeningPorts,
   redactUrl,
 } from './openclaw.js';
@@ -809,6 +810,213 @@ test('gateway close mid-run fails in-flight task deterministically', async () =>
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail, 'task must fail after gateway close');
     assert.equal(fail!.error.code, 'gateway_closed');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('mapPartsToChatInput: text-only parts are joined with newline and carry no attachments', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'text', text: 'first line' },
+    { kind: 'text', text: 'second line' },
+  ]);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.input.message, 'first line\nsecond line');
+  assert.deepEqual(result.input.attachments, []);
+});
+
+test('mapPartsToChatInput: file part with image bytes maps to an OpenClaw image attachment', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'text', text: 'describe this' },
+    {
+      kind: 'file',
+      file: { name: 'cat.png', mimeType: 'image/png', bytes: 'AAAA' },
+    },
+  ]);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.input.message, 'describe this');
+  assert.deepEqual(result.input.attachments, [
+    { type: 'image', mimeType: 'image/png', fileName: 'cat.png', content: 'AAAA' },
+  ]);
+});
+
+test('mapPartsToChatInput: image file without a name omits fileName cleanly', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'file', file: { mimeType: 'image/jpeg', bytes: 'BBBB' } },
+  ]);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.input.attachments.length, 1);
+  assert.equal(result.input.attachments[0].fileName, undefined);
+});
+
+test('mapPartsToChatInput: file.uri is rejected explicitly instead of silently dropped', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'file', file: { uri: 'https://example.com/doc.pdf', mimeType: 'application/pdf' } },
+  ]);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, 'unsupported_file_uri');
+  assert.match(result.error.message, /part\[0\]/);
+});
+
+test('mapPartsToChatInput: non-image file mime is rejected', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'file', file: { mimeType: 'application/pdf', bytes: 'CCCC' } },
+  ]);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, 'unsupported_file_mime');
+  assert.match(result.error.message, /application\/pdf/);
+});
+
+test('mapPartsToChatInput: missing both bytes and uri is rejected', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'file', file: { mimeType: 'image/png' } },
+  ]);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, 'invalid_file_part');
+});
+
+test('mapPartsToChatInput: data part is rejected since OpenClaw has no structured input surface', () => {
+  const result = mapPartsToChatInput([
+    { kind: 'text', text: 'context follows' },
+    { kind: 'data', data: { foo: 'bar', n: 42 } },
+  ]);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.error.code, 'unsupported_data_part');
+  // Error should identify the offending part index (index 1 here).
+  assert.match(result.error.message, /part\[1\]/);
+});
+
+test('handle(): image file part is forwarded to chat.send as attachments', async () => {
+  const observedParams: unknown[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        observedParams.push(req.params);
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-img', status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId: 'run-img',
+                sessionKey: 'agent:main:ctx-t1',
+                seq: 1,
+                state: 'final',
+                message: { text: 'saw a cat' },
+              },
+            }),
+          );
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    const task: TaskAssignFrame = {
+      type: 'task.assign',
+      taskId: 't1',
+      contextId: 'ctx-t1',
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [
+          { kind: 'text', text: 'what is in this image?' },
+          { kind: 'file', file: { name: 'cat.png', mimeType: 'image/png', bytes: 'AAAA' } },
+        ],
+      },
+    };
+    await backend.handle(task, (f) => frames.push(f), NEVER);
+    assert.equal(observedParams.length, 1, 'chat.send should have been issued exactly once');
+    const params = observedParams[0] as { message: string; attachments: unknown };
+    assert.equal(params.message, 'what is in this image?');
+    assert.deepEqual(params.attachments, [
+      { type: 'image', mimeType: 'image/png', fileName: 'cat.png', content: 'AAAA' },
+    ]);
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.equal(complete!.status.state, 'completed');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('handle(): data part fails fast with unsupported_data_part without touching the gateway', async () => {
+  let chatSendSeen = false;
+  const fake = await createFakeGateway({
+    onRequest: (_sock, req) => {
+      if (req.method === 'chat.send') chatSendSeen = true;
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    const task: TaskAssignFrame = {
+      type: 'task.assign',
+      taskId: 't1',
+      contextId: 'ctx-t1',
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [
+          { kind: 'text', text: 'context' },
+          { kind: 'data', data: { hello: 'world' } },
+        ],
+      },
+    };
+    await backend.handle(task, (f) => frames.push(f), NEVER);
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail, 'unsupported data part must fail the task');
+    assert.equal(fail!.error.code, 'unsupported_data_part');
+    // Give any racing chat.send a chance to land so the assertion is meaningful.
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(chatSendSeen, false, 'gateway must not see chat.send for malformed input');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('handle(): file.uri fails fast with unsupported_file_uri', async () => {
+  let chatSendSeen = false;
+  const fake = await createFakeGateway({
+    onRequest: (_sock, req) => {
+      if (req.method === 'chat.send') chatSendSeen = true;
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    const task: TaskAssignFrame = {
+      type: 'task.assign',
+      taskId: 't1',
+      contextId: 'ctx-t1',
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [{ kind: 'file', file: { uri: 'https://example.com/x.png', mimeType: 'image/png' } }],
+      },
+    };
+    await backend.handle(task, (f) => frames.push(f), NEVER);
+    const fail = frames.find((f) => f.type === 'task.fail');
+    assert.ok(fail);
+    assert.equal(fail!.error.code, 'unsupported_file_uri');
+    await new Promise((r) => setTimeout(r, 30));
+    assert.equal(chatSendSeen, false);
   } finally {
     await fake.close();
   }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -316,6 +316,104 @@ class GatewayClient {
   }
 }
 
+// Map A2A message parts to OpenClaw's `chat.send` input shape
+// (`message` + `attachments`). The gateway accepts image attachments via
+// `{ type, mimeType, fileName, content }` where `content` is a base64
+// string; non-image MIME types are dropped with a warning inside OpenClaw,
+// and there is no native surface for structured data or remote URIs.
+//
+// Rather than silently drop non-text parts (the prior behavior), we reject
+// anything we can't represent so callers see a specific error code
+// instead of a lossy request.
+interface OpenclawChatInput {
+  message: string;
+  attachments: Array<{
+    type: 'image';
+    mimeType: string;
+    fileName?: string;
+    content: string;
+  }>;
+}
+
+interface PartMappingError {
+  code: string;
+  message: string;
+}
+
+function isImageMime(mime: string | undefined): mime is string {
+  return typeof mime === 'string' && mime.toLowerCase().startsWith('image/');
+}
+
+// Exported for unit testing; shape matches what `handle()` feeds into
+// `chat.send` (minus `sessionKey` / `idempotencyKey` / `thinking`).
+export function mapPartsToChatInput(
+  parts: Part[],
+): { ok: true; input: OpenclawChatInput } | { ok: false; error: PartMappingError } {
+  const textBits: string[] = [];
+  const attachments: OpenclawChatInput['attachments'] = [];
+  for (const [idx, p] of parts.entries()) {
+    if (p.kind === 'text') {
+      textBits.push(p.text);
+      continue;
+    }
+    if (p.kind === 'file') {
+      const f = p.file;
+      // uri requires fetching and may need caller auth — out of scope for
+      // this backend. Reject explicitly so callers know to inline bytes.
+      if (f.uri !== undefined) {
+        return {
+          ok: false,
+          error: {
+            code: 'unsupported_file_uri',
+            message: `part[${idx}]: file.uri is not supported by the openclaw backend; inline the file as base64 bytes instead`,
+          },
+        };
+      }
+      if (f.bytes === undefined) {
+        return {
+          ok: false,
+          error: {
+            code: 'invalid_file_part',
+            message: `part[${idx}]: file part must carry either bytes or uri`,
+          },
+        };
+      }
+      if (!isImageMime(f.mimeType)) {
+        return {
+          ok: false,
+          error: {
+            code: 'unsupported_file_mime',
+            message: `part[${idx}]: only image/* mimeTypes are supported by the openclaw backend (got ${f.mimeType ?? 'unset'})`,
+          },
+        };
+      }
+      attachments.push({
+        type: 'image',
+        mimeType: f.mimeType,
+        ...(f.name !== undefined ? { fileName: f.name } : {}),
+        content: f.bytes,
+      });
+      continue;
+    }
+    if (p.kind === 'data') {
+      return {
+        ok: false,
+        error: {
+          code: 'unsupported_data_part',
+          message: `part[${idx}]: data parts are not supported by the openclaw backend; serialize to a text part if the agent should see structured input`,
+        },
+      };
+    }
+  }
+  return {
+    ok: true,
+    input: {
+      message: textBits.join('\n').trim(),
+      attachments,
+    },
+  };
+}
+
 function extractFinalText(message: unknown): string {
   if (!message || typeof message !== 'object') return '';
   const m = message as Record<string, unknown>;
@@ -749,6 +847,19 @@ export function createOpenclawBackend(
         return;
       }
 
+      // Validate and normalize A2A parts BEFORE touching the gateway so
+      // malformed input fails fast without opening a WS or consuming a
+      // session slot.
+      const mapped = mapPartsToChatInput(task.message.parts);
+      if (!mapped.ok) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: mapped.error,
+        });
+        return;
+      }
+
       let gw: GatewayClient;
       try {
         gw = await ensureConnected();
@@ -761,10 +872,7 @@ export function createOpenclawBackend(
         return;
       }
       const sessionKey = `${sessionPrefix}:${agent}:${task.contextId}`;
-      const text = task.message.parts
-        .map((p) => (p.kind === 'text' ? p.text : ''))
-        .join('\n')
-        .trim();
+      const { message: text, attachments } = mapped.input;
 
       emit({
         type: 'task.status',
@@ -853,6 +961,9 @@ export function createOpenclawBackend(
             sessionKey,
             message: text,
             idempotencyKey: task.taskId,
+            // Only include `attachments` when non-empty so the text-only
+            // happy path is unchanged on the wire.
+            ...(attachments.length > 0 ? { attachments } : {}),
             ...(thinking ? { thinking } : {}),
           });
         } catch (err) {


### PR DESCRIPTION
## Summary

Replace the silent-drop of non-text A2A message parts with an explicit mapping: image `FilePart`s become OpenClaw attachments, every other non-text part becomes a specific `task.fail`.

Fixes #37.

## Why

Callers sending valid A2A `FilePart` (bytes or uri) or `DataPart` had no way to tell their data wasn't reaching the agent — the backend just filtered them out of the text concat. Non-text shapes either need a real mapping or a loud failure.

## Mapping

| A2A input | Outcome |
|---|---|
| `text` | concatenated into `chat.send` `message` (unchanged) |
| `file` + `bytes` + `image/*` mime | forwarded as OpenClaw attachment `{type:'image', mimeType, fileName, content}` |
| `file` + `uri` | `task.fail` `unsupported_file_uri` (fetching out of scope; may need caller auth) |
| `file` + non-image mime | `task.fail` `unsupported_file_mime` |
| `file` without bytes or uri | `task.fail` `invalid_file_part` |
| `data` | `task.fail` `unsupported_data_part` (no native structured-input surface on OpenClaw) |

Mapping runs before `ensureConnected()` so malformed input fails fast without opening a WS or consuming a session slot. `attachments` is only included in `chat.send` when non-empty, keeping the text-only happy path byte-identical on the wire.

## Agent card

`cards/openclaw.json` `defaultInputModes` gains `image/png`, `image/jpeg`, `image/gif`, `image/webp` to match what the gateway actually accepts; the skill description now mentions inline image parts.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client test` — 40/40 pass. 10 new cases:
  - 7 unit tests on `mapPartsToChatInput` (text-only, text+image, image-without-name, file.uri rejection, non-image mime rejection, missing-bytes rejection, data-part rejection)
  - 3 integration tests through `handle()` (image forwarded to chat.send with attachments; data part fails without touching the gateway; file.uri fails without touching the gateway)
- [x] `pnpm -r typecheck` — clean across all packages.

## Out of scope (acceptance notes)

- File URI fetching: would need to decide on caller-auth propagation and cache policy. Deferred.
- DataPart stringification: rejecting is the safer default; can add a dedicated JSON-to-text path later if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)