### PR TITLE
[codex] Add Claude backend cwd override

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -302,6 +302,27 @@ second WS. Override if yours isn't on the default:
 | `OPENCLAW_AGENT` | `main` | Agent name inside OpenClaw |
 | `OPENCLAW_TASK_TIMEOUT_MS` | backend default | Per-task timeout |
 
+### Claude-specific env
+
+If you're running the Claude backend, point the client at the bundled
+Claude card and optionally set `CLAUDE_CWD` so Claude works against a
+different repository than the directory where `vicoop-client` itself was
+started:
+
+```sh
+SERVER_URL="$SERVER_URL" \
+SERVER_TOKEN="$CLIENT_TOKEN" \
+AGENT_ID="$AGENT_ID" \
+AGENT_CARD="$INSTALL_DIR/cards/claude.json" \
+BACKEND=claude \
+CLAUDE_CWD="$HOME/vicoop-bridge" \
+  "$INSTALL_DIR/bin/vicoop-client"
+```
+
+`CLAUDE_CWD` defaults to the current working directory of the client
+process. Set it when the released bundle lives outside the repository you
+want Claude to edit.
+
 ### Restrict who can call your agent
 
 By default the policy has empty `allowed_callers`, which the dispatcher

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { createClaudeBackend, type ClaudeChildHandle } from './claude.js';
+import { createClaudeBackend, type ClaudeChildHandle, type ClaudeSpawnOptions } from './claude.js';
 import type { TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
 
 const NEVER: AbortSignal = new AbortController().signal;
@@ -9,6 +9,7 @@ const NEVER: AbortSignal = new AbortController().signal;
 interface FakeChild extends ClaudeChildHandle {
   readonly command: string;
   readonly args: readonly string[];
+  readonly cwd?: string;
   killed: boolean;
   killSignal: NodeJS.Signals | null;
   emitStdout(text: string): void;
@@ -17,14 +18,14 @@ interface FakeChild extends ClaudeChildHandle {
 }
 
 interface FakeSpawn {
-  spawn: (cmd: string, args: readonly string[]) => ClaudeChildHandle;
+  spawn: (cmd: string, args: readonly string[], options: ClaudeSpawnOptions) => ClaudeChildHandle;
   lastChild: () => FakeChild | null;
 }
 
 function makeFakeSpawn(configure: (child: FakeChild) => void): FakeSpawn {
   let last: FakeChild | null = null;
   return {
-    spawn(command, args) {
+    spawn(command, args, options) {
       const stdoutEmitter = new EventEmitter();
       const stderrEmitter = new EventEmitter();
       const closeListeners: Array<(code: number | null, sig: NodeJS.Signals | null) => void> = [];
@@ -40,6 +41,7 @@ function makeFakeSpawn(configure: (child: FakeChild) => void): FakeSpawn {
       const child: FakeChild = {
         command,
         args,
+        cwd: options.cwd,
         stdout: mkStream(stdoutEmitter),
         stderr: mkStream(stderrEmitter),
         killed: false,
@@ -322,6 +324,23 @@ test('passes expected argv shape (prompt, session-id, stream-json, verbose, extr
   assert.equal(child.args.at(-1), 'sonnet');
 });
 
+test('passes configured cwd through to the Claude subprocess', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    cwd: '/tmp/claude-worktree',
+  });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(child.cwd, '/tmp/claude-worktree');
+});
+
 test('reuses session via --resume on a second task with the same contextId', async () => {
   const fake = scriptedSpawn({
     lines: [JSON.stringify({ type: 'result', result: 'ok' })],
@@ -434,12 +453,12 @@ test('rolls back the session binding when spawn throws', async () => {
     exitCode: 0,
   });
   let throwOnce = true;
-  const wrappedSpawn = (cmd: string, args: readonly string[]) => {
+  const wrappedSpawn = (cmd: string, args: readonly string[], options: ClaudeSpawnOptions) => {
     if (throwOnce) {
       throwOnce = false;
       throw new Error('ENOENT: claude not found');
     }
-    return fake.spawn(cmd, args);
+    return fake.spawn(cmd, args, options);
   };
   const backend = createClaudeBackend({ spawn: wrappedSpawn });
   const ctx = 'ctx-rollback';

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -13,10 +13,19 @@ export interface ClaudeChildHandle {
   on(event: 'error', listener: (err: Error) => void): void;
 }
 
-export type ClaudeSpawnFn = (command: string, args: readonly string[]) => ClaudeChildHandle;
+export interface ClaudeSpawnOptions {
+  cwd?: string;
+}
+
+export type ClaudeSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: ClaudeSpawnOptions,
+) => ClaudeChildHandle;
 
 export interface ClaudeBackendOptions {
   command?: string;
+  cwd?: string;
   extraArgs?: readonly string[];
   spawn?: ClaudeSpawnFn;
   stderrCaptureBytes?: number;
@@ -46,8 +55,15 @@ interface StreamEvent {
   result?: unknown;
 }
 
-function defaultSpawn(command: string, args: readonly string[]): ClaudeChildHandle {
-  return nodeSpawn(command, Array.from(args), { stdio: ['ignore', 'pipe', 'pipe'] }) as ChildProcess;
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: ClaudeSpawnOptions,
+): ClaudeChildHandle {
+  return nodeSpawn(command, Array.from(args), {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  }) as ChildProcess;
 }
 
 function extractAssistantText(content: unknown): string {
@@ -81,6 +97,7 @@ function collectTextPrompt(parts: readonly Part[]): { ok: true; prompt: string }
 
 export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
   const command = opts.command ?? 'claude';
+  const cwd = opts.cwd;
   const extraArgs = opts.extraArgs ?? [];
   const spawnFn = opts.spawn ?? defaultSpawn;
   const stderrCap = opts.stderrCaptureBytes ?? 8192;
@@ -158,7 +175,7 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
 
       let child: ClaudeChildHandle;
       try {
-        child = spawnFn(command, args);
+        child = spawnFn(command, args, { cwd });
       } catch (err) {
         // Roll back the freshly-minted entry so a retry doesn't try to
         // --resume a session that was never actually created on disk.

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -51,7 +51,9 @@ function pickBackend(name: string): Backend {
     case 'openclaw':
       return createOpenclawBackend();
     case 'claude':
-      return createClaudeBackend();
+      return createClaudeBackend({
+        cwd: process.env.CLAUDE_CWD?.trim() || undefined,
+      });
     default:
       throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude)`);
   }


### PR DESCRIPTION
## Summary
- add a `cwd` option to the Claude backend spawn path
- wire `CLAUDE_CWD` through `vicoop-client` when `BACKEND=claude`
- extend Claude backend tests to verify the configured working directory is passed to the subprocess

## Why
Today the Claude backend always inherits the `vicoop-client` process cwd. That makes it awkward to run the released client bundle from one directory while asking Claude to work on a different repository, and slash-command workarounds like `/add-dir` are not interpreted by the bridge.

## Validation
- `node --import tsx --test packages/client/src/backends/claude.test.ts`
- `pnpm --filter @vicoop-bridge/protocol --filter @vicoop-bridge/client build`
