### PR TITLE
Add `vicoop-client upgrade` self-update subcommand

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -423,6 +423,51 @@ Using `set -a` + `.` keeps secrets out of the process-listing line and
 tolerates quoted values / comment lines in the env file, which the
 `env $(xargs)` pattern does not.
 
+## Updating the client
+
+Once installed, the client updates itself — do not re-run `install.sh`. The
+installer's `FORCE=1` path is destructive (it `rm -rf`s `$INSTALL_DIR` and
+wipes any operator-added cards / files), so it's reserved for bootstrapping.
+
+```sh
+"$INSTALL_DIR/bin/vicoop-client" upgrade --check      # report latest vs current
+"$INSTALL_DIR/bin/vicoop-client" upgrade              # upgrade to latest client-v*
+"$INSTALL_DIR/bin/vicoop-client" upgrade --version client-v0.2.0   # pin / downgrade
+"$INSTALL_DIR/bin/vicoop-client" upgrade --force      # reinstall current version
+```
+
+The upgrade command:
+
+1. Queries GitHub releases for the latest `client-v*` tag (or the `--version`
+   you pin).
+2. Downloads `.tgz` + `.sha256` to a temp directory and verifies the checksum.
+3. Extracts into `$INSTALL_DIR.new/` (sibling of the current install).
+4. Copies operator files that don't ship with the bundle — notably any
+   `cards/*.json` you added or files placed directly under `$INSTALL_DIR`.
+   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`) are always
+   replaced with the new release's versions.
+5. Runs `node $INSTALL_DIR.new/dist/cli.js --version` as a healthcheck. If it
+   exits non-zero or reports the wrong version, `$INSTALL_DIR.new` is deleted
+   and the upgrade aborts with no change to the live install.
+6. Atomically swaps: `$INSTALL_DIR` → `$INSTALL_DIR.prev`,
+   `$INSTALL_DIR.new` → `$INSTALL_DIR`. A failure mid-swap restores the
+   original.
+7. Detects a matching `vicoop-client.service` unit (system or user scope) and
+   runs `systemctl [--user] try-restart vicoop-client.service`. If no unit
+   exists, prints a reminder to restart the client yourself.
+8. Keeps `$INSTALL_DIR.prev` around for manual rollback (`mv` it back into
+   place if needed). Delete it once you've confirmed the new version works.
+
+**Permissions**: for a system-scope install (root-owned `$INSTALL_DIR`),
+run the upgrade via `sudo`. The command checks write access up front and
+fails fast with a clear error otherwise.
+
+**`/etc/vicoop-client.env` and the systemd unit file are not touched.** Those
+belong to `install.sh`; if a release ever changes the unit layout, re-run
+`install.sh` once to refresh the scaffolding. Note that `FORCE=1` deletes
+everything under `$INSTALL_DIR` first — back up any operator-added cards or
+files before running it.
+
 ## Troubleshooting
 
 - **`agent id owned by a different wallet`** (WS register) — your wallet is

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -433,7 +433,7 @@ wipes any operator-added cards / files), so it's reserved for bootstrapping.
 "$INSTALL_DIR/bin/vicoop-client" upgrade --check      # report latest vs current
 "$INSTALL_DIR/bin/vicoop-client" upgrade              # upgrade to latest client-v*
 "$INSTALL_DIR/bin/vicoop-client" upgrade --version client-v0.2.0   # pin / downgrade
-"$INSTALL_DIR/bin/vicoop-client" upgrade --force      # reinstall current version
+"$INSTALL_DIR/bin/vicoop-client" upgrade --force      # reinstall the resolved target even if already on it
 ```
 
 The upgrade command:

--- a/install.sh
+++ b/install.sh
@@ -385,6 +385,9 @@ if [ -n "$SERVICE_INSTALLED" ]; then
        $SERVICE_RELOAD_CMD
        $SERVICE_ENABLE_CMD
 
