### PR TITLE
Admin agent: drop eth-only gate + Google OAuth in admin UI

### DIFF
--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -46,8 +46,9 @@ works for non-admin callers:
   (explicit `ownerPrincipal` is admin-only, but the default is what we want).
 - `agent_policies_update` RLS is `owner OR is_admin`, and the auto-created
   policy's owner is your principal.
-- The admin agent at `POST /` gates only on "caller token has `eth:*`
-  principal", not on admin membership.
+- The admin agent at `POST /` accepts any verified caller token (`eth:*` or
+  `google:sub:*`); admin membership only widens RLS scope to all rows.
+  Non-admin callers see/manage their own clients only.
 
 ## Env
 
@@ -186,10 +187,12 @@ curl -s -X POST "$BRIDGE_URL/agents/$AGENT_ID" \
 
 `POST /` is the admin agent — a Claude-backed A2A endpoint with tools like
 `add_caller`, `remove_caller`, `list_active_agents`, `list_callers`,
-`list_caller_tokens`, `revoke_caller_token`. It requires
-an `eth:*` caller token (not admin membership); tool execution runs under RLS
-with your wallet as the authenticated principal, so mutations on agents you
-own are authorized.
+`list_caller_tokens`, `revoke_caller_token`. It accepts any verified
+caller token (`eth:*` or `google:*`); tool execution runs under RLS with
+your principal as the authenticated subject, so mutations on agents you
+own are authorized. The admin scope (`is_admin()`) is wallet-only and
+gates only the cross-owner tools (`list_caller_tokens`,
+`revoke_caller_token`).
 
 ```bash
 WALLET_PRINCIPAL=eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266   # lowercase

--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { WalletAuth } from './components/wallet-auth';
+import { GoogleAuth } from './components/google-auth';
 import { Chat } from './components/chat';
-import { useAuthToken } from './lib/auth-token';
+import { useAuthToken, setToken } from './lib/auth-token';
 
 export default function App() {
   const token = useAuthToken();
@@ -10,7 +11,30 @@ export default function App() {
       {/* Header */}
       <header className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-6 py-3">
         <h1 className="text-lg font-semibold text-zinc-100">Vicoop Bridge Admin</h1>
-        <WalletAuth />
+        {token ? (
+          // When a token is set, defer to WalletAuth's signed-in display
+          // (it shows the connected wallet + a Sign out button that also
+          // disconnects wagmi). For a Google-issued token there's no wagmi
+          // session to disconnect, so the same Sign out button is fine —
+          // it just clears the auth token. We additionally show a plain
+          // Sign out button here so Google-only sessions have an exit
+          // path even when no wallet is connected.
+          <div className="flex items-center gap-3">
+            <WalletAuth />
+            <button
+              onClick={() => setToken(null)}
+              className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+            >
+              Sign out
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-3">
+            <WalletAuth />
+            <span className="text-xs text-zinc-600">or</span>
+            <GoogleAuth />
+          </div>
+        )}
       </header>
 
       {/* Chat area */}
@@ -18,7 +42,9 @@ export default function App() {
         <Chat />
       ) : (
         <div className="flex flex-1 items-center justify-center">
-          <p className="text-zinc-400">Connect your wallet to start managing clients.</p>
+          <p className="text-zinc-400">
+            Sign in with your wallet (SIWE) or Google account to start managing your clients.
+          </p>
         </div>
       )}
     </div>

--- a/packages/admin-ui/src/components/google-auth.tsx
+++ b/packages/admin-ui/src/components/google-auth.tsx
@@ -1,0 +1,112 @@
+// Google OAuth login button for the admin UI. Drives the bridge's
+// device flow with intent=caller behind a popup so the user signs in
+// to Google in a separate window; the parent page polls the token
+// endpoint and stores the resulting vbc_caller_* in the same auth-token
+// localStorage slot used by SIWE. Google operators reach the chat via
+// is_admin()-gated RLS scope (admin agent at POST / no longer rejects
+// non-eth principals as of the issue #79 option-B server change).
+
+import { useCallback, useRef, useState } from 'react';
+import { setToken } from '../lib/auth-token';
+import { startDeviceFlow, type DeviceFlowSession } from '../lib/device-flow';
+
+interface State {
+  status: 'idle' | 'awaiting' | 'error';
+  userCode?: string;
+  error?: string;
+}
+
+export function GoogleAuth() {
+  const [state, setState] = useState<State>({ status: 'idle' });
+  const sessionRef = useRef<DeviceFlowSession | null>(null);
+  const popupRef = useRef<Window | null>(null);
+
+  const cancel = useCallback(() => {
+    sessionRef.current?.cancel();
+    sessionRef.current = null;
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close();
+    }
+    popupRef.current = null;
+    setState({ status: 'idle' });
+  }, []);
+
+  const signIn = useCallback(async () => {
+    // Synchronously open the popup as part of the user gesture so popup
+    // blockers don't kill it. Navigate to the verification URL once the
+    // device-code response lands.
+    const popup = window.open('about:blank', 'vicoop-bridge-google-auth', 'width=480,height=640');
+    if (!popup) {
+      setState({ status: 'error', error: 'Popup blocked. Allow popups for this site and try again.' });
+      return;
+    }
+    popupRef.current = popup;
+
+    setState({ status: 'awaiting' });
+    let session: DeviceFlowSession;
+    try {
+      session = await startDeviceFlow();
+    } catch (err) {
+      popup.close();
+      popupRef.current = null;
+      setState({ status: 'error', error: (err as Error).message });
+      return;
+    }
+    sessionRef.current = session;
+    popup.location.href = session.verificationUriComplete;
+    setState({ status: 'awaiting', userCode: session.userCode });
+
+    try {
+      const token = await session.result;
+      setToken(token);
+      // Token is set; parent App will swap to Chat. Close the popup if the
+      // user didn't already.
+      if (popup && !popup.closed) popup.close();
+      sessionRef.current = null;
+      popupRef.current = null;
+      setState({ status: 'idle' });
+    } catch (err) {
+      if (popup && !popup.closed) popup.close();
+      sessionRef.current = null;
+      popupRef.current = null;
+      const msg = (err as Error).message;
+      // Don't surface "canceled" as an error — that's the user clicking cancel.
+      if (msg === 'canceled') {
+        setState({ status: 'idle' });
+      } else {
+        setState({ status: 'error', error: msg });
+      }
+    }
+  }, []);
+
+  if (state.status === 'awaiting') {
+    return (
+      <div className="flex items-center gap-3">
+        <span className="text-sm text-zinc-400">
+          Waiting for Google sign-in
+          {state.userCode ? <> (code <code>{state.userCode}</code>)</> : null}…
+        </span>
+        <button
+          onClick={cancel}
+          className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        onClick={signIn}
+        className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-100 px-3 py-1.5 rounded transition-colors"
+      >
+        Sign in with Google
+      </button>
+      {state.status === 'error' && state.error && (
+        <p className="text-sm text-red-400">{state.error}</p>
+      )}
+    </div>
+  );
+}

--- a/packages/admin-ui/src/lib/device-flow.ts
+++ b/packages/admin-ui/src/lib/device-flow.ts
@@ -1,0 +1,149 @@
+// Browser-side driver for the bridge's RFC-8628 device flow with
+// intent=caller. Issues a vbc_caller_* opaque token after the user signs
+// in to Google in a popup window. See packages/server/src/auth/device-flow.ts
+// for the wire surface.
+
+const CALLER_TOKEN_PREFIX = 'vbc_caller_';
+
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface DeviceFlowSession {
+  /** Open this in a popup so the user can sign in to Google. */
+  verificationUriComplete: string;
+  userCode: string;
+  /**
+   * Resolves with a `vbc_caller_*` token once the popup approval completes.
+   * Rejects on expiry, server error, or `cancel()` invocation.
+   */
+  result: Promise<string>;
+  /** Aborts the in-flight poll loop. The result promise will reject. */
+  cancel: () => void;
+}
+
+class CanceledError extends Error {
+  constructor() {
+    super('canceled');
+    this.name = 'CanceledError';
+  }
+}
+
+async function postDeviceCode(): Promise<DeviceCodeResponse> {
+  const body = new URLSearchParams({ intent: 'caller' });
+  const res = await fetch('/oauth/device/code', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!res.ok) {
+    throw new Error(`device/code HTTP ${res.status}`);
+  }
+  const json = (await res.json()) as DeviceCodeResponse;
+  return json;
+}
+
+interface PollOk {
+  kind: 'ok';
+  token: string;
+}
+interface PollPending {
+  kind: 'pending';
+}
+interface PollSlowDown {
+  kind: 'slow_down';
+}
+interface PollFatal {
+  kind: 'fatal';
+  message: string;
+}
+
+async function pollOnce(deviceCode: string): Promise<PollOk | PollPending | PollSlowDown | PollFatal> {
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    device_code: deviceCode,
+  });
+  const res = await fetch('/oauth/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (res.ok) {
+    const payload = (await res.json()) as { access_token?: unknown; token_type?: unknown };
+    if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(CALLER_TOKEN_PREFIX)) {
+      return { kind: 'fatal', message: 'malformed access_token' };
+    }
+    return { kind: 'ok', token: payload.access_token };
+  }
+  let parsed: { error?: string; error_description?: string } | null = null;
+  try {
+    parsed = (await res.json()) as { error?: string; error_description?: string };
+  } catch {
+    // non-JSON
+  }
+  const code = parsed?.error;
+  if (code === 'authorization_pending') return { kind: 'pending' };
+  if (code === 'slow_down') return { kind: 'slow_down' };
+  return {
+    kind: 'fatal',
+    message: parsed?.error_description ?? parsed?.error ?? `HTTP ${res.status}`,
+  };
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new CanceledError());
+      return;
+    }
+    const t = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(t);
+      reject(new CanceledError());
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Start a device-flow session. The caller is responsible for opening
+ * `verificationUriComplete` in a popup as part of a click handler so the
+ * browser doesn't block it. The polling loop runs immediately and resolves
+ * once the user finishes Google approval.
+ */
+export async function startDeviceFlow(): Promise<DeviceFlowSession> {
+  const code = await postDeviceCode();
+  const ac = new AbortController();
+  const deadline = Date.now() + code.expires_in * 1000;
+  let intervalMs = Math.max(code.interval, 1) * 1000;
+
+  const result = (async () => {
+    while (Date.now() < deadline) {
+      const r = await pollOnce(code.device_code);
+      if (r.kind === 'ok') return r.token;
+      if (r.kind === 'fatal') throw new Error(r.message);
+      if (r.kind === 'slow_down') intervalMs += 5000;
+      try {
+        await sleep(intervalMs, ac.signal);
+      } catch {
+        throw new Error('canceled');
+      }
+    }
+    throw new Error('device session expired');
+  })();
+
+  return {
+    verificationUriComplete: code.verification_uri_complete,
+    userCode: code.user_code,
+    result,
+    cancel: () => ac.abort(),
+  };
+}

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -89,21 +89,40 @@ const adminWallets = new Set(
     .filter(Boolean),
 );
 
-function isAdmin(wallet: string): boolean {
-  return adminWallets.has(wallet.toLowerCase());
+// Admin scope is wallet-only by design: only `eth:<addr>` principals whose
+// stripped 0x address appears in ADMIN_WALLET_ADDRESSES match. Non-eth
+// principals (e.g. google:sub:…) authenticate fine but never gain admin
+// scope — they get the RLS-scoped self-service view of their own rows.
+function isAdmin(principalId: string): boolean {
+  if (!principalId.startsWith('eth:')) return false;
+  return adminWallets.has(principalId.slice('eth:'.length).toLowerCase());
 }
 
 export function getAdminWallets(): string[] {
   return [...adminWallets];
 }
 
+// Render principal-kind-specific copy for the "logged in as" line. Email is
+// optional; we surface it for google: principals so the human reading the
+// chat sees their address rather than the opaque numeric `sub`.
+function describePrincipal(principalId: string, email?: string): string {
+  if (principalId.startsWith('eth:')) {
+    const addr = principalId.slice('eth:'.length);
+    return `wallet \`${addr}\``;
+  }
+  if (principalId.startsWith('google:')) {
+    return email ? `Google account \`${email}\`` : `Google account \`${principalId}\``;
+  }
+  return `principal \`${principalId}\``;
+}
+
 // ── System Prompt ────────────────────────────────────────────────
 
