### PR TITLE
Probe OpenClaw gateway and downgrade streaming capability for pre-v2026.3.22

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -42,6 +42,13 @@ one-liner fetching a published `client-v*` bundle). Contrast with:
     scripting SIWE yourself.
 - For the OpenClaw backend specifically: an OpenClaw gateway running
   locally at `ws://127.0.0.1:18789` (override via `OPENCLAW_GATEWAY_URL`).
+  Streaming (per-message A2A artifact cadence) requires OpenClaw
+  **v2026.3.22 or newer** — the `sessions.messages.subscribe` RPC that
+  drives it was introduced in that release. On older gateways the client
+  probes at startup, logs a downgrade warning, and advertises
+  `capabilities.streaming: false` on its agent card so A2A callers don't
+  request `message/stream` against a backend that can't deliver it;
+  task execution still works via the terminal-artifact fallback.
 
 ## Step 1 — Install the client bundle
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/backend.ts
+++ b/packages/client/src/backend.ts
@@ -4,6 +4,11 @@ export type TaskAssign = TaskAssignFrame;
 
 export type Emit = (frame: UpFrame) => void;
 
+export interface DetectedCapabilities {
+  streaming?: boolean;
+  pushNotifications?: boolean;
+}
+
 export interface Backend {
   name: string;
   // `signal` is aborted when the task is canceled (A2A `tasks/cancel` or
@@ -12,4 +17,10 @@ export interface Backend {
   // `handle()` promptly instead of waiting for an upstream terminal event
   // that may never arrive.
   handle(task: TaskAssign, emit: Emit, signal: AbortSignal): Promise<void>;
+  // Optional capability probe. Called once at startup, before the bridge-server
+  // hello frame is sent, so the backend can override advertised card
+  // capabilities based on the actual state of its upstream (e.g. gateway
+  // version support). Returning `{}` — or throwing — leaves the card's
+  // declared capabilities unchanged.
+  resolveCapabilities?(): Promise<DetectedCapabilities>;
 }

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1,8 +1,34 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import type { AddressInfo } from 'node:net';
 import WebSocket, { WebSocketServer } from 'ws';
+
+// Bind a net server to an ephemeral port, record the port, then close the
+// server. The port is now reliably free on this host for the remainder of
+// the test — a subsequent connect attempt gets ECONNREFUSED immediately
+// instead of racing against whatever may happen to be listening on a
+// hard-coded port (e.g. port 1 can be forwarded in some CI environments).
+async function pickUnusedLoopbackPort(): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const server = createNetServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('failed to allocate an unused loopback port'));
+        return;
+      }
+      const { port } = address;
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve(port);
+      });
+    });
+  });
+}
 import {
   createOpenclawBackend,
   listenersToGatewayUrls,
@@ -1770,6 +1796,7 @@ test('resolveCapabilities: treats non-method errors as "method exists" and keeps
 });
 
 test('resolveCapabilities: returns empty override when gateway is unreachable', async () => {
+  const unreachablePort = await pickUnusedLoopbackPort();
   const warnings: string[] = [];
   const originalWarn = console.warn;
   console.warn = (...args: unknown[]) => {
@@ -1777,7 +1804,7 @@ test('resolveCapabilities: returns empty override when gateway is unreachable', 
   };
   try {
     const backend = createOpenclawBackend({
-      url: 'ws://127.0.0.1:1', // port 1 is almost never listening
+      url: `ws://127.0.0.1:${unreachablePort}`,
       handshakeTimeoutMs: 500,
       discoverGatewayUrls: async () => [],
     });

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -6,10 +6,12 @@ import type { AddressInfo } from 'node:net';
 import WebSocket, { WebSocketServer } from 'ws';
 
 // Bind a net server to an ephemeral port, record the port, then close the
-// server. The port is now reliably free on this host for the remainder of
-// the test — a subsequent connect attempt gets ECONNREFUSED immediately
-// instead of racing against whatever may happen to be listening on a
-// hard-coded port (e.g. port 1 can be forwarded in some CI environments).
+// server. The port is unlikely to be rebound by an unrelated process
+// before the test reconnects, so ECONNREFUSED is the overwhelmingly
+// likely outcome — unlike hard-coding port 1, which can be forwarded or
+// listening in some CI environments. It's not a hard guarantee
+// (TOCTOU: another process could bind the port between close() and our
+// connect), but for an in-process test on loopback the window is small.
 async function pickUnusedLoopbackPort(): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const server = createNetServer();

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1638,4 +1638,158 @@ test('discovery skipped when configured URL is remote (non-loopback)', async () 
   assert.equal(discoverCalls, 0, 'discover must not be invoked for non-loopback URLs');
 });
 
+test('resolveCapabilities: returns streaming:true when gateway accepts sessions.messages.subscribe', async () => {
+  const seenMethods: string[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      seenMethods.push(req.method);
+      if (req.method === 'sessions.messages.unsubscribe') {
+        sock.send(JSON.stringify({ type: 'res', id: req.id, ok: true, payload: {} }));
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    assert.ok(backend.resolveCapabilities, 'openclaw backend must expose resolveCapabilities');
+    const caps = await backend.resolveCapabilities!();
+    assert.deepEqual(caps, { streaming: true });
+    assert.ok(
+      seenMethods.includes('sessions.messages.subscribe'),
+      'probe must have attempted sessions.messages.subscribe',
+    );
+    assert.ok(
+      seenMethods.includes('sessions.messages.unsubscribe'),
+      'probe must attempt unsubscribe cleanup after a successful subscribe',
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+// Reusable helper for probe tests that need a subscribe error the main fake
+// gateway helper cannot express (it auto-acks subscribe before onRequest). The
+// teardown terminates existing WebSocket connections before closing the WSS so
+// `wss.close()` doesn't hang waiting for the backend's still-open client.
+async function createFakeGatewayWithSubscribeResponse(
+  subscribeError: { code: string; message: string },
+): Promise<FakeGateway> {
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  const connections: WebSocket[] = [];
+  wss.on('connection', (sock) => {
+    connections.push(sock);
+    sock.send(
+      JSON.stringify({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: `nonce-probe-${connections.length}` },
+      }),
+    );
+    sock.on('message', (raw) => {
+      let frame: ReqFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as ReqFrame;
+      } catch {
+        return;
+      }
+      if (frame.type !== 'req') return;
+      if (frame.method === 'connect') {
+        sock.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: {} }));
+        return;
+      }
+      if (frame.method === 'sessions.messages.subscribe') {
+        sock.send(
+          JSON.stringify({ type: 'res', id: frame.id, ok: false, error: subscribeError }),
+        );
+      }
+    });
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  return {
+    url: `ws://127.0.0.1:${port}`,
+    connections,
+    waitForConnection: () => Promise.reject(new Error('not used')),
+    respond: () => undefined,
+    respondError: () => undefined,
+    emitChat: () => undefined,
+    emitSessionMessage: () => undefined,
+    closeSocket: () => Promise.resolve(),
+    async close() {
+      for (const s of connections) {
+        if (s.readyState !== WebSocket.CLOSED) s.terminate();
+      }
+      await new Promise<void>((resolve) => wss.close(() => resolve()));
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+test('resolveCapabilities: returns streaming:false when gateway reports unknown method', async () => {
+  // Shape matches what OpenClaw v2026.3.13 and earlier return when the RPC
+  // doesn't exist: `errorShape(ErrorCodes.INVALID_REQUEST, "unknown method: <name>")`.
+  const fake = await createFakeGatewayWithSubscribeResponse({
+    code: 'invalid_request',
+    message: 'unknown method: sessions.messages.subscribe',
+  });
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const caps = await backend.resolveCapabilities!();
+    assert.deepEqual(caps, { streaming: false });
+    assert.ok(
+      warnings.some((w) => w.includes('streaming:false') && w.includes('v2026.3.22')),
+      `expected warning about streaming downgrade, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    await fake.close();
+  }
+});
+
+test('resolveCapabilities: treats non-method errors as "method exists" and keeps streaming:true', async () => {
+  // If the gateway implements the RPC but rejects the probe for another
+  // reason (scope denied, invalid key, session not found, etc.), the method
+  // clearly dispatched — we must not downgrade. Only the literal
+  // "unknown method" shape signals absence.
+  const fake = await createFakeGatewayWithSubscribeResponse({
+    code: 'forbidden',
+    message: 'scope operator.read required',
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    const caps = await backend.resolveCapabilities!();
+    assert.deepEqual(caps, { streaming: true });
+  } finally {
+    await fake.close();
+  }
+});
+
+test('resolveCapabilities: returns empty override when gateway is unreachable', async () => {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    const backend = createOpenclawBackend({
+      url: 'ws://127.0.0.1:1', // port 1 is almost never listening
+      handshakeTimeoutMs: 500,
+      discoverGatewayUrls: async () => [],
+    });
+    const caps = await backend.resolveCapabilities!();
+    assert.deepEqual(caps, {}, 'unreachable gateway must leave the card unmodified');
+    assert.ok(
+      warnings.some((w) => w.includes('capability probe skipped')),
+      `expected skip warning, got: ${warnings.join(' | ')}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1792,4 +1792,115 @@ test('resolveCapabilities: returns empty override when gateway is unreachable', 
   }
 });
 
+test('resolveCapabilities: after unknown-method verdict, subsequent handle() skips subscribe and suppresses per-task warn', async () => {
+  // Covers the regression Copilot flagged: before this fix, a pre-v2026.3.22
+  // gateway would see `ensureSessionMessageSubscription` fire for every task,
+  // each producing a "sessions.messages.subscribe failed ... (continuing
+  // without streaming)" warn. The probe's verdict must latch so tasks run
+  // silently against the known-unsupported gateway.
+  const subscribeCalls: Array<{ params: unknown }> = [];
+  const httpServer = createServer();
+  const wss = new WebSocketServer({ server: httpServer });
+  const sockets: WebSocket[] = [];
+  wss.on('connection', (sock) => {
+    sockets.push(sock);
+    sock.send(
+      JSON.stringify({
+        type: 'event',
+        event: 'connect.challenge',
+        payload: { nonce: 'nonce-latch' },
+      }),
+    );
+    sock.on('message', (raw) => {
+      let frame: ReqFrame;
+      try {
+        frame = JSON.parse(raw.toString()) as ReqFrame;
+      } catch {
+        return;
+      }
+      if (frame.type !== 'req') return;
+      if (frame.method === 'connect') {
+        sock.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: {} }));
+        return;
+      }
+      if (frame.method === 'sessions.messages.subscribe') {
+        subscribeCalls.push({ params: frame.params });
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: frame.id,
+            ok: false,
+            error: {
+              code: 'invalid_request',
+              message: 'unknown method: sessions.messages.subscribe',
+            },
+          }),
+        );
+        return;
+      }
+      if (frame.method === 'chat.send') {
+        const params = frame.params as { sessionKey: string; idempotencyKey: string };
+        const runId = `run-${params.idempotencyKey}`;
+        sock.send(
+          JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: { runId, status: 'started' } }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId,
+                sessionKey: params.sessionKey,
+                seq: 1,
+                state: 'final',
+                message: { text: `done ${params.idempotencyKey}` },
+              },
+            }),
+          );
+        });
+      }
+    });
+  });
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+  try {
+    const backend = createOpenclawBackend({ url: `ws://127.0.0.1:${port}` });
+    const caps = await backend.resolveCapabilities!();
+    assert.deepEqual(caps, { streaming: false });
+    assert.equal(subscribeCalls.length, 1, 'probe must call subscribe exactly once');
+
+    const frames1: UpFrame[] = [];
+    await backend.handle(makeTask('t-latch-1', 'hi'), (f) => frames1.push(f), NEVER);
+    const frames2: UpFrame[] = [];
+    await backend.handle(makeTask('t-latch-2', 'hi'), (f) => frames2.push(f), NEVER);
+
+    assert.equal(
+      subscribeCalls.length,
+      1,
+      'tasks after the unknown-method verdict must not re-attempt subscribe',
+    );
+    const perTaskWarns = warnings.filter((w) =>
+      w.includes('sessions.messages.subscribe failed for agent:'),
+    );
+    assert.equal(
+      perTaskWarns.length,
+      0,
+      `per-task subscribe warnings must be suppressed, got: ${perTaskWarns.join(' | ')}`,
+    );
+  } finally {
+    console.warn = originalWarn;
+    for (const s of sockets) {
+      if (s.readyState !== WebSocket.CLOSED) s.terminate();
+    }
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -298,7 +298,7 @@ class GatewayClient {
         client: {
           id: clientId,
           displayName: 'vicoop-bridge-client',
-          version: '0.3.0',
+          version: '0.4.2',
           platform: process.platform,
           mode: clientMode,
         },
@@ -905,6 +905,50 @@ export function createOpenclawBackend(
 
   return {
     name: 'openclaw',
+
+    // Probe whether the gateway implements `sessions.messages.subscribe` so
+    // the bridge-server can advertise a card capability that matches reality.
+    // OpenClaw added the RPC in v2026.3.22; older gateways reject it with
+    // `unknown method: sessions.messages.subscribe`. We treat that specific
+    // error as a negative signal and every other failure mode (scope denied,
+    // invalid key, etc.) as "method exists → streaming available", since they
+    // prove the method dispatched before being rejected. Gateway unreachable
+    // at probe time returns `{}` so the card's declared value wins — the
+    // alternative (assuming "not supported" on transient outages) would
+    // spuriously downgrade healthy deployments.
+    async resolveCapabilities() {
+      let gw: GatewayClient;
+      try {
+        gw = await ensureConnected();
+      } catch (err) {
+        console.warn(
+          `[openclaw] capability probe skipped: gateway unreachable (${errorMessage(err)}); leaving card capabilities as declared`,
+        );
+        return {};
+      }
+      const probeKey = `__vicoop-capability-probe__:${randomUUID()}`;
+      try {
+        await gw.request('sessions.messages.subscribe', { key: probeKey });
+        // Probe succeeded against a synthetic sessionKey. Best-effort cleanup
+        // so the subscriber slot isn't kept alive — subscription state is
+        // connection-scoped anyway, so a failed unsubscribe is harmless.
+        try {
+          await gw.request('sessions.messages.unsubscribe', { key: probeKey });
+        } catch {
+          /* ignore */
+        }
+        return { streaming: true };
+      } catch (err) {
+        const msg = errorMessage(err);
+        if (/unknown method/i.test(msg)) {
+          console.warn(
+            '[openclaw] gateway does not implement sessions.messages.subscribe; advertising streaming:false (streaming requires OpenClaw >= v2026.3.22)',
+          );
+          return { streaming: false };
+        }
+        return { streaming: true };
+      }
+    },
 
     async handle(task, emit, signal) {
       // Fast path: the task was canceled before we even started. Emit a

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -697,6 +697,12 @@ export function createOpenclawBackend(
   // it. Cleared on reconnect because the connId (and therefore the server's
   // subscriber entry) is gone after a WS close.
   const subscribedSessionKeys = new Set<string>();
+  // Latched true once we've observed an `unknown method` response to
+  // `sessions.messages.subscribe` (via the capability probe or a per-task
+  // attempt). When set, every subsequent task skips the subscribe RPC and
+  // its accompanying warn log. Reset on reconnect so an upgraded gateway
+  // can re-enable streaming without a client restart.
+  let gatewayLacksMessageSubscribe = false;
   // Per-sessionKey owner of message-boundary streaming. OpenClaw's
   // `session.message` payload carries no runId, so we cannot route events
   // for two concurrent `chat.send` calls on the same sessionKey. First task
@@ -739,6 +745,10 @@ export function createOpenclawBackend(
     // connection re-subscribes cleanly.
     subscribedSessionKeys.clear();
     sessionMessageOwners.clear();
+    // An upgraded gateway (e.g. OpenClaw <v2026.3.22 → ≥v2026.3.22 across a
+    // restart) may start supporting `sessions.messages.subscribe` after a
+    // reconnect. Clearing the latch lets the next probe/attempt re-evaluate.
+    gatewayLacksMessageSubscribe = false;
     // Fail every in-flight task that was running on this client so handle()
     // does not hang forever waiting for a terminal event that can never come.
     if (taskFinalizers.size === 0) return;
@@ -893,12 +903,24 @@ export function createOpenclawBackend(
     sessionKey: string,
   ): Promise<void> {
     if (subscribedSessionKeys.has(sessionKey)) return;
+    // Short-circuit once we know the gateway doesn't implement the RPC —
+    // attempting it per task would just produce a noisy warn log on every
+    // chat.send against a pre-v2026.3.22 gateway.
+    if (gatewayLacksMessageSubscribe) return;
     try {
       await gw.request('sessions.messages.subscribe', { key: sessionKey });
       subscribedSessionKeys.add(sessionKey);
     } catch (err) {
+      const msg = errorMessage(err);
+      if (/unknown method/i.test(msg)) {
+        gatewayLacksMessageSubscribe = true;
+        console.warn(
+          `[openclaw] gateway does not implement sessions.messages.subscribe; streaming disabled for this connection (requires OpenClaw >= v2026.3.22)`,
+        );
+        return;
+      }
       console.warn(
-        `[openclaw] sessions.messages.subscribe failed for ${sessionKey}: ${errorMessage(err)} (continuing without streaming)`,
+        `[openclaw] sessions.messages.subscribe failed for ${sessionKey}: ${msg} (continuing without streaming)`,
       );
     }
   }
@@ -941,6 +963,7 @@ export function createOpenclawBackend(
       } catch (err) {
         const msg = errorMessage(err);
         if (/unknown method/i.test(msg)) {
+          gatewayLacksMessageSubscribe = true;
           console.warn(
             '[openclaw] gateway does not implement sessions.messages.subscribe; advertising streaming:false (streaming requires OpenClaw >= v2026.3.22)',
           );

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -22,6 +22,12 @@ export class Client {
   private ws: WebSocket | null = null;
   private stopped = false;
   private inflight = new Map<string, AbortController>();
+  // Resolved once per process via backend.resolveCapabilities(); the bridge
+  // hello frame is held until this settles so the advertised card matches the
+  // backend's actual upstream capability. Cached across reconnects so we
+  // don't re-probe on every bridge WS reconnect — the underlying upstream
+  // doesn't change mid-process.
+  private effectiveCardPromise: Promise<AgentCard> | null = null;
 
   constructor(private readonly opts: ClientOptions) {}
 
@@ -37,19 +43,57 @@ export class Client {
     this.ws?.close();
   }
 
+  private resolveEffectiveCard(): Promise<AgentCard> {
+    if (this.effectiveCardPromise) return this.effectiveCardPromise;
+    const base = this.opts.agentCard;
+    const probe = this.opts.backend.resolveCapabilities;
+    if (!probe) {
+      this.effectiveCardPromise = Promise.resolve(base);
+      return this.effectiveCardPromise;
+    }
+    this.effectiveCardPromise = (async () => {
+      try {
+        const detected = await probe.call(this.opts.backend);
+        const merged: AgentCard['capabilities'] = {
+          ...(base.capabilities ?? {}),
+          ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
+          ...(detected.pushNotifications !== undefined
+            ? { pushNotifications: detected.pushNotifications }
+            : {}),
+        };
+        return { ...base, capabilities: merged };
+      } catch (err) {
+        console.warn(
+          `[client] backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
+        );
+        return base;
+      }
+    })();
+    return this.effectiveCardPromise;
+  }
+
   private connect(): void {
     if (this.stopped) return;
     const ws = new WebSocket(`${this.opts.serverUrl.replace(/\/$/, '')}/connect`);
     this.ws = ws;
 
     ws.on('open', () => {
-      console.log('[client] connected, sending hello');
-      this.send({
-        type: 'hello',
-        agentId: this.opts.agentId,
-        agentCard: this.opts.agentCard,
-        version: PROTOCOL_VERSION,
-        token: this.opts.token,
+      // The probe runs in parallel with the bridge TCP/WS handshake; by the
+      // time `open` fires it's usually already settled. Awaiting here means
+      // the bridge-server sees a card whose capabilities match what the
+      // backend can actually deliver. If the probe is still running (slow
+      // gateway handshake), `hello` is delayed by the difference — typically
+      // a few ms on a local loopback gateway.
+      this.resolveEffectiveCard().then((agentCard) => {
+        if (ws.readyState !== WebSocket.OPEN) return;
+        console.log('[client] connected, sending hello');
+        this.send({
+          type: 'hello',
+          agentId: this.opts.agentId,
+          agentCard,
+          version: PROTOCOL_VERSION,
+          token: this.opts.token,
+        });
       });
     });
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -16,7 +16,15 @@ export interface ClientOptions {
   backend: Backend;
   maxConcurrency?: number;
   reconnectDelayMs?: number;
+  // Upper bound on how long we'll wait for `backend.resolveCapabilities()`
+  // before sending the bridge-server hello with the card's declared
+  // capabilities. Defaults to 3000 ms — comfortably under the bridge
+  // server's 10s hello deadline so a slow or hung probe cannot push us
+  // into the 4001 "hello timeout" close and a reconnect loop.
+  probeDeadlineMs?: number;
 }
+
+const DEFAULT_PROBE_DEADLINE_MS = 3000;
 
 export class Client {
   private ws: WebSocket | null = null;
@@ -58,30 +66,43 @@ export class Client {
       this.effectiveCardPromise = Promise.resolve(base);
       return this.effectiveCardPromise;
     }
+    const deadlineMs = this.opts.probeDeadlineMs ?? DEFAULT_PROBE_DEADLINE_MS;
     this.effectiveCardPromise = (async () => {
-      try {
-        const detected = await probe.call(this.opts.backend);
-        // Preserve the documented "no override" contract: an empty detected
-        // object must leave the card byte-for-byte unchanged, including an
-        // absent `capabilities` field. Only materialize `capabilities` when
-        // the probe actually reports a value we need to apply.
-        if (detected.streaming === undefined && detected.pushNotifications === undefined) {
-          return base;
-        }
-        const merged: AgentCard['capabilities'] = {
-          ...(base.capabilities ?? {}),
-          ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
-          ...(detected.pushNotifications !== undefined
-            ? { pushNotifications: detected.pushNotifications }
-            : {}),
-        };
-        return { ...base, capabilities: merged };
-      } catch (err) {
+      const TIMEOUT = Symbol('probe-timeout');
+      const timeoutPromise = new Promise<typeof TIMEOUT>((resolve) => {
+        const t = setTimeout(() => resolve(TIMEOUT), deadlineMs);
+        t.unref?.();
+      });
+      const probePromise = probe.call(this.opts.backend).catch((err: unknown) => {
         console.warn(
           `[client] backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
         );
+        return null;
+      });
+      const outcome = await Promise.race([probePromise, timeoutPromise]);
+      if (outcome === TIMEOUT) {
+        console.warn(
+          `[client] backend capability probe did not complete within ${deadlineMs}ms; sending hello with declared card capabilities`,
+        );
         return base;
       }
+      if (outcome === null) return base;
+      const detected = outcome;
+      // Preserve the documented "no override" contract: an empty detected
+      // object must leave the card byte-for-byte unchanged, including an
+      // absent `capabilities` field. Only materialize `capabilities` when
+      // the probe actually reports a value we need to apply.
+      if (detected.streaming === undefined && detected.pushNotifications === undefined) {
+        return base;
+      }
+      const merged: AgentCard['capabilities'] = {
+        ...(base.capabilities ?? {}),
+        ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
+        ...(detected.pushNotifications !== undefined
+          ? { pushNotifications: detected.pushNotifications }
+          : {}),
+      };
+      return { ...base, capabilities: merged };
     })();
     return this.effectiveCardPromise;
   }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -32,6 +32,13 @@ export class Client {
   constructor(private readonly opts: ClientOptions) {}
 
   start(): void {
+    // Kick off the capability probe before opening the bridge WS so it runs
+    // in parallel with (and usually finishes before) the server's hello
+    // deadline starts ticking at the `open` event. Starting it inside
+    // `ws.on('open')` instead could push `hello` past the server's 10s
+    // hello timeout when the backend probe itself takes a while (e.g. the
+    // openclaw gateway handshake on an unreachable/slow-to-handshake host).
+    void this.resolveEffectiveCard();
     this.connect();
   }
 
@@ -54,6 +61,13 @@ export class Client {
     this.effectiveCardPromise = (async () => {
       try {
         const detected = await probe.call(this.opts.backend);
+        // Preserve the documented "no override" contract: an empty detected
+        // object must leave the card byte-for-byte unchanged, including an
+        // absent `capabilities` field. Only materialize `capabilities` when
+        // the probe actually reports a value we need to apply.
+        if (detected.streaming === undefined && detected.pushNotifications === undefined) {
+          return base;
+        }
         const merged: AgentCard['capabilities'] = {
           ...(base.capabilities ?? {}),
           ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -84,16 +84,25 @@ export class Client {
       // backend can actually deliver. If the probe is still running (slow
       // gateway handshake), `hello` is delayed by the difference — typically
       // a few ms on a local loopback gateway.
+      //
+      // Send on the captured `ws` (not `this.send()` / `this.ws`) so a
+      // reconnect-driven socket swap during the probe's async gap cannot
+      // misdirect the hello onto a fresh connection that has its own `open`
+      // handler coming. Also drop the frame silently if this socket moved
+      // out of OPEN before the probe settled — the next `connect()` cycle
+      // will issue its own hello.
       this.resolveEffectiveCard().then((agentCard) => {
         if (ws.readyState !== WebSocket.OPEN) return;
         console.log('[client] connected, sending hello');
-        this.send({
-          type: 'hello',
-          agentId: this.opts.agentId,
-          agentCard,
-          version: PROTOCOL_VERSION,
-          token: this.opts.token,
-        });
+        ws.send(
+          encodeFrame({
+            type: 'hello',
+            agentId: this.opts.agentId,
+            agentCard,
+            version: PROTOCOL_VERSION,
+            token: this.opts.token,
+          }),
+        );
       });
     });
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -69,40 +69,56 @@ export class Client {
     const deadlineMs = this.opts.probeDeadlineMs ?? DEFAULT_PROBE_DEADLINE_MS;
     this.effectiveCardPromise = (async () => {
       const TIMEOUT = Symbol('probe-timeout');
+      let timer: ReturnType<typeof setTimeout> | undefined;
       const timeoutPromise = new Promise<typeof TIMEOUT>((resolve) => {
-        const t = setTimeout(() => resolve(TIMEOUT), deadlineMs);
-        t.unref?.();
+        timer = setTimeout(() => resolve(TIMEOUT), deadlineMs);
+        timer.unref?.();
       });
-      const probePromise = probe.call(this.opts.backend).catch((err: unknown) => {
-        console.warn(
-          `[client] backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
-        );
-        return null;
-      });
-      const outcome = await Promise.race([probePromise, timeoutPromise]);
-      if (outcome === TIMEOUT) {
-        console.warn(
-          `[client] backend capability probe did not complete within ${deadlineMs}ms; sending hello with declared card capabilities`,
-        );
-        return base;
+      // `Promise.resolve().then(...)` converts a synchronous throw from a
+      // non-async probe implementation into a promise rejection — otherwise
+      // the throw would escape before `.catch` is attached and surface as an
+      // unhandled rejection on `effectiveCardPromise`, which the `open`
+      // handler consumes with `.then` only.
+      const probePromise = Promise.resolve()
+        .then(() => probe.call(this.opts.backend))
+        .catch((err: unknown) => {
+          console.warn(
+            `[client] backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
+          );
+          return null;
+        });
+      try {
+        const outcome = await Promise.race([probePromise, timeoutPromise]);
+        if (outcome === TIMEOUT) {
+          console.warn(
+            `[client] backend capability probe did not complete within ${deadlineMs}ms; sending hello with declared card capabilities`,
+          );
+          return base;
+        }
+        if (outcome === null) return base;
+        const detected = outcome;
+        // Preserve the documented "no override" contract: an empty detected
+        // object must leave the card byte-for-byte unchanged, including an
+        // absent `capabilities` field. Only materialize `capabilities` when
+        // the probe actually reports a value we need to apply.
+        if (detected.streaming === undefined && detected.pushNotifications === undefined) {
+          return base;
+        }
+        const merged: AgentCard['capabilities'] = {
+          ...(base.capabilities ?? {}),
+          ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
+          ...(detected.pushNotifications !== undefined
+            ? { pushNotifications: detected.pushNotifications }
+            : {}),
+        };
+        return { ...base, capabilities: merged };
+      } finally {
+        // Clear the deadline timer so a fast probe doesn't leave an extra
+        // callback and its closure alive until `deadlineMs` elapses. The
+        // unref() above is enough to keep this from blocking process exit,
+        // but clearing is cheaper than letting it fire.
+        if (timer !== undefined) clearTimeout(timer);
       }
-      if (outcome === null) return base;
-      const detected = outcome;
-      // Preserve the documented "no override" contract: an empty detected
-      // object must leave the card byte-for-byte unchanged, including an
-      // absent `capabilities` field. Only materialize `capabilities` when
-      // the probe actually reports a value we need to apply.
-      if (detected.streaming === undefined && detected.pushNotifications === undefined) {
-        return base;
-      }
-      const merged: AgentCard['capabilities'] = {
-        ...(base.capabilities ?? {}),
-        ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
-        ...(detected.pushNotifications !== undefined
-          ? { pushNotifications: detected.pushNotifications }
-          : {}),
-      };
-      return { ...base, capabilities: merged };
     })();
     return this.effectiveCardPromise;
   }
@@ -126,7 +142,7 @@ export class Client {
       // handler coming. Also drop the frame silently if this socket moved
       // out of OPEN before the probe settled — the next `connect()` cycle
       // will issue its own hello.
-      this.resolveEffectiveCard().then((agentCard) => {
+      const sendHello = (agentCard: AgentCard): void => {
         if (ws.readyState !== WebSocket.OPEN) return;
         console.log('[client] connected, sending hello');
         ws.send(
@@ -138,7 +154,19 @@ export class Client {
             token: this.opts.token,
           }),
         );
-      });
+      };
+      // The internal catch inside resolveEffectiveCard() already coerces
+      // every failure into "return base", so this `.catch` is defense in
+      // depth — if a future refactor ever lets a rejection escape, still
+      // send hello with the declared card instead of silently dropping it.
+      this.resolveEffectiveCard()
+        .then(sendHello)
+        .catch((err: unknown) => {
+          console.warn(
+            `[client] effectiveCard promise rejected unexpectedly (${err instanceof Error ? err.message : String(err)}); sending hello with declared card`,
+          );
+          sendHello(this.opts.agentCard);
+        });
     });
 
     ws.on('message', (raw) => {


### PR DESCRIPTION
Closes #61.

## Problem

The v0.3.0 client bumped `capabilities.streaming` from `false` to `true`, backed by the `sessions.messages.subscribe` RPC. That RPC was added in OpenClaw **v2026.3.22** (upstream PR `openclaw/openclaw#50101`); earlier gateways accept the same wire protocol (v3) but reject the call with `unknown method: sessions.messages.subscribe`.

Today the client handles that error gracefully at runtime (single final artifact, no streaming), but the advertised card still lies — A2A callers that honor the card and issue `message/stream` end up with a content-type mismatch. Reporter of #61 is on v2026.3.13 and sees this.

See the issue for the upstream release archaeology and the alternative-implementation review (no non-`sessions.messages.subscribe` push path exists on older gateways).

## Approach

Option (a) from the issue discussion: **don't try to support streaming on pre-v2026.3.22 gateways, but make the downgrade automatic and correct.**

- Add optional `Backend.resolveCapabilities()` — called once at startup, before the bridge-server `hello` frame.
- OpenClaw backend sends `sessions.messages.subscribe` with a synthetic sessionKey and decides from the response:
  - success → `streaming: true` (best-effort unsubscribe cleanup).
  - `unknown method` error → `streaming: false` + one-line downgrade warning.
  - any other error (scope, invalid key, …) → `streaming: true` (method dispatched, just rejected).
  - gateway unreachable → `{}` (no override; card value wins — transient outages shouldn't spuriously downgrade healthy deployments).
- `Client` awaits the probe and merges detected capabilities into the card. Result is cached for the process lifetime so bridge reconnects don't re-probe.
- Document the minimum gateway version in `docs/install-client.md`.
- Bump client to 0.3.1.

## Test plan

- [x] `pnpm -r typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 49/49 passing (4 new `resolveCapabilities` tests covering supported / unknown-method / non-method-error / unreachable paths)
- [x] `pnpm --filter @vicoop-bridge/client build` clean
- [ ] Manual E2E against a v2026.3.13 gateway (optional; probe logic is covered by the unit tests that replay the exact `unknown method` shape)
- [ ] Manual E2E against a v2026.3.22+ gateway (streaming should remain advertised and delivered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)