+  Future updates: run \`$INSTALL_DIR/bin/vicoop-client upgrade\` — no need to
+  re-run this installer. Pass --check to see if a newer release is available.
+
 EOF
   if [ "$SERVICE_INSTALLED" = "user" ]; then
     cat <<'EOF'
@@ -411,6 +414,9 @@ else
 
      For persistent operation, see docs/install-client.md §6
      (launchd on macOS, systemd user unit, tmux).
+
+  Future updates: run \`$INSTALL_DIR/bin/vicoop-client upgrade\` — no need to
+  re-run this installer. Pass --check to see if a newer release is available.
 
 EOF
 fi

--- a/install.sh
+++ b/install.sh
@@ -128,8 +128,14 @@ tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1
 # current uid/gid already. When root *is* extracting, the archive's stored
 # uid (typically ~1000, whoever built the release) would otherwise end up
 # owning a root-run service's files — that's a privilege-escalation vector.
+# After chown-to-root, also strip any setuid/setgid bits tar may have
+# restored — those'd now be *root-owned* suid files, which is far worse
+# than the build-uid case. Archive has no setuid bits today; this is a
+# defense-in-depth invariant.
 if [ "$(id -u)" = "0" ]; then
   chown -R 0:0 "$INSTALL_DIR" || die "chown -R 0:0 $INSTALL_DIR failed — refusing to leave root-extracted files with non-root ownership"
+  find "$INSTALL_DIR" -type f \( -perm -4000 -o -perm -2000 \) -exec chmod u-s,g-s {} + \
+    || die "failed to strip setuid/setgid bits under $INSTALL_DIR after root extraction"
 fi
 
 chmod +x "$INSTALL_DIR/bin/vicoop-client" 2>/dev/null || true
@@ -395,8 +401,10 @@ if [ -n "$SERVICE_INSTALLED" ]; then
        $SERVICE_RELOAD_CMD
        $SERVICE_ENABLE_CMD
 
-  Future updates: run \`$INSTALL_DIR/bin/vicoop-client upgrade\` — no need to
-  re-run this installer. Pass --check to see if a newer release is available.
+  Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
+  to re-run this installer. Pass --check to see if a newer release is
+  available. The quotes keep the command correct even if \$INSTALL_DIR
+  contains whitespace.
 
 EOF
   if [ "$SERVICE_INSTALLED" = "user" ]; then
@@ -425,8 +433,10 @@ else
      For persistent operation, see docs/install-client.md §6
      (launchd on macOS, systemd user unit, tmux).
 
-  Future updates: run \`$INSTALL_DIR/bin/vicoop-client upgrade\` — no need to
-  re-run this installer. Pass --check to see if a newer release is available.
+  Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
+  to re-run this installer. Pass --check to see if a newer release is
+  available. The quotes keep the command correct even if \$INSTALL_DIR
+  contains whitespace.
 
 EOF
 fi

--- a/install.sh
+++ b/install.sh
@@ -119,12 +119,18 @@ printf '%s  %s\n' "$EXPECTED_HASH" "$ARCHIVE" > "$TMP_DIR/$CHECKSUM"
 
 log "extracting into $INSTALL_DIR"
 # Bundle root inside the archive is vicoop-bridge-client-<version>/; strip it
-# so files land directly in INSTALL_DIR. `--no-same-owner` / `--no-same-permissions`
-# guard against root-run extraction restoring the build host's uid/gid or
-# setuid bits — if the archive was built as uid 1000, we'd otherwise create
-# root-running service files writable by that uid.
-tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1 \
-  --no-same-owner --no-same-permissions
+# so files land directly in INSTALL_DIR.
+tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1
+
+# Portable ownership normalization. We can't rely on `tar --no-same-owner`
+# everywhere (busybox tar lacks the long option), so we chown after the
+# fact. Only actually matters under `sudo`: otherwise tar extracts as the
+# current uid/gid already. When root *is* extracting, the archive's stored
+# uid (typically ~1000, whoever built the release) would otherwise end up
+# owning a root-run service's files — that's a privilege-escalation vector.
+if [ "$(id -u)" = "0" ]; then
+  chown -R 0:0 "$INSTALL_DIR" || die "chown -R 0:0 $INSTALL_DIR failed — refusing to leave root-extracted files with non-root ownership"
+fi
 
 chmod +x "$INSTALL_DIR/bin/vicoop-client" 2>/dev/null || true
 

--- a/install.sh
+++ b/install.sh
@@ -134,7 +134,10 @@ tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1
 # defense-in-depth invariant.
 if [ "$(id -u)" = "0" ]; then
   chown -R 0:0 "$INSTALL_DIR" || die "chown -R 0:0 $INSTALL_DIR failed — refusing to leave root-extracted files with non-root ownership"
-  find "$INSTALL_DIR" -type f \( -perm -4000 -o -perm -2000 \) -exec chmod u-s,g-s {} + \
+  # POSIX `-exec ... {} \;` (one-per-file) rather than `{} +` so this works
+  # on older busybox find too. Our archive ships no setuid files, so the
+  # per-file fork overhead is effectively zero in practice.
+  find "$INSTALL_DIR" -type f \( -perm -4000 -o -perm -2000 \) -exec chmod u-s,g-s {} \; \
     || die "failed to strip setuid/setgid bits under $INSTALL_DIR after root extraction"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -119,8 +119,12 @@ printf '%s  %s\n' "$EXPECTED_HASH" "$ARCHIVE" > "$TMP_DIR/$CHECKSUM"
 
 log "extracting into $INSTALL_DIR"
 # Bundle root inside the archive is vicoop-bridge-client-<version>/; strip it
-# so files land directly in INSTALL_DIR.
-tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1
+# so files land directly in INSTALL_DIR. `--no-same-owner` / `--no-same-permissions`
+# guard against root-run extraction restoring the build host's uid/gid or
+# setuid bits — if the archive was built as uid 1000, we'd otherwise create
+# root-running service files writable by that uid.
+tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1 \
+  --no-same-owner --no-same-permissions
 
 chmod +x "$INSTALL_DIR/bin/vicoop-client" 2>/dev/null || true
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -92,11 +92,11 @@ async function runUpgradeCmd(args: string[]): Promise<number> {
     else if (a === '--version') {
       version = args[++i];
       if (!version) {
-        console.error('--version requires a value (e.g. client-v0.3.0)');
+        console.error('--version requires a value (e.g. 0.3.0, v0.3.0, or client-v0.3.0)');
         return 1;
       }
     } else if (a === '-h' || a === '--help') {
-      console.log('usage: vicoop-client upgrade [--check] [--force] [--version <client-vX.Y.Z>]');
+      console.log('usage: vicoop-client upgrade [--check] [--force] [--version <X.Y.Z | vX.Y.Z | client-vX.Y.Z>]');
       return 0;
     } else {
       console.error(`unknown argument to upgrade: ${a}`);

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -6,6 +6,8 @@ import { echoBackend } from './backends/echo.js';
 import { createOpenclawBackend } from './backends/openclaw.js';
 import { createClaudeBackend } from './backends/claude.js';
 import type { Backend } from './backend.js';
+import { clientVersion } from './version.js';
+import { runUpgrade } from './upgrade.js';
 
 interface Args {
   server: string;
@@ -15,8 +17,7 @@ interface Args {
   backend: string;
 }
 
-function parseArgs(): Args {
-  const argv = process.argv.slice(2);
+function parseClientArgs(argv: string[]): Args {
   const out: Partial<Args> = {};
   for (let i = 0; i < argv.length; i++) {
     const key = argv[i];
@@ -56,24 +57,80 @@ function pickBackend(name: string): Backend {
   }
 }
 
-const args = parseArgs();
-const cardJson = JSON.parse(readFileSync(args.card, 'utf8'));
-const agentCard = AgentCard.parse(cardJson);
+function runClient(argv: string[]): void {
+  const args = parseClientArgs(argv);
+  const cardJson = JSON.parse(readFileSync(args.card, 'utf8'));
+  const agentCard = AgentCard.parse(cardJson);
 
-const client = new Client({
-  serverUrl: args.server,
-  token: args.token,
-  agentId: args.agentId,
-  agentCard,
-  backend: pickBackend(args.backend),
+  const client = new Client({
+    serverUrl: args.server,
+    token: args.token,
+    agentId: args.agentId,
+    agentCard,
+    backend: pickBackend(args.backend),
+  });
+
+  client.start();
+
+  const shutdown = () => {
+    console.log('\n[client] shutting down');
+    client.stop();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function runUpgradeCmd(args: string[]): Promise<number> {
+  let check = false;
+  let force = false;
+  let version: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--check') check = true;
+    else if (a === '--force') force = true;
+    else if (a === '--version') {
+      version = args[++i];
+      if (!version) {
+        console.error('--version requires a value (e.g. client-v0.3.0)');
+        return 1;
+      }
+    } else if (a === '-h' || a === '--help') {
+      console.log('usage: vicoop-client upgrade [--check] [--force] [--version <client-vX.Y.Z>]');
+      return 0;
+    } else {
+      console.error(`unknown argument to upgrade: ${a}`);
+      return 1;
+    }
+  }
+  try {
+    return await runUpgrade({ check, force, version });
+  } catch (e) {
+    console.error(`upgrade failed: ${(e as Error).message}`);
+    return 1;
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  // Top-level --version / -v: print and exit before touching anything else.
+  // Also used by the upgrade path's healthcheck on a freshly extracted bundle.
+  if (argv[0] === '--version' || argv[0] === '-v') {
+    process.stdout.write(`${clientVersion}\n`);
+    process.exit(0);
+  }
+
+  if (argv[0] === 'upgrade') {
+    process.exit(await runUpgradeCmd(argv.slice(1)));
+  }
+
+  // Default path: long-running daemon. Do not exit — client.start() keeps the
+  // event loop alive and signal handlers will call process.exit on shutdown.
+  runClient(argv);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
 });
-
-client.start();
-
-const shutdown = () => {
-  console.log('\n[client] shutting down');
-  client.stop();
-  process.exit(0);
-};
-process.on('SIGINT', shutdown);
-process.on('SIGTERM', shutdown);

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { normalizeTag, parseChecksum, preserveOperatorFiles, sha256File } from './upgrade.js';
+
+test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
+  assert.equal(normalizeTag('client-v0.3.0'), 'client-v0.3.0');
+  assert.equal(normalizeTag('0.3.0'), 'client-v0.3.0');
+  assert.equal(normalizeTag('v0.3.0'), 'client-v0.3.0');
+  assert.equal(normalizeTag('1.0.0-alpha.1'), 'client-v1.0.0-alpha.1');
+});
+
+test('parseChecksum extracts hash from `<hash>  <path>` and bare-hash forms', () => {
+  const hash = 'a'.repeat(64);
+  assert.equal(parseChecksum(`${hash}  vicoop-bridge-client-0.3.0.tgz`), hash);
+  assert.equal(parseChecksum(`${hash}\n`), hash);
+  assert.equal(parseChecksum(`${'F'.repeat(64)}  whatever`), 'f'.repeat(64));
+});
+
+test('parseChecksum rejects malformed input', () => {
+  assert.throws(() => parseChecksum(''), /could not parse sha256/);
+  assert.throws(() => parseChecksum('not-a-hash  file'), /could not parse sha256/);
+  assert.throws(() => parseChecksum('a'.repeat(63) + '  file'), /could not parse sha256/);
+  assert.throws(() => parseChecksum('a'.repeat(64) + 'z  file'), /could not parse sha256/);
+});
+
+test('sha256File streams the file and matches a known-answer', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-sha-'));
+  try {
+    const path = join(dir, 'f.bin');
+    writeFileSync(path, 'hello world');
+    // Known sha256 of "hello world".
+    const want = 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
+    assert.equal(await sha256File(path), want);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('preserveOperatorFiles keeps operator-added cards and top-level non-bundle files', () => {
+  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
+  try {
+    const oldDir = join(base, 'old');
+    const newDir = join(base, 'new');
+
+    // Old install: shipped bundle entries + operator additions.
+    mkdirSync(join(oldDir, 'cards'), { recursive: true });
+    mkdirSync(join(oldDir, 'bin'), { recursive: true });
+    mkdirSync(join(oldDir, 'dist'), { recursive: true });
+    mkdirSync(join(oldDir, 'node_modules'), { recursive: true });
+    writeFileSync(join(oldDir, 'package.json'), '{"version":"0.3.0"}');
+    writeFileSync(join(oldDir, 'cards', 'openclaw.json'), '{"marker":"old-shipped"}');
+    writeFileSync(join(oldDir, 'cards', 'my-custom.json'), '{"marker":"operator"}');
+    writeFileSync(join(oldDir, 'operator-notes.txt'), 'hello');
+
+    // Fresh bundle just extracted: has new shipped cards, none of operator's additions.
+    mkdirSync(join(newDir, 'cards'), { recursive: true });
+    mkdirSync(join(newDir, 'bin'), { recursive: true });
+    mkdirSync(join(newDir, 'dist'), { recursive: true });
+    mkdirSync(join(newDir, 'node_modules'), { recursive: true });
+    writeFileSync(join(newDir, 'package.json'), '{"version":"0.4.0"}');
+    writeFileSync(join(newDir, 'cards', 'openclaw.json'), '{"marker":"new-shipped"}');
+
+    preserveOperatorFiles(oldDir, newDir);
+
+    // Shipped card untouched — new bundle wins.
+    assert.equal(JSON.parse(readFileSync(join(newDir, 'cards', 'openclaw.json'), 'utf8')).marker, 'new-shipped');
+    // Operator-added card copied over.
+    assert.equal(readFileSync(join(newDir, 'cards', 'my-custom.json'), 'utf8'), '{"marker":"operator"}');
+    // Top-level operator file preserved.
+    assert.equal(readFileSync(join(newDir, 'operator-notes.txt'), 'utf8'), 'hello');
+    // Shipped top-level files not duplicated.
+    assert.equal(JSON.parse(readFileSync(join(newDir, 'package.json'), 'utf8')).version, '0.4.0');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('preserveOperatorFiles handles missing cards/ on either side without throwing', () => {
+  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
+  try {
+    const oldDir = join(base, 'old');
+    const newDir = join(base, 'new');
+    mkdirSync(oldDir);
+    mkdirSync(newDir);
+    writeFileSync(join(oldDir, 'operator.txt'), 'x');
+
+    preserveOperatorFiles(oldDir, newDir);
+    assert.equal(readFileSync(join(newDir, 'operator.txt'), 'utf8'), 'x');
+    // No cards/ gets fabricated.
+    assert.ok(!readdirSync(newDir).includes('cards'));
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('preserveOperatorFiles recurses into operator-added subdirectories', () => {
+  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
+  try {
+    const oldDir = join(base, 'old');
+    const newDir = join(base, 'new');
+    mkdirSync(join(oldDir, 'custom-state', 'nested'), { recursive: true });
+    writeFileSync(join(oldDir, 'custom-state', 'nested', 'data.bin'), 'payload');
+    mkdirSync(newDir);
+
+    preserveOperatorFiles(oldDir, newDir);
+    assert.equal(readFileSync(join(newDir, 'custom-state', 'nested', 'data.bin'), 'utf8'), 'payload');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -3,13 +3,31 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { normalizeTag, parseChecksum, preserveOperatorFiles, sha256File } from './upgrade.js';
+import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File } from './upgrade.js';
 
 test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
   assert.equal(normalizeTag('client-v0.3.0'), 'client-v0.3.0');
   assert.equal(normalizeTag('0.3.0'), 'client-v0.3.0');
   assert.equal(normalizeTag('v0.3.0'), 'client-v0.3.0');
   assert.equal(normalizeTag('1.0.0-alpha.1'), 'client-v1.0.0-alpha.1');
+  assert.equal(normalizeTag('1.0.0+build.sha'), 'client-v1.0.0+build.sha');
+});
+
+test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () => {
+  for (const bad of [
+    '../etc/passwd',
+    'client-v../0.3.0',
+    'client-v0.3.0/../../etc',
+    'client-v..',
+    '0.3.0/../evil',
+    'client-v 0.3.0',
+    'client-v0.3.0;rm -rf /',
+    'client-v0.3.0\nfoo',
+    'client-v',
+    '',
+  ]) {
+    assert.throws(() => normalizeTag(bad), /invalid version/, `expected rejection for ${JSON.stringify(bad)}`);
+  }
 });
 
 test('parseChecksum extracts hash from `<hash>  <path>` and bare-hash forms', () => {
@@ -93,6 +111,50 @@ test('preserveOperatorFiles handles missing cards/ on either side without throwi
     assert.ok(!readdirSync(newDir).includes('cards'));
   } finally {
     rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('assertLooksLikeInstall accepts a bundle-shaped directory', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
+  try {
+    mkdirSync(join(dir, 'bin'), { recursive: true });
+    mkdirSync(join(dir, 'dist'), { recursive: true });
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(join(dir, 'bin', 'vicoop-client'), '#!/usr/bin/env bash\nexec node ../dist/cli.js\n');
+    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@vicoop-bridge/client', version: '0.3.0' }));
+    assert.doesNotThrow(() => assertLooksLikeInstall(dir));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('assertLooksLikeInstall rejects directories missing bundle markers', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
+  try {
+    // Dev-workspace-shaped: has dist/, package.json, node_modules, but no bin/vicoop-client.
+    mkdirSync(join(dir, 'dist'), { recursive: true });
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@vicoop-bridge/client', version: '0.3.0' }));
+    assert.throws(() => assertLooksLikeInstall(dir), /bin\/vicoop-client/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('assertLooksLikeInstall rejects bundles with wrong package name', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
+  try {
+    mkdirSync(join(dir, 'bin'), { recursive: true });
+    mkdirSync(join(dir, 'dist'), { recursive: true });
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(join(dir, 'bin', 'vicoop-client'), '# stub');
+    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'some-other-package', version: '0.3.0' }));
+    assert.throws(() => assertLooksLikeInstall(dir), /unexpected name/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File } from './upgrade.js';
+import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File, stripSuidBits } from './upgrade.js';
+import { chmodSync, statSync } from 'node:fs';
 
 test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
   assert.equal(normalizeTag('client-v0.3.0'), 'client-v0.3.0');
@@ -153,6 +154,42 @@ test('assertLooksLikeInstall rejects bundles with wrong package name', () => {
     writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
     writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'some-other-package', version: '0.3.0' }));
     assert.throws(() => assertLooksLikeInstall(dir), /unexpected name/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('stripSuidBits clears setuid and setgid bits while leaving other modes untouched', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-suid-'));
+  try {
+    const plain = join(dir, 'plain');
+    const suid = join(dir, 'suid');
+    const sgid = join(dir, 'sgid');
+    const both = join(dir, 'both');
+    const nestedDir = join(dir, 'nested');
+    const nested = join(nestedDir, 'binary');
+    mkdirSync(nestedDir);
+    writeFileSync(plain, '');
+    writeFileSync(suid, '');
+    writeFileSync(sgid, '');
+    writeFileSync(both, '');
+    writeFileSync(nested, '');
+
+    chmodSync(plain, 0o755);
+    chmodSync(suid, 0o4755);
+    chmodSync(sgid, 0o2755);
+    chmodSync(both, 0o6755);
+    chmodSync(nested, 0o4750);
+
+    stripSuidBits(dir);
+
+    // Mask to the low 12 bits so platform-added type bits don't interfere.
+    const mode = (p: string) => statSync(p).mode & 0o7777;
+    assert.equal(mode(plain), 0o755, 'plain file unchanged');
+    assert.equal(mode(suid), 0o755, 'setuid cleared');
+    assert.equal(mode(sgid), 0o755, 'setgid cleared');
+    assert.equal(mode(both), 0o755, 'both cleared');
+    assert.equal(mode(nested), 0o750, 'recurses into subdirectories');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -1,10 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File, stripSuidBits } from './upgrade.js';
-import { chmodSync, statSync } from 'node:fs';
 
 test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
   assert.equal(normalizeTag('client-v0.3.0'), 'client-v0.3.0');

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -31,6 +31,17 @@ const SHIPPED_TOP_LEVEL = new Set(['bin', 'cards', 'dist', 'node_modules', 'pack
 // than block on.
 const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
+// Short cap for GitHub API calls (just listing tags). A stalled DNS resolution
+// or captive portal shouldn't strand the operator with a hung process.
+const API_TIMEOUT_MS = 15_000;
+
+// Generous cap for the actual release-asset download. `AbortSignal.timeout` is
+// a total-operation timeout, so this needs to cover slow-but-real networks
+// pulling a multi-MB bundle; lower it and we'd false-abort on plausible home
+// connections. If the upstream is genuinely dead the operator notices within
+// this window and can Ctrl-C sooner.
+const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+
 // Accepted release-tag shape. Restrictive on purpose: the tag is interpolated
 // into local filenames (archive name, temp path joins) and an external URL,
 // so we want to reject anything that could path-traverse or smuggle shell
@@ -229,10 +240,13 @@ function assertSafeTag(tag: string, raw: string = tag): void {
 }
 
 async function resolveLatestTag(): Promise<string> {
-  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=30`, {
-    headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/vnd.github+json' },
-  });
-  if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+  const url = `https://api.github.com/repos/${REPO}/releases?per_page=30`;
+  const res = await fetchWithTimeout(
+    url,
+    { headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/vnd.github+json' } },
+    API_TIMEOUT_MS,
+  );
+  if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
   const releases = (await res.json()) as Array<{ tag_name?: unknown }>;
   for (const r of releases) {
     if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('client-v')) continue;
@@ -243,6 +257,22 @@ async function resolveLatestTag(): Promise<string> {
     return r.tag_name;
   }
   throw new Error(`no client-v* release found in ${REPO}`);
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  } catch (e) {
+    // Node surfaces AbortSignal.timeout expiry as TimeoutError; older
+    // behavior / proxied fetches sometimes report AbortError. Translate
+    // either into a human-friendly message so operators know to check the
+    // network rather than chase a spurious stack trace.
+    const name = (e as Error).name;
+    if (name === 'TimeoutError' || name === 'AbortError') {
+      throw new Error(`${url} timed out after ${timeoutMs}ms`);
+    }
+    throw e;
+  }
 }
 
 export function assertLooksLikeInstall(dir: string): void {
@@ -273,8 +303,10 @@ export function assertLooksLikeInstall(dir: string): void {
 }
 
 async function download(url: string, dest: string): Promise<void> {
-  const res = await fetch(url, { redirect: 'follow' });
-  if (!res.ok || !res.body) throw new Error(`download failed: ${res.status} ${url}`);
+  const res = await fetchWithTimeout(url, { redirect: 'follow' }, DOWNLOAD_TIMEOUT_MS);
+  if (!res.ok || !res.body) {
+    throw new Error(`download failed: ${res.status} ${res.statusText || ''} (${url})`.trim());
+  }
   await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(dest));
 }
 
