### PR TITLE
Auth: split caller and owner_session audiences

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -159,8 +159,10 @@ AGENT_ID=<your agent id>
 > ⚠ The `CLIENT_TOKEN` is unrecoverable after this single output. The env
 > file is the only place it persists; back it up if you need to rotate
 > hosts. To rotate the token later, use the `rotateClientToken` GraphQL
-> mutation (requires a fresh caller token via either `vicoop-client login`
-> or SIWE — the rotation surfaces a new CLIENT_TOKEN, also one-time).
+> mutation (requires a fresh `vbc_owner_*` session token from
+> `/auth/siwe/exchange?intent=owner_session` or device flow with
+> `intent=owner_session` — the rotation surfaces a new CLIENT_TOKEN, also
+> one-time).
 
 Drop `--env-file` and pass `--json` instead if you want to compose with
 shell tooling:
@@ -297,18 +299,19 @@ want Claude to edit.
 
 By default the policy has empty `allowed_callers`, which the dispatcher
 treats as "public". To lock it down, use the admin agent's `add_caller`
-tool. The admin agent at `POST /` is **wallet-gated** (requires a SIWE
-caller token with an `eth:*` principal — Google operators need to sign in
-separately via SIWE to talk to it; see "Alternative: SIWE onboarding"
-below for the SIWE token exchange).
+tool. The admin agent at `POST /` accepts any **owner-session token**
+(`vbc_owner_*`) — wallet (SIWE) or Google (device flow with
+`intent=owner_session`). Admin scope (`is_admin()`) is wallet-only and
+gates only the cross-owner tools.
 
 ```sh
-# Assumes you've already obtained $CALLER_TOKEN from SIWE — see
-# "Alternative: SIWE onboarding".
+# $OWNER_TOKEN: vbc_owner_* token from /auth/siwe/exchange or
+# /oauth/device/code with intent=owner_session. See "Alternative: SIWE
+# onboarding" below for the SIWE path.
 WALLET_PRINCIPAL="eth:$(a2a-wallet status | awk '/Address/{print tolower($2)}')"
 
 curl -sX POST "$BRIDGE_URL/" \
-  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $OWNER_TOKEN" -H 'Content-Type: application/json' \
   -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"message/send\",\"params\":{\"message\":{\"messageId\":\"ac\",\"role\":\"user\",\"kind\":\"message\",\"parts\":[{\"kind\":\"text\",\"text\":\"Use add_caller to add '${WALLET_PRINCIPAL}' to agent '${AGENT_ID}'.\"}]}}}" \
   | jq -r '.result.status.message.parts[0].text'
 ```
@@ -506,22 +509,21 @@ files before running it.
 ## Alternative: SIWE onboarding
 
 If you'd rather own your client identity with an Ethereum EOA than a
-Google account — or if you need to talk to the wallet-gated admin agent
-at `POST /` — replace Step 3 with the two-step SIWE path:
+Google account, replace Step 3 with the two-step SIWE path:
 
-1. Sign a SIWE message and exchange it for a caller token at
-   `POST /auth/siwe/exchange`. See
-   [`remote-testing.md` §1](./remote-testing.md) for the full snippet
-   (also linked from the `add_caller` example earlier in this doc), or
+1. Sign a SIWE message and exchange it at `POST /auth/siwe/exchange` for a
+   `vbc_owner_*` session token. SIWE exchange defaults to
+   `intent=owner_session`, which is what you want here. See
+   [`remote-testing.md` §1](./remote-testing.md) for the full snippet, or
    use `a2a-wallet siwe auth` if the CLI is installed.