-function buildSystemPrompt(walletAddress: string, sdl?: string): string {
-  const admin = isAdmin(walletAddress);
+function buildSystemPrompt(principalId: string, email: string | undefined, sdl?: string): string {
+  const admin = isAdmin(principalId);
   const scope = admin
     ? 'You are logged in as an **admin**. You can see and manage ALL clients across all owners.'
-    : `You are logged in as wallet \`${walletAddress}\`. You can only see and manage clients you own (RLS enforced).`;
+    : `You are logged in as ${describePrincipal(principalId, email)}. You can only see and manage clients you own (RLS enforced).`;
 
   let prompt = `You are the Server Admin Agent for vicoop-bridge. You manage client registrations and access control.
 
@@ -179,18 +198,18 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 
 // ── Custom Tools (token generation, active agents) ───────────────
 
-function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
-  // Admin agent authenticates via SIWE only (see http.tsx root POST /), so the
-  // current principal is always 'eth:<wallet>'. Caller-side admin tools that
-  // hit the DB pass this through as jwt.claims.principal_id so RLS predicates
-  // (owner_principal = current_principal()) match owned rows.
-  const principalId = `eth:${walletAddress.toLowerCase()}`;
+function buildCustomTools(db: Sql, registry: Registry, principalId: string) {
+  // Caller-side admin tools that hit the DB pass jwt.claims.principal_id
+  // through so RLS predicates (owner_principal = current_principal()) match
+  // the operator's own rows. The principalId arrives already canonicalized
+  // (eth:0x… or google:sub:…) from the http layer, so no normalization
+  // here.
   return {
     list_active_agents: tool({
       description: 'List currently connected agents with their client identity and connection time. Non-admin users only see their own agents.',
       inputSchema: z.object({}),
       execute: async () => {
-        const admin = isAdmin(walletAddress);
+        const admin = isAdmin(principalId);
         return registry.listAgents()
           .filter((a) => admin || a.ownerPrincipal === principalId)
           .map((a) => ({
@@ -328,8 +347,8 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         include_revoked: z.boolean().optional().describe('Include revoked tokens (default false)'),
       }),
       execute: async ({ principal_id, email, include_revoked }) => {
-        if (!isAdmin(walletAddress)) {
-          return { error: 'Admin-only tool. Current wallet is not in ADMIN_WALLET_ADDRESSES.' };
+        if (!isAdmin(principalId)) {
+          return { error: 'Admin-only tool. Current principal is not in ADMIN_WALLET_ADDRESSES (admin scope is wallet-only).' };
         }
         const rows = await listCallerTokens(db, {
           principalId: principal_id,
@@ -362,8 +381,8 @@ function buildCustomTools(db: Sql, registry: Registry, walletAddress: string) {
         caller_id: z.string().describe('The caller token id (from list_caller_tokens)'),
       }),
       execute: async ({ caller_id }) => {
-        if (!isAdmin(walletAddress)) {
-          return { error: 'Admin-only tool. Current wallet is not in ADMIN_WALLET_ADDRESSES.' };
+        if (!isAdmin(principalId)) {
+          return { error: 'Admin-only tool. Current principal is not in ADMIN_WALLET_ADDRESSES (admin scope is wallet-only).' };
         }
         await revokeCallerToken(db, caller_id);
         return { caller_id, revoked: true };
@@ -402,11 +421,11 @@ class AdminA2XExecutor extends AgentExecutor {
     const contextId = task.contextId ?? taskId;
 
     const metadata = (message as { metadata?: Record<string, unknown> }).metadata;
-    const walletAddress = metadata?._walletAddress as string | undefined;
     const principalId = metadata?._principalId as string | undefined;
     const bearerToken = metadata?._bearerToken as string | undefined;
-    if (!walletAddress || !principalId || !bearerToken) {
-      throw new InvalidRequestError('Authenticated wallet address is required.');
+    const callerEmail = metadata?._email as string | undefined;
+    if (!principalId || !bearerToken) {
+      throw new InvalidRequestError('Authenticated principal is required.');
     }
 
     const userText = extractText(message);
@@ -435,7 +454,7 @@ class AdminA2XExecutor extends AgentExecutor {
     try {
       const answer = await runWithBearerToken(bearerToken, async () => {
         const { tools: schemaTools, sdl } = await getSchemaTools();
-        const customTools = buildCustomTools(this.db, this.registry, walletAddress);
+        const customTools = buildCustomTools(this.db, this.registry, principalId);
         const tools = { ...schemaTools, ...customTools };
 
         // Load conversation history from previous tasks in the same
@@ -458,7 +477,7 @@ class AdminA2XExecutor extends AgentExecutor {
 
         return generateText({
           model: anthropic('claude-sonnet-4-6'),
-          system: buildSystemPrompt(walletAddress, sdl),
+          system: buildSystemPrompt(principalId, callerEmail, sdl),
           messages: toModelMessages(history, userText),
           tools,
           stopWhen: stepCountIs(10),

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -161,10 +161,14 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // on all subsequent requests.
   mountSiweExchange(app, { sql: opts.db, domain: siweDomain });
 
-  // Root POST — admin agent A2A endpoint. Requires opaque caller token with
-  // an `eth:*` principal (admin onboarding stays wallet-only; Google callers
-  // can call /agents/:id but the admin agent itself is wallet-gated by design,
-  // see issue #79).
+  // Root POST — admin agent A2A endpoint. Accepts any verified caller token;
+  // RLS scopes what the operator can see (their own clients/policies). The
+  // admin scope itself stays wallet-only — `is_admin()` matches only
+  // `eth:` principals against ADMIN_WALLET_ADDRESSES — but non-admin
+  // wallet and non-admin Google callers both reach the chat now and see
+  // their RLS-scoped view. (Originally eth-only by design; lifted to
+  // open self-service to Google-onboarded operators per issue #79
+  // option B.)
   app.post('/', async (c) => {
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
@@ -174,25 +178,17 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         id: null,
         error: {
           code: -32001,
-          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token). Acquire via /auth/siwe/exchange.`,
+          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token). Acquire via /auth/siwe/exchange or Google OAuth device flow.`,
         },
       }, 401);
     }
 
-    let walletAddress: string;
+    let principalId: string;
+    let callerEmail: string | undefined;
     try {
       const caller = await verifyCallerToken(opts.db, bearerToken);
-      if (!caller.principalId.startsWith('eth:')) {
-        return c.json({
-          jsonrpc: '2.0',
-          id: null,
-          error: {
-            code: -32001,
-            message: 'Admin agent requires a wallet-based caller token (eth:*). Sign in via SIWE.',
-          },
-        }, 403);
-      }
-      walletAddress = caller.principalId.slice('eth:'.length);
+      principalId = caller.principalId;
+      callerEmail = caller.email;
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',
@@ -207,9 +203,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     if (parsed.params?.message) {
       parsed.params.message.metadata = {
         ...parsed.params.message.metadata,
-        _walletAddress: walletAddress,
-        _principalId: `eth:${walletAddress.toLowerCase()}`,
+        _principalId: principalId,
         _bearerToken: bearerToken,
+        ...(callerEmail !== undefined ? { _email: callerEmail } : {}),
       };
     }
 


### PR DESCRIPTION
PR C of #79 — stacks on PR #80. Lifts the eth-only requirement on the admin agent at `POST /` so Google-onboarded operators reach the same chat UI as wallet operators (RLS-scoped to their own rows). Admin scope itself stays wallet-only, by design.

Resolves the open thread from the discussion on #80: "OAuth login for admin-ui" was blocked by the admin agent rejecting non-eth callers; this lifts that gate and adds the corresponding Google sign-in UI.

## Summary

**Server** (`packages/server/src/http.tsx`, `admin.ts`)
- Drop the 403 at root `POST /` for non-`eth:` principals. Any verified caller token now reaches the admin agent.
- `is_admin()` (in `admin.ts` and `schema.sql`) is unchanged — still wallet-only. `list_caller_tokens` / `revoke_caller_token` and the admin-only branch of `register_client(ownerPrincipal=…)` continue to require `eth:`+`ADMIN_WALLET_ADDRESSES`.
- `buildSystemPrompt` now branches by principal kind for the "logged in as …" copy ("wallet `0x…`" vs "Google account `email@…`"). Admin scope copy unchanged.
- `buildCustomTools` takes `principalId` directly (no more `eth:` concat from a bare wallet).
- Message metadata: `_walletAddress` dropped, `_principalId` + optional `_email` passed through.

**Admin UI** (`packages/admin-ui`)
- New `GoogleAuth` component drives the bridge's `intent=caller` device flow inside a popup. The popup is opened synchronously on the click handler (popup-blocker safe), then redirected to `verification_uri_complete` once `/oauth/device/code` lands. Polling runs in the parent and stores the resulting `vbc_caller_*` to the same `auth-token` localStorage slot SIWE uses.
- New `lib/device-flow.ts` driver — fetch + poll with `slow_down` / `expired` / `cancel` semantics.
- `App.tsx` shows both `WalletAuth` and `GoogleAuth` side-by-side in signed-out state; `Sign out` button surfaces explicitly for Google-only sessions.

**Docs**
- `remote-testing.md` §0 and §5 updated to describe the new wallet-only-admin / principal-typed-chat split.

## What's still wallet-only

`is_admin()` semantics are intentionally untouched (per the original "admin stays the same" decision in #79):
- `ADMIN_WALLET_ADDRESSES` remains a CSV of bare 0x addresses
- non-`eth:` principals never match — Google operators can run their own clients but can't see other principals' clients or revoke caller tokens

If a future PR wants to make admin scope itself principal-typed (e.g. allow `google:domain:planetariumhq.com` admins), that's a deliberate follow-up separate from this PR's scope.

## Test plan

- [x] `pnpm -r typecheck` — green (4 packages)
- [x] `node --test` — 83 pass / 0 fail / 20 skipped (DB-gated, behavior unchanged)
- [ ] Live e2e: SIWE-onboarded admin chat round-trip (regression check from PR #80)
- [ ] Live e2e: Google-onboarded user chat round-trip — sign in, list own agents, attempt admin-only tool to confirm 'admin-only' guard still rejects
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)