@@ -323,15 +355,29 @@ function runHealthcheck(newDir: string, expected: string): HealthcheckResult {
     encoding: 'utf8',
     timeout: HEALTHCHECK_TIMEOUT_MS,
   });
+  const stderrSnippet = (r.stderr ?? '').trim().split('\n').slice(0, 3).join(' | ').slice(0, 200);
+  const withStderr = (msg: string) => (stderrSnippet ? `${msg}; stderr: ${stderrSnippet}` : msg);
+
   // spawnSync's `timeout` option kills the child with SIGTERM on expiry; flag
   // that path separately so the operator can distinguish a hang from a normal
-  // non-zero exit.
+  // non-zero exit. Older Node versions surface the timeout via
+  // `error.message` instead of setting `signal`.
   if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
     return { ok: false, detail: `timeout after ${HEALTHCHECK_TIMEOUT_MS}ms` };
   }
+  // `r.error` is set when spawn itself failed (ENOENT on the node binary, for
+  // example). Report it separately from "process ran and exited non-zero".
+  if (r.error) {
+    return { ok: false, detail: withStderr(`spawn failed: ${r.error.message}`) };
+  }
+  // Any other terminating signal (SIGKILL from the OOM killer, SIGBUS from a
+  // native-module crash, etc.) — make the signal visible instead of falling
+  // through to `exit null`.
+  if (r.signal) {
+    return { ok: false, detail: withStderr(`terminated by signal ${r.signal}`) };
+  }
   if (r.status !== 0) {
-    const stderrSnippet = (r.stderr ?? '').trim().split('\n').slice(0, 3).join(' | ').slice(0, 200);
-    return { ok: false, detail: `exit ${r.status}${stderrSnippet ? `; stderr: ${stderrSnippet}` : ''}` };
+    return { ok: false, detail: withStderr(`exit ${r.status}`) };
   }
   const got = r.stdout.trim();
   if (got !== expected) {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -91,8 +91,17 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
     return 0;
   }
 
