### PR TITLE
Device flow client_register intent for vicoop-client onboarding

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -23,24 +23,27 @@ one-liner fetching a published `client-v*` bundle). Contrast with:
 
 - A human operator (or an agent acting on their behalf) standing up a
   brand-new client that will connect to a bridge they do not operate.
-- The operator has an Ethereum EOA they control; that wallet becomes the
-  owner of the resulting agent policy and must sign SIWE to obtain tokens.
+- The operator has either a Google account (used throughout) or an Ethereum
+  EOA they control. Either becomes the owner of the resulting client and
+  agent policy.
 
 ## Prerequisites
 
 - Node.js 20 or newer (`node -v`).
-- `curl`, `tar`, `jq`, `base64` (usually part of `coreutils` / `busybox`),
-  and one of `sha256sum` / `shasum`. `jq` is used by the token-extraction
-  snippets in Steps 2–3; `base64` is used for the SIWE-token decode in
-  Step 2.
+- `curl`, `tar`, and one of `sha256sum` / `shasum`. `jq` is recommended for
+  the optional SIWE alternative path; the default Google flow doesn't need
+  it.
 - A reachable bridge URL. The public deployment is
   `https://vicoop-bridge-server.fly.dev`; substitute your own below if you
   run the server yourself.
-- An operator EOA. Either:
-  - [`a2a-wallet`](https://github.com/planetarium/a2a-x402-wallet) CLI with a
-    local wallet imported — this is the shortest path, used throughout.
-  - Or the raw-curl path from `remote-testing.md` §1-2 if you prefer
-    scripting SIWE yourself.
+- A browser on **any** device you can open URLs in. The CLI doesn't need
+  to run on the same machine as the browser — device flow is designed for
+  exactly that case (e.g. headless server + laptop browser).
+- A Google account. No wallet, `a2a-wallet`, or seed phrase required.
+- (Optional, alternative path) For wallet-based onboarding instead of
+  Google, [`a2a-wallet`](https://github.com/planetarium/a2a-x402-wallet)
+  CLI with an imported wallet — see "Alternative: SIWE onboarding" near
+  the end of this doc.
 - For the OpenClaw backend specifically: an OpenClaw gateway running
   locally at `ws://127.0.0.1:18789` (override via `OPENCLAW_GATEWAY_URL`).
   Streaming (per-message A2A artifact cadence) requires OpenClaw
@@ -100,146 +103,100 @@ operator runs the `systemctl enable --now` command from the installer's
 output once they're filled in. Opt out with `INSTALL_SKIP_SERVICE=1`, or
 force a scope with `INSTALL_SERVICE_SCOPE=user|system|none`.
 
-## Step 2 — Obtain a caller token (SIWE)
+## Step 2 — Pick an agent id
 
-A caller token (`vbc_caller_*`) is the opaque session token you present to
-the bridge's admin endpoints. It is minted by signing a SIWE message at
-`POST /auth/siwe/exchange` (see `packages/server/src/auth/siwe-exchange.ts`
-for the exchange, `schema.sql` `used_siwe_nonces` for single-use-nonce
-enforcement). TTL equals the SIWE `expirationTime`, capped at 7 days.
-
-### Using `a2a-wallet`
+The agent id is the routing key external A2A callers use to reach your
+client. Pick something unlikely to collide across operators:
 
 ```sh
 export BRIDGE_URL=https://vicoop-bridge-server.fly.dev
 
-# The server compares the SIWE `domain` field against PUBLIC_URL's hostname
-# exactly, so derive the bare hostname via URL parsing — a naïve
-# ${BRIDGE_URL#https://} breaks on http:// or trailing paths/slashes.
-BRIDGE_HOSTNAME=$(BRIDGE_URL="$BRIDGE_URL" node -p 'new URL(process.env.BRIDGE_URL).hostname')
-
-# Generate, sign, and encode a SIWE token in one step with your local wallet.
-TOKEN=$(a2a-wallet siwe auth \
-  --wallet <wallet-name> \
-  --domain "$BRIDGE_HOSTNAME" \
-  --uri "$BRIDGE_URL" \
-  --ttl 1h \
-  --json | jq -r .token)
-
-# The CLI's token is base64url(JSON({message, signature})). Decode and pipe
-# the {message, signature} JSON straight into the exchange endpoint — never
-# write the signed payload to disk where another local user could read it
-# off /tmp before we delete it. `openssl base64 -d -A` works on macOS and
-# Linux, so we avoid shell-specific word-splitting around `base64 -d/-D`.
-PAD=$(printf '%*s' $(( (4 - ${#TOKEN} % 4) % 4 )) '' | tr ' ' '=')
-
-CALLER_TOKEN=$(echo "${TOKEN}${PAD}" | tr '_-' '/+' | openssl base64 -d -A \
-  | curl -sX POST "$BRIDGE_URL/auth/siwe/exchange" \
-      -H 'Content-Type: application/json' --data-binary @- \
-  | jq -r .access_token)
-
-echo "$CALLER_TOKEN"  # vbc_caller_...
-```
-
-Replace `<wallet-name>` with the label from `a2a-wallet wallet list`. The
-default wallet is used if you omit `--wallet`.
-
-The `a2a-wallet siwe` subcommand is marked deprecated (its tokens are
-CLI-wallet-scoped and not shareable with a Web UI) but is the correct tool
-here — the bridge's exchange endpoint explicitly wants a wallet-signed
-SIWE message.
-
-### Alternative: raw curl
-
-If you'd rather not depend on `a2a-wallet`, follow
-[`remote-testing.md` §1 (SIWE exchange)](./remote-testing.md) — it builds
-the SIWE message in Node with `viem` + `siwe` and POSTs to the same
-endpoint. The resulting `CALLER_TOKEN` is interchangeable with the one
-produced above.
-
-## Step 3 — Register the client
-
-Call the `registerClient` GraphQL mutation with your caller token. This
-creates a `clients` row scoped to your wallet and issues a raw
-`CLIENT_TOKEN` (64-hex). **Save it immediately — it is unrecoverable.**
-
-```sh
-AGENT_ID=openclaw-local     # see "Choosing an agent_id" below
-HOSTNAME=$(hostname)
-CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
-
-REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
-  -H "Authorization: Bearer $CALLER_TOKEN" \
-  -H 'Content-Type: application/json' \
-  -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerPrincipal allowedAgentIds}}}\"}")
-
-echo "$REG" | jq .
-CLIENT_TOKEN=$(echo "$REG" | jq -r .data.registerClient.clientWithToken.token)
-```
-
-`allowedAgentIds` is a whitelist — the client may only register as one of
-these agent IDs at WS connect time. Include every ID you plan to run under
-this single token if you know them up front; you can also amend the
-allowlist later via the `updateClientAllowedAgents` GraphQL mutation
-(backed by `update_client_allowed_agents()` in `schema.sql`) without
-issuing a new token. Re-registration is only required if you intentionally
-want a new client with a fresh token.
-
-### Choosing an agent_id
-
-Before calling `registerClient`, probe the id with the
-`agentIdAvailable(agentId)` GraphQL query. It's a `SECURITY DEFINER`
-function (`packages/server/schema.sql`) that returns a plain boolean
-across every owner — no `owner_principal` leaks — and raises
-`invalid_parameter_value` on empty input. Requires your caller token.
-
-```sh
-AGENT_ID=openclaw-local    # or one of the patterns below
-
-AVAILABLE=$(curl -sX POST "$BRIDGE_URL/graphql" \
-  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"query\":\"{agentIdAvailable(agentId:\\\"$AGENT_ID\\\")}\"}" \
-  | jq -r .data.agentIdAvailable)
-[ "$AVAILABLE" = "true" ] || { echo "agent_id '$AGENT_ID' is taken"; exit 1; }
-```
-
-`true` means no `agent_policies` row exists for that id yet, so your first
-WS register in Step 5 will claim ownership. `false` means another principal
-already owns it — pick a different id. A small race window exists between
-this probe and your WS register; if another principal claims the id in
-between, Step 5 emits `'agent id owned by a different principal'` and you can
-fall back to the recovery path in "Troubleshooting".
-
-Even with the probe, prefer names unlikely to collide across operators.
-Pick one:
-
-```sh
 # By hostname
 AGENT_ID="openclaw-$(hostname | cut -d. -f1)"
 
-# By wallet prefix — derive WALLET from a2a-wallet status (same format used
-# later for add_caller); strip the 0x and take the first 6 hex chars
-WALLET=$(a2a-wallet status | awk '/Address/{print tolower($2)}')
-AGENT_ID="openclaw-$(printf '%s' "${WALLET#0x}" | cut -c1-6)"
-
-# Random
+# Or random
 AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
+
+echo "$AGENT_ID"
 ```
 
-On reinstalls, `agentIdAvailable` reports `false` for an id you yourself
-already registered. To distinguish "mine" from "somebody else's", also
-query `agentPolicyByAgentId` — RLS returns a non-null row only when *you*
-are the owner:
+`registerClient` (called for you by `vicoop-client login` in Step 3) does
+not pre-validate availability; collisions surface only at WS connect time.
+If you want to probe ahead, hit `agentIdAvailable(agentId)` GraphQL after
+login — it's a SECURITY DEFINER probe that returns boolean availability
+across every owner without leaking `owner_principal`. Most operators just
+pick a hostname/uuid prefix and skip the probe.
+
+## Step 3 — Login and register your client (device flow)
+
+`vicoop-client login` drives Google OAuth device flow against the bridge
+to register a fresh client and hand you a one-time `CLIENT_TOKEN`. No
+wallet, no SIWE, no GraphQL calls.
 
 ```sh
-curl -sX POST "$BRIDGE_URL/graphql" \
-  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
-  -d "{\"query\":\"{agentPolicyByAgentId(agentId:\\\"$AGENT_ID\\\"){agentId ownerPrincipal}}\"}" | jq .
+HOSTNAME=$(hostname)
+CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
+
+"$INSTALL_DIR/bin/vicoop-client" login \
+  --bridge "$BRIDGE_URL" \
+  --client-name "$CLIENT_NAME" \
+  --agent-ids "$AGENT_ID" \
+  --env-file "$INSTALL_DIR/vicoop-client.env"
 ```
 
-A non-null response means you own it and a reinstall will reuse the
-existing policy; null after `agentIdAvailable=false` means someone else
-owns it.
+The CLI prints a verification URL to stderr — open it in **any** browser
+(the same machine, or your laptop while running the CLI on a headless
+host) and authorize with your Google account. The CLI polls the bridge in
+the background and writes the resulting env block to
+`vicoop-client.env` (mode 600) on success:
+
+```text
+SERVER_URL=wss://vicoop-bridge-server.fly.dev
+SERVER_TOKEN=<64-hex CLIENT_TOKEN — shown ONLY here>
+AGENT_ID=<your agent id>
+```
+
+> ⚠ The `CLIENT_TOKEN` is unrecoverable after this single output. The env
+> file is the only place it persists; back it up if you need to rotate
+> hosts. To rotate the token later, use the `rotateClientToken` GraphQL
+> mutation (requires a fresh caller token via either `vicoop-client login`
+> or SIWE — the rotation surfaces a new CLIENT_TOKEN, also one-time).
+
+Drop `--env-file` and pass `--json` instead if you want to compose with
+shell tooling:
+
+```sh
+"$INSTALL_DIR/bin/vicoop-client" login \
+  --bridge "$BRIDGE_URL" --client-name "$CLIENT_NAME" \
+  --agent-ids "$AGENT_ID" --json \
+  | tee /tmp/vicoop-login.json
+CLIENT_TOKEN=$(jq -r .client_token /tmp/vicoop-login.json)
+```
+
+`--agent-ids` is a comma-separated allowlist. Include every id you plan to
+run under this single token if you know them up front; amend later via
+the `updateClientAllowedAgents` GraphQL mutation (backed by
+`update_client_allowed_agents()` in `schema.sql`) without issuing a new
+token.
+
+### What login does on the server
+
+1. `POST /oauth/device/code` with `intent=client_register` + `client_name`
+   + `allowed_agent_ids` — the bridge stores these on a `device_sessions`
+   row and returns a one-time `device_code` + 8-char user code.
+2. Operator opens the verification URL, signs in with Google, and the
+   approval page shows exactly what's being authorized
+   ("Register a bridge client `<name>` … with allowed agent ids …").
+3. CLI polls `POST /oauth/token`. Once status flips to `approved`, the
+   bridge calls `register_client()` on behalf of the Google principal,
+   stamps `clients.owner_email` for admin readability, and returns
+   `{client_id, client_token, owner_principal, allowed_agent_ids}`.
+4. The CLI never sees a `vbc_caller_*` token — `client_register` issues
+   the long-lived `CLIENT_TOKEN` directly. No `callers` row is created.
+
+This means a Google-only operator can stand up a bridge client without
+ever holding a wallet or seed phrase. Owner is recorded as
+`google:sub:<sub>` (stable id, not the email).
 
 ## Step 4 — Prepare the agent card
 
@@ -340,11 +297,14 @@ want Claude to edit.
 
 By default the policy has empty `allowed_callers`, which the dispatcher
 treats as "public". To lock it down, use the admin agent's `add_caller`
-tool — this is the same flow as
-[`remote-testing.md` §5](./remote-testing.md). Example for gating to your
-own wallet only:
+tool. The admin agent at `POST /` is **wallet-gated** (requires a SIWE
+caller token with an `eth:*` principal — Google operators need to sign in
+separately via SIWE to talk to it; see "Alternative: SIWE onboarding"
+below for the SIWE token exchange).
 
 ```sh
+# Assumes you've already obtained $CALLER_TOKEN from SIWE — see
+# "Alternative: SIWE onboarding".
 WALLET_PRINCIPAL="eth:$(a2a-wallet status | awk '/Address/{print tolower($2)}')"
 
 curl -sX POST "$BRIDGE_URL/" \
@@ -516,13 +476,17 @@ files before running it.
   GraphQL — the caller token was missing, malformed, or expired, so the
   request fell back to the `app_anonymous` Postgres role (see
   `packages/server/src/postgraphile.ts`) which has no EXECUTE on
-  authenticated functions. Send a valid `Bearer vbc_caller_*` token; if
-  expired, re-run Step 2 to refresh via the SIWE exchange. SIWE nonces are
-  single-use, so every exchange needs a freshly signed message.
+  authenticated functions. Re-run `vicoop-client login` (or the SIWE
+  exchange in the alternative section below) to refresh.
 
 - **`SIWE message has already expired`** — the `expirationTime` was in the
   past when the bridge verified it. Increase `--ttl` or check host clock
   skew.
+
+- **Device flow timed out** — the `vicoop-client login` deadline matches
+  the bridge's `device_sessions.expires_at` (10 min by default). If the
+  browser approval is delayed past that, re-run `login`; the previous
+  device code is invalidated automatically.
 
 - **Client reconnects but `/agents/:id` returns 404** — the
   `agent_policies` row exists but no WS session is live. Check the client
@@ -538,6 +502,40 @@ files before running it.
   you intentionally want a new client identity; in that case the old
   `clients` row (and cascading `agent_policies`) can be cleaned up via
   the admin agent's CRUD mutations (#29).
+
+## Alternative: SIWE onboarding
+
+If you'd rather own your client identity with an Ethereum EOA than a
+Google account — or if you need to talk to the wallet-gated admin agent
+at `POST /` — replace Step 3 with the two-step SIWE path:
+
+1. Sign a SIWE message and exchange it for a caller token at
+   `POST /auth/siwe/exchange`. See
+   [`remote-testing.md` §1](./remote-testing.md) for the full snippet
+   (also linked from the `add_caller` example earlier in this doc), or
+   use `a2a-wallet siwe auth` if the CLI is installed.
+2. Call the `registerClient` GraphQL mutation with that caller token to
+   mint a `CLIENT_TOKEN`:
+
+```sh
+CALLER_TOKEN=...   # from POST /auth/siwe/exchange
+
+REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
+  -H "Authorization: Bearer $CALLER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerPrincipal allowedAgentIds}}}\"}")
+
+CLIENT_TOKEN=$(echo "$REG" | jq -r .data.registerClient.clientWithToken.token)
+```
+
+The resulting `CLIENT_TOKEN` is identical in shape to the device-flow one;
+it just owns the row under an `eth:0x…` principal instead of
+`google:sub:…`. After that, Steps 4-6 (agent card, run, persist) are the
+same as the Google path.
+
+This SIWE caller token is also what you need to invoke the admin agent for
+managing `allowed_callers` (see "Restrict who can call your agent"
+above) — the admin agent rejects non-`eth:` principals by design.
 
 ## What's next
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -8,6 +8,7 @@ import { createClaudeBackend } from './backends/claude.js';
 import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
+import { runLogin } from './login.js';
 
 interface Args {
   server: string;
@@ -125,6 +126,10 @@ async function main(): Promise<void> {
 
   if (argv[0] === 'upgrade') {
     process.exit(await runUpgradeCmd(argv.slice(1)));
+  }
+
+  if (argv[0] === 'login') {
+    process.exit(await runLogin(argv.slice(1)));
   }
 
   // Default path: long-running daemon. Do not exit — client.start() keeps the

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -1,0 +1,295 @@
+// `vicoop-client login` — device-flow client registration (issue #79).
+//
+// Drives the bridge's RFC-8628 device authorization endpoint with
+// intent=client_register, prints the verification URL + user_code for the
+// operator to open in a browser, polls /oauth/token until approved, and
+// hands back a CLIENT_TOKEN. No SIWE / wallet involved.
+//
+// Output goes to stderr for human guidance; the final result is written to
+// stdout as either an env-style block or a JSON document. That keeps shell
+// composition (`$(vicoop-client login --json | jq -r .client_token)`)
+// straightforward.
+
+import { writeFileSync, chmodSync } from 'node:fs';
+
+interface LoginArgs {
+  bridge: string;
+  clientName: string;
+  allowedAgentIds: string[];
+  envFile: string | null;
+  json: boolean;
+  pollOnce: boolean; // for tests / CI smoke
+}
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+interface TokenSuccessResponse {
+  intent: 'client_register';
+  client_id: string;
+  client_token: string;
+  owner_principal: string;
+  owner_email: string | null;
+  client_name: string;
+  allowed_agent_ids: string[];
+}
+
+interface OAuthError {
+  error: string;
+  error_description?: string;
+}
+
+function usage(): void {
+  process.stderr.write(
+    [
+      'usage: vicoop-client login --bridge <https://...> --client-name <name>',
+      '                          --agent-ids <id1,id2> [--env-file <path>] [--json]',
+      '',
+      'Drives Google OAuth device flow against the bridge to register a new client.',
+      'Prints the resulting CLIENT_TOKEN once — save it immediately, it is unrecoverable.',
+      '',
+      'Flags:',
+      '  --bridge          Bridge HTTP URL (e.g. https://vicoop-bridge-server.fly.dev)',
+      '  --client-name     Human-readable client name shown in admin tooling',
+      '  --agent-ids       CSV of agent ids this client is allowed to register as',
+      '  --env-file PATH   Write SERVER_URL / SERVER_TOKEN / AGENT_ID env block to PATH',
+      '                    (chmod 600). When omitted, the env block is printed to stdout.',
+      '  --json            Print the token endpoint response as JSON to stdout instead.',
+      '',
+    ].join('\n'),
+  );
+}
+
+function parseArgs(args: string[]): LoginArgs | null {
+  const out: Partial<LoginArgs> & { allowedAgentIds: string[] } = {
+    allowedAgentIds: [],
+    envFile: null,
+    json: false,
+    pollOnce: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '-h' || a === '--help') {
+      usage();
+      return null;
+    }
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    if (a === '--poll-once') {
+      // Internal: bail after a single poll, regardless of state. Used by tests.
+      out.pollOnce = true;
+      continue;
+    }
+    const v = args[i + 1];
+    if (v === undefined) {
+      process.stderr.write(`flag ${a} requires a value\n`);
+      return null;
+    }
+    switch (a) {
+      case '--bridge':
+        out.bridge = v;
+        break;
+      case '--client-name':
+        out.clientName = v;
+        break;
+      case '--agent-ids':
+        out.allowedAgentIds = v.split(',').map((s) => s.trim()).filter(Boolean);
+        break;
+      case '--env-file':
+        out.envFile = v;
+        break;
+      default:
+        process.stderr.write(`unknown flag: ${a}\n`);
+        return null;
+    }
+    i++;
+  }
+  if (!out.bridge || !out.clientName || out.allowedAgentIds.length === 0) {
+    usage();
+    return null;
+  }
+  return out as LoginArgs;
+}
+
+async function fetchDeviceCode(args: LoginArgs): Promise<DeviceCodeResponse> {
+  const body = new URLSearchParams({
+    intent: 'client_register',
+    client_name: args.clientName,
+    allowed_agent_ids: args.allowedAgentIds.join(','),
+  });
+  const res = await fetch(`${args.bridge.replace(/\/$/, '')}/oauth/device/code`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    let parsed: OAuthError | null = null;
+    try {
+      parsed = JSON.parse(text) as OAuthError;
+    } catch {
+      // ignore
+    }
+    const detail = parsed?.error_description ?? parsed?.error ?? text;
+    throw new Error(`device/code request failed (${res.status}): ${detail}`);
+  }
+  return JSON.parse(text) as DeviceCodeResponse;
+}
+
+async function pollOnce(
+  bridgeUrl: string,
+  deviceCode: string,
+): Promise<
+  | { kind: 'pending' }
+  | { kind: 'slow_down' }
+  | { kind: 'expired' }
+  | { kind: 'error'; message: string }
+  | { kind: 'success'; body: TokenSuccessResponse }
+> {
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    device_code: deviceCode,
+  });
+  const res = await fetch(`${bridgeUrl.replace(/\/$/, '')}/oauth/token`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  if (res.ok) {
+    return { kind: 'success', body: JSON.parse(text) as TokenSuccessResponse };
+  }
+  let parsed: OAuthError | null = null;
+  try {
+    parsed = JSON.parse(text) as OAuthError;
+  } catch {
+    // not JSON — wrap raw text below
+  }
+  const code = parsed?.error;
+  if (code === 'authorization_pending') return { kind: 'pending' };
+  if (code === 'slow_down') return { kind: 'slow_down' };
+  if (code === 'expired_token') return { kind: 'expired' };
+  return {
+    kind: 'error',
+    message: parsed?.error_description ?? parsed?.error ?? text,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function writeEnvFile(path: string, success: TokenSuccessResponse, bridgeUrl: string): void {
+  const wsUrl = bridgeUrl.replace(/^http(s?):\/\//, (_m, s) => (s === 's' ? 'wss://' : 'ws://'));
+  const lines = [
+    `# vicoop-client env (generated by 'vicoop-client login')`,
+    `SERVER_URL=${wsUrl}`,
+    `SERVER_TOKEN=${success.client_token}`,
+    `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
+    '',
+  ].join('\n');
+  writeFileSync(path, lines);
+  // chmod 600 so a peer process on the same host can't read the token. Best
+  // effort — fails silently on filesystems that don't support POSIX modes.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // ignore
+  }
+}
+
+export async function runLogin(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if (!parsed) return 1;
+
+  let device: DeviceCodeResponse;
+  try {
+    device = await fetchDeviceCode(parsed);
+  } catch (e) {
+    process.stderr.write(`${(e as Error).message}\n`);
+    return 1;
+  }
+
+  process.stderr.write(
+    [
+      '',
+      'Open the following URL in your browser to authorize this client:',
+      `  ${device.verification_uri_complete}`,
+      '',
+      `If the URL is unwieldy, browse to ${device.verification_uri} and enter:`,
+      `  ${device.user_code}`,
+      '',
+      `Waiting for approval (expires in ${Math.floor(device.expires_in / 60)} min)…`,
+      '',
+    ].join('\n'),
+  );
+
+  // Hard cap polling at the session's expires_in so we don't poll forever
+  // on an abandoned approval.
+  const deadline = Date.now() + device.expires_in * 1000;
+  let intervalMs = Math.max(device.interval, 1) * 1000;
+
+  while (Date.now() < deadline) {
+    const result = await pollOnce(parsed.bridge, device.device_code);
+    if (result.kind === 'success') {
+      const success = result.body;
+      process.stderr.write('\nApproved.\n\n');
+      process.stderr.write(
+        `  client_id        ${success.client_id}\n` +
+          `  owner_principal  ${success.owner_principal}\n` +
+          `  owner_email      ${success.owner_email ?? '(none)'}\n` +
+          `  client_name      ${success.client_name}\n` +
+          `  allowed_agents   ${success.allowed_agent_ids.join(', ')}\n\n`,
+      );
+      process.stderr.write(
+        '⚠ The CLIENT_TOKEN below is shown only once and cannot be retrieved later.\n' +
+          '  Save it now (export to env, write to a vault, etc.).\n\n',
+      );
+
+      if (parsed.envFile) {
+        writeEnvFile(parsed.envFile, success, parsed.bridge);
+        process.stderr.write(`Wrote env block to ${parsed.envFile} (mode 600).\n`);
+      } else if (parsed.json) {
+        process.stdout.write(`${JSON.stringify(success, null, 2)}\n`);
+      } else {
+        const wsUrl = parsed.bridge.replace(/^http(s?):\/\//, (_m, s) =>
+          s === 's' ? 'wss://' : 'ws://',
+        );
+        process.stdout.write(
+          [
+            `SERVER_URL=${wsUrl}`,
+            `SERVER_TOKEN=${success.client_token}`,
+            `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
+            '',
+          ].join('\n'),
+        );
+      }
+      return 0;
+    }
+    if (result.kind === 'expired') {
+      process.stderr.write('\nDevice session expired. Re-run `vicoop-client login`.\n');
+      return 1;
+    }
+    if (result.kind === 'error') {
+      process.stderr.write(`\nToken endpoint error: ${result.message}\n`);
+      return 1;
+    }
+    if (result.kind === 'slow_down') {
+      // RFC-8628 §3.5: bump interval by 5 seconds on slow_down.
+      intervalMs += 5000;
+    }
+    if (parsed.pollOnce) return 0;
+    await sleep(intervalMs);
+  }
+
+  process.stderr.write('\nDeadline exceeded waiting for approval.\n');
+  return 1;
+}

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -172,12 +172,21 @@ $$;
 CREATE TABLE IF NOT EXISTS clients (
   id                TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   owner_principal   TEXT NOT NULL,
+  -- Display-only contact for non-eth principals (Google sub is opaque, so
+  -- admin tooling renders email for human readability). Populated only by
+  -- the device-flow client_register intent path; SIWE-onboarded clients
+  -- leave this NULL.
+  owner_email       TEXT,
   client_name       TEXT NOT NULL,
   token_hash        TEXT NOT NULL UNIQUE,
   allowed_agent_ids TEXT[] NOT NULL DEFAULT '{}',
   revoked           BOOLEAN NOT NULL DEFAULT FALSE,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- Idempotent: existing dev DBs from PR A only have the columns above sans
+-- owner_email. Add it here so re-applying schema.sql brings them forward.
+ALTER TABLE clients ADD COLUMN IF NOT EXISTS owner_email TEXT;
 
 ALTER TABLE clients ENABLE ROW LEVEL SECURITY;
 
@@ -560,17 +569,33 @@ CREATE POLICY callers_postgraphile ON callers
 -- Server-managed only; never expose via GraphQL
 COMMENT ON TABLE callers IS E'@omit';
 
--- Transient device flow sessions (RFC-8628)
+-- Transient device flow sessions (RFC-8628). `intent` selects what the token
+-- endpoint materializes once the session is approved:
+--   'caller'           — issue a vbc_caller_* token in the callers table
+--                        (the original A2A-caller authorization use case).
+--   'client_register'  — call register_client() and return CLIENT_TOKEN +
+--                        client_id without ever creating a callers row;
+--                        intent_params carries client_name and
+--                        allowed_agent_ids for the call. This is the
+--                        device-flow onboarding path for vicoop-client
+--                        operators (issue #79).
 CREATE TABLE IF NOT EXISTS device_sessions (
   device_code       TEXT PRIMARY KEY,
   user_code         TEXT NOT NULL UNIQUE,
   status            TEXT NOT NULL,
   principal_id      TEXT,
   email             TEXT,
+  intent            TEXT NOT NULL DEFAULT 'caller',
+  intent_params     JSONB,
   expires_at        TIMESTAMPTZ NOT NULL,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
   approved_at       TIMESTAMPTZ
 );
+
+-- Idempotent: existing dev DBs from PR A only have the original columns. Add
+-- the new ones here so re-applying schema.sql brings them forward.
+ALTER TABLE device_sessions ADD COLUMN IF NOT EXISTS intent TEXT NOT NULL DEFAULT 'caller';
+ALTER TABLE device_sessions ADD COLUMN IF NOT EXISTS intent_params JSONB;
 
 CREATE INDEX IF NOT EXISTS device_sessions_pending_idx
   ON device_sessions(user_code) WHERE status = 'pending';

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -2,11 +2,31 @@
 // Exposes POST /oauth/device/code and POST /oauth/token. The UI approval path
 // (that sets status='approved' and fills principal_id/email) is implemented
 // separately in device-ui.ts.
+//
+// Two intents flow through the same approval pipeline (see issue #79):
+//   * 'caller'           — issue a vbc_caller_* opaque token to the polling
+//                          CLI for use as a Bearer credential against
+//                          /agents/:id and the admin GraphQL surface.
+//   * 'client_register'  — call register_client() on behalf of the approved
+//                          principal and return the resulting CLIENT_TOKEN +
+//                          client_id, no callers row created. This is the
+//                          device-flow vicoop-client onboarding path.
+//
+// Token endpoint dispatches on `device_sessions.intent`. Approval UI surfaces
+// the difference to the operator (device-ui.ts).
+//
+// Bootstrap-mode tokenTtlMs: device-flow caller tokens default to 90 days,
+// matching SIWE-issued tokens for ergonomic admin-GraphQL reuse. Operators
+// who only want a one-shot bootstrap can set bootstrapTokenTtlMs to scope
+// the issued token tighter; that doesn't apply to the client_register branch
+// (its CLIENT_TOKEN has no TTL — it's revoked, not expired).
 
 import { randomBytes, randomInt } from 'node:crypto';
 import type { Hono, Context } from 'hono';
 import type { Sql } from '../db.js';
 import { issueCallerToken } from './caller-token.js';
+
+export type DeviceFlowIntent = 'caller' | 'client_register';
 
 export interface DeviceFlowOptions {
   sql: Sql;
@@ -29,12 +49,25 @@ const USER_CODE_LENGTH = 8;
 const USER_CODE_HYPHEN_AT = 4;
 const MAX_USER_CODE_RETRIES = 5;
 
+// Bound the size of intent_params so an attacker can't drive a DB into
+// large-row territory on what is otherwise a transient session table.
+const MAX_CLIENT_NAME_LEN = 256;
+const MAX_AGENT_ID_LEN = 256;
+const MAX_AGENT_IDS_COUNT = 32;
+
+interface ClientRegisterParams {
+  client_name: string;
+  allowed_agent_ids: string[];
+}
+
 interface DeviceSessionRow {
   device_code: string;
   user_code: string;
   status: string;
   principal_id: string | null;
   email: string | null;
+  intent: string;
+  intent_params: ClientRegisterParams | null;
   expires_at: Date;
 }
 
@@ -78,6 +111,60 @@ async function readBody(c: Context): Promise<Record<string, unknown>> {
   }
 }
 
+// Coerce a body field into string[] tolerating both JSON arrays (JS SDKs)
+// and CSV strings (curl/form). Strips empties.
+function toStringArray(raw: unknown): string[] | null {
+  if (Array.isArray(raw)) {
+    return raw.filter((v): v is string => typeof v === 'string' && v.length > 0);
+  }
+  if (typeof raw === 'string') {
+    return raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  }
+  return null;
+}
+
+// Validate a client_register intent's params. Returns either the canonicalized
+// params object or an error string suitable for invalid_request error_description.
+function parseClientRegisterParams(
+  body: Record<string, unknown>,
+): { ok: true; params: ClientRegisterParams } | { ok: false; reason: string } {
+  const clientName = typeof body.client_name === 'string' ? body.client_name.trim() : '';
+  if (!clientName) {
+    return { ok: false, reason: 'client_name is required for intent=client_register' };
+  }
+  if (clientName.length > MAX_CLIENT_NAME_LEN) {
+    return { ok: false, reason: `client_name exceeds ${MAX_CLIENT_NAME_LEN} chars` };
+  }
+
+  const ids = toStringArray(body.allowed_agent_ids);
+  if (!ids || ids.length === 0) {
+    return {
+      ok: false,
+      reason: 'allowed_agent_ids is required for intent=client_register (CSV or JSON array)',
+    };
+  }
+  if (ids.length > MAX_AGENT_IDS_COUNT) {
+    return { ok: false, reason: `allowed_agent_ids exceeds ${MAX_AGENT_IDS_COUNT} entries` };
+  }
+  for (const id of ids) {
+    if (id.length > MAX_AGENT_ID_LEN) {
+      return { ok: false, reason: `agent id exceeds ${MAX_AGENT_ID_LEN} chars` };
+    }
+  }
+
+  return { ok: true, params: { client_name: clientName, allowed_agent_ids: ids } };
+}
+
+interface RegisterClientResult {
+  id: string;
+  owner_principal: string;
+  client_name: string;
+  allowed_agent_ids: string[];
+  revoked: boolean;
+  created_at: Date;
+  token: string;
+}
+
 export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
   const sql = opts.sql;
   const sessionTtlMs = opts.sessionTtlMs ?? DEFAULT_SESSION_TTL_MS;
@@ -97,7 +184,27 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
   }
 
   app.post('/oauth/device/code', async (c) => {
-    // Body is deliberately ignored — we don't do external client registration yet.
+    const body = await readBody(c);
+    const intentRaw = typeof body.intent === 'string' ? body.intent : 'caller';
+    let intent: DeviceFlowIntent;
+    let intentParams: ClientRegisterParams | null = null;
+
+    if (intentRaw === 'caller' || intentRaw === '') {
+      intent = 'caller';
+    } else if (intentRaw === 'client_register') {
+      intent = 'client_register';
+      const parsed = parseClientRegisterParams(body);
+      if (!parsed.ok) {
+        return c.json({ error: 'invalid_request', error_description: parsed.reason }, 400);
+      }
+      intentParams = parsed.params;
+    } else {
+      return c.json(
+        { error: 'invalid_request', error_description: `unknown intent: ${intentRaw}` },
+        400,
+      );
+    }
+
     const deviceCode = generateDeviceCode();
     const expiresAt = new Date(Date.now() + sessionTtlMs);
 
@@ -107,8 +214,15 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
       const candidate = generateUserCode();
       try {
         await sql`
-          INSERT INTO device_sessions (device_code, user_code, status, expires_at)
-          VALUES (${deviceCode}, ${candidate}, 'pending', ${expiresAt})
+          INSERT INTO device_sessions (device_code, user_code, status, expires_at, intent, intent_params)
+          VALUES (
+            ${deviceCode},
+            ${candidate},
+            'pending',
+            ${expiresAt},
+            ${intent},
+            ${intentParams ? sql.json(JSON.parse(JSON.stringify(intentParams))) : null}
+          )
         `;
         userCode = candidate;
         break;
@@ -161,7 +275,7 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
     lastPoll.set(deviceCode, now);
 
     const rows = await sql<DeviceSessionRow[]>`
-      SELECT device_code, user_code, status, principal_id, email, expires_at
+      SELECT device_code, user_code, status, principal_id, email, intent, intent_params, expires_at
       FROM device_sessions
       WHERE device_code = ${deviceCode}
       LIMIT 1
@@ -198,9 +312,65 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
         return c.json({ error: 'expired_token' }, 400);
       }
 
-      // Issue the caller token and delete the session atomically. The transaction
-      // object from postgres.js is type-compatible with Sql, so issueCallerToken
-      // participates in the same tx.
+      if (row.intent === 'client_register') {
+        const params = row.intent_params;
+        if (!params) {
+          // Approved client_register session must have intent_params; if it
+          // doesn't, the session is unusable. Treat as expired so the CLI
+          // restarts with a fresh request.
+          lastPoll.delete(deviceCode);
+          return c.json({ error: 'expired_token' }, 400);
+        }
+
+        const principalId = row.principal_id;
+        const email = row.email;
+
+        const issued = await sql.begin(async (tx) => {
+          // SECURITY INVOKER on register_client(); set the session principal
+          // so RLS WITH CHECK passes and the new row's owner_principal is
+          // correct without us needing to pass it as the explicit override
+          // (which would require admin scope).
+          await tx`SELECT set_config('role', 'app_authenticated', true)`;
+          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
+          // app.admin_addresses left empty — non-admin path is what we want
+          // here; the function falls through to current_principal().
+          await tx`SELECT set_config('app.admin_addresses', '', true)`;
+
+          const result = await tx<RegisterClientResult[]>`
+            SELECT * FROM register_client(
+              ${params.client_name},
+              ${params.allowed_agent_ids}::text[],
+              NULL
+            )
+          `;
+          const r = result[0];
+          if (!r) throw new Error('register_client returned no row');
+
+          // Stamp owner_email so admin tooling can render a human-readable
+          // identity for Google-onboarded clients (sub is opaque).
+          if (email) {
+            await tx`UPDATE clients SET owner_email = ${email} WHERE id = ${r.id}`;
+          }
+
+          await tx`DELETE FROM device_sessions WHERE device_code = ${deviceCode}`;
+          return r;
+        });
+
+        lastPoll.delete(deviceCode);
+        prunePollMap();
+
+        return c.json({
+          intent: 'client_register' as const,
+          client_id: issued.id,
+          client_token: issued.token,
+          owner_principal: issued.owner_principal,
+          owner_email: email ?? null,
+          client_name: issued.client_name,
+          allowed_agent_ids: issued.allowed_agent_ids,
+        });
+      }
+
+      // intent === 'caller' (default) — original behavior
       const issued = await sql.begin(async (tx) => {
         const i = await issueCallerToken(tx as unknown as Sql, {
           principalId: row.principal_id!,

--- a/packages/server/src/auth/device-ui.ts
+++ b/packages/server/src/auth/device-ui.ts
@@ -121,11 +121,45 @@ function normalizeUserCode(raw: string): string {
 
 // ---- route handlers --------------------------------------------------------
 
+interface ClientRegisterParams {
+  client_name: string;
+  allowed_agent_ids: string[];
+}
+
 interface DeviceRow {
   device_code: string;
   user_code: string;
   status: string;
+  intent: string;
+  intent_params: ClientRegisterParams | null;
   expires_at: Date;
+}
+
+// Render the intent-specific intro shown on the approval landing page.
+// The whole point of the intent split (issue #79) is that the operator sees
+// what they're authorizing — a one-shot caller session vs. a long-lived
+// client registration with a stated agent-id allowlist.
+function renderIntentIntro(intent: string, params: ClientRegisterParams | null): string {
+  if (intent === 'client_register' && params) {
+    const safeName = escapeHtml(params.client_name);
+    const ids = params.allowed_agent_ids.length === 0
+      ? '<em>(none)</em>'
+      : params.allowed_agent_ids
+          .map((id) => `<code>${escapeHtml(id)}</code>`)
+          .join(', ');
+    return `
+      <p><strong>Register a bridge client</strong></p>
+      <p>This will create a long-lived bridge client named <strong>${safeName}</strong>
+         owned by your Google account, authorized to register the following
+         agent ids: ${ids}.</p>
+      <p>You'll be asked to sign in to Google to confirm.</p>
+    `;
+  }
+  // Default 'caller' intent.
+  return `
+    <p>This will authorize a CLI session to call agents on your behalf.
+       You'll be asked to sign in to Google to confirm.</p>
+  `;
 }
 
 export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
@@ -144,7 +178,7 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
 
     const normalized = normalizeUserCode(raw);
     const rows = await opts.sql<DeviceRow[]>`
-      SELECT device_code, user_code, status, expires_at
+      SELECT device_code, user_code, status, intent, intent_params, expires_at
       FROM device_sessions
       WHERE user_code = ${normalized}
         AND status = 'pending'
@@ -161,15 +195,20 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
       return c.html(page('Invalid code', body), 400);
     }
 
+    const session = rows[0]!;
     const safeCode = escapeHtml(normalized);
     const href = `/oauth/google/start?user_code=${encodeURIComponent(normalized)}`;
+    const intro = renderIntentIntro(session.intent, session.intent_params);
+    const headerText = session.intent === 'client_register'
+      ? 'Authorize bridge client registration'
+      : 'Authorize device';
     const body = `
-      <h1>Authorize device</h1>
+      <h1>${escapeHtml(headerText)}</h1>
       <div class="code">${safeCode}</div>
-      <p>You'll be asked to sign in to Google to authorize device <strong>${safeCode}</strong>.</p>
+      ${intro}
       <p><a class="btn" href="${escapeHtml(href)}">Continue with Google</a></p>
     `;
-    return c.html(page('Authorize device', body));
+    return c.html(page(headerText, body));
   });
 
   app.get('/oauth/google/start', async (c) => {


### PR DESCRIPTION
PR B of #79 — stacks on top of #80 (PR A: ownership generalization). Adds intent-dispatched device flow so operators can register a bridge client via Google OAuth without ever holding a wallet or signing SIWE.

## Summary

- `device_sessions.intent` (`'caller'` | `'client_register'`) + `intent_params JSONB`
- `clients.owner_email` for human-readable identity rendering when owner is a Google `sub:`
- `POST /oauth/device/code` accepts `intent` + `client_name` + `allowed_agent_ids` (CSV/array, validated)
- `POST /oauth/token` branches:
  - `caller` — unchanged, mints `vbc_caller_*` in `callers`
  - `client_register` — calls `register_client()` under the approved principal, stamps `owner_email`, returns `{client_id, client_token, owner_principal, owner_email, client_name, allowed_agent_ids}`. **No `callers` row created** — the operator is registered as the client owner directly, not as a caller.
- Approval UI surfaces the intent-specific copy: `"Register a bridge client <name> with allowed agent ids …"` for `client_register`, original copy for `caller`. Page title and header text branch too.
- New `vicoop-client login` subcommand drives the full flow: prints verification URL + user_code, polls `/oauth/token`, on success writes `SERVER_URL`/`SERVER_TOKEN`/`AGENT_ID` to `--env-file` (mode 600) or stdout. `--json` for shell composition.
- `docs/install-client.md` rewritten around the new path; SIWE flow moved to "Alternative: SIWE onboarding" section near the end. `add_caller` snippet annotated to clarify admin agent stays wallet-only by design.

Idempotent ALTER TABLE … ADD COLUMN IF NOT EXISTS for both `clients.owner_email` and `device_sessions.intent`/`intent_params`, so re-applying schema.sql brings PR A dev DBs forward without manual migration.

## End-to-end verification on `vicoop-bridge-server.fly.dev`

Already ran on a deploy of this branch (version 29):

1. `POST /oauth/device/code intent=client_register&client_name=…&allowed_agent_ids=…` → device/user codes + verification URL
2. `GET /oauth/device?user_code=…` → approval page renders the intent-specific copy with the actual client name + agent ids
3. Browser approval via Google OAuth
4. CLI polls and receives `{client_token, owner_principal: "google:117535647789389656258", owner_email: "…@planetariumhq.com", …}`
5. Echo client connects with that `CLIENT_TOKEN` — WS hello passes (`lookupByTokenHash` + `ensureAgentPolicy` both work with Google principal)
6. `POST /agents/<id>` round-trip: `"echo: hello pr-B device flow"` ✅

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `node --test` (no DB) — 83 pass / 0 fail / 20 skipped (DB-gated)
- [x] Live deploy + e2e on fly.dev with Google account
- [ ] DB-gated tests on a fresh Postgres (caller intent regression + new client_register intent test follow-up)

## Out of scope / follow-ups

- DB-gated unit test for the `client_register` token-endpoint branch (the existing `caller` test still passes; new branch tested only via e2e here)
- `vicoop-client login --intent caller` for Google operators who need a caller token to talk to the wallet-gated admin agent at `POST /` (today they still have to SIWE)
- approval-UI extra confirmation checkbox for `client_register` (open question on issue #79)
- principal-typed admin set (admin agent is intentionally still wallet-only per #79)

🤖 Generated with [Claude Code](https://claude.com/claude-code)