### PR TITLE
Stream openclaw assistant messages as independent A2A artifacts

### DIFF
--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -120,6 +120,50 @@ docker run --rm \
 response to a `chat.abort` RPC — i.e. the backend's signal-abort path
 reached the gateway correctly.
 
+## Streaming verification
+
+A second E2E exercise lives at `packages/client/scripts/e2e-openclaw-streaming.mjs`.
+It sends a tool-use-prone prompt, collects the emitted A2A frames, and
+asserts:
+
+- at least one `task.artifact` arrives before `task.complete`,
+- all `artifactId`s are distinct,
+- the terminal frame is `task.complete` with `state: "completed"`,
+- if two or more artifacts were emitted, the first precedes the
+  terminal frame in time (otherwise the assertion is skipped — a
+  single-artifact run is the documented graceful-degradation shape and
+  still satisfies the streaming contract).
+
+Run the same way as the cancel example, with the agent's auth
+configured so a real model can respond:
+
+```bash
+# Either mount a prepared auth-profiles.json into the gateway:
+docker run --rm -d --name openclaw-e2e \
+  -v "$HOME/.openclaw-e2e/auth-profiles.json:/home/node/.openclaw/agents/main/agent/auth-profiles.json:ro" \
+  ghcr.io/openclaw/openclaw:latest
+
+# ...or interactively register a provider before running the sidecar:
+docker exec -it openclaw-e2e openclaw agents add main
+
+TOKEN=$(docker exec openclaw-e2e sh -c 'cat /home/node/.openclaw/openclaw.json' \
+  | grep -oE '"token":\s*"[a-f0-9]+"' | head -1 | sed 's/.*"\([a-f0-9]*\)"/\1/')
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  -e OPENCLAW_GATEWAY_TOKEN="$TOKEN" \
+  node:20 \
+  node ./scripts/e2e-openclaw-streaming.mjs
+```
+
+Without auth configured the harness still passes (the gateway emits a
+single assistant "agent failed before reply" transcript entry, which
+proves the `session.message → task.artifact` wiring end-to-end), but
+you cannot verify the multi-artifact cadence a real tool-use run
+produces. Use `DEBUG=1` in the sidecar env to see every chat /
+session.message frame as it arrives.
+
 ## Teardown
 
 ```bash

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -3,7 +3,7 @@
   "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text and inline image attachments.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": false },
+  "capabilities": { "streaming": true },
   "defaultInputModes": ["text/plain", "image/png", "image/jpeg", "image/gif", "image/webp"],
   "defaultOutputModes": ["text/plain"],
   "skills": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/scripts/e2e-openclaw-streaming.mjs
+++ b/packages/client/scripts/e2e-openclaw-streaming.mjs
@@ -1,0 +1,109 @@
+// E2E harness for message-boundary streaming against a real OpenClaw
+// gateway. Meant to be run from a Node sidecar that shares the gateway
+// container's network namespace; see docs/openclaw-e2e.md.
+//
+// Success criteria:
+//   - at least one task.artifact frame arrives before task.complete
+//   - artifactIds are all distinct
+//   - terminal frame state === 'completed'
+//
+// Exits non-zero if any assertion fails so the outer `docker run` run
+// propagates a clear pass/fail status.
+
+import { createOpenclawBackend } from '../dist/backends/openclaw.js';
+
+const TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN;
+if (!TOKEN) {
+  console.error('set OPENCLAW_GATEWAY_TOKEN');
+  process.exit(2);
+}
+
+// Pick a prompt that ordinarily induces multi-step agent output
+// (tool use + final response => multiple assistant transcript writes).
+// Fallback to a simple text response if the agent doesn't take the tool
+// path — the test still passes with a single artifact (matches the
+// no-streaming fallback behavior).
+const PROMPT = process.env.E2E_PROMPT ?? 'List the files in /tmp using bash, then summarize what you found in two sentences.';
+
+const backend = createOpenclawBackend({
+  url: 'ws://127.0.0.1:18789',
+  token: TOKEN,
+  debug: process.env.DEBUG === '1',
+  taskTimeoutMs: 180_000,
+});
+
+const frames = [];
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-stream-${t0}`,
+  contextId: `e2e-stream-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `e2e-stream-msg-${t0}`,
+    parts: [{ kind: 'text', text: PROMPT }],
+  },
+};
+
+console.log(`[e2e] prompt: ${PROMPT}`);
+console.log(`[e2e] task=${task.taskId} context=${task.contextId}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    const summary = f.type === 'task.artifact'
+      ? `artifact id=${f.artifact.artifactId.slice(0, 8)} name=${f.artifact.name} bytes=${JSON.stringify(f.artifact.parts).length} lastChunk=${f.lastChunk}`
+      : f.type === 'task.complete'
+        ? `complete state=${f.status.state}`
+        : f.type === 'task.fail'
+          ? `fail code=${f.error.code} msg=${f.error.message}`
+          : f.type === 'task.status'
+            ? `status state=${f.status.state}`
+            : f.type;
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifactIds = new Set(artifacts.map((a) => a.artifact.artifactId));
+
+console.log('');
+console.log(`[e2e] artifacts: ${artifacts.length}`);
+console.log(`[e2e] distinct artifactIds: ${artifactIds.size}`);
+console.log(`[e2e] total elapsed: ${Date.now() - t0}ms`);
+console.log(`[e2e] terminal: ${terminal?.type} ${terminal?.type === 'task.complete' ? terminal.status.state : ''}`);
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(artifacts.length >= 1, 'at least one task.artifact emitted');
+assert(artifactIds.size === artifacts.length, 'all artifactIds are distinct');
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  'terminal frame is task.complete with state=completed',
+);
+
+// Streaming-specific claim: if the run went through more than one
+// assistant message (tool use path), the first artifact must arrive
+// strictly before the terminal frame. When only one artifact was
+// emitted it is the final-result fallback and this timing check is
+// vacuous — which still matches option (b) design (multi-artifact is
+// best-effort, single-artifact is a documented graceful-degradation case).
+if (artifacts.length >= 2) {
+  const firstArtifactT = artifacts[0].t;
+  const terminalT = terminal?.t ?? Infinity;
+  assert(firstArtifactT < terminalT, 'first streaming artifact arrives before terminal frame');
+}
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -37,6 +37,7 @@ interface FakeGateway {
   respond(sock: WebSocket, id: string, payload: unknown): void;
   respondError(sock: WebSocket, id: string, error: { code: string; message: string }): void;
   emitChat(sock: WebSocket, payload: unknown): void;
+  emitSessionMessage(sock: WebSocket, payload: unknown): void;
   closeSocket(sock: WebSocket): Promise<void>;
   close(): Promise<void>;
 }