-  if (!canWrite(installDir) || !canWrite(dirname(installDir))) {
-    err(`$INSTALL_DIR or its parent is not writable (${installDir}).`);
+  // Preflight: the operations that actually matter are parent-directory
+  // renames (moving $INSTALL_DIR aside + $INSTALL_DIR.new into place) and
+  // reading through the current bundle (version.ts + preserveOperatorFiles).
+  // So: parent must be writable + executable, installDir itself only needs
+  // read + execute. A hardened chmod 555 install that the operator intends
+  // to leave read-only passes here and upgrades cleanly.
+  try {
+    accessSync(installDir, fsConstants.R_OK | fsConstants.X_OK);
+    accessSync(dirname(installDir), fsConstants.W_OK | fsConstants.X_OK);
+  } catch {
+    err(`$INSTALL_DIR must be readable/executable and its parent must be writable (${installDir}).`);
     err('If this is a system-scope install, re-run with sudo.');
     return 1;
   }
@@ -137,7 +146,25 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       mkdirSync(newDir, { recursive: true });
       const tarRes = spawnSync(
         'tar',
-        ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
+        [
+          '-xzf',
+          join(dlDir, archiveName),
+          '-C',
+          newDir,
+          '--strip-components=1',
+          // Under `sudo vicoop-client upgrade`, root would otherwise restore
+          // the archive's stored uid/gid — typically the 1000-ish user that
+          // built the release — leaving installed files owned by an
+          // unprivileged local account. That's a privilege-escalation path
+          // for a root-run service: any local user with that uid could
+          // modify `dist/cli.js` between service restarts.
+          // `--no-same-owner` forces the extracted files to the current
+          // effective uid/gid. `--no-same-permissions` drops any stored
+          // setuid/setgid bits; the archive has none today, but we want a
+          // known-safe default.
+          '--no-same-owner',
+          '--no-same-permissions',
+        ],
         { stdio: 'inherit' },
       );
       if (tarRes.error) {
@@ -411,15 +438,6 @@ function safeRemove(path: string): void {
     rmSync(path, { recursive: true, force: true });
   } catch (e) {
     log(`warning: failed to clean up ${path}: ${(e as Error).message}`);
-  }
-}
-
-function canWrite(path: string): boolean {
-  try {
-    accessSync(path, fsConstants.W_OK);
-    return true;
-  } catch {
-    return false;
   }
 }
 

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -441,7 +441,11 @@ function detectSystemdUnit(): { scope: 'system' | 'user' } | null {
   if (existsSync('/etc/systemd/system/vicoop-client.service')) return { scope: 'system' };
   const home = process.env.HOME;
   if (home) {
-    const userCfg = process.env.XDG_CONFIG_HOME ?? join(home, '.config');
+    // `||` rather than `??` so an empty `XDG_CONFIG_HOME=` (common
+    // accidental mis-export, and what shells treat as unset via
+    // `${XDG_CONFIG_HOME:-...}`) falls back to $HOME/.config instead of
+    // turning the path relative.
+    const userCfg = process.env.XDG_CONFIG_HOME || join(home, '.config');
     if (existsSync(join(userCfg, 'systemd', 'user', 'vicoop-client.service'))) {
       return { scope: 'user' };
     }

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -4,6 +4,7 @@ import {
   accessSync,
   constants as fsConstants,
   cpSync,
+  createReadStream,
   createWriteStream,
   existsSync,
   mkdirSync,
@@ -24,6 +25,11 @@ const REPO = 'planetarium/vicoop-bridge';
 // Top-level entries that the release bundle owns. Anything else under
 // $INSTALL_DIR is assumed operator-placed and preserved on upgrade.
 const SHIPPED_TOP_LEVEL = new Set(['bin', 'cards', 'dist', 'node_modules', 'package.json', 'README.md']);
+
+// Cap for the new-bundle --version probe. It's meant to be instantaneous;
+// anything close to the timeout indicates a regression we'd rather surface
+// than block on.
+const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
 export interface UpgradeOptions {
   check: boolean;
@@ -65,60 +71,85 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
   rmSync(newDir, { recursive: true, force: true });
 
   const dlDir = mkdtempSync(join(tmpdir(), 'vicoop-upgrade-'));
+
+  // `swapDone` gates the .new cleanup: any exit path before the atomic swap
+  // completes (explicit `return`, thrown exception, failed rollback) must
+  // leave the original install in place and remove .new. The outer finally
+  // checks this flag so we don't have to duplicate cleanup at every failure
+  // site.
+  let swapDone = false;
+
   try {
-    const archiveName = `vicoop-bridge-client-${targetVersion}.tgz`;
-    const checksumName = `${archiveName}.sha256`;
-    const baseUrl = `https://github.com/${REPO}/releases/download/${targetTag}`;
+    try {
+      const archiveName = `vicoop-bridge-client-${targetVersion}.tgz`;
+      const checksumName = `${archiveName}.sha256`;
+      const baseUrl = `https://github.com/${REPO}/releases/download/${targetTag}`;
 
-    log(`downloading ${archiveName}`);
-    await download(`${baseUrl}/${archiveName}`, join(dlDir, archiveName));
-    await download(`${baseUrl}/${checksumName}`, join(dlDir, checksumName));
+      log(`downloading ${archiveName}`);
+      await download(`${baseUrl}/${archiveName}`, join(dlDir, archiveName));
+      await download(`${baseUrl}/${checksumName}`, join(dlDir, checksumName));
 
-    log('verifying checksum');
-    const expected = parseChecksum(readFileSync(join(dlDir, checksumName), 'utf8'));
-    const actual = sha256File(join(dlDir, archiveName));
-    if (expected !== actual) {
-      err(`checksum mismatch: expected ${expected}, got ${actual}`);
+      log('verifying checksum');
+      const expected = parseChecksum(readFileSync(join(dlDir, checksumName), 'utf8'));
+      const actual = await sha256File(join(dlDir, archiveName));
+      if (expected !== actual) {
+        err(`checksum mismatch: expected ${expected}, got ${actual}`);
+        return 1;
+      }
+
+      log(`extracting into ${newDir}`);
+      mkdirSync(newDir, { recursive: true });
+      const tarRes = spawnSync(
+        'tar',
+        ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
+        { stdio: 'inherit' },
+      );
+      if (tarRes.status !== 0) {
+        err('extraction failed');
+        return 1;
+      }
+
+      preserveOperatorFiles(installDir, newDir);
+
+      const health = runHealthcheck(newDir, targetVersion);
+      if (!health.ok) {
+        err(`new bundle failed --version healthcheck; aborting${health.detail ? ` (${health.detail})` : ''}`);
+        return 1;
+      }
+
+      // Atomic swap. Both renames inside a guarded block so any failure
+      // restores the original install dir; the outer `finally` still deletes
+      // `.new` since `swapDone` stays false.
+      rmSync(prevDir, { recursive: true, force: true });
+      let movedOriginal = false;
+      try {
+        log(`swap: ${installDir} -> ${prevDir}`);
+        renameSync(installDir, prevDir);
+        movedOriginal = true;
+        log(`swap: ${newDir} -> ${installDir}`);
+        renameSync(newDir, installDir);
+        swapDone = true;
+      } catch (e) {
+        err(`swap failed, rolling back: ${(e as Error).message}`);
+        if (movedOriginal && !existsSync(installDir)) {
+          try {
+            renameSync(prevDir, installDir);
+          } catch (rollbackErr) {
+            err(`rollback rename failed: ${(rollbackErr as Error).message}`);
+          }
+        }
+        return 1;
+      }
+    } catch (e) {
+      err(`upgrade failed: ${(e as Error).message}`);
       return 1;
-    }
-
-    log(`extracting into ${newDir}`);
-    mkdirSync(newDir, { recursive: true });
-    const tarRes = spawnSync(
-      'tar',
-      ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
-      { stdio: 'inherit' },
-    );
-    if (tarRes.status !== 0) {
-      err('extraction failed');
-      rmSync(newDir, { recursive: true, force: true });
-      return 1;
-    }
-
-    preserveOperatorFiles(installDir, newDir);
-
-    if (!healthcheck(newDir, targetVersion)) {
-      err('new bundle failed --version healthcheck; aborting');
-      rmSync(newDir, { recursive: true, force: true });
-      return 1;
+    } finally {
+      if (!swapDone) {
+        rmSync(newDir, { recursive: true, force: true });
+      }
     }
   } finally {
     rmSync(dlDir, { recursive: true, force: true });
-  }
-
-  // Atomic swap. The first rename is the point of no return for $INSTALL_DIR;
-  // if the second fails we put the original back before bailing.
-  rmSync(prevDir, { recursive: true, force: true });
-  log(`swap: ${installDir} -> ${prevDir}`);
-  renameSync(installDir, prevDir);
-  try {
-    log(`swap: ${newDir} -> ${installDir}`);
-    renameSync(newDir, installDir);
-  } catch (e) {
-    err(`swap failed, rolling back: ${(e as Error).message}`);
-    renameSync(prevDir, installDir);
-    rmSync(newDir, { recursive: true, force: true });
-    return 1;
   }
 
   const unit = detectSystemdUnit();
@@ -136,7 +167,7 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
   return 0;
 }
 
-function normalizeTag(v: string): string {
+export function normalizeTag(v: string): string {
   return v.startsWith('client-v') ? v : `client-v${v.replace(/^v/, '')}`;
 }
 
@@ -158,11 +189,13 @@ async function download(url: string, dest: string): Promise<void> {
   await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(dest));
 }
 
-function sha256File(path: string): string {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
+export async function sha256File(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  await pipeline(createReadStream(path), hash);
+  return hash.digest('hex');
 }
 
-function parseChecksum(contents: string): string {
+export function parseChecksum(contents: string): string {
   // Matches install.sh: take the first whitespace-separated token from the first line.
   const first = contents.trim().split(/\s+/)[0];
   if (!first || !/^[0-9a-f]{64}$/i.test(first)) {
@@ -171,7 +204,7 @@ function parseChecksum(contents: string): string {
   return first.toLowerCase();
 }
 
-function preserveOperatorFiles(oldDir: string, newDir: string): void {
+export function preserveOperatorFiles(oldDir: string, newDir: string): void {
   for (const entry of readdirSync(oldDir)) {
     if (SHIPPED_TOP_LEVEL.has(entry)) continue;
     const src = join(oldDir, entry);
@@ -190,11 +223,32 @@ function preserveOperatorFiles(oldDir: string, newDir: string): void {
   }
 }
 
-function healthcheck(newDir: string, expected: string): boolean {
+interface HealthcheckResult {
+  ok: boolean;
+  detail?: string;
+}
+
+function runHealthcheck(newDir: string, expected: string): HealthcheckResult {
   const cli = join(newDir, 'dist', 'cli.js');
-  const r = spawnSync(process.execPath, [cli, '--version'], { encoding: 'utf8' });
-  if (r.status !== 0) return false;
-  return r.stdout.trim() === expected;
+  const r = spawnSync(process.execPath, [cli, '--version'], {
+    encoding: 'utf8',
+    timeout: HEALTHCHECK_TIMEOUT_MS,
+  });
+  // spawnSync's `timeout` option kills the child with SIGTERM on expiry; flag
+  // that path separately so the operator can distinguish a hang from a normal
+  // non-zero exit.
+  if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
+    return { ok: false, detail: `timeout after ${HEALTHCHECK_TIMEOUT_MS}ms` };
+  }
+  if (r.status !== 0) {
+    const stderrSnippet = (r.stderr ?? '').trim().split('\n').slice(0, 3).join(' | ').slice(0, 200);
+    return { ok: false, detail: `exit ${r.status}${stderrSnippet ? `; stderr: ${stderrSnippet}` : ''}` };
+  }
+  const got = r.stdout.trim();
+  if (got !== expected) {
+    return { ok: false, detail: `reported '${got}', expected '${expected}'` };
+  }
+  return { ok: true };
 }
 
 function detectSystemdUnit(): { scope: 'system' | 'user' } | null {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -88,7 +88,12 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 
   const newDir = `${installDir}.new`;
   const prevDir = `${installDir}.prev`;
-  rmSync(newDir, { recursive: true, force: true });
+  try {
+    rmSync(newDir, { recursive: true, force: true });
+  } catch (e) {
+    err(`could not clean up stale ${newDir}: ${(e as Error).message}`);
+    return 1;
+  }
 
   const dlDir = mkdtempSync(join(tmpdir(), 'vicoop-upgrade-'));
 
@@ -153,7 +158,12 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       // Atomic swap. Both renames inside a guarded block so any failure
       // restores the original install dir; the outer `finally` still deletes
       // `.new` since `swapDone` stays false.
-      rmSync(prevDir, { recursive: true, force: true });
+      try {
+        rmSync(prevDir, { recursive: true, force: true });
+      } catch (e) {
+        err(`could not clear existing ${prevDir}: ${(e as Error).message}`);
+        return 1;
+      }
       let movedOriginal = false;
       try {
         log(`swap: ${installDir} -> ${prevDir}`);
@@ -177,12 +187,15 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       err(`upgrade failed: ${(e as Error).message}`);
       return 1;
     } finally {
-      if (!swapDone) {
-        rmSync(newDir, { recursive: true, force: true });
-      }
+      // Cleanup paths must not mask the operation's real exit code. `rmSync`
+      // with `force: true` silences ENOENT but still throws on EACCES /
+      // EPERM / EBUSY, so a finally-block rmSync can turn a clean failure
+      // (or a clean success) into an uncaught exception. Downgrade to a
+      // warning instead.
+      if (!swapDone) safeRemove(newDir);
     }
   } finally {
-    rmSync(dlDir, { recursive: true, force: true });
+    safeRemove(dlDir);
   }
 
   const unit = detectSystemdUnit();
@@ -345,6 +358,14 @@ function tryRestartSystemd(scope: 'system' | 'user'): boolean {
     : ['try-restart', 'vicoop-client.service'];
   const r = spawnSync('systemctl', args, { stdio: 'inherit' });
   return r.status === 0;
+}
+
+function safeRemove(path: string): void {
+  try {
+    rmSync(path, { recursive: true, force: true });
+  } catch (e) {
+    log(`warning: failed to clean up ${path}: ${(e as Error).message}`);
+  }
 }
 
 function canWrite(path: string): boolean {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -31,6 +31,19 @@ const SHIPPED_TOP_LEVEL = new Set(['bin', 'cards', 'dist', 'node_modules', 'pack
 // than block on.
 const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
+// Accepted release-tag shape. Restrictive on purpose: the tag is interpolated
+// into local filenames (archive name, temp path joins) and an external URL,
+// so we want to reject anything that could path-traverse or smuggle shell
+// metacharacters before it's used. Permissive enough for semver-ish tags
+// including pre-release/build suffixes (`client-v1.0.0-rc.1`, `...+sha.abc`).
+const TAG_RE = /^client-v[A-Za-z0-9][A-Za-z0-9.+\-]*$/;
+
+// Top-level entries a legitimate release bundle must contain. Missing any one
+// of these is taken as "not an installed bundle" and aborts upgrade before
+// anything on disk can move — guards against running the command from a dev
+// workspace where `packages/client` lacks the synthesized bin wrapper.
+const BUNDLE_MARKERS = ['bin/vicoop-client', 'dist/cli.js', 'package.json', 'node_modules'];
+
 export interface UpgradeOptions {
   check: boolean;
   force: boolean;
@@ -39,6 +52,13 @@ export interface UpgradeOptions {
 
 export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
   log(`current: ${clientVersion} (${installDir})`);
+
+  try {
+    assertLooksLikeInstall(installDir);
+  } catch (e) {
+    err((e as Error).message);
+    return 1;
+  }
 
   const targetTag = opts.version
     ? normalizeTag(opts.version)
@@ -104,8 +124,21 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
         ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
         { stdio: 'inherit' },
       );
+      if (tarRes.error) {
+        // Most common failure: `tar` missing on PATH. spawnSync flags it via
+        // an ENOENT on `error.code`. Keep the message specific so an operator
+        // knows to install `tar` instead of chasing a bad-archive hypothesis.
+        const code = (tarRes.error as NodeJS.ErrnoException).code;
+        const hint = code === 'ENOENT' ? ' (tar not found on PATH — install it and retry)' : '';
+        err(`extraction failed: ${tarRes.error.message}${hint}`);
+        return 1;
+      }
+      if (tarRes.signal) {
+        err(`extraction failed: tar terminated by signal ${tarRes.signal}`);
+        return 1;
+      }
       if (tarRes.status !== 0) {
-        err('extraction failed');
+        err(`extraction failed: tar exited with status ${tarRes.status}`);
         return 1;
       }
 
@@ -168,7 +201,18 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 }
 
 export function normalizeTag(v: string): string {
-  return v.startsWith('client-v') ? v : `client-v${v.replace(/^v/, '')}`;
+  const candidate = v.startsWith('client-v') ? v : `client-v${v.replace(/^v/, '')}`;
+  assertSafeTag(candidate, v);
+  return candidate;
+}
+
+function assertSafeTag(tag: string, raw: string = tag): void {
+  // The tag is interpolated into local paths (archive name / temp joins) and
+  // an outbound URL. Reject anything that could path-traverse or inject shell
+  // metacharacters before it reaches `join(dlDir, ...)`.
+  if (!TAG_RE.test(tag) || tag.includes('..')) {
+    throw new Error(`invalid version '${raw}': expected client-v<semver>, got '${tag}'`);
+  }
 }
 
 async function resolveLatestTag(): Promise<string> {
@@ -178,9 +222,41 @@ async function resolveLatestTag(): Promise<string> {
   if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText}`);
   const releases = (await res.json()) as Array<{ tag_name?: unknown }>;
   for (const r of releases) {
-    if (typeof r.tag_name === 'string' && r.tag_name.startsWith('client-v')) return r.tag_name;
+    if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('client-v')) continue;
+    // Defensively validate the API response — a future rename or a
+    // compromised upstream shouldn't get to interpolate arbitrary strings
+    // into local filenames.
+    assertSafeTag(r.tag_name);
+    return r.tag_name;
   }
   throw new Error(`no client-v* release found in ${REPO}`);
+}
+
+export function assertLooksLikeInstall(dir: string): void {
+  for (const rel of BUNDLE_MARKERS) {
+    if (!existsSync(join(dir, rel))) {
+      throw new Error(
+        `${dir} does not look like an installed vicoop-client bundle ` +
+          `(missing ${rel}). Run install.sh for first-time setup; upgrade only manages existing installs.`,
+      );
+    }
+  }
+  // The workspace package.json at packages/client has the same name, so this
+  // isn't definitive on its own — but combined with the bin/vicoop-client
+  // check above (which the dev workspace lacks) it's enough to catch a
+  // `tsx src/cli.ts upgrade` or `node packages/client/dist/cli.js upgrade`
+  // run-from-source invocation before it mutates anything.
+  try {
+    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { name?: unknown };
+    if (pkg.name !== '@vicoop-bridge/client') {
+      throw new Error(`${dir}/package.json has unexpected name '${String(pkg.name)}' — refusing to upgrade`);
+    }
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      throw new Error(`${dir}/package.json is not valid JSON — refusing to upgrade`);
+    }
+    throw e;
+  }
 }
 
 async function download(url: string, dest: string): Promise<void> {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -201,6 +201,22 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 
       preserveOperatorFiles(installDir, newDir);
 
+      // Re-strip setuid/setgid after preservation. `cpSync` preserves mode
+      // bits, so any operator file that had suid/sgid bits set in the old
+      // install would arrive in newDir with those bits intact — and under
+      // `sudo vicoop-client upgrade` that file's dest would be owned by
+      // root (cpSync as root) or left owner-preserved, either way yielding
+      // a privileged binary inside the next install. Second strip closes
+      // that gap; non-root path is a no-op beyond the directory walk.
+      if (process.getuid?.() === 0) {
+        try {
+          stripSuidBits(newDir);
+        } catch (e) {
+          err(`failed to strip setuid/setgid bits under ${newDir} after preserving operator files: ${(e as Error).message}`);
+          return 1;
+        }
+      }
+
       const health = runHealthcheck(newDir, targetVersion);
       if (!health.ok) {
         err(`new bundle failed --version healthcheck; aborting${health.detail ? ` (${health.detail})` : ''}`);

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -146,25 +146,7 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       mkdirSync(newDir, { recursive: true });
       const tarRes = spawnSync(
         'tar',
-        [
-          '-xzf',
-          join(dlDir, archiveName),
-          '-C',
-          newDir,
-          '--strip-components=1',
-          // Under `sudo vicoop-client upgrade`, root would otherwise restore
-          // the archive's stored uid/gid — typically the 1000-ish user that
-          // built the release — leaving installed files owned by an
-          // unprivileged local account. That's a privilege-escalation path
-          // for a root-run service: any local user with that uid could
-          // modify `dist/cli.js` between service restarts.
-          // `--no-same-owner` forces the extracted files to the current
-          // effective uid/gid. `--no-same-permissions` drops any stored
-          // setuid/setgid bits; the archive has none today, but we want a
-          // known-safe default.
-          '--no-same-owner',
-          '--no-same-permissions',
-        ],
+        ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
         { stdio: 'inherit' },
       );
       if (tarRes.error) {
@@ -183,6 +165,23 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       if (tarRes.status !== 0) {
         err(`extraction failed: tar exited with status ${tarRes.status}`);
         return 1;
+      }
+
+      // Portable replacement for `tar --no-same-owner`: busybox tar lacks
+      // the long option, so we normalize ownership after the fact. Non-root
+      // tar already extracts as the current uid/gid (kernel enforces), so
+      // the chown only actually matters under `sudo vicoop-client upgrade`
+      // — where the archive's stored uid (typically ~1000, whatever built
+      // the release) would otherwise end up owning a root-run service's
+      // files. That's a privilege-escalation vector: any local user with
+      // that uid could modify `dist/cli.js` between restarts.
+      if (process.getuid?.() === 0) {
+        const chownRes = spawnSync('chown', ['-R', '0:0', newDir], { stdio: 'inherit' });
+        if (chownRes.error || chownRes.signal || chownRes.status !== 0) {
+          const detail = chownRes.error?.message ?? `signal ${chownRes.signal ?? 'none'}, status ${chownRes.status}`;
+          err(`chown -R 0:0 on ${newDir} failed (${detail}) — refusing to leave root-extracted files with non-root ownership`);
+          return 1;
+        }
       }
 
       preserveOperatorFiles(installDir, newDir);
@@ -279,16 +278,21 @@ async function resolveLatestTag(): Promise<string> {
     API_TIMEOUT_MS,
   );
   if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
-  const releases = (await res.json()) as Array<{ tag_name?: unknown }>;
+  const releases = (await res.json()) as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
   for (const r of releases) {
     if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('client-v')) continue;
+    // Skip drafts (no uploaded assets — the .tgz download would 404) and
+    // prereleases (assets exist but operators on the default channel don't
+    // want them). `--version client-vX.Y.Z-rc.1` still lets an operator
+    // pin an explicit prerelease when they want to test one.
+    if (r.draft === true || r.prerelease === true) continue;
     // Defensively validate the API response — a future rename or a
     // compromised upstream shouldn't get to interpolate arbitrary strings
     // into local filenames.
     assertSafeTag(r.tag_name);
     return r.tag_name;
   }
-  throw new Error(`no client-v* release found in ${REPO}`);
+  throw new Error(`no published (non-draft, non-prerelease) client-v* release found in ${REPO}`);
 }
 
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -260,9 +260,14 @@ export function normalizeTag(v: string): string {
 function assertSafeTag(tag: string, raw: string = tag): void {
   // The tag is interpolated into local paths (archive name / temp joins) and
   // an outbound URL. Reject anything that could path-traverse or inject shell
-  // metacharacters before it reaches `join(dlDir, ...)`.
+  // metacharacters before it reaches `join(dlDir, ...)`. The regex is
+  // intentionally looser than strict semver — we want to accept future
+  // pre-release and build-metadata variants that GitHub might tag — so the
+  // error describes the literal character set rather than implying semver.
   if (!TAG_RE.test(tag) || tag.includes('..')) {
-    throw new Error(`invalid version '${raw}': expected client-v<semver>, got '${tag}'`);
+    throw new Error(
+      `invalid version '${raw}': expected a client-v* tag with only [A-Za-z0-9.+-] (no '..'), got '${tag}'`,
+    );
   }
 }
 
@@ -430,7 +435,21 @@ function tryRestartSystemd(scope: 'system' | 'user'): boolean {
     ? ['--user', 'try-restart', 'vicoop-client.service']
     : ['try-restart', 'vicoop-client.service'];
   const r = spawnSync('systemctl', args, { stdio: 'inherit' });
-  return r.status === 0;
+  if (r.error) {
+    const code = (r.error as NodeJS.ErrnoException).code;
+    const hint = code === 'ENOENT' ? ' (systemctl not on PATH)' : '';
+    err(`systemctl spawn failed${hint}: ${r.error.message}`);
+    return false;
+  }
+  if (r.signal) {
+    err(`systemctl terminated by signal ${r.signal}`);
+    return false;
+  }
+  if (r.status !== 0) {
+    err(`systemctl try-restart exited with status ${r.status}`);
+    return false;
+  }
+  return true;
 }
 
 function safeRemove(path: string): void {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import {
   accessSync,
   constants as fsConstants,
+  chmodSync,
   cpSync,
   createReadStream,
   createWriteStream,
@@ -13,6 +14,7 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  statSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -175,11 +177,24 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       // the release) would otherwise end up owning a root-run service's
       // files. That's a privilege-escalation vector: any local user with
       // that uid could modify `dist/cli.js` between restarts.
+      //
+      // Under root we also strip setuid/setgid bits that tar may have
+      // restored from the archive. After the chown above, any such bits
+      // would become root-owned suid files under $INSTALL_DIR — much worse
+      // than the build-host-uid case. The archive has no setuid bits today;
+      // this is a defense-in-depth invariant so we don't silently start
+      // shipping a privileged binary if someone adds one.
       if (process.getuid?.() === 0) {
         const chownRes = spawnSync('chown', ['-R', '0:0', newDir], { stdio: 'inherit' });
         if (chownRes.error || chownRes.signal || chownRes.status !== 0) {
           const detail = chownRes.error?.message ?? `signal ${chownRes.signal ?? 'none'}, status ${chownRes.status}`;
           err(`chown -R 0:0 on ${newDir} failed (${detail}) — refusing to leave root-extracted files with non-root ownership`);
+          return 1;
+        }
+        try {
+          stripSuidBits(newDir);
+        } catch (e) {
+          err(`failed to strip setuid/setgid bits under ${newDir}: ${(e as Error).message}`);
           return 1;
         }
       }
@@ -454,6 +469,20 @@ function tryRestartSystemd(scope: 'system' | 'user'): boolean {
     return false;
   }
   return true;
+}
+
+// Recursively clear the setuid (04000) and setgid (02000) bits on every file
+// under `dir`. Exported for tests.
+export function stripSuidBits(dir: string): void {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      stripSuidBits(p);
+    } else if (entry.isFile()) {
+      const mode = statSync(p).mode;
+      if (mode & 0o6000) chmodSync(p, mode & ~0o6000);
+    }
+  }
 }
 
 function safeRemove(path: string): void {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -1,0 +1,235 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  accessSync,
+  constants as fsConstants,
+  cpSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { clientVersion, installDir } from './version.js';
+
+const REPO = 'planetarium/vicoop-bridge';
+
+// Top-level entries that the release bundle owns. Anything else under
+// $INSTALL_DIR is assumed operator-placed and preserved on upgrade.
+const SHIPPED_TOP_LEVEL = new Set(['bin', 'cards', 'dist', 'node_modules', 'package.json', 'README.md']);
+
+export interface UpgradeOptions {
+  check: boolean;
+  force: boolean;
+  version?: string;
+}
+
+export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
+  log(`current: ${clientVersion} (${installDir})`);
+
+  const targetTag = opts.version
+    ? normalizeTag(opts.version)
+    : await resolveLatestTag();
+  const targetVersion = targetTag.replace(/^client-v/, '');
+  log(`target:  ${targetVersion} (${targetTag})`);
+
+  if (opts.check) {
+    if (targetVersion === clientVersion) {
+      log('up to date');
+    } else {
+      log(`update available: ${clientVersion} -> ${targetVersion}`);
+    }
+    return 0;
+  }
+
+  if (targetVersion === clientVersion && !opts.force) {
+    log('already on target version (pass --force to reinstall)');
+    return 0;
+  }
+
+  if (!canWrite(installDir) || !canWrite(dirname(installDir))) {
+    err(`$INSTALL_DIR or its parent is not writable (${installDir}).`);
+    err('If this is a system-scope install, re-run with sudo.');
+    return 1;
+  }
+
+  const newDir = `${installDir}.new`;
+  const prevDir = `${installDir}.prev`;
+  rmSync(newDir, { recursive: true, force: true });
+
+  const dlDir = mkdtempSync(join(tmpdir(), 'vicoop-upgrade-'));
+  try {
+    const archiveName = `vicoop-bridge-client-${targetVersion}.tgz`;
+    const checksumName = `${archiveName}.sha256`;
+    const baseUrl = `https://github.com/${REPO}/releases/download/${targetTag}`;
+
+    log(`downloading ${archiveName}`);
+    await download(`${baseUrl}/${archiveName}`, join(dlDir, archiveName));
+    await download(`${baseUrl}/${checksumName}`, join(dlDir, checksumName));
+
+    log('verifying checksum');
+    const expected = parseChecksum(readFileSync(join(dlDir, checksumName), 'utf8'));
+    const actual = sha256File(join(dlDir, archiveName));
+    if (expected !== actual) {
+      err(`checksum mismatch: expected ${expected}, got ${actual}`);
+      return 1;
+    }
+
+    log(`extracting into ${newDir}`);
+    mkdirSync(newDir, { recursive: true });
+    const tarRes = spawnSync(
+      'tar',
+      ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
+      { stdio: 'inherit' },
+    );
+    if (tarRes.status !== 0) {
+      err('extraction failed');
+      rmSync(newDir, { recursive: true, force: true });
+      return 1;
+    }
+
+    preserveOperatorFiles(installDir, newDir);
+
+    if (!healthcheck(newDir, targetVersion)) {
+      err('new bundle failed --version healthcheck; aborting');
+      rmSync(newDir, { recursive: true, force: true });
+      return 1;
+    }
+  } finally {
+    rmSync(dlDir, { recursive: true, force: true });
+  }
+
+  // Atomic swap. The first rename is the point of no return for $INSTALL_DIR;
+  // if the second fails we put the original back before bailing.
+  rmSync(prevDir, { recursive: true, force: true });
+  log(`swap: ${installDir} -> ${prevDir}`);
+  renameSync(installDir, prevDir);
+  try {
+    log(`swap: ${newDir} -> ${installDir}`);
+    renameSync(newDir, installDir);
+  } catch (e) {
+    err(`swap failed, rolling back: ${(e as Error).message}`);
+    renameSync(prevDir, installDir);
+    rmSync(newDir, { recursive: true, force: true });
+    return 1;
+  }
+
+  const unit = detectSystemdUnit();
+  if (unit) {
+    log(`restarting systemd unit (${unit.scope} scope)`);
+    if (!tryRestartSystemd(unit.scope)) {
+      err('systemctl try-restart failed; restart the service manually');
+    }
+  } else {
+    log('no systemd unit detected — restart your client manually to pick up the new version');
+  }
+
+  log(`upgraded ${clientVersion} -> ${targetVersion}`);
+  log(`previous install kept at ${prevDir} (delete when satisfied)`);
+  return 0;
+}
+
+function normalizeTag(v: string): string {
+  return v.startsWith('client-v') ? v : `client-v${v.replace(/^v/, '')}`;
+}
+
+async function resolveLatestTag(): Promise<string> {
+  const res = await fetch(`https://api.github.com/repos/${REPO}/releases?per_page=30`, {
+    headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText}`);
+  const releases = (await res.json()) as Array<{ tag_name?: unknown }>;
+  for (const r of releases) {
+    if (typeof r.tag_name === 'string' && r.tag_name.startsWith('client-v')) return r.tag_name;
+  }
+  throw new Error(`no client-v* release found in ${REPO}`);
+}
+
+async function download(url: string, dest: string): Promise<void> {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok || !res.body) throw new Error(`download failed: ${res.status} ${url}`);
+  await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(dest));
+}
+
+function sha256File(path: string): string {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+function parseChecksum(contents: string): string {
+  // Matches install.sh: take the first whitespace-separated token from the first line.
+  const first = contents.trim().split(/\s+/)[0];
+  if (!first || !/^[0-9a-f]{64}$/i.test(first)) {
+    throw new Error(`could not parse sha256 hash from checksum file (got: ${contents.slice(0, 80)})`);
+  }
+  return first.toLowerCase();
+}
+
+function preserveOperatorFiles(oldDir: string, newDir: string): void {
+  for (const entry of readdirSync(oldDir)) {
+    if (SHIPPED_TOP_LEVEL.has(entry)) continue;
+    const src = join(oldDir, entry);
+    const dst = join(newDir, entry);
+    if (existsSync(dst)) continue;
+    cpSync(src, dst, { recursive: true });
+  }
+
+  const oldCards = join(oldDir, 'cards');
+  const newCards = join(newDir, 'cards');
+  if (!existsSync(oldCards) || !existsSync(newCards)) return;
+  for (const entry of readdirSync(oldCards)) {
+    const dst = join(newCards, entry);
+    if (existsSync(dst)) continue;
+    cpSync(join(oldCards, entry), dst, { recursive: true });
+  }
+}
+
+function healthcheck(newDir: string, expected: string): boolean {
+  const cli = join(newDir, 'dist', 'cli.js');
+  const r = spawnSync(process.execPath, [cli, '--version'], { encoding: 'utf8' });
+  if (r.status !== 0) return false;
+  return r.stdout.trim() === expected;
+}
+
+function detectSystemdUnit(): { scope: 'system' | 'user' } | null {
+  if (existsSync('/etc/systemd/system/vicoop-client.service')) return { scope: 'system' };
+  const home = process.env.HOME;
+  if (home) {
+    const userCfg = process.env.XDG_CONFIG_HOME ?? join(home, '.config');
+    if (existsSync(join(userCfg, 'systemd', 'user', 'vicoop-client.service'))) {
+      return { scope: 'user' };
+    }
+  }
+  return null;
+}
+
+function tryRestartSystemd(scope: 'system' | 'user'): boolean {
+  const args = scope === 'user'
+    ? ['--user', 'try-restart', 'vicoop-client.service']
+    : ['try-restart', 'vicoop-client.service'];
+  const r = spawnSync('systemctl', args, { stdio: 'inherit' });
+  return r.status === 0;
+}
+
+function canWrite(path: string): boolean {
+  try {
+    accessSync(path, fsConstants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function log(msg: string): void {
+  process.stderr.write(`==> ${msg}\n`);
+}
+
+function err(msg: string): void {
+  process.stderr.write(`error: ${msg}\n`);
+}

--- a/packages/client/src/version.ts
+++ b/packages/client/src/version.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// In the shipped bundle, this file compiles to $INSTALL_DIR/dist/version.js and
+// package.json sits at $INSTALL_DIR/package.json. Resolving from import.meta.url
+// gives us both the running version and the install root in one step, without
+// any build-time codegen.
+const here = dirname(fileURLToPath(import.meta.url));
+
+export const installDir: string = dirname(here);
+
+export const clientVersion: string = (() => {
+  try {
+    const pkg = JSON.parse(readFileSync(join(installDir, 'package.json'), 'utf8')) as { version?: unknown };
+    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();


### PR DESCRIPTION
Closes #57.

## Summary

- CLI owns the steady-state upgrade path; `install.sh` stays as bootstrap + systemd/env scaffolding.
- New `vicoop-client upgrade [--check] [--force] [--version client-vX.Y.Z]` subcommand: resolve latest `client-v*` from GitHub releases → download + sha256 verify → extract to `$INSTALL_DIR.new/` → preserve operator-added `cards/*.json` and top-level non-bundle files → healthcheck (`node cli.js --version` on the new bundle) → atomic swap keeping previous install as `$INSTALL_DIR.prev` → `systemctl [--user] try-restart vicoop-client.service` if a unit is registered.
- Rollback: any pre-swap failure deletes `.new` with the original untouched; a rename failure mid-swap restores the first rename before bailing.
- Version introspection reads the bundle's own `package.json` at runtime via `import.meta.url`, which also yields the install dir — no build-time codegen.
- `install.sh` prints a "future updates: `vicoop-client upgrade`" hint in both the systemd and manual-run next-steps blocks.
- `docs/install-client.md` gets an "Updating the client" section before Troubleshooting.

Design notes and phasing discussion live on #57. Phase 1 only — systemd timer and channel concepts are deferred.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 58/58 pass, no regressions
- [x] Sandbox install from locally built tarball: `--version`, `upgrade --check`, `upgrade --help` all behave correctly
- [x] Rollback-on-healthcheck-failure: `upgrade --force` against the publicly released `client-v0.3.0` (predates `--version`) correctly aborts, deletes `.new`, leaves original install + operator files untouched
- [ ] End-to-end happy-path swap with a real newer release (can only be exercised after this PR lands and a tag is cut; the atomic-swap code path itself is exercised up to `renameSync` by the rollback test above)
- [ ] Systemd `try-restart` on a Linux host with a real `vicoop-client.service` unit (CI / manual verification on deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)