-2. Call the `registerClient` GraphQL mutation with that caller token to
-   mint a `CLIENT_TOKEN`:
+2. Call the `registerClient` GraphQL mutation with that owner-session
+   token to mint a `CLIENT_TOKEN`:
 
 ```sh
-CALLER_TOKEN=...   # from POST /auth/siwe/exchange
+OWNER_TOKEN=...   # vbc_owner_* from POST /auth/siwe/exchange
 
 REG=$(curl -sX POST "$BRIDGE_URL/graphql" \
-  -H "Authorization: Bearer $CALLER_TOKEN" \
+  -H "Authorization: Bearer $OWNER_TOKEN" \
   -H 'Content-Type: application/json' \
   -d "{\"query\":\"mutation{registerClient(input:{clientName:\\\"$CLIENT_NAME\\\",allowedAgentIds:[\\\"$AGENT_ID\\\"]}){clientWithToken{id token ownerPrincipal allowedAgentIds}}}\"}")
 
@@ -533,9 +535,11 @@ it just owns the row under an `eth:0x…` principal instead of
 `google:sub:…`. After that, Steps 4-6 (agent card, run, persist) are the
 same as the Google path.
 
-This SIWE caller token is also what you need to invoke the admin agent for
-managing `allowed_callers` (see "Restrict who can call your agent"
-above) — the admin agent rejects non-`eth:` principals by design.
+The same `OWNER_TOKEN` is what you'd present to the admin agent at
+`POST /` for managing `allowed_callers` (see "Restrict who can call your
+agent" above). Google operators get an equivalent `vbc_owner_*` from the
+device flow and can use the admin agent the same way; admin **scope**
+(visibility into all owners' rows) remains wallet-only.
 
 ## What's next
 

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -7,22 +7,33 @@ access** and **no admin wallet** required.
 
 This is the shortest path and matches the intended production flow:
 
-1. Sign SIWE with any EOA → exchange for an opaque caller token
+1. Sign SIWE with any EOA → exchange for a `vbc_owner_*` session token
+   (default `intent=owner_session`)
 2. Register a client via the public GraphQL mutation → receive a raw client token
 3. Run a local echo backend connected over WSS
 4. Grant a principal on the auto-created agent policy via `add_caller` (admin
    agent, RLS-owner-gated, not admin-only)
-5. Dispatch to `/agents/:id` with an opaque token matching that principal
+5. Dispatch to `/agents/:id` with an opaque `vbc_caller_*` token matching that principal
 
-Two dispatch-side variants are covered:
+Note the **two distinct token audiences** used below (issue #79 PR D):
 
-- **Default (eth principal)** — caller uses the SIWE-issued opaque token
-  directly. Good for integrators whose callers are wallets.
+- `vbc_owner_*` (owner-session): issued by SIWE exchange or device flow
+  with `intent=owner_session`. Presented to `/graphql` and `POST /` for
+  self-service operations. Used in steps 1, 2, 4 below.
+- `vbc_caller_*` (caller): issued by SIWE exchange with `intent=caller`
+  or device flow with `intent=caller`. Presented to `/agents/:id` to
+  invoke somebody's agent. Used in step 5.
+
+Two dispatch-side (step 5) variants are covered:
+
+- **Default (eth principal)** — caller uses a SIWE-issued
+  `vbc_caller_*` (re-exchange with `intent=caller`). Good for integrators
+  whose callers are wallets.
 - **Google-authenticated caller** — principal is `google:email:*` /
-  `google:domain:*` / `google:sub:*`; the caller acquires a long-lived opaque
-  token via the OAuth device flow and uses that for dispatch. Setup (steps
-  1-3) still requires SIWE because `register_client` and `add_caller`
-  demand an eth-authenticated session.
+  `google:domain:*` / `google:sub:*`; the caller acquires a long-lived
+  `vbc_caller_*` via the OAuth device flow with `intent=caller`. Setup
+  (steps 1-3) still uses SIWE because `register_client` and `add_caller`
+  expect an eth-authenticated owner session.
 
 Contrast with [`local-testing.md`](./local-testing.md): that doc runs both
 server and client locally and uses `psql` to write `clients` /

--- a/packages/admin-ui/src/lib/device-flow.ts
+++ b/packages/admin-ui/src/lib/device-flow.ts
@@ -1,9 +1,11 @@
 // Browser-side driver for the bridge's RFC-8628 device flow with
-// intent=caller. Issues a vbc_caller_* opaque token after the user signs
-// in to Google in a popup window. See packages/server/src/auth/device-flow.ts
-// for the wire surface.
+// intent=owner_session. Issues a vbc_owner_* opaque token after the user
+// signs in to Google in a popup window — that token is what the admin UI
+// presents to /graphql and POST / for self-service. See
+// packages/server/src/auth/device-flow.ts for the wire surface and
+// issue #79 PR D for the audience split.
 
-const CALLER_TOKEN_PREFIX = 'vbc_caller_';
+const OWNER_SESSION_PREFIX = 'vbc_owner_';
 
 interface DeviceCodeResponse {
   device_code: string;
@@ -19,7 +21,7 @@ export interface DeviceFlowSession {
   verificationUriComplete: string;
   userCode: string;
   /**
-   * Resolves with a `vbc_caller_*` token once the popup approval completes.
+   * Resolves with a `vbc_owner_*` token once the popup approval completes.
    * Rejects on expiry, server error, or `cancel()` invocation.
    */
   result: Promise<string>;
@@ -35,7 +37,7 @@ class CanceledError extends Error {
 }
 
 async function postDeviceCode(): Promise<DeviceCodeResponse> {
-  const body = new URLSearchParams({ intent: 'caller' });
+  const body = new URLSearchParams({ intent: 'owner_session' });
   const res = await fetch('/oauth/device/code', {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -75,8 +77,8 @@ async function pollOnce(deviceCode: string): Promise<PollOk | PollPending | Poll
   });
   if (res.ok) {
     const payload = (await res.json()) as { access_token?: unknown; token_type?: unknown };
-    if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(CALLER_TOKEN_PREFIX)) {
-      return { kind: 'fatal', message: 'malformed access_token' };
+    if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(OWNER_SESSION_PREFIX)) {
+      return { kind: 'fatal', message: 'malformed access_token (expected vbc_owner_* prefix)' };
     }
     return { kind: 'ok', token: payload.access_token };
   }

--- a/packages/admin-ui/src/lib/siwe-exchange.ts
+++ b/packages/admin-ui/src/lib/siwe-exchange.ts
@@ -1,10 +1,10 @@
 // Exchanges a signed SIWE (message, signature) pair for a bridge-issued
-// opaque caller token (`vbc_caller_*`). The returned token is the only
-// credential subsequently presented to the bridge — admin GraphQL, A2A
-// /agents/:id, and the root admin agent all accept opaque tokens and no
-// longer accept raw SIWE bearers (see issue #31).
+// opaque owner-session token (`vbc_owner_*`). The returned token is what
+// the admin UI presents on /graphql and POST / for self-service operations
+// (see issue #31 for the original opaque-token model and #79 PR D for the
+// caller/owner-session audience split).
 
-const CALLER_TOKEN_PREFIX = 'vbc_caller_';
+const OWNER_SESSION_PREFIX = 'vbc_owner_';
 
 export async function exchangeSiweForCallerToken(
   message: string,
@@ -13,7 +13,12 @@ export async function exchangeSiweForCallerToken(
   const res = await fetch('/auth/siwe/exchange', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ message, signature }),
+    // intent=owner_session: SIWE in the admin UI is for the wallet owner
+    // managing their own clients/policies, not for being added as a third-
+    // party caller of someone else's agent. The server defaults to
+    // owner_session anyway, but be explicit so a future server default
+    // change doesn't silently break the UI.
+    body: JSON.stringify({ message, signature, intent: 'owner_session' }),
   });
   if (!res.ok) {
     let description = `HTTP ${res.status}`;
@@ -36,8 +41,8 @@ export async function exchangeSiweForCallerToken(
     throw new Error('SIWE exchange returned a non-JSON response');
   }
   const payload = body as { access_token?: unknown; token_type?: unknown };
-  if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(CALLER_TOKEN_PREFIX)) {
-    throw new Error('SIWE exchange response missing or malformed access_token');
+  if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(OWNER_SESSION_PREFIX)) {
+    throw new Error('SIWE exchange response missing or malformed access_token (expected vbc_owner_* prefix)');
   }
   if (typeof payload.token_type === 'string' && payload.token_type.toLowerCase() !== 'bearer') {
     throw new Error(`SIWE exchange returned unsupported token_type: ${payload.token_type}`);

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -542,13 +542,26 @@ COMMENT ON FUNCTION agent_id_available(TEXT) IS
   'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any principal (including the caller) already owns it. Never exposes owner_principal or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';
 
 -- ============================================================
--- 6. Caller auth: opaque tokens issued via Google OAuth device flow
+-- 6. Session tokens: opaque tokens issued via SIWE / device flow
 -- ============================================================
+-- `audience` partitions the table into two distinct token kinds with
+-- different prefixes, sites of use, and security envelopes (see #79):
+--   'caller'         — `vbc_caller_*`, used as Bearer at /agents/:id by
+--                       a third-party A2A caller invoking somebody else's
+--                       agent. Matched against allowed_callers.
+--   'owner_session'  — `vbc_owner_*`, used as Bearer at /graphql and
+--                       POST / by the resource owner for self-service
+--                       (admin agent chat, client/policy CRUD). Matched
+--                       against owner_principal under RLS.
+-- The two kinds intentionally cannot be cross-used; the corresponding
+-- HTTP guards reject mismatched prefixes (see agent-auth.ts /
+-- http.tsx / postgraphile.ts).
 CREATE TABLE IF NOT EXISTS callers (
   id              TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
   token_hash      TEXT NOT NULL UNIQUE,
   principal_id    TEXT NOT NULL,
   provider        TEXT NOT NULL,
+  audience        TEXT NOT NULL DEFAULT 'caller',
   email           TEXT,
   label           TEXT,
   expires_at      TIMESTAMPTZ NOT NULL,
@@ -557,8 +570,15 @@ CREATE TABLE IF NOT EXISTS callers (
   created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- Idempotent: re-applying schema.sql on dev DBs from earlier PRs adds the
+-- audience column. Existing rows default to 'caller', preserving prior
+-- behavior for anyone who already has a vbc_caller_* token in flight.
+ALTER TABLE callers ADD COLUMN IF NOT EXISTS audience TEXT NOT NULL DEFAULT 'caller';
+
 CREATE INDEX IF NOT EXISTS callers_principal_active_idx
   ON callers(principal_id) WHERE revoked = false;
+CREATE INDEX IF NOT EXISTS callers_audience_active_idx
+  ON callers(audience) WHERE revoked = false;
 
 ALTER TABLE callers ENABLE ROW LEVEL SECURITY;
 

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -19,9 +19,12 @@ export interface AgentAuthOptions {
 }
 
 export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
+  // /agents/:id only accepts caller-audience tokens. Owner-session tokens
+  // (vbc_owner_*) are for self-service surfaces and explicitly rejected
+  // here even if they belong to a principal in allowed_callers.
   const acquisitionHint = opts.deviceFlowEnabled
-    ? '/auth/siwe/exchange (SIWE) or /oauth/token (device flow)'
-    : '/auth/siwe/exchange (SIWE)';
+    ? '/auth/siwe/exchange (SIWE, intent=caller) or /oauth/token (device flow, intent=caller)'
+    : '/auth/siwe/exchange (SIWE, intent=caller)';
 
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;

--- a/packages/server/src/auth/caller-token.test.ts
+++ b/packages/server/src/auth/caller-token.test.ts
@@ -58,7 +58,7 @@ test('verifyCallerToken rejects bad prefix without hitting DB', async () => {
   }) as unknown as Parameters<typeof verifyCallerToken>[0];
   await assert.rejects(
     () => verifyCallerToken(sqlStub, 'not-a-caller-token'),
-    /Invalid caller token format/,
+    /Invalid session token format/,
   );
 });
 
@@ -114,7 +114,7 @@ test(
       // Use a fresh token string variant to sidestep any prior cache.
       await assert.rejects(
         () => verifyCallerToken(sql, issued.rawToken),
-        /Caller token revoked/,
+        /Session token revoked/,
       );
 
       await sql`DELETE FROM callers WHERE id = ${issued.callerId}`;
@@ -140,7 +140,7 @@ test(
       await new Promise((r) => setTimeout(r, 10));
       await assert.rejects(
         () => verifyCallerToken(sql, issued.rawToken),
-        /Caller token expired/,
+        /Session token expired/,
       );
       await sql`DELETE FROM callers WHERE id = ${issued.callerId}`;
     } finally {

--- a/packages/server/src/auth/caller-token.ts
+++ b/packages/server/src/auth/caller-token.ts
@@ -2,24 +2,43 @@ import { createHash, randomBytes } from 'node:crypto';
 import type { Sql } from '../db.js';
 import type { VerifiedCaller } from './principal.js';
 
-// Bridge-issued opaque token for A2A caller auth.
-// Wire format: 'vbc_caller_' + 43-char base64url (32 bytes of entropy).
+// Bridge-issued opaque session tokens.
+// Two distinct audiences with distinct prefixes (issue #79 PR D):
+//
+//   `vbc_caller_*` (audience='caller')
+//     Used as Bearer at /agents/:id by a third-party A2A caller invoking
+//     somebody else's agent. Matched against the agent's allowed_callers.
+//
+//   `vbc_owner_*`  (audience='owner_session')
+//     Used as Bearer at /graphql and POST / by the resource owner for
+//     self-service (admin chat, client/policy CRUD). Matched against
+//     owner_principal under RLS.
+//
+// The two are intentionally non-substitutable: the call-site guards
+// (agent-auth.ts / http.tsx / postgraphile.ts) reject the wrong prefix
+// up front. Verification additionally enforces audience server-side
+// against the persisted row in case a token is hand-crafted past the
+// prefix check.
 
 export const CALLER_TOKEN_PREFIX = 'vbc_caller_';
+export const OWNER_SESSION_PREFIX = 'vbc_owner_';
 
-// Provider label persisted on the `callers` row. Expands as new issuance
-// methods are added (e.g. passkey, ssh-agent). Not enforced by schema.
+export type Audience = 'caller' | 'owner_session';
+
+// Provider label persisted on the row. Expands as new issuance methods
+// are added (e.g. passkey, ssh-agent). Not enforced by schema.
 export type CallerProvider = 'google' | 'siwe';
 
-export interface IssueCallerTokenInput {
+export interface IssueSessionTokenInput {
   principalId: string;        // 'google:<sub>' | 'eth:0x<addr>'
   provider: CallerProvider;
+  audience: Audience;
   email?: string;
   label?: string;
   ttlMs?: number;             // default 90 days
 }
 
-export interface IssuedCallerToken {
+export interface IssuedSessionToken {
   rawToken: string;           // shown once to the user
   callerId: string;
   expiresAt: Date;
@@ -27,12 +46,14 @@ export interface IssuedCallerToken {
 
 const DEFAULT_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
-// In-memory verification cache. Mirrors pattern in siwe-token.ts.
-// Keyed by raw token. Values hold the VerifiedCaller plus an `expiresAt`
-// (ms epoch) bounded to `now + CACHE_MAX_ENTRY_TTL_MS` so revocations
-// take effect within ~60s without us having to do explicit invalidation.
+// In-memory verification cache. Mirrors pattern in siwe-token.ts. Keyed by
+// raw token; the prefix encodes audience so a single key space is fine.
+// Values hold the VerifiedCaller plus an `expiresAt` (ms epoch) bounded to
+// `now + CACHE_MAX_ENTRY_TTL_MS` so revocations take effect within ~60s
+// without us having to do explicit invalidation.
 interface VerifyCacheEntry {
   caller: VerifiedCaller;
+  audience: Audience;
   expiresAt: number;
 }
 
@@ -58,9 +79,25 @@ function evictExpired(): void {
   }
 }
 
-// Generate a new unguessable opaque token string. Does not touch DB.
+function prefixFor(audience: Audience): string {
+  return audience === 'caller' ? CALLER_TOKEN_PREFIX : OWNER_SESSION_PREFIX;
+}
+
+function audienceFromRaw(rawToken: string): Audience | null {
+  if (rawToken.startsWith(CALLER_TOKEN_PREFIX)) return 'caller';
+  if (rawToken.startsWith(OWNER_SESSION_PREFIX)) return 'owner_session';
+  return null;
+}
+
+// Generate an unguessable opaque token string. Does not touch DB.
+export function generateSessionToken(audience: Audience): string {
+  return prefixFor(audience) + randomBytes(32).toString('base64url');
+}
+
+// Backward-compat alias used by older callers; emits a `vbc_caller_*` token.
+// New code should call generateSessionToken(audience) directly.
 export function generateCallerToken(): string {
-  return CALLER_TOKEN_PREFIX + randomBytes(32).toString('base64url');
+  return generateSessionToken('caller');
 }
 
 // sha256 hex of the raw token, for DB lookup.
@@ -69,21 +106,22 @@ export function hashCallerToken(raw: string): string {
 }
 
 // Issue a new token and persist to `callers`. Returns raw token (one-time).
-export async function issueCallerToken(
+export async function issueSessionToken(
   sql: Sql,
-  input: IssueCallerTokenInput,
-): Promise<IssuedCallerToken> {
-  const rawToken = generateCallerToken();
+  input: IssueSessionTokenInput,
+): Promise<IssuedSessionToken> {
+  const rawToken = generateSessionToken(input.audience);
   const tokenHash = hashCallerToken(rawToken);
   const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS;
   const expiresAt = new Date(Date.now() + ttlMs);
 
   const rows = await sql<{ id: string; expires_at: Date }[]>`
