### PR TITLE
admin-ui Google sign-in: drop polling, deliver token via postMessage

### DIFF
--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -12,22 +12,20 @@ export default function App() {
       <header className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-6 py-3">
         <h1 className="text-lg font-semibold text-zinc-100">Vicoop Bridge Admin</h1>
         {token ? (
-          // When a token is set, defer to WalletAuth's signed-in display
-          // (it shows the connected wallet + a Sign out button that also
-          // disconnects wagmi). For a Google-issued token there's no wagmi
-          // session to disconnect, so the same Sign out button is fine —
-          // it just clears the auth token. We additionally show a plain
-          // Sign out button here so Google-only sessions have an exit
-          // path even when no wallet is connected.
-          <div className="flex items-center gap-3">
+          // SIWE-issued tokens use the `vbc_caller_*` prefix; anything else
+          // (currently `vbc_owner_*` from Google) is a non-wallet session.
+          // The wallet-auth subtree only makes sense for wallet sessions —
+          // it owns the wagmi disconnect on sign-out.
+          token.startsWith('vbc_caller_') ? (
             <WalletAuth />
+          ) : (
             <button
               onClick={() => setToken(null)}
-              className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
+              className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-100 px-3 py-1.5 rounded transition-colors"
             >
               Sign out
             </button>
-          </div>
+          )
         ) : (
           <div className="flex items-center gap-3">
             <WalletAuth />

--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { useAccount } from 'wagmi';
 import { WalletAuth } from './components/wallet-auth';
 import { GoogleAuth } from './components/google-auth';
 import { Chat } from './components/chat';
@@ -5,6 +6,7 @@ import { useAuthToken, setToken } from './lib/auth-token';
 
 export default function App() {
   const token = useAuthToken();
+  const { isConnected } = useAccount();
 
   return (
     <div className="flex h-screen flex-col">
@@ -12,11 +14,13 @@ export default function App() {
       <header className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-6 py-3">
         <h1 className="text-lg font-semibold text-zinc-100">Vicoop Bridge Admin</h1>
         {token ? (
-          // SIWE-issued tokens use the `vbc_caller_*` prefix; anything else
-          // (currently `vbc_owner_*` from Google) is a non-wallet session.
-          // The wallet-auth subtree only makes sense for wallet sessions —
-          // it owns the wagmi disconnect on sign-out.
-          token.startsWith('vbc_caller_') ? (
+          // Both SIWE and Google sign-in produce `vbc_owner_*` tokens
+          // (audience='owner_session'), so prefix doesn't tell us the
+          // provider. Use the live wagmi connection instead: if a wallet
+          // is connected, defer to WalletAuth's signed-in display (it
+          // owns the wagmi disconnect on sign-out); otherwise show a
+          // plain Sign out that just clears the auth token.
+          isConnected ? (
             <WalletAuth />
           ) : (
             <button

--- a/packages/admin-ui/src/App.tsx
+++ b/packages/admin-ui/src/App.tsx
@@ -1,30 +1,26 @@
-import { useAccount } from 'wagmi';
 import { WalletAuth } from './components/wallet-auth';
 import { GoogleAuth } from './components/google-auth';
 import { Chat } from './components/chat';
-import { useAuthToken, setToken } from './lib/auth-token';
+import { useAuthSession, setSession } from './lib/auth-token';
 
 export default function App() {
-  const token = useAuthToken();
-  const { isConnected } = useAccount();
+  const session = useAuthSession();
 
   return (
     <div className="flex h-screen flex-col">
       {/* Header */}
       <header className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-6 py-3">
         <h1 className="text-lg font-semibold text-zinc-100">Vicoop Bridge Admin</h1>
-        {token ? (
-          // Both SIWE and Google sign-in produce `vbc_owner_*` tokens
-          // (audience='owner_session'), so prefix doesn't tell us the
-          // provider. Use the live wagmi connection instead: if a wallet
-          // is connected, defer to WalletAuth's signed-in display (it
-          // owns the wagmi disconnect on sign-out); otherwise show a
-          // plain Sign out that just clears the auth token.
-          isConnected ? (
+        {session ? (
+          // Provider is recorded at sign-in time (auth-token.ts). For
+          // wallet sessions, defer to WalletAuth so its Sign out also
+          // disconnects wagmi; for Google sessions, just clear the
+          // session.
+          session.provider === 'wallet' ? (
             <WalletAuth />
           ) : (
             <button
-              onClick={() => setToken(null)}
+              onClick={() => setSession(null)}
               className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-100 px-3 py-1.5 rounded transition-colors"
             >
               Sign out
@@ -40,7 +36,7 @@ export default function App() {
       </header>
 
       {/* Chat area */}
-      {token ? (
+      {session ? (
         <Chat />
       ) : (
         <div className="flex flex-1 items-center justify-center">

--- a/packages/admin-ui/src/components/chat.tsx
+++ b/packages/admin-ui/src/components/chat.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { Send, MessageSquare } from 'lucide-react';
 import type { A2XClient } from '@a2x/sdk/client';
-import { useAuthToken } from '../lib/auth-token';
+import { useAuthSession } from '../lib/auth-token';
 import { createA2AClient, type Message as A2AMessage } from '../lib/a2a-client';
 import { Message } from './message';
 
@@ -21,7 +21,8 @@ const EXAMPLE_PROMPTS = [
 ];
 
 export function Chat() {
-  const token = useAuthToken();
+  const session = useAuthSession();
+  const token = session?.token ?? null;
   const [messages, setMessages] = useState<{ role: 'user' | 'agent'; text: string }[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/packages/admin-ui/src/components/google-auth.tsx
+++ b/packages/admin-ui/src/components/google-auth.tsx
@@ -7,7 +7,7 @@
 // non-eth principals as of the issue #79 option-B server change).
 
 import { useCallback, useRef, useState } from 'react';
-import { setToken } from '../lib/auth-token';
+import { setSession } from '../lib/auth-token';
 import { startDeviceFlow, type DeviceFlowSession } from '../lib/device-flow';
 
 interface State {
@@ -58,7 +58,7 @@ export function GoogleAuth() {
 
     try {
       const token = await session.result;
-      setToken(token);
+      setSession({ token, provider: 'google' });
       // Token is set; parent App will swap to Chat. Close the popup if the
       // user didn't already.
       if (popup && !popup.closed) popup.close();

--- a/packages/admin-ui/src/components/wallet-auth.tsx
+++ b/packages/admin-ui/src/components/wallet-auth.tsx
@@ -2,7 +2,7 @@ import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useAccount, useSignMessage, useDisconnect } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAuthToken, setToken } from '../lib/auth-token';
+import { useAuthSession, setSession } from '../lib/auth-token';
 import { exchangeSiweForCallerToken } from '../lib/siwe-exchange';
 
 export function WalletAuth() {
@@ -10,7 +10,7 @@ export function WalletAuth() {
   const { signMessageAsync } = useSignMessage();
   const { disconnect } = useDisconnect();
   const { openConnectModal } = useConnectModal();
-  const token = useAuthToken();
+  const session = useAuthSession();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const autoSignInAttempted = useRef(false);
@@ -41,7 +41,7 @@ export function WalletAuth() {
       const message = siweMessage.prepareMessage();
       const signature = await signMessageAsync({ message });
       const accessToken = await exchangeSiweForCallerToken(message, signature);
-      setToken(accessToken);
+      setSession({ token: accessToken, provider: 'wallet' });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (!msg.toLowerCase().includes('user rejected')) {
@@ -53,18 +53,28 @@ export function WalletAuth() {
   }, [address, chainId, signMessageAsync]);
 
   useEffect(() => {
-    if (isConnected && address && !token && !isAuthenticating && !autoSignInAttempted.current) {
+    // Auto-attempt SIWE on a fresh wallet connection only when there's
+    // no live session (or the live session belongs to another provider
+    // — we don't want to auto-overwrite a Google sign-in).
+    const hasWalletSession = session?.provider === 'wallet';
+    if (
+      isConnected &&
+      address &&
+      !hasWalletSession &&
+      !session &&
+      !isAuthenticating &&
+      !autoSignInAttempted.current
+    ) {
       autoSignInAttempted.current = true;
       signIn();
     }
-  }, [isConnected, address, token, isAuthenticating, signIn]);
+  }, [isConnected, address, session, isAuthenticating, signIn]);
 
   useEffect(() => {
     // Reset the auto-sign-in latch on disconnect so a future reconnect
-    // can attempt SIWE again. The token itself is left alone — both
-    // SIWE and Google now issue `vbc_owner_*`, so prefix can't tell us
-    // who owns the token, and forcing a sign-out on every wagmi
-    // disconnect would nuke a still-valid Google session.
+    // can attempt SIWE again. The session is left alone — clearing it
+    // here would also nuke an unrelated Google session, and the user
+    // can always Sign out explicitly.
     if (!isConnected) {
       autoSignInAttempted.current = false;
     }
@@ -86,13 +96,13 @@ export function WalletAuth() {
 
   return (
     <div className="flex items-center gap-3">
-      {token ? (
+      {session?.provider === 'wallet' ? (
         <>
           <span className="text-sm text-zinc-400 font-mono">
             {address?.slice(0, 6)}...{address?.slice(-4)}
           </span>
           <button
-            onClick={() => { setToken(null); disconnect(); }}
+            onClick={() => { setSession(null); disconnect(); }}
             className="text-sm text-zinc-500 hover:text-zinc-300 transition-colors"
           >
             Sign out

--- a/packages/admin-ui/src/components/wallet-auth.tsx
+++ b/packages/admin-ui/src/components/wallet-auth.tsx
@@ -1,4 +1,4 @@
-import { ConnectButton } from '@rainbow-me/rainbowkit';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { useAccount, useSignMessage, useDisconnect } from 'wagmi';
 import { SiweMessage } from 'siwe';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -9,6 +9,7 @@ export function WalletAuth() {
   const { address, isConnected, chainId } = useAccount();
   const { signMessageAsync } = useSignMessage();
   const { disconnect } = useDisconnect();
+  const { openConnectModal } = useConnectModal();
   const token = useAuthToken();
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,14 +62,22 @@ export function WalletAuth() {
   useEffect(() => {
     if (!isConnected) {
       autoSignInAttempted.current = false;
-      if (token) setToken(null);
+      // Only clear tokens this component owns (SIWE issues `vbc_caller_*`).
+      // Google sign-in produces `vbc_owner_*` tokens managed by GoogleAuth;
+      // those must survive a wallet disconnect (or never-connected state).
+      if (token && token.startsWith('vbc_caller_')) setToken(null);
     }
   }, [isConnected, token]);
 
   if (!isConnected) {
     return (
       <div className="flex items-center gap-3">
-        <ConnectButton />
+        <button
+          onClick={openConnectModal}
+          className="text-sm bg-zinc-800 hover:bg-zinc-700 text-zinc-100 px-3 py-1.5 rounded transition-colors"
+        >
+          Connect Wallet
+        </button>
         {error && <p className="text-sm text-red-400">{error}</p>}
       </div>
     );

--- a/packages/admin-ui/src/components/wallet-auth.tsx
+++ b/packages/admin-ui/src/components/wallet-auth.tsx
@@ -60,14 +60,15 @@ export function WalletAuth() {
   }, [isConnected, address, token, isAuthenticating, signIn]);
 
   useEffect(() => {
+    // Reset the auto-sign-in latch on disconnect so a future reconnect
+    // can attempt SIWE again. The token itself is left alone — both
+    // SIWE and Google now issue `vbc_owner_*`, so prefix can't tell us
+    // who owns the token, and forcing a sign-out on every wagmi
+    // disconnect would nuke a still-valid Google session.
     if (!isConnected) {
       autoSignInAttempted.current = false;
-      // Only clear tokens this component owns (SIWE issues `vbc_caller_*`).
-      // Google sign-in produces `vbc_owner_*` tokens managed by GoogleAuth;
-      // those must survive a wallet disconnect (or never-connected state).
-      if (token && token.startsWith('vbc_caller_')) setToken(null);
     }
-  }, [isConnected, token]);
+  }, [isConnected]);
 
   if (!isConnected) {
     return (

--- a/packages/admin-ui/src/lib/auth-token.ts
+++ b/packages/admin-ui/src/lib/auth-token.ts
@@ -1,11 +1,57 @@
 import { useSyncExternalStore } from 'react';
 
-const AUTH_TOKEN_KEY = 'vicoop-admin-auth-token';
+// SIWE and Google sign-in both produce `vbc_owner_*` tokens after the
+// audience split (#84), so the token prefix can't tell us who issued
+// the session. Persist the provider alongside the token so the header
+// can decide whether to defer to WalletAuth (which owns the wagmi
+// disconnect on sign-out) or just clear the token.
+export type AuthProvider = 'wallet' | 'google';
+
+export interface AuthSession {
+  token: string;
+  provider: AuthProvider;
+}
+
+const AUTH_KEY = 'vicoop-admin-auth-token';
 
 const listeners = new Set<() => void>();
 
-function getSnapshot(): string | null {
-  return localStorage.getItem(AUTH_TOKEN_KEY);
+// `useSyncExternalStore` requires `getSnapshot` to return a stable
+// reference when nothing changed (otherwise React detects state churn
+// and bails out with "infinite loop"). Cache the parsed object keyed
+// by the raw localStorage string so repeat reads return the same
+// object identity.
+let cachedRaw: string | null = null;
+let cachedSession: AuthSession | null = null;
+let cacheInitialized = false;
+
+function parse(raw: string | null): AuthSession | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as { token?: unknown }).token === 'string' &&
+      ((parsed as { provider?: unknown }).provider === 'wallet' ||
+        (parsed as { provider?: unknown }).provider === 'google')
+    ) {
+      return parsed as AuthSession;
+    }
+  } catch {
+    // Pre-provider blobs were a bare token string and won't parse as
+    // JSON. Drop them; user re-signs in.
+  }
+  return null;
+}
+
+function read(): AuthSession | null {
+  const raw = localStorage.getItem(AUTH_KEY);
+  if (cacheInitialized && raw === cachedRaw) return cachedSession;
+  cachedRaw = raw;
+  cachedSession = parse(raw);
+  cacheInitialized = true;
+  return cachedSession;
 }
 
 function subscribe(callback: () => void): () => void {
@@ -13,15 +59,15 @@ function subscribe(callback: () => void): () => void {
   return () => listeners.delete(callback);
 }
 
-export function setToken(token: string | null) {
-  if (token) {
-    localStorage.setItem(AUTH_TOKEN_KEY, token);
+export function setSession(session: AuthSession | null) {
+  if (session) {
+    localStorage.setItem(AUTH_KEY, JSON.stringify(session));
   } else {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
+    localStorage.removeItem(AUTH_KEY);
   }
   listeners.forEach((cb) => cb());
 }
 
-export function useAuthToken(): string | null {
-  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+export function useAuthSession(): AuthSession | null {
+  return useSyncExternalStore(subscribe, read, () => null);
 }

--- a/packages/admin-ui/src/lib/device-flow.ts
+++ b/packages/admin-ui/src/lib/device-flow.ts
@@ -1,9 +1,15 @@
-// Browser-side driver for the bridge's RFC-8628 device flow with
-// intent=owner_session. Issues a vbc_owner_* opaque token after the user
-// signs in to Google in a popup window — that token is what the admin UI
-// presents to /graphql and POST / for self-service. See
-// packages/server/src/auth/device-flow.ts for the wire surface and
-// issue #79 PR D for the audience split.
+// Browser-side driver for the bridge's onsite Google sign-in.
+//
+// The wire surface is still RFC-8628 device flow under the hood —
+// /oauth/device/code allocates a device_session row, /oauth/google/start
+// runs Google consent — but the browser receives the issued
+// `vbc_owner_*` token via `postMessage` from the popup once the callback
+// finishes, instead of polling /oauth/token. The server-side onsite
+// branch (packages/server/src/auth/device-ui.ts) issues the token inline
+// in the callback handler and posts it back to the opener.
+//
+// CLI device flow (no `onsite_origin` in state) keeps polling — that
+// path is unchanged.
 
 const OWNER_SESSION_PREFIX = 'vbc_owner_';
 
@@ -25,15 +31,16 @@ export interface DeviceFlowSession {
    * Rejects on expiry, server error, or `cancel()` invocation.
    */
   result: Promise<string>;
-  /** Aborts the in-flight poll loop. The result promise will reject. */
+  /** Aborts the pending flow. The result promise will reject. */
   cancel: () => void;
 }
 
-class CanceledError extends Error {
-  constructor() {
-    super('canceled');
-    this.name = 'CanceledError';
-  }
+interface PostMessagePayload {
+  type?: unknown;
+  access_token?: unknown;
+  token_type?: unknown;
+  expires_in?: unknown;
+  audience?: unknown;
 }
 
 async function postDeviceCode(): Promise<DeviceCodeResponse> {
@@ -46,106 +53,77 @@ async function postDeviceCode(): Promise<DeviceCodeResponse> {
   if (!res.ok) {
     throw new Error(`device/code HTTP ${res.status}`);
   }
-  const json = (await res.json()) as DeviceCodeResponse;
-  return json;
-}
-
-interface PollOk {
-  kind: 'ok';
-  token: string;
-}
-interface PollPending {
-  kind: 'pending';
-}
-interface PollSlowDown {
-  kind: 'slow_down';
-}
-interface PollFatal {
-  kind: 'fatal';
-  message: string;
-}
-
-async function pollOnce(deviceCode: string): Promise<PollOk | PollPending | PollSlowDown | PollFatal> {
-  const body = new URLSearchParams({
-    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-    device_code: deviceCode,
-  });
-  const res = await fetch('/oauth/token', {
-    method: 'POST',
-    headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-  });
-  if (res.ok) {
-    const payload = (await res.json()) as { access_token?: unknown; token_type?: unknown };
-    if (typeof payload.access_token !== 'string' || !payload.access_token.startsWith(OWNER_SESSION_PREFIX)) {
-      return { kind: 'fatal', message: 'malformed access_token (expected vbc_owner_* prefix)' };
-    }
-    return { kind: 'ok', token: payload.access_token };
-  }
-  let parsed: { error?: string; error_description?: string } | null = null;
-  try {
-    parsed = (await res.json()) as { error?: string; error_description?: string };
-  } catch {
-    // non-JSON
-  }
-  const code = parsed?.error;
-  if (code === 'authorization_pending') return { kind: 'pending' };
-  if (code === 'slow_down') return { kind: 'slow_down' };
-  return {
-    kind: 'fatal',
-    message: parsed?.error_description ?? parsed?.error ?? `HTTP ${res.status}`,
-  };
-}
-
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal.aborted) {
-      reject(new CanceledError());
-      return;
-    }
-    const t = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(t);
-      reject(new CanceledError());
-    };
-    signal.addEventListener('abort', onAbort, { once: true });
-  });
+  return (await res.json()) as DeviceCodeResponse;
 }
 
 /**
- * Start a device-flow session. The caller is responsible for opening
- * `verificationUriComplete` in a popup as part of a click handler so the
- * browser doesn't block it. The polling loop runs immediately and resolves
- * once the user finishes Google approval.
+ * Start an onsite Google sign-in session. The caller opens
+ * `verificationUriComplete` in a popup as part of a click handler.
+ * The popup runs Google consent on the bridge origin, then posts the
+ * issued token back here via `postMessage`.
  */
 export async function startDeviceFlow(): Promise<DeviceFlowSession> {
   const code = await postDeviceCode();
-  const ac = new AbortController();
-  const deadline = Date.now() + code.expires_in * 1000;
-  let intervalMs = Math.max(code.interval, 1) * 1000;
+  const expiresAt = Date.now() + code.expires_in * 1000;
 
-  const result = (async () => {
-    while (Date.now() < deadline) {
-      const r = await pollOnce(code.device_code);
-      if (r.kind === 'ok') return r.token;
-      if (r.kind === 'fatal') throw new Error(r.message);
-      if (r.kind === 'slow_down') intervalMs += 5000;
-      try {
-        await sleep(intervalMs, ac.signal);
-      } catch {
-        throw new Error('canceled');
-      }
+  // Skip the CLI-style /oauth/device confirmation page; popup goes
+  // straight to /oauth/google/start. Pass the admin UI's own origin so
+  // the callback knows where to postMessage the issued token. The
+  // popup still loads on the bridge origin (PUBLIC_URL), reused from
+  // verification_uri_complete.
+  const startUrl = new URL(code.verification_uri_complete);
+  const bridgeOrigin = startUrl.origin;
+  startUrl.pathname = '/oauth/google/start';
+  startUrl.search =
+    `?user_code=${encodeURIComponent(code.user_code)}` +
+    `&onsite_origin=${encodeURIComponent(window.location.origin)}`;
+  const directStart = startUrl.toString();
+
+  let resolve!: (token: string) => void;
+  let reject!: (err: Error) => void;
+  const result = new Promise<string>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  let settled = false;
+  let timer: number | undefined;
+
+  const onMessage = (event: MessageEvent) => {
+    if (event.origin !== bridgeOrigin) return;
+    const data = event.data as PostMessagePayload | null;
+    if (!data || typeof data !== 'object') return;
+    if (data.type !== 'vbc_session_token') return;
+    const token = data.access_token;
+    if (typeof token !== 'string' || !token.startsWith(OWNER_SESSION_PREFIX)) {
+      finish(() => reject(new Error('malformed access_token (expected vbc_owner_* prefix)')));
+      return;
     }
-    throw new Error('device session expired');
-  })();
+    finish(() => resolve(token));
+  };
+
+  const finish = (run: () => void) => {
+    if (settled) return;
+    settled = true;
+    if (timer !== undefined) window.clearTimeout(timer);
+    window.removeEventListener('message', onMessage);
+    run();
+  };
+
+  window.addEventListener('message', onMessage);
+
+  // Reject if the device session window passes without a token. The
+  // server-side TTL is what matters for security; this is just a UI
+  // safety net so the result promise doesn't dangle forever.
+  const remainingMs = Math.max(1, expiresAt - Date.now());
+  timer = window.setTimeout(() => {
+    finish(() => reject(new Error('sign-in window expired')));
+  }, remainingMs);
 
   return {
-    verificationUriComplete: code.verification_uri_complete,
+    verificationUriComplete: directStart,
     userCode: code.user_code,
     result,
-    cancel: () => ac.abort(),
+    cancel: () => finish(() => reject(new Error('canceled'))),
   };
 }

--- a/packages/server/src/auth/device-ui.test.ts
+++ b/packages/server/src/auth/device-ui.test.ts
@@ -58,7 +58,13 @@ describe('state build/parse round-trip', () => {
     const state = buildState(secret, deviceCode);
     assert.match(state, /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
     const decoded = verifyState(secret, state);
-    assert.equal(decoded, deviceCode);
+    assert.deepEqual(decoded, { deviceCode });
+  });
+
+  it('round-trips an onsite_origin payload', () => {
+    const state = buildState(secret, deviceCode, 'http://localhost:5174');
+    const decoded = verifyState(secret, state);
+    assert.deepEqual(decoded, { deviceCode, onsiteOrigin: 'http://localhost:5174' });
   });
 
   it('binds to the secret — wrong secret rejects', () => {

--- a/packages/server/src/auth/device-ui.ts
+++ b/packages/server/src/auth/device-ui.ts
@@ -10,6 +10,7 @@ import {
   exchangeCode,
   type GoogleConfig,
 } from './google-oauth.js';
+import { issueSessionToken } from './caller-token.js';
 import type { Sql } from '../db.js';
 
 export interface DeviceUiOptions {
@@ -77,15 +78,24 @@ function hmacOf(secret: string, deviceCode: string): Buffer {
   return createHmac('sha256', secret).update(deviceCode).digest();
 }
 
-// state = base64url(HMAC) + '.' + base64url(device_code)
-function buildState(secret: string, deviceCode: string): string {
-  const mac = hmacOf(secret, deviceCode);
-  return `${b64urlEncode(mac)}.${b64urlEncode(Buffer.from(deviceCode, 'utf8'))}`;
+// state = base64url(HMAC) + '.' + base64url(payload)
+// payload is `device_code` for CLI flow, or `device_code|onsite_origin` for
+// the onsite popup flow. The `|` separator is safe: device codes are URL-safe
+// base64 (no `|`) and onsite origins are URLs (no `|`).
+function buildState(secret: string, deviceCode: string, onsiteOrigin?: string): string {
+  const payload = onsiteOrigin ? `${deviceCode}|${onsiteOrigin}` : deviceCode;
+  const mac = hmacOf(secret, payload);
+  return `${b64urlEncode(mac)}.${b64urlEncode(Buffer.from(payload, 'utf8'))}`;
 }
 
-// Returns the decoded device_code on success, or null on any failure.
+interface VerifiedState {
+  deviceCode: string;
+  onsiteOrigin?: string;
+}
+
+// Returns the decoded payload on success, or null on any failure.
 // Uses timingSafeEqual with equal-length buffers.
-function verifyState(secret: string, state: string): string | null {
+function verifyState(secret: string, state: string): VerifiedState | null {
   if (typeof state !== 'string' || state.length === 0) return null;
   const dot = state.indexOf('.');
   if (dot < 0) return null;
@@ -94,20 +104,43 @@ function verifyState(secret: string, state: string): string | null {
   if (!macPart || !dcPart) return null;
 
   let presented: Buffer;
-  let deviceCodeBuf: Buffer;
+  let payloadBuf: Buffer;
   try {
     presented = b64urlDecode(macPart);
-    deviceCodeBuf = b64urlDecode(dcPart);
+    payloadBuf = b64urlDecode(dcPart);
   } catch {
     return null;
   }
-  const deviceCode = deviceCodeBuf.toString('utf8');
-  if (deviceCode.length === 0) return null;
+  const payload = payloadBuf.toString('utf8');
+  if (payload.length === 0) return null;
 
-  const expected = hmacOf(secret, deviceCode);
+  const expected = hmacOf(secret, payload);
   if (presented.length !== expected.length) return null;
   if (!timingSafeEqual(presented, expected)) return null;
-  return deviceCode;
+
+  const sep = payload.indexOf('|');
+  if (sep < 0) return { deviceCode: payload };
+  return {
+    deviceCode: payload.slice(0, sep),
+    onsiteOrigin: payload.slice(sep + 1),
+  };
+}
+
+// Validate an onsite_origin query value. We're going to use it as a
+// postMessage targetOrigin and embed it in HTML, so it must be a syntactically
+// valid http(s) origin with no path/query/fragment and no embedded quotes.
+function normalizeOnsiteOrigin(raw: string | undefined): string | null {
+  if (!raw) return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+  if (url.pathname !== '/' && url.pathname !== '') return null;
+  if (url.search || url.hash) return null;
+  return url.origin;
 }
 
 // Normalize "wdjb mjht" / "wdjb-mjht" / "WDJBMJHT" → "WDJB-MJHT"
@@ -255,7 +288,13 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
       );
     }
 
-    const state = buildState(opts.stateSecret, row.device_code);
+    // Onsite popup flow signals its opener origin so the callback can
+    // postMessage the issued token directly back instead of relying on
+    // the CLI-style /oauth/token poll loop. A bad/missing value silently
+    // falls back to the CLI flow (status='approved', polling continues).
+    const onsiteOrigin = normalizeOnsiteOrigin(c.req.query('onsite_origin'));
+
+    const state = buildState(opts.stateSecret, row.device_code, onsiteOrigin ?? undefined);
     const url = buildAuthorizeUrl(opts.google, state);
     return c.redirect(url, 302);
   });
@@ -272,8 +311,8 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
     }
 
     const state = c.req.query('state') ?? '';
-    const deviceCode = verifyState(opts.stateSecret, state);
-    if (!deviceCode) {
+    const verified = verifyState(opts.stateSecret, state);
+    if (!verified) {
       return c.html(
         page(
           'Invalid state',
@@ -282,6 +321,7 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
         400,
       );
     }
+    const { deviceCode, onsiteOrigin } = verified;
 
     const code = c.req.query('code');
     if (!code) {
@@ -294,8 +334,13 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
       );
     }
 
-    const rows = await opts.sql<{ status: string; expires_at: Date }[]>`
-      SELECT status, expires_at
+    const rows = await opts.sql<{
+      status: string;
+      expires_at: Date;
+      intent: string;
+      intent_params: ClientRegisterParams | null;
+    }[]>`
+      SELECT status, expires_at, intent, intent_params
       FROM device_sessions
       WHERE device_code = ${deviceCode}
       LIMIT 1
@@ -333,6 +378,84 @@ export function mountDeviceUi(app: Hono, opts: DeviceUiOptions): void {
     }
 
     const principalId = `google:${user.sub}`;
+
+    // Onsite popup flow: issue the session token inline and postMessage it
+    // back to the opener. Only supported for caller / owner_session intents
+    // — `client_register` uses CLI-style polling because it needs SQL
+    // function invocation that's already wired in /oauth/token.
+    const onsiteEligible =
+      onsiteOrigin !== undefined && (row.intent === 'caller' || row.intent === 'owner_session');
+
+    if (onsiteEligible) {
+      const audience = row.intent === 'owner_session' ? 'owner_session' : 'caller';
+      let issued;
+      try {
+        issued = await opts.sql.begin(async (tx) => {
+          const i = await issueSessionToken(tx as unknown as Sql, {
+            principalId,
+            provider: 'google',
+            audience,
+            email: user.email ?? undefined,
+          });
+          // Drop the device_session: the token has been delivered via
+          // postMessage, polling won't find it and shouldn't.
+          await tx`DELETE FROM device_sessions WHERE device_code = ${deviceCode}`;
+          return i;
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'unknown error';
+        return c.html(
+          page(
+            'Session issuance failed',
+            `<h1 class="error">Failed to issue session</h1><p>${escapeHtml(msg)}</p>`,
+          ),
+          500,
+        );
+      }
+
+      const expiresInSec = Math.max(
+        0,
+        Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
+      );
+
+      // Embed token + target origin via JSON.stringify in a JSON island
+      // (`<script type="application/json">`) and read it from the script
+      // body. This avoids the XSS pitfalls of interpolating user-derived
+      // strings into JS source — even though the values here are
+      // server-generated, the convention keeps the surface small.
+      const payload = JSON.stringify({
+        type: 'vbc_session_token',
+        access_token: issued.rawToken,
+        token_type: 'Bearer',
+        expires_in: expiresInSec,
+        audience,
+      }).replace(/</g, '\\u003c');
+      const targetOrigin = JSON.stringify(onsiteOrigin).replace(/</g, '\\u003c');
+
+      const body = `
+        <h1>Approved</h1>
+        <p>Approved as <strong>${escapeHtml(user.email)}</strong>. Returning to admin UI…</p>
+        <script id="vbc-payload" type="application/json">${payload}</script>
+        <script>
+          (function () {
+            var raw = document.getElementById('vbc-payload').textContent;
+            var msg = JSON.parse(raw);
+            try {
+              if (window.opener && !window.opener.closed) {
+                window.opener.postMessage(msg, ${targetOrigin});
+              }
+            } finally {
+              window.close();
+            }
+          })();
+        </script>
+      `;
+      return c.html(page('Approved', body));
+    }
+
+    // CLI / device-flow path (no onsite_origin in state, or
+    // intent=client_register) — keep the existing behavior so callers
+    // poll /oauth/token for the token.
     const updated = await opts.sql`
       UPDATE device_sessions
       SET status = 'approved',

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -4,6 +4,7 @@ import { Hono, type Context } from 'hono';
 import { serveStatic } from '@hono/node-server/serve-static';
 import { stream } from 'hono/streaming';
 import { html } from 'hono/html';
+import { cors } from 'hono/cors';
 import {
   A2XAgent,
   DefaultRequestHandler,
@@ -32,6 +33,22 @@ export interface ServerHttpOptions {
 
 export function createHttpApp(opts: ServerHttpOptions): Hono {
   const app = new Hono();
+
+  // The deployed admin UI lives at the same origin as the bridge (mounted
+  // under /admin), but during local dev it runs on Vite. Reflect the
+  // request Origin so cross-origin XHR from the dev UI works without
+  // baking a wildcard into the response. `credentials: true` is needed
+  // because A2XClient sends `Authorization: Bearer ...` headers.
+  app.use(
+    '*',
+    cors({
+      origin: (origin) => origin ?? '',
+      allowHeaders: ['Authorization', 'Content-Type'],
+      allowMethods: ['GET', 'POST', 'OPTIONS'],
+      credentials: true,
+      maxAge: 600,
+    }),
+  );
 
   // Built-in admin agent at root. The admin agent owns its own taskStore
   // (Postgres-backed) for context-aware history loading; client agents


### PR DESCRIPTION
## Summary

- The admin UI was running RFC-8628 device-flow polling for browser-side Google sign-in — wrong shape for an onsite popup. The popup landed on the CLI confirmation page (\`/oauth/device\`) showing a user_code the user never typed, and after Google consent the popup never closed and the token never reached the opener.
- Server: \`/oauth/google/start\` accepts an \`onsite_origin\` query param, signs it into the state HMAC alongside the device_code, and the callback issues the session token inline + \`postMessage\`s it to the opener and \`window.close()\`s. CLI device-flow callers (no \`onsite_origin\`) still take the existing approve-and-poll path.
- Admin UI: \`device-flow.ts\` swaps the poll loop for a \`message\` listener bound to the bridge origin; popup goes straight to \`/oauth/google/start\`, skipping the CLI-only confirmation page.
- Header layout: WalletAuth no longer renders for Google sessions (\`App.tsx\` branches on token prefix), Connect Wallet uses a custom button via \`useConnectModal\` so it matches the Sign in with Google style. WalletAuth's wallet-disconnect cleanup now only clears \`vbc_caller_*\` tokens — Google's \`vbc_owner_*\` survives a never-connected wallet (this was the actual reason login appeared to silently fail).
- CORS: bridge reflects the request origin with credentials so the admin UI dev server (Vite on a separate port) can hit the agent endpoint with the Authorization header. Same-origin in production is unchanged.

## Test plan

- [x] \`pnpm --filter @vicoop-bridge/server typecheck\` passes
- [x] \`pnpm --filter @vicoop-bridge/admin-ui typecheck\` passes
- [x] \`tsx --test packages/server/src/auth/device-ui.test.ts\` — 13/13 pass (incl. new \`onsite_origin\` round-trip)
- [x] Local end-to-end: Sign in with Google → popup goes straight to Google consent → \`postMessage\` delivers \`vbc_owner_*\` → admin chat returns LLM response (verified \`swen@planetariumhq.com\` listing clients)
- [ ] Verify CLI device flow (\`vicoop-client\` registration) still works — backend path is unchanged but worth a smoke test before merge
- [ ] Verify SIWE/wallet sign-in still works on a fresh session