### PR TITLE
Invalidate cached A2A transport on agent (re)registration

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,8 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
-    "start": "tsx src/cli.ts"
+    "start": "tsx src/cli.ts",
+    "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.13",

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -144,6 +144,19 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   opts.registry.onCallerChange((agentId) => {
     transports.delete(agentId);
   });
+  // Also invalidate on (re)registration or disconnect. The SDK's
+  // DefaultRequestHandler captures the agent card at construction time —
+  // including `capabilities.streaming` — so a client that reconnects with
+  // an updated card would otherwise be served by a stale transport that
+  // still advertises the old capabilities. Concrete failure mode: after a
+  // client upgrades from streaming:false → streaming:true, `message/stream`
+  // requests are rejected with `unsupportedOperation` even though the
+  // public `/.well-known/agent-card.json` reports `streaming:true` (that
+  // endpoint reads `conn.agentCard` on every request, while the transport
+  // captures a snapshot).
+  opts.registry.onAgentChange((agentId) => {
+    transports.delete(agentId);
+  });
 
   async function handleTransportResult(result: unknown, c: Context) {
     if (Symbol.asyncIterator in (result as object)) {

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -1,0 +1,181 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { WebSocket } from 'ws';
+import type { AgentCard } from '@vicoop-bridge/protocol';
+import { Registry } from './registry.js';
+
+// Minimal WebSocket stub — Registry only uses `.close()` on replacement and
+// equality (`existing.ws !== ws`) on unregister. Nothing else on the real ws
+// interface is exercised here.
+function makeWs(): WebSocket {
+  return { close: () => undefined } as unknown as WebSocket;
+}
+
+function makeCard(streaming: boolean): AgentCard {
+  return {
+    name: 'test',
+    description: 'test',
+    version: '0.0.0',
+    protocolVersion: '0.3.0',
+    capabilities: { streaming },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [{ id: 's1', name: 'skill', description: 'd', tags: [] }],
+  };
+}
+
+test('onAgentChange fires on first registration', () => {
+  const registry = new Registry();
+  const seen: string[] = [];
+  registry.onAgentChange((id) => seen.push(id));
+  const result = registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(seen, ['a1']);
+});
+
+test('onAgentChange fires again when the same client reconnects with an updated card', () => {
+  // This is the fix's core guarantee: a client upgrading from streaming:false
+  // to streaming:true must trigger invalidation so consumers (e.g. the HTTP
+  // layer's cached JsonRpcTransportHandler) rebuild against the fresh card.
+  const registry = new Registry();
+  const seen: string[] = [];
+  registry.onAgentChange((id) => seen.push(id));
+  const base = {
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    allowedCallers: [],
+    connectedAt: 0,
+  };
+  registry.registerAgent({ ...base, agentCard: makeCard(false), ws: makeWs() });
+  registry.registerAgent({ ...base, agentCard: makeCard(true), ws: makeWs() });
+  assert.deepEqual(seen, ['a1', 'a1']);
+  // Current conn reflects the new card, confirming we're not just firing
+  // the notification — the registry state is actually advancing.
+  const current = registry.getAgent('a1');
+  assert.ok(current);
+  assert.equal(current.agentCard.capabilities?.streaming, true);
+});
+
+test('onAgentChange does NOT fire when registration is refused (different client owns the agentId)', () => {
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  const seen: string[] = [];
+  registry.onAgentChange((id) => seen.push(id));
+  const rejected = registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c2', // different client
+    ownerWallet: '0x0',
+    agentCard: makeCard(true),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  assert.equal(rejected.ok, false);
+  // A rejected registration must not invalidate the incumbent's cached
+  // transport — it has not been replaced.
+  assert.deepEqual(seen, []);
+});
+
+test('onAgentChange fires on disconnect (unregister) so stale transports do not persist past a dead connection', () => {
+  const registry = new Registry();
+  const ws = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const seen: string[] = [];
+  registry.onAgentChange((id) => seen.push(id));
+  registry.unregisterAgent('a1', ws);
+  assert.deepEqual(seen, ['a1']);
+});
+
+test('onAgentChange does NOT fire on unregister if the ws does not match the current connection', () => {
+  // Defensive: a late-arriving close event from a superseded socket must not
+  // trigger invalidation of the new connection's cached transport.
+  const registry = new Registry();
+  const oldWs = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: oldWs,
+    connectedAt: 0,
+  });
+  // New connection replaces the old one (fires once, as expected).
+  const newWs = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(true),
+    allowedCallers: [],
+    ws: newWs,
+    connectedAt: 0,
+  });
+  const seen: string[] = [];
+  registry.onAgentChange((id) => seen.push(id));
+  // Late unregister from the *old* ws — should be a no-op.
+  registry.unregisterAgent('a1', oldWs);
+  assert.deepEqual(seen, []);
+  // Registry still holds the new connection.
+  const current = registry.getAgent('a1');
+  assert.ok(current, 'agent should still be registered');
+  assert.equal(current.agentCard.capabilities?.streaming, true);
+});
+
+test('a throwing onAgentChange listener does not abort other listeners or the registerAgent call', () => {
+  // The change notification runs inside registerAgent/unregisterAgent. A bad
+  // listener must not corrupt the caller's control flow or prevent
+  // subsequent listeners from receiving the event.
+  const registry = new Registry();
+  const seen: string[] = [];
+  const originalError = console.error;
+  const errors: string[] = [];
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map(String).join(' '));
+  };
+  try {
+    registry.onAgentChange(() => {
+      throw new Error('listener boom');
+    });
+    registry.onAgentChange((id) => seen.push(id));
+    const result = registry.registerAgent({
+      agentId: 'a1',
+      clientId: 'c1',
+      ownerWallet: '0x0',
+      agentCard: makeCard(false),
+      allowedCallers: [],
+      ws: makeWs(),
+      connectedAt: 0,
+    });
+    assert.deepEqual(result, { ok: true });
+    assert.deepEqual(seen, ['a1']);
+    assert.ok(errors.some((e) => e.includes('listener boom')));
+  } finally {
+    console.error = originalError;
+  }
+});

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -153,12 +153,12 @@ test('a throwing onAgentChange listener does not abort other listeners or the re
   // subsequent listeners from receiving the event.
   //
   // Use the test runner's scoped mock so parallel tests that also touch
-  // console.error don't race with this stub — node:test auto-restores the
+  // console.log don't race with this stub — node:test auto-restores the
   // original at test teardown, removing the need for a manual try/finally
   // and the "what if the test body throws before finally" window.
-  const errors: string[] = [];
-  t.mock.method(console, 'error', (...args: unknown[]) => {
-    errors.push(args.map(String).join(' '));
+  const logs: string[] = [];
+  t.mock.method(console, 'log', (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
   });
   const registry = new Registry();
   const seen: string[] = [];
@@ -177,5 +177,61 @@ test('a throwing onAgentChange listener does not abort other listeners or the re
   });
   assert.deepEqual(result, { ok: true });
   assert.deepEqual(seen, ['a1']);
-  assert.ok(errors.some((e) => e.includes('listener boom')));
+  // Error is emitted as a structured logEvent() JSON line — assert on both
+  // the event name and the embedded error text so we catch regressions
+  // where the event is renamed or the error is dropped.
+  const errorLine = logs.find(
+    (l) => l.includes('registry_agent_listener_error') && l.includes('listener boom'),
+  );
+  assert.ok(errorLine, `expected structured error log, got: ${logs.join(' | ')}`);
+});
+
+test('notifyAgentChange log cannot be hijacked by newline injection via agentId', (t) => {
+  // agentId originates from the client's hello frame and is an
+  // unconstrained string at this layer. A malicious client sending
+  // "a\nfake-log-line" as its agentId must not be able to synthesize
+  // a second line in operator logs. logEvent() serializes via
+  // JSON.stringify which escapes newlines; this test locks that
+  // invariant in place so a future switch back to a raw
+  // console.error(`...${agentId}...`) template-string regresses loudly.
+  const logs: string[] = [];
+  t.mock.method(console, 'log', (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  const registry = new Registry();
+  registry.onAgentChange(() => {
+    throw new Error('boom');
+  });
+  registry.registerAgent({
+    agentId: 'good\nevent: fake_login\nextra: attacker-controlled',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  assert.equal(logs.length, 1, 'exactly one log line must be emitted');
+  // Raw newlines in the output would split into multiple lines when a
+  // downstream log aggregator processes them. JSON.stringify escapes
+  // them as `\n`, which survives as a single physical line.
+  assert.ok(!logs[0].includes('\n'), 'structured log must not contain raw newlines');
+  assert.ok(logs[0].includes('\\n'), 'newlines must be JSON-escaped');
+  // Parse the log and verify the attacker's pseudo-fields live *inside*
+  // the agentId string value, not as top-level fields of the JSON object.
+  // A raw console.error(`...${agentId}...`) would have smuggled a second
+  // "event: fake_login" line past a line-oriented log scanner; structured
+  // logging keeps it bottled up inside the quoted agentId string.
+  const parsed = JSON.parse(logs[0]) as Record<string, unknown>;
+  assert.equal(parsed.event, 'registry_agent_listener_error');
+  assert.equal(
+    typeof parsed.agentId === 'string' && (parsed.agentId as string).includes('fake_login'),
+    true,
+    'agentId value should retain the attacker input verbatim (escaped, not stripped)',
+  );
+  assert.equal(
+    parsed.fake_login,
+    undefined,
+    'attacker payload must not surface as a top-level JSON field',
+  );
 });

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -147,35 +147,35 @@ test('onAgentChange does NOT fire on unregister if the ws does not match the cur
   assert.equal(current.agentCard.capabilities?.streaming, true);
 });
 
-test('a throwing onAgentChange listener does not abort other listeners or the registerAgent call', () => {
+test('a throwing onAgentChange listener does not abort other listeners or the registerAgent call', (t) => {
   // The change notification runs inside registerAgent/unregisterAgent. A bad
   // listener must not corrupt the caller's control flow or prevent
   // subsequent listeners from receiving the event.
+  //
+  // Use the test runner's scoped mock so parallel tests that also touch
+  // console.error don't race with this stub — node:test auto-restores the
+  // original at test teardown, removing the need for a manual try/finally
+  // and the "what if the test body throws before finally" window.
+  const errors: string[] = [];
+  t.mock.method(console, 'error', (...args: unknown[]) => {
+    errors.push(args.map(String).join(' '));
+  });
   const registry = new Registry();
   const seen: string[] = [];
-  const originalError = console.error;
-  const errors: string[] = [];
-  console.error = (...args: unknown[]) => {
-    errors.push(args.map(String).join(' '));
-  };
-  try {
-    registry.onAgentChange(() => {
-      throw new Error('listener boom');
-    });
-    registry.onAgentChange((id) => seen.push(id));
-    const result = registry.registerAgent({
-      agentId: 'a1',
-      clientId: 'c1',
-      ownerWallet: '0x0',
-      agentCard: makeCard(false),
-      allowedCallers: [],
-      ws: makeWs(),
-      connectedAt: 0,
-    });
-    assert.deepEqual(result, { ok: true });
-    assert.deepEqual(seen, ['a1']);
-    assert.ok(errors.some((e) => e.includes('listener boom')));
-  } finally {
-    console.error = originalError;
-  }
+  registry.onAgentChange(() => {
+    throw new Error('listener boom');
+  });
+  registry.onAgentChange((id) => seen.push(id));
+  const result = registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerWallet: '0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(seen, ['a1']);
+  assert.ok(errors.some((e) => e.includes('listener boom')));
 });

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -2,6 +2,7 @@ import type { WebSocket } from 'ws';
 import type { AgentCard, DownFrame } from '@vicoop-bridge/protocol';
 import { encodeFrame } from '@vicoop-bridge/protocol';
 import type { ExecutionEventBus } from '@a2a-js/sdk/server';
+import { logEvent, truncate } from './log.js';
 
 export interface ClientConnection {
   agentId: string;
@@ -127,14 +128,18 @@ export class Registry {
         listener(agentId);
       } catch (err) {
         // A misbehaving listener must not abort further notifications or
-        // corrupt the register/unregister call site. Log the full error —
-        // stack trace included when it's an Error, verbatim value otherwise
-        // — so a listener that throws a non-Error primitive still produces
-        // an actionable log line (not `undefined`).
-        console.error(
-          `[registry] agent change listener threw for agentId=${agentId}:`,
-          err,
-        );
+        // corrupt the register/unregister call site. Log through
+        // logEvent() so user-controlled agentId (originates in the hello
+        // frame and is an unconstrained string at this layer) is JSON-
+        // escaped rather than interpolated into a format string — this
+        // prevents CRLF log injection. Truncate it too so a pathological
+        // client can't inflate each error line unbounded. Preserve the
+        // stack when available; fall back to String() for non-Error
+        // throws so the log is still actionable.
+        logEvent('registry_agent_listener_error', {
+          agentId: truncate(String(agentId), 128),
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+        });
       }
     }
   }

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -22,12 +22,15 @@ export interface TaskBinding {
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;
 // Fires whenever the agent connection (including its embedded agentCard) is
-// replaced or removed. Downstream consumers that cache objects derived from
-// the card — e.g. the HTTP layer's per-agent JsonRpcTransportHandler, which
-// captures `capabilities.streaming` at construction time — must evict on
-// this signal, otherwise a client that reconnects with an updated card
-// (say, `streaming: false` → `true`) will continue to be served by a
-// transport built against the old card until the server restarts.
+// newly registered, replaced, or removed. Downstream consumers that cache
+// objects derived from the card — e.g. the HTTP layer's per-agent
+// JsonRpcTransportHandler, which captures `capabilities.streaming` at
+// construction time — must evict on this signal, otherwise a client that
+// reconnects with an updated card (say, `streaming: false` → `true`) will
+// continue to be served by a transport built against the old card until the
+// server restarts. Fires on first registration too so any transient cache
+// entry left behind by a previous lifecycle (e.g. a lingering entry from
+// before an unclean shutdown) is cleared unconditionally.
 export type AgentChangeListener = (agentId: string) => void;
 
 export class Registry {
@@ -124,8 +127,14 @@ export class Registry {
         listener(agentId);
       } catch (err) {
         // A misbehaving listener must not abort further notifications or
-        // corrupt the register/unregister call site. Log and continue.
-        console.error('[registry] agent change listener threw:', (err as Error).message);
+        // corrupt the register/unregister call site. Log the full error —
+        // stack trace included when it's an Error, verbatim value otherwise
+        // — so a listener that throws a non-Error primitive still produces
+        // an actionable log line (not `undefined`).
+        console.error(
+          `[registry] agent change listener threw for agentId=${agentId}:`,
+          err,
+        );
       }
     }
   }

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -21,11 +21,20 @@ export interface TaskBinding {
 }
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;
+// Fires whenever the agent connection (including its embedded agentCard) is
+// replaced or removed. Downstream consumers that cache objects derived from
+// the card — e.g. the HTTP layer's per-agent JsonRpcTransportHandler, which
+// captures `capabilities.streaming` at construction time — must evict on
+// this signal, otherwise a client that reconnects with an updated card
+// (say, `streaming: false` → `true`) will continue to be served by a
+// transport built against the old card until the server restarts.
+export type AgentChangeListener = (agentId: string) => void;
 
 export class Registry {
   private agents = new Map<string, ClientConnection>();
   private bindings = new Map<string, TaskBinding>();
   private callerChangeListeners: CallerChangeListener[] = [];
+  private agentChangeListeners: AgentChangeListener[] = [];
 
   registerAgent(conn: ClientConnection): { ok: true } | { ok: false; reason: string } {
     const existing = this.agents.get(conn.agentId);
@@ -33,11 +42,13 @@ export class Registry {
       if (existing.clientId === conn.clientId) {
         existing.ws.close(4009, 'replaced by new connection');
         this.agents.set(conn.agentId, conn);
+        this.notifyAgentChange(conn.agentId);
         return { ok: true };
       }
       return { ok: false, reason: 'agent already registered by different client' };
     }
     this.agents.set(conn.agentId, conn);
+    this.notifyAgentChange(conn.agentId);
     return { ok: true };
   }
 
@@ -45,6 +56,7 @@ export class Registry {
     const existing = this.agents.get(agentId);
     if (!existing || existing.ws !== ws) return;
     this.agents.delete(agentId);
+    this.notifyAgentChange(agentId);
     for (const binding of [...this.bindings.values()]) {
       if (binding.agentId !== agentId) continue;
       binding.eventBus.publish({
@@ -94,11 +106,27 @@ export class Registry {
     this.callerChangeListeners.push(listener);
   }
 
+  onAgentChange(listener: AgentChangeListener): void {
+    this.agentChangeListeners.push(listener);
+  }
+
   updateAllowedCallers(agentId: string, callers: string[]): void {
     const conn = this.agents.get(agentId);
     if (conn) conn.allowedCallers = callers;
     for (const listener of this.callerChangeListeners) {
       listener(agentId, callers);
+    }
+  }
+
+  private notifyAgentChange(agentId: string): void {
+    for (const listener of this.agentChangeListeners) {
+      try {
+        listener(agentId);
+      } catch (err) {
+        // A misbehaving listener must not abort further notifications or
+        // corrupt the register/unregister call site. Log and continue.
+        console.error('[registry] agent change listener threw:', (err as Error).message);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a stale-card bug surfaced by running a2a-tck against the Fly-deployed server after the client-v0.3.0 rollout (see PR #56): the agent card endpoint reports the new \`capabilities.streaming: true\`, but \`message/stream\` still fails with

> Failed to send message: HTTP Error 400: Invalid SSE response or protocol error: Expected response header Content-Type to contain 'text/event-stream', got 'application/json'

Client + server card view confirms the mismatch:

```console
$ curl -s https://vicoop-bridge-server.fly.dev/agents/<agent>/.well-known/agent-card.json | jq .capabilities
{ \"streaming\": true, \"pushNotifications\": false }
```

but the JSON-RPC pipe on the same agent rejects \`message/stream\` as \`unsupportedOperation\`.

## Root cause

Two things conspired:

1. \`@a2a-js/sdk\`'s \`DefaultRequestHandler\` **captures the agent card at construction time** — its \`getAgentCard()\` just returns the stored reference:
   ```js
   constructor(agentCard, ...) { this.agentCard = agentCard; ... }
   async getAgentCard() { return this.agentCard; }
   ```
   and the pre-dispatch check in \`JsonRpcTransportHandler\` fails closed when the snapshot says \`streaming: false\`:
   ```js
   if (method === \"message/stream\" || method === \"tasks/resubscribe\") {
     const agentCard = await this.requestHandler.getAgentCard();
     if (!agentCard.capabilities.streaming) {
       throw A2AError.unsupportedOperation(\`Method \${method} requires streaming capability.\`);
     }
     ...
   }
   ```
2. Our server caches one \`JsonRpcTransportHandler\` per agentId (\`http.tsx:130\`) and only invalidated that cache on \`registry.onCallerChange\` (allowedCallers updates). A client reconnecting with an updated card (e.g. streaming false → true after the 0.3.0 upgrade) was silently served by the stale transport.

Meanwhile \`GET /agents/:id/.well-known/agent-card.json\` reads \`conn.agentCard\` on every request, so the card URL looks correct — which makes the bug particularly confusing to diagnose from the outside.

## Fix

- \`Registry\` grows \`onAgentChange(agentId)\` alongside \`onCallerChange\`. Fires on:
  - successful \`registerAgent\` (first registration AND replacement — i.e. same client reconnecting);
  - \`unregisterAgent\` whose ws matches the current connection.
- Does NOT fire when:
  - \`registerAgent\` is rejected because a different client already owns the agentId (incumbent's cached transport is still valid for them);
  - \`unregisterAgent\` is called with a superseded ws (late close event from an already-replaced socket — must not invalidate the live connection's transport).
- \`http.tsx\` subscribes and evicts the transports cache. Next request rebuilds \`DefaultRequestHandler\` against the current card.
- Listener exceptions are caught + logged so a broken subscriber can't corrupt register/unregister control flow.

\`admin.ts\` uses the same SDK classes but with a server-owned card that never changes at runtime, so no cache-invalidation concern there.

## Test plan

- [x] \`pnpm --filter @vicoop-bridge/server test\` — 102 tests, 82 pass + 20 SIWE-env skips, 0 fail.
- [x] \`pnpm --filter @vicoop-bridge/client test\` — 45/45 pass (regression check for the multi-artifact streaming from #56).
- [x] \`pnpm -r build\` — clean.
- [ ] Post-deploy: \`message/stream\` on the Fly-deployed \`openclaw-swen-2026042301\` returns an SSE stream (or an SSE-wrapped error if content is blocked), NOT \`application/json\` with HTTP 400.

Also adds a \`test\` script to \`packages/server/package.json\` — the \`*.test.ts\` files alongside existing server modules had no \`pnpm\` entry point before (probably a regression when the test runner was never wired into CI). No behavior change for production, just makes the existing and new tests runnable via the filter.

## Follow-ups (not in this PR)

- Consider not caching \`JsonRpcTransportHandler\` at all — constructing one per request is ~free and eliminates this whole class of bug. The cache pays for nothing in the steady state because \`DefaultRequestHandler\` is essentially stateless.
- The SDK capturing the card by reference (not by getter) is arguably the wrong shape upstream; filing against \`@a2a-js/sdk\` could save downstream users the same papercut.