-    INSERT INTO callers (token_hash, principal_id, provider, email, label, expires_at)
+    INSERT INTO callers (token_hash, principal_id, provider, audience, email, label, expires_at)
     VALUES (
       ${tokenHash},
       ${input.principalId},
       ${input.provider},
+      ${input.audience},
       ${input.email ?? null},
       ${input.label ?? null},
       ${expiresAt}
@@ -93,7 +131,7 @@ export async function issueCallerToken(
 
   const row = rows[0];
   if (!row) {
-    throw new Error('Failed to insert caller token');
+    throw new Error('Failed to insert session token');
   }
 
   return {
@@ -103,14 +141,39 @@ export async function issueCallerToken(
   };
 }
 
-// Verify a raw token. Checks revoked + expires_at. Updates last_used_at.
-// Throws on any failure. Returns VerifiedCaller with principal and metadata.
-export async function verifyCallerToken(
+// Backward-compat alias — fixes audience to 'caller'. New code should use
+// issueSessionToken directly with an explicit audience.
+export async function issueCallerToken(
+  sql: Sql,
+  input: Omit<IssueSessionTokenInput, 'audience'>,
+): Promise<IssuedSessionToken> {
+  return issueSessionToken(sql, { ...input, audience: 'caller' });
+}
+
+export interface VerifyOptions {
+  // When set, throws if the verified token's audience does not match.
+  // Call sites that handle a single audience kind (e.g. agent-auth.ts only
+  // accepts 'caller') pass this so a stolen token cannot be repurposed
+  // across the eth-only-vs-Google split or the caller-vs-owner split.
+  expectedAudience?: Audience;
+}
+
+// Verify a raw token. Checks revoked + expires_at + audience. Updates
+// last_used_at on cache miss. Throws on any failure. Returns
+// VerifiedCaller with principal and metadata.
+export async function verifySessionToken(
   sql: Sql,
   rawToken: string,
+  opts: VerifyOptions = {},
 ): Promise<VerifiedCaller> {
-  if (!rawToken.startsWith(CALLER_TOKEN_PREFIX)) {
-    throw new Error('Invalid caller token format');
+  const audience = audienceFromRaw(rawToken);
+  if (audience === null) {
+    throw new Error('Invalid session token format');
+  }
+  if (opts.expectedAudience && opts.expectedAudience !== audience) {
+    throw new Error(
+      `Token audience mismatch: this endpoint expects ${prefixFor(opts.expectedAudience)}* but got ${prefixFor(audience)}*`,
+    );
   }
 
   evictExpired();
@@ -118,6 +181,11 @@ export async function verifyCallerToken(
   const now = Date.now();
   const cached = verifyCache.get(rawToken);
   if (cached && cached.expiresAt > now) {
+    if (opts.expectedAudience && cached.audience !== opts.expectedAudience) {
+      throw new Error(
+        `Token audience mismatch: cached audience ${cached.audience} does not satisfy ${opts.expectedAudience}`,
+      );
+    }
     // Deliberately do not touch last_used_at on cache hits to avoid
     // write amplification.
     return cached.caller;
@@ -128,12 +196,13 @@ export async function verifyCallerToken(
     {
       id: string;
       principal_id: string;
+      audience: string;
       email: string | null;
       expires_at: Date;
       revoked: boolean;
     }[]
   >`
-    SELECT id, principal_id, email, expires_at, revoked
+    SELECT id, principal_id, audience, email, expires_at, revoked
     FROM callers
     WHERE token_hash = ${tokenHash}
     LIMIT 1
@@ -141,13 +210,24 @@ export async function verifyCallerToken(
 
   const row = rows[0];
   if (!row) {
-    throw new Error('Caller token not found');
+    throw new Error('Session token not found');
   }
   if (row.revoked) {
-    throw new Error('Caller token revoked');
+    throw new Error('Session token revoked');
   }
   if (row.expires_at.getTime() <= now) {
-    throw new Error('Caller token expired');
+    throw new Error('Session token expired');
+  }
+  // Defense-in-depth: row's persisted audience must match the prefix we
+  // saw on the wire. A mismatch indicates either DB corruption or someone
+  // who changed the prefix on the wire to bypass call-site guards.
+  if (row.audience !== audience) {
+    throw new Error('Session token audience corruption');
+  }
+  if (opts.expectedAudience && opts.expectedAudience !== audience) {
+    throw new Error(
+      `Token audience mismatch: this endpoint expects ${prefixFor(opts.expectedAudience)}* but got ${prefixFor(audience)}*`,
+    );
   }
 
   // Stamp last_used_at. Awaited for test determinism; the write is cheap
@@ -164,12 +244,22 @@ export async function verifyCallerToken(
   };
 
   const cacheExpiresAt = Math.min(row.expires_at.getTime(), now + CACHE_MAX_ENTRY_TTL_MS);
-  verifyCache.set(rawToken, { caller, expiresAt: cacheExpiresAt });
+  verifyCache.set(rawToken, { caller, audience, expiresAt: cacheExpiresAt });
 
   return caller;
 }
 
-// Mark a caller token as revoked. Idempotent.
+// Backward-compat alias for verifySessionToken({ expectedAudience: 'caller' }).
+// Call sites that haven't been migrated to audience-aware verification still
+// reach this; the explicit audience check is enforced.
+export async function verifyCallerToken(
+  sql: Sql,
+  rawToken: string,
+): Promise<VerifiedCaller> {
+  return verifySessionToken(sql, rawToken, { expectedAudience: 'caller' });
+}
+
+// Mark a session token as revoked. Idempotent.
 // NOTE: We intentionally do not invalidate the in-memory LRU here. Cache
 // entries are bounded to `now + 60s` at insert time, so revocations take
 // effect within ~60s without requiring us to track id → token mappings.
@@ -181,6 +271,7 @@ export interface CallerTokenRow {
   id: string;
   principalId: string;
   provider: string;
+  audience: Audience;
   email: string | null;
   label: string | null;
   expiresAt: Date;
@@ -193,6 +284,7 @@ interface RawCallerRow {
   id: string;
   principal_id: string;
   provider: string;
+  audience: string;
   email: string | null;
   label: string | null;
   expires_at: Date;
@@ -204,7 +296,7 @@ interface RawCallerRow {
 // List tokens with optional filters. Used by admin tools.
 export async function listCallerTokens(
   sql: Sql,
-  filter: { principalId?: string; email?: string; includeRevoked?: boolean },
+  filter: { principalId?: string; email?: string; audience?: Audience; includeRevoked?: boolean },
 ): Promise<CallerTokenRow[]> {
   const conditions: ReturnType<Sql>[] = [];
   if (filter.principalId) {
@@ -212,6 +304,9 @@ export async function listCallerTokens(
   }
   if (filter.email) {
     conditions.push(sql`email = ${filter.email}`);
+  }
+  if (filter.audience) {
+    conditions.push(sql`audience = ${filter.audience}`);
   }
   if (!filter.includeRevoked) {
     conditions.push(sql`revoked = false`);
@@ -223,7 +318,7 @@ export async function listCallerTokens(
       : sql``;
 
   const rows = await sql<RawCallerRow[]>`
-    SELECT id, principal_id, provider, email, label, expires_at, last_used_at, revoked, created_at
+    SELECT id, principal_id, provider, audience, email, label, expires_at, last_used_at, revoked, created_at
     FROM callers
     ${where}
     ORDER BY created_at DESC
@@ -233,6 +328,7 @@ export async function listCallerTokens(
     id: r.id,
     principalId: r.principal_id,
     provider: r.provider,
+    audience: r.audience as Audience,
     email: r.email,
     label: r.label,
     expiresAt: r.expires_at,

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -3,30 +3,27 @@
 // (that sets status='approved' and fills principal_id/email) is implemented
 // separately in device-ui.ts.
 //
-// Two intents flow through the same approval pipeline (see issue #79):
-//   * 'caller'           — issue a vbc_caller_* opaque token to the polling
-//                          CLI for use as a Bearer credential against
-//                          /agents/:id and the admin GraphQL surface.
-//   * 'client_register'  — call register_client() on behalf of the approved
-//                          principal and return the resulting CLIENT_TOKEN +
-//                          client_id, no callers row created. This is the
-//                          device-flow vicoop-client onboarding path.
+// Three intents flow through the same approval pipeline (see issue #79):
+//   * 'caller'          — issue a `vbc_caller_*` Bearer for an external A2A
+//                         caller invoking somebody else's agent at
+//                         /agents/:id (audience='caller').
+//   * 'owner_session'   — issue a `vbc_owner_*` Bearer for the resource
+//                         owner's self-service surface (admin chat,
+//                         /graphql) (audience='owner_session'). PR D.
+//   * 'client_register' — call register_client() on behalf of the approved
+//                         principal and return the resulting CLIENT_TOKEN +
+//                         client_id, no callers row created. This is the
+//                         device-flow vicoop-client onboarding path.
 //
 // Token endpoint dispatches on `device_sessions.intent`. Approval UI surfaces
 // the difference to the operator (device-ui.ts).
-//
-// Bootstrap-mode tokenTtlMs: device-flow caller tokens default to 90 days,
-// matching SIWE-issued tokens for ergonomic admin-GraphQL reuse. Operators
-// who only want a one-shot bootstrap can set bootstrapTokenTtlMs to scope
-// the issued token tighter; that doesn't apply to the client_register branch
-// (its CLIENT_TOKEN has no TTL — it's revoked, not expired).
 
 import { randomBytes, randomInt } from 'node:crypto';
 import type { Hono, Context } from 'hono';
 import type { Sql } from '../db.js';
-import { issueCallerToken } from './caller-token.js';
+import { issueSessionToken } from './caller-token.js';
 
-export type DeviceFlowIntent = 'caller' | 'client_register';
+export type DeviceFlowIntent = 'caller' | 'owner_session' | 'client_register';
 
 export interface DeviceFlowOptions {
   sql: Sql;
@@ -191,6 +188,8 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
 
     if (intentRaw === 'caller' || intentRaw === '') {
       intent = 'caller';
+    } else if (intentRaw === 'owner_session') {
+      intent = 'owner_session';
     } else if (intentRaw === 'client_register') {
       intent = 'client_register';
       const parsed = parseClientRegisterParams(body);
@@ -370,11 +369,17 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
         });
       }
 
-      // intent === 'caller' (default) — original behavior
+      // intent === 'caller' or 'owner_session' — issue a session token of
+      // the matching audience. The two paths are otherwise identical
+      // (single principal, persisted to callers, returned via OAuth-style
+      // access_token response). Audience selects the prefix
+      // (`vbc_caller_*` vs `vbc_owner_*`) and constrains downstream usage.
+      const audience = row.intent === 'owner_session' ? 'owner_session' : 'caller';
       const issued = await sql.begin(async (tx) => {
-        const i = await issueCallerToken(tx as unknown as Sql, {
+        const i = await issueSessionToken(tx as unknown as Sql, {
           principalId: row.principal_id!,
           provider: 'google',
+          audience,
           email: row.email ?? undefined,
           ttlMs: tokenTtlMs,
         });

--- a/packages/server/src/auth/device-ui.ts
+++ b/packages/server/src/auth/device-ui.ts
@@ -155,6 +155,16 @@ function renderIntentIntro(intent: string, params: ClientRegisterParams | null):
       <p>You'll be asked to sign in to Google to confirm.</p>
     `;
   }
+  if (intent === 'owner_session') {
+    return `
+      <p><strong>Sign in to manage your bridge clients</strong></p>
+      <p>This will issue a session token bound to your Google account so you
+         can view and manage clients and agent policies you own (admin chat,
+         GraphQL self-service). It does not authorize calls to other people's
+         agents.</p>
+      <p>You'll be asked to sign in to Google to confirm.</p>
+    `;
+  }
   // Default 'caller' intent.
   return `
     <p>This will authorize a CLI session to call agents on your behalf.
@@ -199,9 +209,12 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
     const safeCode = escapeHtml(normalized);
     const href = `/oauth/google/start?user_code=${encodeURIComponent(normalized)}`;
     const intro = renderIntentIntro(session.intent, session.intent_params);
-    const headerText = session.intent === 'client_register'
-      ? 'Authorize bridge client registration'
-      : 'Authorize device';
+    const headerText =
+      session.intent === 'client_register'
+        ? 'Authorize bridge client registration'
+        : session.intent === 'owner_session'
+          ? 'Sign in to manage your bridge clients'
+          : 'Authorize device';
     const body = `
       <h1>${escapeHtml(headerText)}</h1>
       <div class="code">${safeCode}</div>

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -1,22 +1,31 @@
-// POST /auth/siwe/exchange — issues an opaque caller token in exchange for a
-// verified SIWE (message, signature) pair.
+// POST /auth/siwe/exchange — issues an opaque session token in exchange for
+// a verified SIWE (message, signature) pair.
 //
-// This unifies SIWE with the bridge's opaque token model: after exchange, the
-// SIWE signature is never presented to the server again. The caller presents
-// the opaque `vbc_caller_*` token on subsequent requests (admin GraphQL, A2A
-// /agents/:id, root POST /). Revocation, audit (`last_used_at`, `label`), and
-// admin tooling (`list_caller_tokens` / `revoke_caller_token`) all apply.
+// `intent` selects the audience of the issued token (issue #79 PR D):
+//   'owner_session' (default) — `vbc_owner_*`. Used by admin UI / install
+//                                bootstrap to manage one's own clients and
+//                                policies. This is the dominant case for
+//                                SIWE — wallets self-identify as owners.
+//   'caller'                  — `vbc_caller_*`. For an external A2A caller
+//                                whose wallet wants to invoke somebody
+//                                else's agent at /agents/:id.
+//
+// After exchange, the SIWE signature is never presented to the server again;
+// the opaque token is the only credential. Revocation, audit
+// (`last_used_at`, `label`), and admin tooling (`list_caller_tokens` /
+// `revoke_caller_token`) all apply to both audiences.
 //
 // TTL is inherited from the SIWE message's `expirationTime` rather than the
-// 90-day caller-token default; SIWE messages cap at 7 days by convention.
+// 90-day default; SIWE messages cap at 7 days by convention.
 //
-// See issue #31 for the design rationale.
+// See issue #31 for the original design rationale and #79 for the
+// audience split.
 
 import type { Hono } from 'hono';
 import { SiweMessage } from 'siwe';
 import type { Sql } from '../db.js';
 import { MAX_TOKEN_TTL_MS, verifySiweMessage } from '../siwe-token.js';
-import { issueCallerToken } from './caller-token.js';
+import { issueSessionToken, type Audience } from './caller-token.js';
 
 export interface SiweExchangeOptions {
   sql: Sql;
@@ -26,6 +35,7 @@ export interface SiweExchangeOptions {
 interface ExchangeBody {
   message?: unknown;
   signature?: unknown;
+  intent?: unknown;
 }
 
 export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
@@ -42,6 +52,19 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
     if (!message || !signature) {
       return c.json(
         { error: 'invalid_request', error_description: 'message and signature are required' },
+        400,
+      );
+    }
+
+    let audience: Audience;
+    const intentRaw = typeof body.intent === 'string' ? body.intent : 'owner_session';
+    if (intentRaw === 'owner_session' || intentRaw === '') {
+      audience = 'owner_session';
+    } else if (intentRaw === 'caller') {
+      audience = 'caller';
+    } else {
+      return c.json(
+        { error: 'invalid_request', error_description: `unknown intent: ${intentRaw}` },
         400,
       );
     }
@@ -102,9 +125,10 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
           );
         }
 
-        const issued = await issueCallerToken(tx as unknown as typeof opts.sql, {
+        const issued = await issueSessionToken(tx as unknown as typeof opts.sql, {
           principalId,
           provider: 'siwe',
+          audience,
           ttlMs,
         });
 

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -12,7 +12,7 @@ import {
 import type { ClientConnection, Registry } from './registry.js';
 import { createAdminA2XAgent, getAdminWallets } from './admin.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
-import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
+import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
 import { mountDeviceFlow } from './auth/device-flow.js';
 import { mountDeviceUi } from './auth/device-ui.js';
 import { mountSiweExchange } from './auth/siwe-exchange.js';
@@ -161,24 +161,27 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // on all subsequent requests.
   mountSiweExchange(app, { sql: opts.db, domain: siweDomain });
 
-  // Root POST — admin agent A2A endpoint. Accepts any verified caller token;
-  // RLS scopes what the operator can see (their own clients/policies). The
-  // admin scope itself stays wallet-only — `is_admin()` matches only
-  // `eth:` principals against ADMIN_WALLET_ADDRESSES — but non-admin
-  // wallet and non-admin Google callers both reach the chat now and see
-  // their RLS-scoped view. (Originally eth-only by design; lifted to
-  // open self-service to Google-onboarded operators per issue #79
-  // option B.)
+  // Root POST — admin agent A2A endpoint. Owner-session-audience only
+  // (`vbc_owner_*`); caller-audience tokens (`vbc_caller_*`) are rejected
+  // because admin chat is for the resource owner managing their own
+  // clients/policies, not for third-party agent invocation. RLS scopes
+  // what the operator can see; admin scope (`is_admin()`) stays
+  // wallet-only by design (issue #79).
   app.post('/', async (c) => {
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
-    if (!bearerToken || !bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+    if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
         error: {
           code: -32001,
-          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token). Acquire via /auth/siwe/exchange or Google OAuth device flow.`,
+          message:
+            `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
+            `Acquire via /auth/siwe/exchange (intent=owner_session) or ` +
+            `/oauth/device/code (intent=owner_session). ` +
+            `${CALLER_TOKEN_PREFIX}* tokens are not accepted here — those ` +
+            `are for /agents/:id calls.`,
         },
       }, 401);
     }
@@ -186,14 +189,16 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     let principalId: string;
     let callerEmail: string | undefined;
     try {
-      const caller = await verifyCallerToken(opts.db, bearerToken);
+      const caller = await verifySessionToken(opts.db, bearerToken, {
+        expectedAudience: 'owner_session',
+      });
       principalId = caller.principalId;
       callerEmail = caller.email;
     } catch (err) {
       return c.json({
         jsonrpc: '2.0',
         id: null,
-        error: { code: -32001, message: `Invalid caller token: ${(err as Error).message}` },
+        error: { code: -32001, message: `Invalid session token: ${(err as Error).message}` },
       }, 401);
     }
 

--- a/packages/server/src/postgraphile.ts
+++ b/packages/server/src/postgraphile.ts
@@ -3,7 +3,7 @@ import { postgraphile } from 'postgraphile';
 import { Pool } from 'pg';
 import type { IncomingMessage } from 'node:http';
 import type { Sql } from './db.js';
-import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
+import { OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
 
 const ADMIN_WALLET_ADDRESSES = (process.env.ADMIN_WALLET_ADDRESSES ?? '')
   .split(',')
@@ -41,12 +41,16 @@ export async function startPostGraphile(databaseUrl: string, sql: Sql): Promise<
         const auth = req.headers.authorization;
         if (auth?.startsWith('Bearer ')) {
           const token = auth.slice(7);
-          // Opaque caller tokens are the only accepted admin GraphQL credential
-          // as of #31. Any verified principal (eth:* or google:*) gets RLS-gated
-          // access scoped to rows whose owner_principal matches.
-          if (token.startsWith(CALLER_TOKEN_PREFIX)) {
+          // /graphql is owner-self-service: only `vbc_owner_*` tokens are
+          // honored. `vbc_caller_*` tokens are for third-party agent calls
+          // at /agents/:id and intentionally fall through to anonymous
+          // here so a leaked caller token cannot be used to enumerate the
+          // owner's GraphQL surface (issue #79 PR D).
+          if (token.startsWith(OWNER_SESSION_PREFIX)) {
             try {
-              const caller = await verifyCallerToken(sql, token);
+              const caller = await verifySessionToken(sql, token, {
+                expectedAudience: 'owner_session',
+              });
               return {
                 role: 'app_authenticated',
                 'jwt.claims.principal_id': caller.principalId,


### PR DESCRIPTION
PR D of #79. Stacks on #83. Splits `vbc_caller_*` into two distinct audiences with separate prefixes and call-site guards.

## Why

The original `vbc_caller_*` token was named "caller" but actually carried two different identities:

| Today's `vbc_caller_*` use | Real identity |
|---|---|
| `/agents/:id` (Bearer matched against allowed_callers) | external A2A caller |
| `/graphql` (RLS-scoped CRUD on own clients/policies) | resource owner |
| `POST /` admin chat | resource owner |

Same token, two purposes — leaked caller token could enumerate the owner's GraphQL surface and chat with the admin agent. Lifecycles also differ: a caller token's blast radius should be a single agent it's been added to; an owner-session's blast radius is the owner's whole estate.

This PR makes the two non-substitutable.

## Changes

**Schema** (`callers.audience`)
- `audience TEXT NOT NULL DEFAULT 'caller'`. Idempotent ADD COLUMN IF NOT EXISTS for re-applied dev DBs.

**Server**
- `auth/caller-token.ts` — `OWNER_SESSION_PREFIX = 'vbc_owner_'`, `Audience` type. `issueSessionToken` / `verifySessionToken` take explicit audience and enforce a wire-prefix-vs-DB-row consistency check (defense in depth). `issueCallerToken` / `verifyCallerToken` retained as audience-fixed shims.
- `auth/siwe-exchange.ts` — `intent=caller|owner_session`, default `owner_session` (SIWE is wallet self-identity in the dominant case).
- `auth/device-flow.ts` — adds `intent=owner_session` alongside `caller` and `client_register`. Token endpoint dispatches by intent.
- `auth/device-ui.ts` — intent-conditional approval copy on the consent screen.
- `agent-auth.ts` — `/agents/:id` rejects non-`vbc_caller_*` tokens.
- `http.tsx POST /` — admin chat rejects non-`vbc_owner_*` tokens.
- `postgraphile.ts` — `/graphql` rejects non-`vbc_owner_*` tokens (caller tokens fall through to anonymous).

**Admin UI**
- `lib/siwe-exchange.ts` — sends `intent=owner_session`, validates `vbc_owner_*` response prefix.
- `lib/device-flow.ts` — popup driver requests `intent=owner_session`.

**Docs**
- `install-client.md` and `remote-testing.md` updated around the two-audience split.

## Audience matrix

| Endpoint | Accepted prefix | Audience guard at verify |
|---|---|---|
| `/agents/:id` | `vbc_caller_*` | `expectedAudience='caller'` |
| `POST /` (admin chat) | `vbc_owner_*` | `expectedAudience='owner_session'` |
| `/graphql` | `vbc_owner_*` | `expectedAudience='owner_session'` |
| `WS /connect` (hello) | (CLIENT_TOKEN, unchanged) | n/a |

The defense-in-depth check at `verifySessionToken` (DB-row audience must equal wire-prefix audience) means an attacker who hand-crafts a valid-looking token cannot bypass the call-site guard by flipping the prefix.

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `node --test` — 83 pass / 0 fail / 20 skipped
- [ ] Live e2e on fly: SIWE → admin chat with `vbc_owner_*` (regression)
- [ ] Live e2e on fly: Google device flow `intent=owner_session` → admin chat
- [ ] Live e2e on fly: device flow `intent=caller` → `/agents/:id` (regression of caller path)
- [ ] Live e2e on fly: prefix guard rejection (vbc_caller_* on POST / → 401)

## Out of scope

- Renaming the `callers` table to a more general name (`sessions`) — table name stays for now to bound the diff. The audience column already disambiguates rows.
- Issuing both prefixes from a single SIWE exchange — same call still issues only one audience per request; operators that need both retransmit with the other intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)