@@ -69,6 +70,24 @@ async function createFakeGateway(opts: FakeGatewayOptions = {}): Promise<FakeGat
       if (frame.type !== 'req') return;
       if (frame.method === 'connect' && autoHandshake) {
         sock.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: {} }));
+        return;
+      }
+      // Every backend task path now calls `sessions.messages.subscribe` once
+      // per sessionKey to enable message-boundary streaming. Auto-ack here so
+      // existing tests that don't care about streaming don't have to wire up
+      // a handler — the onRequest hook still runs if a test wants to inspect
+      // the subscription call itself.
+      if (frame.method === 'sessions.messages.subscribe') {
+        const key = (frame.params as { key?: string } | undefined)?.key ?? '';
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: frame.id,
+            ok: true,
+            payload: { subscribed: true, key },
+          }),
+        );
+        opts.onRequest?.(sock, frame);
         return;
       }
       opts.onRequest?.(sock, frame);
@@ -106,6 +125,9 @@ async function createFakeGateway(opts: FakeGatewayOptions = {}): Promise<FakeGat
     },
     emitChat(sock, payload) {
       sock.send(JSON.stringify({ type: 'event', event: 'chat', payload }));
+    },
+    emitSessionMessage(sock, payload) {
+      sock.send(JSON.stringify({ type: 'event', event: 'session.message', payload }));
     },
     async closeSocket(sock) {
       await new Promise<void>((resolve) => {
@@ -1021,6 +1043,327 @@ test('handle(): file.uri fails fast with unsupported_file_uri', async () => {
     await fake.close();
   }
 });
+
+test('streaming: assistant session.message events emit as distinct artifacts before final completion', async () => {
+  // Simulates openclaw's in-run transcript writes: two assistant messages
+  // arrive via session.message, then the chat run terminates with `final`.
+  // Each session.message should surface as its own task.artifact (distinct
+  // artifactId, lastChunk:true), and the terminal `final` must NOT tack on
+  // a redundant final-result artifact because streaming already delivered
+  // content. task.complete still carries the final text in status.message.
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+      );
+      setImmediate(() => {
+        fake.emitSessionMessage(sock, {
+          sessionKey: params.sessionKey,
+          messageId: 'm1',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'thinking out loud' }] },
+        });
+        fake.emitSessionMessage(sock, {
+          sessionKey: params.sessionKey,
+          messageId: 'm2',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'final answer' }] },
+        });
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'final',
+          message: { text: 'final answer' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-stream', 'hi'), (f) => frames.push(f), NEVER);
+
+    const artifacts = frames.filter((f) => f.type === 'task.artifact');
+    assert.equal(artifacts.length, 2, 'each assistant message should emit its own artifact');
+    const ids = new Set(artifacts.map((a) => a.artifact.artifactId));
+    assert.equal(ids.size, 2, 'artifactIds should be distinct per message (option b: independent artifacts)');
+    for (const a of artifacts) {
+      assert.equal(a.lastChunk, true, 'each message-artifact is complete on emission');
+      assert.equal(a.artifact.name, 'openclaw-message');
+    }
+    assert.equal(
+      (artifacts[0].artifact.parts[0] as { kind: 'text'; text: string }).text,
+      'thinking out loud',
+    );
+    assert.equal(
+      (artifacts[1].artifact.parts[0] as { kind: 'text'; text: string }).text,
+      'final answer',
+    );
+
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.equal(complete!.status.state, 'completed');
+    // Sanity: exactly one completion + one status(working) + two artifacts,
+    // no third artifact emitted from the final event's text.
+    assert.deepEqual(
+      frames.map((f) => f.type),
+      ['task.status', 'task.artifact', 'task.artifact', 'task.complete'],
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+test('streaming: no session.message events falls back to single final-result artifact', async () => {
+  // When the gateway never emits session.message (e.g. subscription failed or
+  // the agent wrote no intermediate messages), handle() must still behave
+  // like today: one final artifact derived from the terminal chat.final
+  // message, then task.complete.
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+      );
+      setImmediate(() => {
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'final',
+          message: { text: 'hello' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-noop', 'hi'), (f) => frames.push(f), NEVER);
+    assert.deepEqual(
+      frames.map((f) => f.type),
+      ['task.status', 'task.artifact', 'task.complete'],
+    );
+    const artifact = frames.find((f) => f.type === 'task.artifact');
+    assert.equal(artifact!.artifact.name, 'openclaw-result');
+    assert.equal(
+      (artifact!.artifact.parts[0] as { kind: 'text'; text: string }).text,
+      'hello',
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+test('streaming: non-assistant session.message events are ignored', async () => {
+  // Transcript records user inputs and tool outputs as well as assistant
+  // replies. Only `role:"assistant"` entries should map to A2A artifacts;
+  // echoing user input back would loop the caller's own message to them.
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+      );
+      setImmediate(() => {
+        fake.emitSessionMessage(sock, {
+          sessionKey: params.sessionKey,
+          messageId: 'u1',
+          message: { role: 'user', content: [{ type: 'text', text: 'the prompt' }] },
+        });
+        fake.emitSessionMessage(sock, {
+          sessionKey: params.sessionKey,
+          messageId: 't1',
+          message: { role: 'tool', content: [{ type: 'text', text: 'tool output' }] },
+        });
+        fake.emitSessionMessage(sock, {
+          sessionKey: params.sessionKey,
+          messageId: 'a1',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'the reply' }] },
+        });
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'final',
+          message: { text: 'the reply' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-roles', 'hi'), (f) => frames.push(f), NEVER);
+    const artifacts = frames.filter((f) => f.type === 'task.artifact');
+    assert.equal(artifacts.length, 1, 'only the assistant message should emit an artifact');
+    assert.equal(
+      (artifacts[0].artifact.parts[0] as { kind: 'text'; text: string }).text,
+      'the reply',
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+test('streaming: duplicate messageId for an assistant message is deduplicated', async () => {
+  // openclaw can republish a transcript entry (e.g. after a rewrite). The
+  // adapter must not emit two artifacts for the same messageId even though
+  // the event payload itself was valid both times.
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+      );
+      setImmediate(() => {
+        const msg = {
+          sessionKey: params.sessionKey,
+          messageId: 'dup',
+          message: { role: 'assistant', content: [{ type: 'text', text: 'once' }] },
+        };
+        fake.emitSessionMessage(sock, msg);
+        fake.emitSessionMessage(sock, msg);
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'final',
+          message: { text: 'once' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-dup', 'hi'), (f) => frames.push(f), NEVER);
+    const artifacts = frames.filter((f) => f.type === 'task.artifact');
+    assert.equal(artifacts.length, 1, 'duplicate messageId must not double-emit');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('streaming: sessions.messages.subscribe RPC failure degrades gracefully to single final artifact', async () => {
+  // The subscribe call must not be fatal. If the gateway rejects it (e.g.
+  // older openclaw without session message subscription, or scope denied),
+  // handle() should log, skip streaming, and behave like the no-events
+  // fallback path — one final-result artifact derived from chat.final.
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  const failingGateway = await createFakeGatewaySubscribeError();
+  try {
+    const backend = createOpenclawBackend({ url: failingGateway.url });
+    const frames: UpFrame[] = [];
+    await backend.handle(makeTask('t-noSub', 'hi'), (f) => frames.push(f), NEVER);
+    assert.deepEqual(
+      frames.map((f) => f.type),
+      ['task.status', 'task.artifact', 'task.complete'],
+    );
+    assert.ok(
+      warnings.some((w) => w.includes('sessions.messages.subscribe failed')),
+      `expected warn about failed subscribe, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    await failingGateway.close();
+  }
+});
+
+// Dedicated fake gateway that responds with an error to
+// `sessions.messages.subscribe` but still handles chat.send normally. Used
+// by the graceful-degradation test above; kept separate from the main
+// helper because the main helper auto-acks subscribes for convenience.
+async function createFakeGatewaySubscribeError(): Promise<FakeGateway> {
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  const connections: WebSocket[] = [];
+  wss.on('connection', (sock) => {
+    connections.push(sock);
+    sock.send(
+      JSON.stringify({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: 'nonce-sub-err' },
+      }),
+    );
+    sock.on('message', (raw) => {
+      let frame: ReqFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as ReqFrame;
+      } catch {
+        return;
+      }
+      if (frame.type !== 'req') return;
+      if (frame.method === 'connect') {
+        sock.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: {} }));
+        return;
+      }
+      if (frame.method === 'sessions.messages.subscribe') {
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: frame.id,
+            ok: false,
+            error: { code: 'forbidden', message: 'subscription unavailable' },
+          }),
+        );
+        return;
+      }
+      if (frame.method === 'chat.send') {
+        const params = frame.params as { sessionKey: string; idempotencyKey: string };
+        const runId = `run-${params.idempotencyKey}`;
+        sock.send(
+          JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: { runId, status: 'started' } }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: params.sessionKey,
+                seq: 1,
+                state: 'final',
+                message: { text: 'no-stream result' },
+              },
+            }),
+          );
+        });
+      }
+    });
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `ws://127.0.0.1:${port}`,
+    connections,
+    waitForConnection: () => Promise.resolve(connections[0]),
+    respond: () => undefined,
+    respondError: () => undefined,
+    emitChat: () => undefined,
+    emitSessionMessage: () => undefined,
+    closeSocket: () => Promise.resolve(),
+    close: async () => {
+      for (const s of connections) if (s.readyState !== WebSocket.CLOSED) s.terminate();
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
 
 test('parseLsofListeningPorts extracts loopback/wildcard listeners and preserves host', () => {
   const sample = [

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -298,7 +298,7 @@ class GatewayClient {
         client: {
           id: clientId,
           displayName: 'vicoop-bridge-client',
-          version: '0.2.0',
+          version: '0.3.0',
           platform: process.platform,
           mode: clientMode,
         },

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -90,6 +90,19 @@ interface ChatEventPayload {
   stopReason?: string;
 }
 
+// OpenClaw broadcasts this on every `emitSessionTranscriptUpdate` to
+// connections that called `sessions.messages.subscribe` for the sessionKey.
+// The `message` field is the full assistant/user/tool entry that was appended
+// to the transcript — not a token delta. We use it to drive message-boundary
+// A2A artifact streaming in lieu of true per-token deltas (which only reach
+// `role:"node"` clients subscribed via `chat.subscribe` node events today).
+interface SessionMessageEventPayload {
+  sessionKey: string;
+  message?: unknown;
+  messageId?: string;
+  messageSeq?: number;
+}
+
 type FinalizerCause = 'gateway_closed' | 'timeout' | 'abort_failed';
 
 type FinalizerEvent = ChatEventPayload & { cause?: FinalizerCause };
@@ -678,6 +691,24 @@ export function createOpenclawBackend(
   const runToTask = new Map<string, { taskId: string; sessionKey: string }>();
   const taskFinalizers = new Map<string, (evt: FinalizerEvent) => void>();
   const pendingRunEvents = new Map<string, ChatEventPayload[]>();
+  // sessionKeys we have already called `sessions.messages.subscribe` on for
+  // the current gateway connection. Subscription is idempotent per
+  // connection: one call per sessionKey regardless of how many tasks reuse
+  // it. Cleared on reconnect because the connId (and therefore the server's
+  // subscriber entry) is gone after a WS close.
+  const subscribedSessionKeys = new Set<string>();
+  // Per-sessionKey owner of message-boundary streaming. OpenClaw's
+  // `session.message` payload carries no runId, so we cannot route events
+  // for two concurrent `chat.send` calls on the same sessionKey. First task
+  // wins ownership; a second concurrent task on the same sessionKey skips
+  // registration and falls back to the one-shot final artifact. Normal
+  // sequential use on the same contextId is unaffected because the owner
+  // entry is released in finally{}.
+  type SessionMessageOwner = {
+    taskId: string;
+    handler: (p: SessionMessageEventPayload) => void;
+  };
+  const sessionMessageOwners = new Map<string, SessionMessageOwner>();
   // Bounded memory of recently-finalized runIds. Any chat event carrying one
   // of these is dropped instead of buffered in pendingRunEvents, so late or
   // duplicate deltas from OpenClaw cannot accumulate forever after the task
@@ -703,6 +734,11 @@ export function createOpenclawBackend(
     // scoped to a single gateway session, so a reconnect starts clean.
     pendingRunEvents.clear();
     recentlyFinalizedRuns.clear();
+    // Subscriptions are connId-scoped on the gateway side; after a close
+    // there is no remote state to reconcile. Forget them so the next
+    // connection re-subscribes cleanly.
+    subscribedSessionKeys.clear();
+    sessionMessageOwners.clear();
     // Fail every in-flight task that was running on this client so handle()
     // does not hang forever waiting for a terminal event that can never come.
     if (taskFinalizers.size === 0) return;
@@ -729,6 +765,21 @@ export function createOpenclawBackend(
     const c = new GatewayClient(candidateUrl, token, hsTimeoutMs);
     await c.connect();
     c.onEvent((evt) => {
+      if (evt.event === 'session.message') {
+        const p = evt.payload as SessionMessageEventPayload | undefined;
+        if (!p?.sessionKey) return;
+        if (debug) {
+          console.log('[openclaw] session.message event:', JSON.stringify(p).slice(0, 500));
+        }
+        const owner = sessionMessageOwners.get(p.sessionKey);
+        if (!owner) return;
+        try {
+          owner.handler(p);
+        } catch (err) {
+          console.error('[openclaw] session.message handler threw:', (err as Error).message);
+        }
+        return;
+      }
       if (evt.event !== 'chat') return;
       const p = evt.payload as ChatEventPayload | undefined;
       if (!p?.runId) return;
@@ -832,6 +883,26 @@ export function createOpenclawBackend(
     return connecting;
   }
 
+  // Idempotent per (connection, sessionKey). Subscription is the mechanism
+  // that unlocks message-boundary streaming: OpenClaw will broadcast a
+  // `session.message` event to this connection whenever the transcript for
+  // `sessionKey` gets a new entry. Failure is non-fatal — the task falls
+  // back to today's single-artifact-on-final behavior.
+  async function ensureSessionMessageSubscription(
+    gw: GatewayClient,
+    sessionKey: string,
+  ): Promise<void> {
+    if (subscribedSessionKeys.has(sessionKey)) return;
+    try {
+      await gw.request('sessions.messages.subscribe', { key: sessionKey });
+      subscribedSessionKeys.add(sessionKey);
+    } catch (err) {
+      console.warn(
+        `[openclaw] sessions.messages.subscribe failed for ${sessionKey}: ${errorMessage(err)} (continuing without streaming)`,
+      );
+    }
+  }
+
   return {
     name: 'openclaw',
 
@@ -879,6 +950,78 @@ export function createOpenclawBackend(
         taskId: task.taskId,
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
+
+      // Subscribe to per-message transcript events for this sessionKey so we
+      // can forward each assistant message as a separate A2A artifact while
+      // the run is in progress. Subscribing here (before chat.send) avoids
+      // races where fast agents write their first message before we would
+      // otherwise have registered. Failure degrades to the non-streaming
+      // final-only path — not fatal.
+      await ensureSessionMessageSubscription(gw, sessionKey);
+
+      // Per-task streaming state. `emittedAnyArtifact` decides whether the
+      // terminal `chat.final` should also emit a final-only artifact (i.e.
+      // whether the streaming path already delivered content). `seenAssistantMessageIds`
+      // drops duplicate transcript events for the same message (e.g. if
+      // OpenClaw re-emits after a rewrite). `sessionMessageSettled` closes
+      // the gate at terminal time so a late `session.message` arriving after
+      // we have already emitted `task.complete` cannot produce an artifact
+      // past the terminal frame.
+      let emittedAnyArtifact = false;
+      const seenAssistantMessageIds = new Set<string>();
+      let sessionMessageSettled = false;
+
+      const onSessionMessage = (p: SessionMessageEventPayload): void => {
+        if (sessionMessageSettled) return;
+        const msg = p.message;
+        if (!msg || typeof msg !== 'object') return;
+        const role = (msg as { role?: unknown }).role;
+        // Transcript also records user/tool entries — only assistant output
+        // maps to A2A artifacts. The user's own message was delivered by
+        // the caller and re-emitting it would loop back to them.
+        if (role !== 'assistant') return;
+        const mid = typeof p.messageId === 'string' ? p.messageId : '';
+        if (mid) {
+          if (seenAssistantMessageIds.has(mid)) return;
+          seenAssistantMessageIds.add(mid);
+        }
+        const artifactText = extractFinalText(msg);
+        if (!artifactText) return;
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'openclaw-message',
+            parts: [{ kind: 'text', text: artifactText }],
+          },
+          // Each message is a self-contained artifact (option (b) in the
+          // design discussion): distinct artifactId, complete on emission.
+          // The end-of-run signal is carried by task.complete, not by any
+          // individual artifact.
+          lastChunk: true,
+        });
+        emittedAnyArtifact = true;
+      };
+
+      // First task on this sessionKey wins streaming ownership. A concurrent
+      // second task on the same contextId would see interleaved session.message
+      // events with no runId to disambiguate, so it falls back to the
+      // one-shot final artifact path. This is the common-case tradeoff —
+      // serial reuse of a contextId (the normal A2A usage pattern) streams
+      // fine because the first task releases ownership in finally{}.
+      const ownedSession =
+        subscribedSessionKeys.has(sessionKey) && !sessionMessageOwners.has(sessionKey);
+      if (ownedSession) {
+        sessionMessageOwners.set(sessionKey, {
+          taskId: task.taskId,
+          handler: onSessionMessage,
+        });
+      } else if (subscribedSessionKeys.has(sessionKey)) {
+        console.warn(
+          `[openclaw] ${sessionKey} already has a streaming owner; task ${task.taskId} will emit a single final artifact`,
+        );
+      }
 
       // Register the finalizer BEFORE sending chat.send so that:
       //   1. a gateway close between send and ack still fails this task,
@@ -997,6 +1140,12 @@ export function createOpenclawBackend(
 
         const result = await settled;
 
+        // Close the streaming gate before any terminal emit. Any
+        // `session.message` that arrives from this point on (e.g. a
+        // transcript write that races with the final event) must not
+        // produce an artifact after task.complete/fail.
+        sessionMessageSettled = true;
+
         if (result.cause === 'timeout') {
           emit({
             type: 'task.fail',
@@ -1052,13 +1201,21 @@ export function createOpenclawBackend(
 
         const text2 = extractFinalText(result.message);
         const parts: Part[] = [{ kind: 'text', text: text2 }];
-        const artifactId = randomUUID();
-        emit({
-          type: 'task.artifact',
-          taskId: task.taskId,
-          artifact: { artifactId, name: 'openclaw-result', parts },
-          lastChunk: true,
-        });
+        // Only emit the final-result artifact when streaming produced
+        // nothing — otherwise each assistant message already went out as its
+        // own artifact and re-emitting the final text here would be a
+        // redundant copy of the last one. task.complete still carries the
+        // final message in status.message, which is how A2A conventionally
+        // stamps the terminal content anyway.
+        if (!emittedAnyArtifact) {
+          const artifactId = randomUUID();
+          emit({
+            type: 'task.artifact',
+            taskId: task.taskId,
+            artifact: { artifactId, name: 'openclaw-result', parts },
+            lastChunk: true,
+          });
+        }
         emit({
           type: 'task.complete',
           taskId: task.taskId,
@@ -1080,6 +1237,13 @@ export function createOpenclawBackend(
           runToTask.delete(runId);
           pendingRunEvents.delete(runId);
           markRunFinalized(runId);
+        }
+        // Defensive: if we bailed out of handle() before reaching the
+        // explicit gate close above (synchronous throw, early return), the
+        // session.message handler could otherwise still fire for this task.
+        sessionMessageSettled = true;
+        if (ownedSession && sessionMessageOwners.get(sessionKey)?.taskId === task.taskId) {
+          sessionMessageOwners.delete(sessionKey);
         }
       }
     },


### PR DESCRIPTION
## Summary

- Flips `capabilities.streaming` to `true` on the openclaw card and adds message-boundary streaming to the adapter — without any upstream OpenClaw change.
- Each assistant message appended to the transcript surfaces as its own `TaskArtifactUpdateEvent` SSE frame to the A2A caller, followed by the terminal `TaskStatusUpdateEvent(final:true)`.

## Why this route (option b: run-level multi-artifact)

True per-token deltas remain blocked on the upstream fix described in #2: OpenClaw's `chat.send` handler doesn't register a `clientRunId` in `chatRunState.registry`, so `emitChatDelta()` (which publishes via `nodeSendToSession`) never reaches an `role:\"operator\"` connection.

OpenClaw does, however, emit a `session.message` event on every transcript write to connections that called `sessions.messages.subscribe` for the sessionKey (scope `operator.read`, which we already hold). That gives us one event per completed assistant message — thinking / tool-use / final response typically arrive as separate events. Not token-level, but more than enough to qualify as A2A streaming and unblock clients today.

Mapping choice: each `session.message` becomes a new `task.artifact` with a fresh `artifactId` and `lastChunk:true`. That matches the natural grain of the data (each message is complete on arrival, not a chunk of a larger artifact) and avoids introducing an `append` field to the wire protocol.

## Changes

- `packages/client/cards/openclaw.json` — `streaming: true`.
- `packages/client/src/backends/openclaw.ts`:
  - New `sessions.messages.subscribe` call (idempotent per connection, per sessionKey). Failure is logged and non-fatal; task falls back to the single-final-artifact path.
  - Routes `session.message` events via a per-sessionKey owner map to the right in-flight task's handler.
  - Handler emits `task.artifact` per assistant message (skips `user`/`tool` entries, dedups by `messageId`, drops late events after the terminal frame).
  - Terminal `chat.final` path skips the final-result artifact when streaming already delivered content; `task.complete.status.message` still carries the final text per A2A convention.
- `packages/client/src/backends/openclaw.test.ts`:
  - Fake gateway helper auto-acks `sessions.messages.subscribe` so unrelated tests need no changes.
  - Adds 5 streaming tests: multi-message emits as distinct artifacts, no-event fallback, role filtering, `messageId` dedup, subscribe-failure graceful degradation.

All 45 tests pass (40 pre-existing + 5 new).

## Constraints / tradeoffs

- **Not token-level.** Each event is a complete transcript entry. A simple \"say hi\" run emits 1 artifact; a tool-using run emits 2–3.
- **Concurrent same-sessionKey runs aren't both streamed.** `session.message` carries no `runId` so we can't route to two tasks at once. First task wins ownership; a concurrent second task on the same contextId uses the one-shot fallback. Normal sequential A2A usage is unaffected.
- **Subscribe failure ⇒ silent fallback.** If the gateway rejects the RPC (older OpenClaw, scope denied, etc.), we log and behave like before.

The ~20-line upstream PR described in #2 remains the path to true per-token streaming; this PR unblocks the streaming capability today with zero OpenClaw changes.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client test` — 45/45 pass.
- [x] `pnpm -r build` — typecheck/build clean.
- [ ] **Manual E2E one-shot verification** using the pattern in `docs/openclaw-e2e.md`: spin up `ghcr.io/openclaw/openclaw:latest` with `CLAUDE_AI_SESSION_KEY` mounted, run a prompt that triggers tool use (e.g. \"list /tmp with bash, summarize\"), and observe multiple `task.artifact` frames with distinct `artifactId`s preceding `task.complete`. Reviewer note: this must be run once before merge; automated E2E is out of scope for this PR.

Refs: #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)