### PR TITLE
[codex] Fix zsh-incompatible SIWE decode snippet in install docs

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -129,11 +129,11 @@ TOKEN=$(a2a-wallet siwe auth \
 # The CLI's token is base64url(JSON({message, signature})). Decode and pipe
 # the {message, signature} JSON straight into the exchange endpoint — never
 # write the signed payload to disk where another local user could read it
-# off /tmp before we delete it. GNU base64 uses -d, BSD/macOS uses -D.
+# off /tmp before we delete it. `openssl base64 -d -A` works on macOS and
+# Linux, so we avoid shell-specific word-splitting around `base64 -d/-D`.
 PAD=$(printf '%*s' $(( (4 - ${#TOKEN} % 4) % 4 )) '' | tr ' ' '=')
-if printf '' | base64 -d >/dev/null 2>&1; then B64DEC='base64 -d'; else B64DEC='base64 -D'; fi
 
-CALLER_TOKEN=$(echo "${TOKEN}${PAD}" | tr '_-' '/+' | $B64DEC \
+CALLER_TOKEN=$(echo "${TOKEN}${PAD}" | tr '_-' '/+' | openssl base64 -d -A \
   | curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
       -H 'Content-Type: application/json' --data-binary @- \
   | jq -r .access_token)


### PR DESCRIPTION
## What changed

This updates the `docs/install-client.md` Step 2 SIWE exchange snippet to use `openssl base64 -d -A` instead of storing `base64 -d/-D` in a shell variable and invoking it later.

## Why

Issue #77 identified that the previous snippet relied on bash word-splitting for `$B64DEC`. That works in bash but fails in zsh, which is the default shell on macOS and a documented target for this guide.

## Impact

The install guide now works as written in both zsh and bash without requiring readers to wrap the block in bash explicitly.

## Root cause

The old snippet assigned `B64DEC="base64 -d"` or `B64DEC="base64 -D"` and then executed `$B64DEC`. In zsh, scalar parameter expansion is not word-split by default, so it tried to execute a literal command named `base64 -d`.

## Validation

- Reproduced the original failure under `zsh`
- Verified the updated decode pipeline under `zsh`
- Verified the updated decode pipeline under `bash`

Closes #77
