### PR TITLE
Generalize ownership: owner_wallet → owner_principal

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -171,7 +171,7 @@ CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
   -H "Authorization: Bearer $CALLER_TOKEN" \
   -H 'Content-Type: application/json' \
-  -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerWallet allowedAgentIds}}}\"}")
+  -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerPrincipal allowedAgentIds}}}\"}")
 
 echo "$REG" | jq .
 CLIENT_TOKEN=$(echo "$REG" | jq -r .data.registerClient.clientWithToken.token)
@@ -190,7 +190,7 @@ want a new client with a fresh token.
 Before calling `registerClient`, probe the id with the
 `agentIdAvailable(agentId)` GraphQL query. It's a `SECURITY DEFINER`
 function (`packages/server/schema.sql`) that returns a plain boolean
-across every owner — no `owner_wallet` leaks — and raises
+across every owner — no `owner_principal` leaks — and raises
 `invalid_parameter_value` on empty input. Requires your caller token.
 
 ```sh
@@ -204,10 +204,10 @@ AVAILABLE=$(curl -sX POST "$BRIDGE_URL/graphql" \
 ```
 
 `true` means no `agent_policies` row exists for that id yet, so your first
-WS register in Step 5 will claim ownership. `false` means another wallet
+WS register in Step 5 will claim ownership. `false` means another principal
 already owns it — pick a different id. A small race window exists between
-this probe and your WS register; if another wallet claims the id in
-between, Step 5 emits `'agent id owned by a different wallet'` and you can
+this probe and your WS register; if another principal claims the id in
+between, Step 5 emits `'agent id owned by a different principal'` and you can
 fall back to the recovery path in "Troubleshooting".
 
 Even with the probe, prefer names unlikely to collide across operators.
@@ -234,7 +234,7 @@ are the owner:
 ```sh
 curl -sX POST "$BRIDGE_URL/graphql" \
   -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"query\":\"{agentPolicyByAgentId(agentId:\\\"$AGENT_ID\\\"){agentId ownerWallet}}\"}" | jq .
+  -d "{\"query\":\"{agentPolicyByAgentId(agentId:\\\"$AGENT_ID\\\"){agentId ownerPrincipal}}\"}" | jq .
 ```
 
 A non-null response means you own it and a reinstall will reuse the
@@ -504,13 +504,13 @@ files before running it.
 
 ## Troubleshooting
 
-- **`agent id owned by a different wallet`** (WS register) — your wallet is
-  not the `owner_wallet` on the existing `agent_policies` row. Pick a
-  different `agent_id`, amend the existing client's allowlist via
-  `updateClientAllowedAgents` (no token rotation), and restart
+- **`agent id owned by a different principal`** (WS register) — your
+  principal is not the `owner_principal` on the existing `agent_policies`
+  row. Pick a different `agent_id`, amend the existing client's allowlist
+  via `updateClientAllowedAgents` (no token rotation), and restart
   `vicoop-client` with the new `AGENT_ID`. Re-run Step 3 only if you
   intentionally want a new client/token; otherwise sign in from the
-  original owner's wallet.
+  original owner.
 
 - **`permission denied for function register_client`** (or similar) on
   GraphQL — the caller token was missing, malformed, or expired, so the

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -72,9 +72,9 @@ route requests to.
 # 1. Pick a raw token and insert the hashed form into clients.
 TOKEN=dev-client-token-raw-12345
 psql vicoop_bridge_dev <<SQL
-INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
+INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
 VALUES (
-  '0x0000000000000000000000000000000000000001',
+  'eth:0x0000000000000000000000000000000000000001',
   'dev-echo-client',
   encode(digest('$TOKEN', 'sha256'), 'hex'),
   ARRAY['echo-agent']
@@ -283,8 +283,8 @@ Verified scenarios:
 - raw SIWE bearer on `/agents/:id` → 401 `Invalid bearer token: expected vbc_caller_* prefix`
 - expired SIWE message on exchange → 401 `invalid_grant`
 - domain mismatch on exchange → 401 `invalid_grant`
-- admin UI / admin GraphQL: same opaque token grants `wallet_address` claim and
-  (if wallet in `ADMIN_WALLET_ADDRESSES`) admin scope
+- admin UI / admin GraphQL: same opaque token grants `principal_id` claim and
+  (if the eth: address is in `ADMIN_WALLET_ADDRESSES`) admin scope
 
 ## Unit tests with live DB
 

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -42,10 +42,10 @@ what a real integrator would do against a production bridge.
 You do **not** need your wallet in `ADMIN_WALLET_ADDRESSES`. Every step below
 works for non-admin callers:
 
-- `register_client()` defaults `owner_wallet` to the caller's SIWE address
-  (explicit `ownerWallet` is admin-only, but the default is what we want).
+- `register_client()` defaults `owner_principal` to the caller's principal
+  (explicit `ownerPrincipal` is admin-only, but the default is what we want).
 - `agent_policies_update` RLS is `owner OR is_admin`, and the auto-created
-  policy's owner is your wallet.
+  policy's owner is your principal.
 - The admin agent at `POST /` gates only on "caller token has `eth:*`
   principal", not on admin membership.
 
@@ -133,9 +133,10 @@ echo "client_id=$CLIENT_ID"
 echo "client_token=$CLIENT_TOKEN"   # raw 64-hex token — record it, never retrievable again
 ```
 
-Owner defaults to your SIWE wallet. `ownerWallet` can be passed explicitly,
-but only admins may actually override it; non-admin attempts are silently
-replaced with the caller's own wallet (`register_client` in `schema.sql`).
+Owner defaults to your principal (SIWE → `eth:0x...`). `ownerPrincipal` can be
+passed explicitly, but only admins may actually override it; non-admin
+attempts are silently replaced with the caller's own principal
+(`register_client` in `schema.sql`).
 
 ## Step 3 — Run the echo client against WSS
 
@@ -169,7 +170,7 @@ on every supported platform. We use this in the cleanup step instead of
 agent-id substring.
 
 On WS registration, `agent_policies` auto-inserts a row keyed by `agent_id`
-with `owner_wallet=<your wallet>` and empty `allowed_callers` (publicly
+with `owner_principal=<your principal>` and empty `allowed_callers` (publicly
 callable).
 
 ## Step 4 — Public sanity check

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -27,16 +27,47 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 -- ============================================================
 -- 1a. owner_wallet → owner_principal rename (one-time, idempotent)
 -- ============================================================
--- We have no production users, so this block exists only so existing dev
--- databases can be re-applied without dropping. It detects the legacy
--- VARCHAR(42)-typed wallet column and rewrites it to TEXT owner_principal,
--- prefixing 'eth:' on existing rows. Functions/types depending on the old
--- column are dropped first; the rest of this file recreates them.
-DO $$ BEGIN
-  IF EXISTS (
+-- We have no production users, so this block exists only so existing dev /
+-- staging databases can be re-applied without manual intervention. It
+-- detects either (a) the legacy `owner_wallet` column or (b) a half-renamed
+-- `owner_principal` column still typed VARCHAR(42), and brings either state
+-- forward to TEXT-typed `owner_principal` with an `eth:`-prefixed value.
+--
+-- ALTER COLUMN ... TYPE is rejected by Postgres while RLS policies reference
+-- the column, so we drop policies and dependent functions/types here; the
+-- rest of this file recreates them with their new shape. The DO block is
+-- implicitly transactional, so a partial run aborts cleanly and the next
+-- deploy starts from the same `owner_wallet` baseline.
+DO $$
+DECLARE
+  needs_clients_migration boolean;
+  needs_policies_migration boolean;
+  needs_tasks_migration boolean;
+BEGIN
+  SELECT EXISTS (
     SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'public' AND table_name = 'clients' AND column_name = 'owner_wallet'
-  ) THEN
+    WHERE table_schema = 'public' AND table_name = 'clients'
+      AND (column_name = 'owner_wallet'
+           OR (column_name = 'owner_principal' AND data_type = 'character varying'))
+  ) INTO needs_clients_migration;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'agent_policies'
+      AND (column_name = 'owner_wallet'
+           OR (column_name = 'owner_principal' AND data_type = 'character varying'))
+  ) INTO needs_policies_migration;
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'infra' AND table_name = 'a2a_tasks'
+      AND (column_name = 'owner_wallet'
+           OR (column_name = 'owner_principal' AND data_type = 'character varying'))
+  ) INTO needs_tasks_migration;
+
+  IF needs_clients_migration OR needs_policies_migration THEN
+    -- Functions and types must be dropped because their argument/field
+    -- declarations bind to the legacy VARCHAR signature.
     DROP FUNCTION IF EXISTS register_client(TEXT, TEXT[], VARCHAR);
     DROP FUNCTION IF EXISTS register_client(TEXT, TEXT[], TEXT);
     DROP FUNCTION IF EXISTS rotate_client_token(TEXT);
@@ -44,28 +75,57 @@ DO $$ BEGIN
     DROP FUNCTION IF EXISTS unrevoke_client(TEXT);
     DROP FUNCTION IF EXISTS update_client_allowed_agents(TEXT, TEXT[]);
     DROP TYPE IF EXISTS client_with_token CASCADE;
+    -- normalize_wallet_address used to validate VARCHAR(42); not needed
+    -- after this PR (validation moved to TS).
+    DROP FUNCTION IF EXISTS normalize_wallet_address(TEXT);
+  END IF;
 
-    ALTER TABLE clients RENAME COLUMN owner_wallet TO owner_principal;
+  IF needs_clients_migration THEN
+    DROP POLICY IF EXISTS clients_select ON clients;
+    DROP POLICY IF EXISTS clients_insert ON clients;
+    DROP POLICY IF EXISTS clients_update ON clients;
+    DROP POLICY IF EXISTS clients_delete ON clients;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'clients' AND column_name = 'owner_wallet'
+    ) THEN
+      ALTER TABLE clients RENAME COLUMN owner_wallet TO owner_principal;
+    END IF;
+
     ALTER TABLE clients ALTER COLUMN owner_principal TYPE TEXT;
     UPDATE clients SET owner_principal = 'eth:' || lower(owner_principal)
       WHERE owner_principal !~ '^[a-z]+:';
   END IF;
 
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'public' AND table_name = 'agent_policies' AND column_name = 'owner_wallet'
-  ) THEN
-    ALTER TABLE agent_policies RENAME COLUMN owner_wallet TO owner_principal;
+  IF needs_policies_migration THEN
+    DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
+    DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
+    DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
+    DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
+
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'agent_policies' AND column_name = 'owner_wallet'
+    ) THEN
+      ALTER TABLE agent_policies RENAME COLUMN owner_wallet TO owner_principal;
+    END IF;
+
     ALTER TABLE agent_policies ALTER COLUMN owner_principal TYPE TEXT;
     UPDATE agent_policies SET owner_principal = 'eth:' || lower(owner_principal)
       WHERE owner_principal !~ '^[a-z]+:';
   END IF;
 
-  IF EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_schema = 'infra' AND table_name = 'a2a_tasks' AND column_name = 'owner_wallet'
-  ) THEN
-    ALTER TABLE infra.a2a_tasks RENAME COLUMN owner_wallet TO owner_principal;
+  IF needs_tasks_migration THEN
+    -- a2a_tasks has no RLS policy referencing the column, so no policy drop
+    -- needed here.
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'infra' AND table_name = 'a2a_tasks' AND column_name = 'owner_wallet'
+    ) THEN
+      ALTER TABLE infra.a2a_tasks RENAME COLUMN owner_wallet TO owner_principal;
+    END IF;
+
     ALTER TABLE infra.a2a_tasks ALTER COLUMN owner_principal TYPE TEXT;
     UPDATE infra.a2a_tasks SET owner_principal = 'eth:' || lower(owner_principal)
       WHERE owner_principal IS NOT NULL AND owner_principal !~ '^[a-z]+:';

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -25,22 +25,75 @@ END $$;
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 -- ============================================================
+-- 1a. owner_wallet → owner_principal rename (one-time, idempotent)
+-- ============================================================
+-- We have no production users, so this block exists only so existing dev
+-- databases can be re-applied without dropping. It detects the legacy
+-- VARCHAR(42)-typed wallet column and rewrites it to TEXT owner_principal,
+-- prefixing 'eth:' on existing rows. Functions/types depending on the old
+-- column are dropped first; the rest of this file recreates them.
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'clients' AND column_name = 'owner_wallet'
+  ) THEN
+    DROP FUNCTION IF EXISTS register_client(TEXT, TEXT[], VARCHAR);
+    DROP FUNCTION IF EXISTS register_client(TEXT, TEXT[], TEXT);
+    DROP FUNCTION IF EXISTS rotate_client_token(TEXT);
+    DROP FUNCTION IF EXISTS revoke_client(TEXT);
+    DROP FUNCTION IF EXISTS unrevoke_client(TEXT);
+    DROP FUNCTION IF EXISTS update_client_allowed_agents(TEXT, TEXT[]);
+    DROP TYPE IF EXISTS client_with_token CASCADE;
+
+    ALTER TABLE clients RENAME COLUMN owner_wallet TO owner_principal;
+    ALTER TABLE clients ALTER COLUMN owner_principal TYPE TEXT;
+    UPDATE clients SET owner_principal = 'eth:' || lower(owner_principal)
+      WHERE owner_principal !~ '^[a-z]+:';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'agent_policies' AND column_name = 'owner_wallet'
+  ) THEN
+    ALTER TABLE agent_policies RENAME COLUMN owner_wallet TO owner_principal;
+    ALTER TABLE agent_policies ALTER COLUMN owner_principal TYPE TEXT;
+    UPDATE agent_policies SET owner_principal = 'eth:' || lower(owner_principal)
+      WHERE owner_principal !~ '^[a-z]+:';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'infra' AND table_name = 'a2a_tasks' AND column_name = 'owner_wallet'
+  ) THEN
+    ALTER TABLE infra.a2a_tasks RENAME COLUMN owner_wallet TO owner_principal;
+    ALTER TABLE infra.a2a_tasks ALTER COLUMN owner_principal TYPE TEXT;
+    UPDATE infra.a2a_tasks SET owner_principal = 'eth:' || lower(owner_principal)
+      WHERE owner_principal IS NOT NULL AND owner_principal !~ '^[a-z]+:';
+  END IF;
+END $$;
+
+-- ============================================================
 -- 2. Helper functions
 -- ============================================================
-CREATE OR REPLACE FUNCTION current_wallet_address()
+CREATE OR REPLACE FUNCTION current_principal()
   RETURNS TEXT
   LANGUAGE SQL STABLE
 AS $$
-  SELECT nullif(current_setting('jwt.claims.wallet_address', true), '');
+  SELECT nullif(current_setting('jwt.claims.principal_id', true), '');
 $$;
 
+-- ADMIN_WALLET_ADDRESSES env stays a CSV of bare 0x... addresses (admin
+-- onboarding is wallet-only by design; see issue #79). is_admin() therefore
+-- only matches when the current principal is `eth:<addr>` whose stripped
+-- address is in the list. Non-`eth:` principals never match.
 CREATE OR REPLACE FUNCTION is_admin()
   RETURNS BOOLEAN
   LANGUAGE SQL STABLE
 AS $$
   SELECT COALESCE(
-    current_wallet_address() IS NOT NULL
-    AND lower(current_wallet_address()) = ANY(
+    current_principal() IS NOT NULL
+    AND current_principal() LIKE 'eth:%'
+    AND lower(substring(current_principal() FROM 5)) = ANY(
       string_to_array(
         lower(replace(
           coalesce(current_setting('app.admin_addresses', true), ''),
@@ -53,29 +106,12 @@ AS $$
   );
 $$;
 
--- Validate and normalize an Ethereum wallet address (0x + 40 hex chars).
--- Raises invalid_parameter_value if the input does not match. Used by
--- register_client to reject typo'd or malformed addresses before creating a
--- client that the intended owner could never access under RLS.
-CREATE OR REPLACE FUNCTION normalize_wallet_address(addr TEXT)
-  RETURNS VARCHAR(42)
-  LANGUAGE plpgsql IMMUTABLE
-AS $$
-BEGIN
-  IF addr IS NULL OR addr !~ '^0x[0-9a-fA-F]{40}$' THEN
-    RAISE EXCEPTION 'invalid wallet address: %', addr
-      USING ERRCODE = 'invalid_parameter_value';
-  END IF;
-  RETURN lower(addr);
-END;
-$$;
-
 -- ============================================================
 -- 3. Clients table
 -- ============================================================
 CREATE TABLE IF NOT EXISTS clients (
   id                TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
-  owner_wallet      VARCHAR(42) NOT NULL,
+  owner_principal   TEXT NOT NULL,
   client_name       TEXT NOT NULL,
   token_hash        TEXT NOT NULL UNIQUE,
   allowed_agent_ids TEXT[] NOT NULL DEFAULT '{}',
@@ -89,27 +125,27 @@ ALTER TABLE clients ENABLE ROW LEVEL SECURITY;
 DROP POLICY IF EXISTS clients_select ON clients;
 CREATE POLICY clients_select ON clients
   FOR SELECT TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin());
 
--- Users can insert clients they own; admins can insert on behalf of any wallet.
+-- Users can insert clients they own; admins can insert on behalf of any principal.
 -- The admin branch is needed by register_client() when called with an explicit
--- owner_wallet argument.
+-- owner_principal argument.
 DROP POLICY IF EXISTS clients_insert ON clients;
 CREATE POLICY clients_insert ON clients
   FOR INSERT TO app_authenticated
-  WITH CHECK (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  WITH CHECK (owner_principal = current_principal() OR is_admin());
 
 -- Users can update their own clients; admins can update all
 DROP POLICY IF EXISTS clients_update ON clients;
 CREATE POLICY clients_update ON clients
   FOR UPDATE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin());
 
 -- Users can delete their own clients; admins can delete all
 DROP POLICY IF EXISTS clients_delete ON clients;
 CREATE POLICY clients_delete ON clients
   FOR DELETE TO app_authenticated
-  USING (owner_wallet = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin());
 
 -- app_postgraphile bypasses RLS (used by server for token lookup)
 DROP POLICY IF EXISTS clients_postgraphile ON clients;
@@ -134,7 +170,7 @@ COMMENT ON TABLE clients IS E'@omit create';
 DO $$ BEGIN
   CREATE TYPE client_with_token AS (
     id                TEXT,
-    owner_wallet      VARCHAR(42),
+    owner_principal   TEXT,
     client_name       TEXT,
     allowed_agent_ids TEXT[],
     revoked           BOOLEAN,
@@ -144,15 +180,17 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
--- Register a new client. Admins may pass an explicit owner_wallet to create on
--- behalf of another wallet; non-admins own the client themselves regardless of
--- what they pass. Returns the raw bearer token — shown only once.
--- Arg names match clients column names, so the body qualifies them with
--- `register_client.*` to disambiguate from columns in enclosing SQL scopes.
+-- Register a new client. Admins may pass an explicit owner_principal to create
+-- on behalf of another principal; non-admins own the client themselves
+-- regardless of what they pass. Returns the raw bearer token — shown only once.
+-- Principal validation/normalization is performed in the TypeScript layer
+-- (packages/server/src/auth/principal.ts validatePrincipal) before the value
+-- ever reaches this function or the jwt.claims.principal_id session var, so
+-- this body trusts its inputs.
 CREATE OR REPLACE FUNCTION register_client(
   client_name       TEXT,
   allowed_agent_ids TEXT[],
-  owner_wallet      VARCHAR(42) DEFAULT NULL
+  owner_principal   TEXT DEFAULT NULL
 ) RETURNS client_with_token
   LANGUAGE plpgsql
   SECURITY INVOKER
@@ -160,42 +198,37 @@ AS $$
 DECLARE
   v_raw_token  TEXT;
   v_token_hash TEXT;
-  v_owner      VARCHAR(42);
+  v_owner      TEXT;
   v_row        client_with_token;
 BEGIN
   v_raw_token  := encode(gen_random_bytes(32), 'hex');
   v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
 
-  IF is_admin() AND register_client.owner_wallet IS NOT NULL THEN
-    -- Validate the explicit owner_wallet: a typo'd address would create a row
-    -- that the intended owner could never read or update under RLS.
-    v_owner := normalize_wallet_address(register_client.owner_wallet);
+  IF is_admin() AND register_client.owner_principal IS NOT NULL THEN
+    v_owner := register_client.owner_principal;
   ELSE
-    IF current_wallet_address() IS NULL THEN
-      RAISE EXCEPTION 'current wallet address is not set';
+    IF current_principal() IS NULL THEN
+      RAISE EXCEPTION 'current principal is not set';
     END IF;
-    -- Sanity check: current_wallet_address() comes from the SIWE token claim
-    -- and should already be well-formed. Validate anyway so a compromised or
-    -- buggy auth layer cannot plant malformed rows.
-    v_owner := normalize_wallet_address(current_wallet_address());
+    v_owner := current_principal();
   END IF;
 
-  INSERT INTO clients AS c (owner_wallet, client_name, token_hash, allowed_agent_ids)
+  INSERT INTO clients AS c (owner_principal, client_name, token_hash, allowed_agent_ids)
   VALUES (
     v_owner,
     register_client.client_name,
     v_token_hash,
     COALESCE(register_client.allowed_agent_ids, '{}')
   )
-  RETURNING c.id, c.owner_wallet, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
   INTO v_row;
 
   RETURN v_row;
 END;
 $$;
 
-COMMENT ON FUNCTION register_client(TEXT, TEXT[], VARCHAR) IS
-  'Register a new client. Admins may pass ownerWallet to create on behalf of another wallet; non-admins always own the resulting client. Returns the raw bearer token — shown only once.';
+COMMENT ON FUNCTION register_client(TEXT, TEXT[], TEXT) IS
+  'Register a new client. Admins may pass ownerPrincipal to create on behalf of another principal; non-admins always own the resulting client. Returns the raw bearer token — shown only once.';
 
 -- Mark a client as revoked. Does not delete the row so history is preserved.
 -- RLS authorizes the update (owner or admin).
@@ -264,7 +297,7 @@ BEGIN
   UPDATE clients AS c
   SET token_hash = v_token_hash
   WHERE c.id = rotate_client_token.client_id
-  RETURNING c.id, c.owner_wallet, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
   INTO v_row;
 
   IF NOT FOUND THEN
@@ -311,17 +344,21 @@ COMMENT ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) IS
 CREATE SCHEMA IF NOT EXISTS infra;
 
 CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
-  task_id    TEXT PRIMARY KEY,
-  context_id TEXT NOT NULL,
-  state      TEXT NOT NULL,
-  task_json  JSONB NOT NULL,
-  owner_wallet VARCHAR(42),
-  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+  task_id         TEXT PRIMARY KEY,
+  context_id      TEXT NOT NULL,
+  state           TEXT NOT NULL,
+  task_json       JSONB NOT NULL,
+  owner_principal TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_wallet
-  ON infra.a2a_tasks (context_id, owner_wallet, created_at);
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_principal
+  ON infra.a2a_tasks (context_id, owner_principal, created_at);
+
+-- Drop the legacy index name from before the rename so re-running schema.sql
+-- on a renamed dev DB doesn't leave a stale index pointing at the old column.
+DROP INDEX IF EXISTS infra.idx_a2a_tasks_context_wallet;
 
 GRANT USAGE ON SCHEMA infra TO app_postgraphile;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA infra TO app_postgraphile;
@@ -336,83 +373,12 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA infra
 -- accumulate (see #23). client_id is set in INSERT/upsert on WS registration.
 CREATE TABLE IF NOT EXISTS agent_policies (
   agent_id         TEXT PRIMARY KEY,
-  owner_wallet     VARCHAR(42) NOT NULL,
-  client_id        TEXT REFERENCES clients(id) ON DELETE CASCADE,
+  owner_principal  TEXT NOT NULL,
+  client_id        TEXT NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
   allowed_callers  TEXT[] NOT NULL DEFAULT '{}',
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
-
--- Idempotent migration for pre-#23 deployments. ensureSchema() runs schema.sql
--- without an outer transaction, so each step must tolerate resuming from a
--- half-applied state: the FK is added NOT VALID first, rows are scrubbed, and
--- the constraint is validated only after the table is consistent.
-ALTER TABLE agent_policies ADD COLUMN IF NOT EXISTS client_id TEXT;
-
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'agent_policies_client_id_fkey'
-      AND conrelid = 'agent_policies'::regclass
-  ) THEN
-    ALTER TABLE agent_policies
-      ADD CONSTRAINT agent_policies_client_id_fkey
-      FOREIGN KEY (client_id) REFERENCES clients(id) ON DELETE CASCADE
-      NOT VALID;
-  END IF;
-END $$;
-
--- Partial-run safety: if a row already has a client_id but it points at a
--- missing client (e.g. deleted while the FK was NOT VALID), reset it to NULL
--- rather than deleting — the backfill below will try to reassign the policy
--- to another client of the same wallet and preserve allowed_callers.
-UPDATE agent_policies ap
-SET client_id = NULL
-WHERE ap.client_id IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM clients c WHERE c.id = ap.client_id);
-
--- Backfill: prefer a client whose allowed_agent_ids still lists this agent,
--- otherwise fall back to the most recent client of the same wallet. The
--- fallback preserves existing allowed_callers when allowed_agent_ids is out
--- of sync. Case-insensitive wallet compare guards against legacy casing.
-UPDATE agent_policies ap
-SET client_id = sub.client_id
-FROM (
-  SELECT DISTINCT ON (p.agent_id) p.agent_id, c.id AS client_id
-  FROM agent_policies p
-  JOIN clients c ON lower(c.owner_wallet) = lower(p.owner_wallet)
-  WHERE p.client_id IS NULL
-  ORDER BY p.agent_id,
-           (p.agent_id = ANY(c.allowed_agent_ids)) DESC,
-           c.created_at DESC
-) sub
-WHERE ap.agent_id = sub.agent_id AND ap.client_id IS NULL;
-
--- Only rows whose wallet truly has no clients left are orphaned.
-DELETE FROM agent_policies ap
-WHERE ap.client_id IS NULL
-  AND NOT EXISTS (
-    SELECT 1 FROM clients c
-    WHERE lower(c.owner_wallet) = lower(ap.owner_wallet)
-  );
-
-ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_fkey;
-
--- Enforce NOT NULL via a validated CHECK constraint instead of ALTER COLUMN
--- SET NOT NULL so the migration avoids the ACCESS EXCLUSIVE full-table scan.
-DO $$ BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint
-    WHERE conname = 'agent_policies_client_id_not_null'
-      AND conrelid = 'agent_policies'::regclass
-  ) THEN
-    ALTER TABLE agent_policies
-      ADD CONSTRAINT agent_policies_client_id_not_null
-      CHECK (client_id IS NOT NULL) NOT VALID;
-  END IF;
-END $$;
-
-ALTER TABLE agent_policies VALIDATE CONSTRAINT agent_policies_client_id_not_null;
 
 CREATE INDEX IF NOT EXISTS idx_agent_policies_client_id
   ON agent_policies (client_id);
@@ -425,12 +391,10 @@ COMMENT ON TABLE agent_policies IS E'@omit create,update,delete';
 COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit create,update';
 
 -- Authenticated users see their own policies; admins see all.
--- lower(owner_wallet) compare tolerates any legacy mixed-case rows, matching
--- the normalization used in the migration backfill and WS upsert guard.
 DROP POLICY IF EXISTS agent_policies_select ON agent_policies;
 CREATE POLICY agent_policies_select ON agent_policies
   FOR SELECT TO app_authenticated
-  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin());
 
 -- No INSERT policy for app_authenticated. UPDATE is allowed for the same
 -- owner/admin predicate because admin tools (add_caller / remove_caller) run
@@ -439,8 +403,8 @@ DROP POLICY IF EXISTS agent_policies_insert ON agent_policies;
 DROP POLICY IF EXISTS agent_policies_update ON agent_policies;
 CREATE POLICY agent_policies_update ON agent_policies
   FOR UPDATE TO app_authenticated
-  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin())
-  WITH CHECK (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin())
+  WITH CHECK (owner_principal = current_principal() OR is_admin());
 
 -- DELETE policy exists solely so ON DELETE CASCADE from clients works when a
 -- user (running as app_authenticated) deletes their own client. The direct
@@ -448,7 +412,7 @@ CREATE POLICY agent_policies_update ON agent_policies
 DROP POLICY IF EXISTS agent_policies_delete ON agent_policies;
 CREATE POLICY agent_policies_delete ON agent_policies
   FOR DELETE TO app_authenticated
-  USING (lower(owner_wallet) = lower(current_wallet_address()) OR is_admin());
+  USING (owner_principal = current_principal() OR is_admin());
 
 -- app_postgraphile bypasses RLS (used by server for auth checks)
 DROP POLICY IF EXISTS agent_policies_postgraphile ON agent_policies;
@@ -463,14 +427,14 @@ CREATE POLICY agent_policies_postgraphile ON agent_policies
 -- registerClient() accepts an allowed_agent_ids list but does not verify that
 -- the ids are free — collisions surface only at first WS register
 -- (packages/server/src/ws.ts ensureAgentPolicy → 'agent id owned by a
--- different wallet'), by which point the CLIENT_TOKEN has already been issued
--- and rotation is needed. agent_policies_select RLS also hides rows owned by
--- other wallets, so a non-admin cannot distinguish 'free' from 'taken by
--- someone else' with a direct query.
+-- different principal'), by which point the CLIENT_TOKEN has already been
+-- issued and rotation is needed. agent_policies_select RLS also hides rows
+-- owned by other principals, so a non-admin cannot distinguish 'free' from
+-- 'taken by someone else' with a direct query.
 --
 -- This function returns boolean availability only, bypassing RLS via
 -- SECURITY DEFINER so the check is authoritative across all owners. It does
--- NOT expose owner_wallet or any metadata — callers learn only whether the
+-- NOT expose owner_principal or any metadata — callers learn only whether the
 -- id is claimable.
 CREATE OR REPLACE FUNCTION agent_id_available(agent_id TEXT)
   RETURNS BOOLEAN
@@ -502,11 +466,11 @@ $$;
 -- definer context would be superuser — overkill for reading one table and a
 -- latent escalation surface for future edits. app_postgraphile already has
 -- the RLS-bypass policy on agent_policies, which is exactly (and only) what
--- this function needs to cross-wallet SELECT.
+-- this function needs to cross-principal SELECT.
 ALTER FUNCTION agent_id_available(TEXT) OWNER TO app_postgraphile;
 
 COMMENT ON FUNCTION agent_id_available(TEXT) IS
-  'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any wallet (including the caller) already owns it. Never exposes owner_wallet or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';
+  'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any principal (including the caller) already owns it. Never exposes owner_principal or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';
 
 -- ============================================================
 -- 6. Caller auth: opaque tokens issued via Google OAuth device flow
@@ -598,14 +562,14 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE O
 -- these via GraphQL (they'd fail inside, but we want them off the anonymous
 -- surface entirely). Revoke PUBLIC and grant back only to the authenticated
 -- role and to app_postgraphile (used for introspection).
-REVOKE EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION register_client(TEXT, TEXT[], TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION revoke_client(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION unrevoke_client(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION rotate_client_token(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION agent_id_available(TEXT) FROM PUBLIC;
 
-GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], VARCHAR)
+GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], TEXT)
   TO app_authenticated, app_postgraphile;
 GRANT EXECUTE ON FUNCTION revoke_client(TEXT)
   TO app_authenticated, app_postgraphile;

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -115,7 +115,7 @@ ${scope}
 
 Clients are services that connect to the server via WebSocket to register A2A agents. Each client has:
 - **id**: Unique identifier (UUID)
-- **owner_wallet**: Wallet address of the owner
+- **owner_principal**: Principal of the owner (e.g. \`eth:0x<40 hex>\` or \`google:sub:<sub>\`)
 - **client_name**: Human-readable name
 - **allowed_agent_ids**: List of agent IDs this client is authorized to register
 - **revoked**: Whether this client has been revoked
@@ -126,7 +126,7 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 
 - Use \`query_*\` tools to read clients and agent policies. RLS enforces ownership (admins see all).
 - Client lifecycle mutations are exposed as custom GraphQL functions:
-  - \`mutate_registerClient(clientName, allowedAgentIds, ownerWallet?)\` — creates a new client and returns the raw bearer token (shown only once). Admins may pass \`ownerWallet\` to create on behalf of another wallet; non-admins always own the resulting client.
+  - \`mutate_registerClient(clientName, allowedAgentIds, ownerPrincipal?)\` — creates a new client and returns the raw bearer token (shown only once). Admins may pass \`ownerPrincipal\` to create on behalf of another principal; non-admins always own the resulting client.
   - \`mutate_revokeClient(clientId)\` / \`mutate_unrevokeClient(clientId)\` — toggle the \`revoked\` flag. Existing WebSocket sessions stay connected until they reconnect.
   - \`mutate_rotateClientToken(clientId)\` — issues a new bearer token and invalidates the previous one. Returns the raw token once.
   - \`mutate_updateClientAllowedAgents(clientId, allowedAgentIds)\` — replaces the agent allowlist.
@@ -142,11 +142,11 @@ Each agent has an access policy (\`agent_policies\` table) with an \`allowed_cal
 - **Empty \`allowed_callers\`**: Agent is public — anyone can call it via A2A.
 - **Non-empty \`allowed_callers\`**: Agent requires an authenticated Bearer token, and only listed principals can call.
 
-Supported principal formats in \`allowed_callers\`:
+Supported principal formats in \`allowed_callers\` (and as \`owner_principal\`):
 - \`eth:0x<40 hex>\` — SIWE-authenticated Ethereum address
 - \`google:sub:<sub>\` — specific Google account by stable id
 - \`google:email:<email>\` — Google account by email (pinned to sub on first match)
-- \`google:domain:<domain>\` — any verified Google Workspace account from the domain
+- \`google:domain:<domain>\` — any verified Google Workspace account from the domain (allowed_callers only)
 
 When an agent registers via WebSocket, a default policy (public) is auto-created. Use \`add_caller\` to restrict access. The agent card automatically advertises \`securitySchemes\` when callers are configured.
 
@@ -157,7 +157,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 ## Important rules
 
 - When registering a client or rotating a token, always warn the user that the raw token is shown only once.
-- When registering on behalf of another wallet (admin only), echo back the chosen \`ownerWallet\` so the user can confirm.
+- When registering on behalf of another principal (admin only), echo back the chosen \`ownerPrincipal\` so the user can confirm.
 - When adding a caller, explain that the agent will require an authenticated bearer token from that point on (either SIWE-exchanged or Google-device-flow-issued, depending on the principal format).
 - Present data clearly in tables or lists.
 - If asked about something outside client management, politely explain your scope.
@@ -167,7 +167,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 - **Connection types**: List queries return \`{ nodes { ...fields } totalCount }\`.
 - **Filtering**: Use \`condition\` argument, e.g. \`condition: { revoked: false }\`.
 - **Sorting**: Use \`orderBy\` with values like \`CREATED_AT_DESC\`.
-- **Field naming**: snake_case SQL → camelCase GraphQL (e.g. \`owner_wallet\` → \`ownerWallet\`).
+- **Field naming**: snake_case SQL → camelCase GraphQL (e.g. \`owner_principal\` → \`ownerPrincipal\`).
 `;
 
   if (sdl) {
@@ -180,6 +180,11 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 // ── Custom Tools (token generation, active agents) ───────────────
 
 function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
+  // Admin agent authenticates via SIWE only (see http.tsx root POST /), so the
+  // current principal is always 'eth:<wallet>'. Caller-side admin tools that
+  // hit the DB pass this through as jwt.claims.principal_id so RLS predicates
+  // (owner_principal = current_principal()) match owned rows.
+  const principalId = `eth:${walletAddress.toLowerCase()}`;
   return {
     list_active_agents: tool({
       description: 'List currently connected agents with their client identity and connection time. Non-admin users only see their own agents.',
@@ -187,7 +192,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
       execute: async () => {
         const admin = isAdmin(walletAddress);
         return registry.listAgents()
-          .filter((a) => admin || a.ownerWallet.toLowerCase() === walletAddress.toLowerCase())
+          .filter((a) => admin || a.ownerPrincipal === principalId)
           .map((a) => ({
             agent_id: a.agentId,
             client_id: a.clientId,
@@ -219,7 +224,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
           return tx`
             UPDATE agent_policies
@@ -227,14 +232,14 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
                 updated_at = now()
             WHERE agent_id = ${agent_id}
               AND NOT (${normalized} = ANY(allowed_callers))
-            RETURNING agent_id, owner_wallet, allowed_callers
+            RETURNING agent_id, owner_principal, allowed_callers
           `;
         });
         if (result.length === 0) {
           const adminAddrs = process.env.ADMIN_WALLET_ADDRESSES ?? '';
           const existing = await db.begin(async (tx) => {
             await tx`SELECT set_config('role', 'app_authenticated', true)`;
-            await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+            await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
             await tx`SELECT set_config('app.admin_addresses', ${adminAddrs}, true)`;
             return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
           });
@@ -266,7 +271,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
           return tx`
             UPDATE agent_policies
@@ -274,7 +279,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
                 updated_at = now()
             WHERE agent_id = ${agent_id}
               AND ${normalized} = ANY(allowed_callers)
-            RETURNING agent_id, owner_wallet, allowed_callers
+            RETURNING agent_id, owner_principal, allowed_callers
           `;
         });
         if (result.length === 0) {
@@ -295,10 +300,10 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
         const result = await db.begin(async (tx) => {
           await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.wallet_address', ${walletAddress.toLowerCase()}, true)`;
+          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
           await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
           return tx`
-            SELECT agent_id, owner_wallet, allowed_callers, created_at, updated_at
+            SELECT agent_id, owner_principal, allowed_callers, created_at, updated_at
             FROM agent_policies WHERE agent_id = ${agent_id}
           `;
         });
@@ -306,7 +311,7 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         const policy = result[0];
         return {
           agent_id: policy.agent_id,
-          owner_wallet: policy.owner_wallet,
+          owner_principal: policy.owner_principal,
           allowed_callers: policy.allowed_callers,
           is_public: (policy.allowed_callers as string[]).length === 0,
         };
@@ -398,8 +403,9 @@ class AdminA2XExecutor extends AgentExecutor {
 
     const metadata = (message as { metadata?: Record<string, unknown> }).metadata;
     const walletAddress = metadata?._walletAddress as string | undefined;
+    const principalId = metadata?._principalId as string | undefined;
     const bearerToken = metadata?._bearerToken as string | undefined;
-    if (!walletAddress || !bearerToken) {
+    if (!walletAddress || !principalId || !bearerToken) {
       throw new InvalidRequestError('Authenticated wallet address is required.');
     }
 
@@ -436,7 +442,7 @@ class AdminA2XExecutor extends AgentExecutor {
         // context, plus any history already on the current task.
         const previousTasks = await this.taskStoreImpl.loadByContextId(
           contextId,
-          walletAddress,
+          principalId,
           taskId,
         );
         const contextHistory: Message[] = [];

--- a/packages/server/src/agent-id-available.test.ts
+++ b/packages/server/src/agent-id-available.test.ts
@@ -32,16 +32,16 @@ test(
     const sql = postgres(process.env.DATABASE_URL!);
     try {
       const agentId = `availability-taken-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const owner = '0x1111111111111111111111111111111111111111';
+      const owner = 'eth:0x1111111111111111111111111111111111111111';
       const clients = await sql<{ id: string }[]>`
-        INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
+        INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
         VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
         RETURNING id
       `;
       const clientId = clients[0]!.id;
       try {
         await sql`
-          INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
+          INSERT INTO agent_policies (agent_id, owner_principal, client_id)
           VALUES (${agentId}, ${owner}, ${clientId})
         `;
 
@@ -60,35 +60,35 @@ test(
 );
 
 test(
-  'authenticated caller from a different wallet still sees available=false (RLS bypass)',
+  'authenticated caller from a different principal still sees available=false (RLS bypass)',
   { skip: !hasDb },
   async () => {
     // Guards the SECURITY DEFINER posture: agent_policies_select restricts
-    // SELECT to the owning wallet, so without RLS bypass a different wallet's
-    // direct query would return no rows and the function would wrongly report
-    // the id as available. Exercising app_authenticated with a mismatched
-    // wallet claim proves the bypass is effective.
+    // SELECT to the owning principal, so without RLS bypass a different
+    // principal's direct query would return no rows and the function would
+    // wrongly report the id as available. Exercising app_authenticated with a
+    // mismatched principal claim proves the bypass is effective.
     const sql = postgres(process.env.DATABASE_URL!);
     try {
       const agentId = `availability-cross-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      const owner = '0x2222222222222222222222222222222222222222';
-      const other = '0x3333333333333333333333333333333333333333';
+      const owner = 'eth:0x2222222222222222222222222222222222222222';
+      const other = 'eth:0x3333333333333333333333333333333333333333';
 
       const clients = await sql<{ id: string }[]>`
-        INSERT INTO clients (owner_wallet, client_name, token_hash, allowed_agent_ids)
+        INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
         VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
         RETURNING id
       `;
       const clientId = clients[0]!.id;
       try {
         await sql`
-          INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
+          INSERT INTO agent_policies (agent_id, owner_principal, client_id)
           VALUES (${agentId}, ${owner}, ${clientId})
         `;
 
         const available = await sql.begin(async (tx) => {
           await tx`SET LOCAL ROLE app_authenticated`;
-          await tx`SELECT set_config('jwt.claims.wallet_address', ${other}, true)`;
+          await tx`SELECT set_config('jwt.claims.principal_id', ${other}, true)`;
           const rows = await tx<{ available: boolean }[]>`
             SELECT agent_id_available(${agentId}) AS available
           `;

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -162,9 +162,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   mountSiweExchange(app, { sql: opts.db, domain: siweDomain });
 
   // Root POST — admin agent A2A endpoint. Requires opaque caller token with
-  // an `eth:*` principal (admin agent is wallet-based; Google-only callers
-  // can still call /agents/:id but have no admin GraphQL access under the
-  // current owner_wallet schema).
+  // an `eth:*` principal (admin onboarding stays wallet-only; Google callers
+  // can call /agents/:id but the admin agent itself is wallet-gated by design,
+  // see issue #79).
   app.post('/', async (c) => {
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
@@ -208,6 +208,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       parsed.params.message.metadata = {
         ...parsed.params.message.metadata,
         _walletAddress: walletAddress,
+        _principalId: `eth:${walletAddress.toLowerCase()}`,
         _bearerToken: bearerToken,
       };
     }

--- a/packages/server/src/postgraphile.ts
+++ b/packages/server/src/postgraphile.ts
@@ -42,20 +42,16 @@ export async function startPostGraphile(databaseUrl: string, sql: Sql): Promise<
         if (auth?.startsWith('Bearer ')) {
           const token = auth.slice(7);
           // Opaque caller tokens are the only accepted admin GraphQL credential
-          // as of #31. Wallet-based callers (eth:* principals) get RLS-gated
-          // access; Google-only callers have no owner_wallet so their queries
-          // fall through to anonymous.
+          // as of #31. Any verified principal (eth:* or google:*) gets RLS-gated
+          // access scoped to rows whose owner_principal matches.
           if (token.startsWith(CALLER_TOKEN_PREFIX)) {
             try {
               const caller = await verifyCallerToken(sql, token);
-              if (caller.principalId.startsWith('eth:')) {
-                const walletAddress = caller.principalId.slice('eth:'.length);
-                return {
-                  role: 'app_authenticated',
-                  'jwt.claims.wallet_address': walletAddress,
-                  'app.admin_addresses': ADMIN_WALLET_ADDRESSES,
-                };
-              }
+              return {
+                role: 'app_authenticated',
+                'jwt.claims.principal_id': caller.principalId,
+                'app.admin_addresses': ADMIN_WALLET_ADDRESSES,
+              };
             } catch {
               // fall through to anonymous
             }

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -13,22 +13,22 @@ const MAX_CONTEXT_TASKS = 10;
 
 type MessageWithMetadata = Message & { metadata?: Record<string, unknown> };
 
-function extractOwnerWallet(task: Task): string | undefined {
+function extractOwnerPrincipal(task: Task): string | undefined {
   for (const msg of task.history ?? []) {
-    const wallet = (msg as MessageWithMetadata).metadata?._walletAddress;
-    if (typeof wallet === 'string') return wallet.toLowerCase();
+    const principal = (msg as MessageWithMetadata).metadata?._principalId;
+    if (typeof principal === 'string') return principal;
   }
-  const statusWallet = (task.status?.message as MessageWithMetadata | undefined)?.metadata
-    ?._walletAddress;
-  if (typeof statusWallet === 'string') return statusWallet.toLowerCase();
+  const statusPrincipal = (task.status?.message as MessageWithMetadata | undefined)?.metadata
+    ?._principalId;
+  if (typeof statusPrincipal === 'string') return statusPrincipal;
   return undefined;
 }
 
 function stripMessageMetadata(msg: Message): Message {
-  const { _bearerToken, _walletAddress, ...rest } =
+  const { _bearerToken, _principalId, ...rest } =
     (msg as MessageWithMetadata).metadata ?? {};
   void _bearerToken;
-  void _walletAddress;
+  void _principalId;
   const clean = Object.keys(rest).length ? rest : undefined;
   if (clean) return { ...msg, metadata: clean };
   const { metadata: _meta, ...m } = msg as MessageWithMetadata;
@@ -48,7 +48,7 @@ function stripSensitiveMetadata(task: Task): Task {
 }
 
 export interface ContextAwareTaskStore extends TaskStore {
-  loadByContextId(contextId: string, walletAddress: string, excludeTaskId?: string): Promise<Task[]>;
+  loadByContextId(contextId: string, principalId: string, excludeTaskId?: string): Promise<Task[]>;
 }
 
 export class PostgresTaskStore implements ContextAwareTaskStore {
@@ -92,14 +92,14 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
 
   async loadByContextId(
     contextId: string,
-    walletAddress: string,
+    principalId: string,
     excludeTaskId?: string,
   ): Promise<Task[]> {
     const rows = excludeTaskId
       ? await this.sql<{ task_json: Task }[]>`
           SELECT task_json FROM infra.a2a_tasks
           WHERE context_id = ${contextId}
-            AND owner_wallet = ${walletAddress.toLowerCase()}
+            AND owner_principal = ${principalId}
             AND task_id != ${excludeTaskId}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
@@ -107,7 +107,7 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
       : await this.sql<{ task_json: Task }[]>`
           SELECT task_json FROM infra.a2a_tasks
           WHERE context_id = ${contextId}
-            AND owner_wallet = ${walletAddress.toLowerCase()}
+            AND owner_principal = ${principalId}
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
         `;
@@ -115,36 +115,36 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
   }
 
   private async upsert(task: Task): Promise<void> {
-    const ownerWallet = extractOwnerWallet(task);
+    const ownerPrincipal = extractOwnerPrincipal(task);
     const sanitized = stripSensitiveMetadata(task);
     const contextId = task.contextId ?? task.id;
 
     await this.sql`
-      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json, owner_wallet)
+      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json, owner_principal)
       VALUES (
         ${task.id},
         ${contextId},
         ${task.status.state},
         ${this.sql.json(JSON.parse(JSON.stringify(sanitized)))},
-        ${ownerWallet ?? null}
+        ${ownerPrincipal ?? null}
       )
       ON CONFLICT (task_id) DO UPDATE SET
         context_id = EXCLUDED.context_id,
         state = EXCLUDED.state,
         task_json = EXCLUDED.task_json,
-        owner_wallet = COALESCE(infra.a2a_tasks.owner_wallet, EXCLUDED.owner_wallet),
+        owner_principal = COALESCE(infra.a2a_tasks.owner_principal, EXCLUDED.owner_principal),
         updated_at = now()
     `;
 
     // Enforce retention only when this task reaches a terminal state
     const isTerminal = TERMINAL_STATES.has(task.status.state);
-    if (ownerWallet && isTerminal) {
+    if (ownerPrincipal && isTerminal) {
       await this.sql`
         DELETE FROM infra.a2a_tasks
         WHERE task_id IN (
           SELECT task_id FROM infra.a2a_tasks
           WHERE context_id = ${contextId}
-            AND owner_wallet = ${ownerWallet}
+            AND owner_principal = ${ownerPrincipal}
             AND state IN ('completed', 'failed', 'canceled', 'rejected')
           ORDER BY created_at DESC, task_id DESC
           OFFSET ${MAX_CONTEXT_TASKS}

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -31,7 +31,7 @@ test('onAgentChange fires on first registration', () => {
   const result = registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws: makeWs(),
@@ -51,7 +51,7 @@ test('onAgentChange fires again when the same client reconnects with an updated 
   const base = {
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     allowedCallers: [],
     connectedAt: 0,
   };
@@ -70,7 +70,7 @@ test('onAgentChange does NOT fire when registration is refused (different client
   registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws: makeWs(),
@@ -81,7 +81,7 @@ test('onAgentChange does NOT fire when registration is refused (different client
   const rejected = registry.registerAgent({
     agentId: 'a1',
     clientId: 'c2', // different client
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(true),
     allowedCallers: [],
     ws: makeWs(),
@@ -99,7 +99,7 @@ test('onAgentChange fires on disconnect (unregister) so stale transports do not 
   registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws,
@@ -119,7 +119,7 @@ test('onAgentChange does NOT fire on unregister if the ws does not match the cur
   registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws: oldWs,
@@ -130,7 +130,7 @@ test('onAgentChange does NOT fire on unregister if the ws does not match the cur
   registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(true),
     allowedCallers: [],
     ws: newWs,
@@ -169,7 +169,7 @@ test('a throwing onAgentChange listener does not abort other listeners or the re
   const result = registry.registerAgent({
     agentId: 'a1',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws: makeWs(),
@@ -205,7 +205,7 @@ test('notifyAgentChange log cannot be hijacked by newline injection via agentId'
   registry.registerAgent({
     agentId: 'good\nevent: fake_login\nextra: attacker-controlled',
     clientId: 'c1',
-    ownerWallet: '0x0',
+    ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
     ws: makeWs(),

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -7,7 +7,7 @@ import { logEvent, truncate } from './log.js';
 export interface ClientConnection {
   agentId: string;
   clientId: string;
-  ownerWallet: string;
+  ownerPrincipal: string;
   agentCard: AgentCard;
   allowedCallers: string[];
   ws: WebSocket;

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -16,55 +16,54 @@ import { logEvent, truncate } from './log.js';
 
 interface ClientRow {
   id: string;
-  owner_wallet: string;
+  owner_principal: string;
   allowed_agent_ids: string[];
 }
 
 async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
   const rows = await sql<ClientRow[]>`
-    SELECT id, owner_wallet, allowed_agent_ids FROM clients WHERE token_hash = ${hash} AND revoked = false
+    SELECT id, owner_principal, allowed_agent_ids FROM clients WHERE token_hash = ${hash} AND revoked = false
   `;
   return rows[0] ?? null;
 }
 
 interface PolicyRow {
-  owner_wallet: string;
+  owner_principal: string;
   allowed_callers: string[];
 }
 
 async function ensureAgentPolicy(
   sql: Sql,
   agentId: string,
-  ownerWallet: string,
+  ownerPrincipal: string,
   clientId: string,
 ): Promise<{ ok: true; allowedCallers: string[] } | { ok: false; reason: string }> {
   // Refresh client_id on re-registration so cascade follows the currently
-  // registering client. Case-insensitive compare mirrors the lowercase
-  // normalization used elsewhere, so a legacy mixed-case row still matches;
-  // the ownership check below still rejects cross-wallet attempts. The
-  // IS DISTINCT FROM guard skips the write when nothing actually changed to
-  // avoid WAL churn on frequent reconnects.
+  // registering client. Principals are stored in canonical form (lowercased
+  // for eth/email/domain at issuance time; google:sub: is numeric so case is
+  // moot), so direct equality is sufficient. The IS DISTINCT FROM guard skips
+  // the write when nothing actually changed to avoid WAL churn on frequent
+  // reconnects.
   await sql`
-    INSERT INTO agent_policies (agent_id, owner_wallet, client_id)
-    VALUES (${agentId}, ${ownerWallet.toLowerCase()}, ${clientId})
+    INSERT INTO agent_policies (agent_id, owner_principal, client_id)
+    VALUES (${agentId}, ${ownerPrincipal}, ${clientId})
     ON CONFLICT (agent_id) DO UPDATE
-      SET owner_wallet = EXCLUDED.owner_wallet,
+      SET owner_principal = EXCLUDED.owner_principal,
           client_id = EXCLUDED.client_id,
           updated_at = now()
-      WHERE lower(agent_policies.owner_wallet) = lower(EXCLUDED.owner_wallet)
+      WHERE agent_policies.owner_principal = EXCLUDED.owner_principal
         AND (
           agent_policies.client_id IS DISTINCT FROM EXCLUDED.client_id
-          OR agent_policies.owner_wallet IS DISTINCT FROM EXCLUDED.owner_wallet
         )
   `;
   const rows = await sql<PolicyRow[]>`
-    SELECT owner_wallet, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
+    SELECT owner_principal, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
   `;
   if (rows.length === 0) {
     return { ok: false, reason: 'failed to create agent policy' };
   }
-  if (rows[0].owner_wallet.toLowerCase() !== ownerWallet.toLowerCase()) {
-    return { ok: false, reason: 'agent id owned by a different wallet' };
+  if (rows[0].owner_principal !== ownerPrincipal) {
+    return { ok: false, reason: 'agent id owned by a different principal' };
   }
   return { ok: true, allowedCallers: rows[0].allowed_callers };
 }
@@ -114,9 +113,9 @@ async function authenticateAndRegister(
     return { ok: false, code: 4008, reason: 'agent id not authorized for this client' };
   }
   const clientId = client.id;
-  const ownerWallet = client.owner_wallet;
+  const ownerPrincipal = client.owner_principal;
 
-  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerWallet, clientId);
+  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerPrincipal, clientId);
   if (!policyResult.ok) {
     logEvent('client_rejected', {
       reason: policyResult.reason,
@@ -129,7 +128,7 @@ async function authenticateAndRegister(
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
-    ownerWallet,
+    ownerPrincipal,
     agentCard: frame.agentCard,
     allowedCallers: policyResult.allowedCallers,
     ws,


### PR DESCRIPTION
PR A of #79 — server schema and code-side rename only. WS auth, admin gating, and onboarding flow are unchanged.

## Summary

- `clients.owner_wallet VARCHAR(42)` → `owner_principal TEXT` (also `agent_policies` and `infra.a2a_tasks`)
- `current_wallet_address()` → `current_principal()`; PostgreSQL session var renamed `jwt.claims.wallet_address` → `jwt.claims.principal_id`
- PostGraphile field `ownerWallet` → `ownerPrincipal`
- `register_client(client_name, allowed_agent_ids, owner_principal TEXT DEFAULT NULL)` — admin override is now any principal type
- `normalize_wallet_address()` dropped; principal validation lives in TS (`auth/principal.ts validatePrincipal`)
- Pre-#23 migration backfill block removed (no production users)
- Idempotent rename block at top of `schema.sql` so dev DBs re-applying the file get auto-migrated (eth: prefix prepended to existing bare addresses)

## What stays the same (per #79 scope)

- **Admin set is still wallet-only.** `ADMIN_WALLET_ADDRESSES` env unchanged; `is_admin()` strips `eth:` from `current_principal()` and compares against the bare 0x list. Non-`eth:` principals never match — that's the desired behavior.
- **Admin agent gating** at root `POST /` still 403's non-`eth:` callers.
- **WS-layer auth** (`CLIENT_TOKEN` / `clients.token_hash`) unchanged.
- **`allowed_callers`** unchanged (already principal-typed).
- **SIWE exchange** at `/auth/siwe/exchange` unchanged.

## Test plan

- [x] `pnpm -r typecheck` — green (4 packages)
- [x] `node --test` (no DB) — 83 pass, 0 fail, 20 skipped (DB-gated)
- [ ] DB-gated tests on a fresh Postgres (`agent-id-available`, `siwe-exchange`, `caller-token`, `device-flow`, `device-ui`, `openclaw`)
- [ ] CI passes
- [ ] Manual smoke: SIWE exchange → registerClient → WS hello on a fresh DB

## Follow-ups (out of scope for this PR)

- PR B (#79): device-flow `intent=client_register` + `vicoop-client login` CLI + `clients.owner_email` + approval-UI intent dispatch + `docs/install-client.md` rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)