### PR TITLE
feat(server): expose connected clients via Mentionable v0.1 WebFinger

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -261,6 +261,29 @@ $$;
 COMMENT ON FUNCTION assert_no_reserved_agent_ids(TEXT[]) IS
   'Raise if any element of allowed_agent_ids is reserved (e.g. "admin"). Mirrors RESERVED_AGENT_IDS in packages/server/src/reserved-agent-ids.ts.';
 
+-- Trigger that runs the assertion on every INSERT and UPDATE of clients.
+-- Catches paths the explicit PERFORM in register_client() /
+-- update_client_allowed_agents() can't reach: PostGraphile's auto-generated
+-- updateClientById / patchClient mutations (the `clients` table only carries
+-- `@omit create`, not `@omit update`), direct SQL from psql, and any future
+-- code that bypasses the wrapper functions. This is the load-bearing gate;
+-- the explicit PERFORM calls in the wrapper functions are kept for clearer
+-- error context but are no longer the only line of defense.
+CREATE OR REPLACE FUNCTION trg_clients_assert_no_reserved_agent_ids()
+RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM assert_no_reserved_agent_ids(NEW.allowed_agent_ids);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS clients_assert_no_reserved_agent_ids ON clients;
+CREATE TRIGGER clients_assert_no_reserved_agent_ids
+  BEFORE INSERT OR UPDATE OF allowed_agent_ids ON clients
+  FOR EACH ROW EXECUTE FUNCTION trg_clients_assert_no_reserved_agent_ids();
+
 -- Token-carrying return type for register / rotate.
 -- Wrapped in DO so the migration is idempotent.
 DO $$ BEGIN

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -234,6 +234,33 @@ COMMENT ON TABLE clients IS E'@omit create';
 -- ------------------------------------------------------------
 -- 3a. Client CRUD mutations (exposed by PostGraphile)
 -- ------------------------------------------------------------
+
+-- Agent ids the bridge reserves for itself. Mirrored in
+-- packages/server/src/reserved-agent-ids.ts — keep both lists in sync.
+-- The case-insensitive comparison matches the TS layer's behavior so a
+-- caller can't bypass by sending 'Admin' / 'ADMIN'.
+CREATE OR REPLACE FUNCTION assert_no_reserved_agent_ids(allowed_agent_ids TEXT[])
+RETURNS VOID
+  LANGUAGE plpgsql
+  IMMUTABLE
+AS $$
+DECLARE
+  v_reserved TEXT[] := ARRAY['admin'];
+  v_id TEXT;
+BEGIN
+  IF allowed_agent_ids IS NULL THEN RETURN; END IF;
+  FOREACH v_id IN ARRAY allowed_agent_ids LOOP
+    IF lower(v_id) = ANY(v_reserved) THEN
+      RAISE EXCEPTION 'agent id "%" is reserved by the bridge', v_id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END LOOP;
+END;
+$$;
+
+COMMENT ON FUNCTION assert_no_reserved_agent_ids(TEXT[]) IS
+  'Raise if any element of allowed_agent_ids is reserved (e.g. "admin"). Mirrors RESERVED_AGENT_IDS in packages/server/src/reserved-agent-ids.ts.';
+
 -- Token-carrying return type for register / rotate.
 -- Wrapped in DO so the migration is idempotent.
 DO $$ BEGIN
@@ -270,6 +297,8 @@ DECLARE
   v_owner      TEXT;
   v_row        client_with_token;
 BEGIN
+  PERFORM assert_no_reserved_agent_ids(register_client.allowed_agent_ids);
+
   v_raw_token  := encode(gen_random_bytes(32), 'hex');
   v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
 
@@ -391,6 +420,8 @@ AS $$
 DECLARE
   v_row clients;
 BEGIN
+  PERFORM assert_no_reserved_agent_ids(update_client_allowed_agents.allowed_agent_ids);
+
   UPDATE clients AS c
   SET allowed_agent_ids = COALESCE(update_client_allowed_agents.allowed_agent_ids, '{}')
   WHERE c.id = update_client_allowed_agents.client_id

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -22,6 +22,7 @@ import { randomBytes, randomInt } from 'node:crypto';
 import type { Hono, Context } from 'hono';
 import type { Sql } from '../db.js';
 import { issueSessionToken } from './caller-token.js';
+import { findReservedAgentId } from '../reserved-agent-ids.js';
 
 export type DeviceFlowIntent = 'caller' | 'owner_session' | 'client_register';
 
@@ -147,6 +148,10 @@ function parseClientRegisterParams(
     if (id.length > MAX_AGENT_ID_LEN) {
       return { ok: false, reason: `agent id exceeds ${MAX_AGENT_ID_LEN} chars` };
     }
+  }
+  const reserved = findReservedAgentId(ids);
+  if (reserved) {
+    return { ok: false, reason: `agent id "${reserved}" is reserved by the bridge` };
   }
 
   return { ok: true, params: { client_name: clientName, allowed_agent_ids: ids } };

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -138,7 +138,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     try {
       siweDomain = new URL(opts.publicUrl).hostname;
     } catch {
-      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
+      throw new Error(
+        `PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification or well-known Mentionable routes`,
+      );
     }
   }
 

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -143,12 +143,14 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   app.get('/.well-known/agent-card.json', (c) => c.json(adminCard));
 
   // Mentionable v0.1 surface (WebFinger + agent-card + Agent Directory)
-  // exposing every connected client as `@<agentId>@<bridge-host>`. The
-  // admin agent intentionally stays on the existing
-  // `/.well-known/agent-card.json` and is not part of this directory.
+  // exposing every connected client as `@<agentId>@<bridge-host>`, plus
+  // the bridge's own admin agent at `@admin@<bridge-host>`. The agentId
+  // "admin" is reserved (see reserved-agent-ids.ts) so a connected client
+  // cannot shadow the admin entry.
   const wellKnownDeps: WellKnownDeps = {
     listAgents: () => opts.registry.listAgents(),
     getAgentCard: (conn) => getAgentForConn(conn).getAgentCard() as AgentCardV03,
+    adminCard,
     publicUrl: opts.publicUrl,
     domain: siweDomain,
     deviceFlowEnabled,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -22,6 +22,7 @@ import type { Sql } from './db.js';
 import { Landing } from './landing.js';
 import { logEvent } from './log.js';
 import { buildAgentA2XAgent, type AgentA2XOptions } from './agent-card.js';
+import { buildLandingDirectory, mountWellKnown, type WellKnownDeps } from './well-known.js';
 
 export interface ServerHttpOptions {
   registry: Registry;
@@ -124,10 +125,36 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     return c.json(result as Record<string, unknown>);
   }
 
+  // Derive the public hostname once. Used both for SIWE domain verification
+  // and for the Mentionable / WebFinger surface, which keys lookups on the
+  // bridge's external hostname.
+  let siweDomain: string | undefined;
+  if (opts.publicUrl) {
+    try {
+      siweDomain = new URL(opts.publicUrl).hostname;
+    } catch {
+      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
+    }
+  }
+
   app.get('/healthz', (c) => c.json({ ok: true }));
 
   // Root agent card — the server itself is an A2A agent
   app.get('/.well-known/agent-card.json', (c) => c.json(adminCard));
+
+  // Mentionable v0.1 surface (WebFinger + agent-card + Agent Directory)
+  // exposing every connected client as `@<agentId>@<bridge-host>`. The
+  // admin agent intentionally stays on the existing
+  // `/.well-known/agent-card.json` and is not part of this directory.
+  const wellKnownDeps: WellKnownDeps = {
+    listAgents: () => opts.registry.listAgents(),
+    getAgentCard: (conn) => getAgentForConn(conn).getAgentCard() as AgentCardV03,
+    publicUrl: opts.publicUrl,
+    domain: siweDomain,
+    deviceFlowEnabled,
+    organizationName: adminCard.name,
+  };
+  mountWellKnown(app, wellKnownDeps);
 
   // Server info — HTML landing for browsers, JSON for API clients
   app.get('/', (c) => {
@@ -152,26 +179,18 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         clients,
       });
     }
+    const directory = buildLandingDirectory(wellKnownDeps);
     return c.html(
       html`<!DOCTYPE html>${(
         <Landing
           adminCard={adminCard}
           clients={clients}
           adminWallets={getAdminWallets()}
+          directory={directory}
         />
       )}`,
     );
   });
-
-  // Derive SIWE domain early so both admin and agent endpoints use it
-  let siweDomain: string | undefined;
-  if (opts.publicUrl) {
-    try {
-      siweDomain = new URL(opts.publicUrl).hostname;
-    } catch {
-      throw new Error(`PUBLIC_URL "${opts.publicUrl}" is not a valid URL — cannot configure SIWE domain verification`);
-    }
-  }
 
   // SIWE → opaque caller token exchange. Admin UI and any wallet-based client
   // signs a SIWE message once, then presents the returned vbc_caller_* token

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -22,7 +22,12 @@ import type { Sql } from './db.js';
 import { Landing } from './landing.js';
 import { logEvent } from './log.js';
 import { buildAgentA2XAgent, type AgentA2XOptions } from './agent-card.js';
-import { buildLandingDirectory, mountWellKnown, type WellKnownDeps } from './well-known.js';
+import {
+  buildLandingDirectory,
+  mountWellKnown,
+  type ConnectionPair,
+  type WellKnownDeps,
+} from './well-known.js';
 
 export interface ServerHttpOptions {
   registry: Registry;
@@ -160,12 +165,22 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   // Server info — HTML landing for browsers, JSON for API clients
   app.get('/', (c) => {
-    const clients = opts.registry.listAgents().map((a) => ({
-      id: a.agentId,
+    // Single registry walk per request: the HTML landing's `clients` array
+    // and the JSON-LD directory it embeds both derive from the same
+    // (connection, AgentCardV03) snapshot. Reusing one snapshot means the
+    // two views can never disagree mid-request — and getAgentCard, which
+    // reads from a per-agent cache that's invalidated on caller-policy /
+    // hello-frame changes, is called once per agent instead of twice.
+    const pairs: ConnectionPair[] = opts.registry.listAgents().map((conn) => ({
+      conn,
+      card: getAgentForConn(conn).getAgentCard() as AgentCardV03,
+    }));
+    const clients = pairs.map(({ conn, card }) => ({
+      id: conn.agentId,
       url: opts.publicUrl
-        ? `${opts.publicUrl}/agents/${a.agentId}`
-        : `/agents/${a.agentId}`,
-      card: getAgentForConn(a).getAgentCard() as AgentCardV03,
+        ? `${opts.publicUrl}/agents/${conn.agentId}`
+        : `/agents/${conn.agentId}`,
+      card,
     }));
 
     const accept = c.req.header('accept') ?? '';
@@ -181,7 +196,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         clients,
       });
     }
-    const directory = buildLandingDirectory(wellKnownDeps);
+    const directory = buildLandingDirectory(wellKnownDeps, pairs);
     return c.html(
       html`<!DOCTYPE html>${(
         <Landing

--- a/packages/server/src/landing.tsx
+++ b/packages/server/src/landing.tsx
@@ -1,11 +1,25 @@
 import type { FC } from 'hono/jsx';
 import { raw } from 'hono/html';
 import type { AgentCardV03 } from '@a2x/sdk';
+import type { AgentDirectoryOrganization } from './mentionable.js';
 
 interface LandingProps {
   adminCard: AgentCardV03;
   clients: Array<{ id: string; url: string; card: AgentCardV03 }>;
   adminWallets: string[];
+  // Layer-1 source of truth for the Mentionable Agent Directory: the same
+  // Schema.org Organization payload served by /.well-known/mentionable-agents.json
+  // is embedded here as JSON-LD so generic crawlers (search engines, AI
+  // browsers, scrapers) discover the connected agents without speaking
+  // any Mentionable-specific protocol.
+  directory?: AgentDirectoryOrganization;
+}
+
+// Per JSON-LD §1.4 the only character that can break a `<script>` block is
+// `</`. Escape the forward slash to neutralize an inline `</script>`
+// terminator without otherwise altering the bytes of the JSON.
+function escapeJsonLd(payload: unknown): string {
+  return JSON.stringify(payload).replace(/<\/(script)/gi, '<\\/$1');
 }
 
 const STYLES = `
@@ -37,13 +51,16 @@ const STYLES = `
   a { color: inherit; }
 `;
 
-export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets }) => (
+export const Landing: FC<LandingProps> = ({ adminCard, clients, adminWallets, directory }) => (
   <html lang="en">
     <head>
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <title>vicoop-bridge</title>
       <style>{raw(STYLES)}</style>
+      {directory ? (
+        <script type="application/ld+json">{raw(escapeJsonLd(directory))}</script>
+      ) : null}
     </head>
     <body>
       <h1>vicoop-bridge</h1>

--- a/packages/server/src/mentionable.test.ts
+++ b/packages/server/src/mentionable.test.ts
@@ -39,7 +39,16 @@ test('isValidMentionableLocal accepts safe LDH+dot+underscore', () => {
 });
 
 test('isValidMentionableLocal rejects unsafe chars and empty / overlong', () => {
-  for (const bad of ['', 'foo@bar', 'foo bar', 'foo/bar', 'foo\nbar', 'a'.repeat(65)]) {
+  for (const bad of [
+    '',
+    '.',
+    '..',
+    'foo@bar',
+    'foo bar',
+    'foo/bar',
+    'foo\nbar',
+    'a'.repeat(65),
+  ]) {
     assert.equal(isValidMentionableLocal(bad), false, JSON.stringify(bad));
   }
 });

--- a/packages/server/src/mentionable.test.ts
+++ b/packages/server/src/mentionable.test.ts
@@ -1,0 +1,197 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { AgentCardV03 } from '@a2x/sdk';
+import {
+  MENTIONABLE_PROTOCOL_VERSION,
+  buildAgentDirectory,
+  buildMentionableCard,
+  isValidMentionableLocal,
+  parseAcct,
+  toMode,
+} from './mentionable.js';
+
+function baseCard(overrides: Partial<AgentCardV03> = {}): AgentCardV03 {
+  return {
+    name: 'Test Agent',
+    description: 'an agent for tests',
+    version: '1.2.3',
+    protocolVersion: '0.3',
+    url: 'https://bridge.example.com/agents/foo',
+    capabilities: { streaming: true, pushNotifications: false },
+    defaultInputModes: ['text/plain', 'text/markdown'],
+    defaultOutputModes: ['text/plain'],
+    skills: [
+      {
+        id: 'do-thing',
+        name: 'Do the thing',
+        description: 'does it',
+        tags: ['demo'],
+      },
+    ],
+    ...overrides,
+  } as AgentCardV03;
+}
+
+test('isValidMentionableLocal accepts safe LDH+dot+underscore', () => {
+  for (const ok of ['foo', 'foo.bar', 'foo-bar', 'foo_bar', 'A1', 'agent-7']) {
+    assert.equal(isValidMentionableLocal(ok), true, ok);
+  }
+});
+
+test('isValidMentionableLocal rejects unsafe chars and empty / overlong', () => {
+  for (const bad of ['', 'foo@bar', 'foo bar', 'foo/bar', 'foo\nbar', 'a'.repeat(65)]) {
+    assert.equal(isValidMentionableLocal(bad), false, JSON.stringify(bad));
+  }
+});
+
+test('parseAcct extracts local + domain, scheme is case-insensitive', () => {
+  assert.deepEqual(parseAcct('acct:foo@bar.test'), { local: 'foo', domain: 'bar.test' });
+  assert.deepEqual(parseAcct('ACCT:foo@bar.test'), { local: 'foo', domain: 'bar.test' });
+  assert.equal(parseAcct('foo@bar.test'), null);
+  assert.equal(parseAcct('acct:no-at-symbol'), null);
+});
+
+test('toMode maps the common A2A strings to Mentionable Mode objects', () => {
+  assert.deepEqual(toMode('text/plain'), { kind: 'text', mime: 'text/plain' });
+  assert.deepEqual(toMode('text'), { kind: 'text', mime: 'text/plain' });
+  assert.deepEqual(toMode('text/markdown'), { kind: 'text', mime: 'text/markdown' });
+  assert.deepEqual(toMode('text/html'), { kind: 'text', mime: 'text/html' });
+  assert.deepEqual(toMode('link'), { kind: 'link' });
+  assert.deepEqual(toMode('image/png'), { kind: 'file', mime: 'image/png' });
+});
+
+test('buildMentionableCard renders @<local>@<domain> address and v0.1 shape', () => {
+  const card = buildMentionableCard(baseCard(), {
+    local: 'foo',
+    domain: 'bridge.example.com',
+    baseUrl: 'https://bridge.example.com',
+    publicUrl: 'https://bridge.example.com',
+    deviceFlowEnabled: false,
+  });
+  assert.equal(card.address, '@foo@bridge.example.com');
+  assert.equal(card.protocol_version, MENTIONABLE_PROTOCOL_VERSION);
+  assert.equal(card.name, 'Test Agent');
+  assert.equal(card.version, '1.2.3');
+  assert.equal(card.a2a.endpoint, 'https://bridge.example.com/agents/foo');
+  // streaming:true → SSE transport
+  assert.equal(card.a2a.transport, 'https+sse');
+  assert.equal(card.a2a.capabilities.streaming, true);
+  assert.equal(card.a2a.capabilities.push_notifications, false);
+  assert.deepEqual(card.a2a.input_modes, [
+    { kind: 'text', mime: 'text/plain' },
+    { kind: 'text', mime: 'text/markdown' },
+  ]);
+  assert.deepEqual(card.a2a.output_modes, [{ kind: 'text', mime: 'text/plain' }]);
+  assert.equal(card.a2a.skills.length, 1);
+  assert.equal(card.a2a.skills[0]!.id, 'do-thing');
+  assert.deepEqual(card.mentionable.supported_inbound, ['a2a']);
+  assert.equal(card.mentionable.homepage, 'https://bridge.example.com');
+});
+
+test('buildMentionableCard picks https+jsonrpc transport when streaming is off', () => {
+  const card = buildMentionableCard(
+    baseCard({ capabilities: { streaming: false, pushNotifications: false } }),
+    {
+      local: 'foo',
+      domain: 'bridge.example.com',
+      baseUrl: 'https://bridge.example.com',
+      publicUrl: 'https://bridge.example.com',
+      deviceFlowEnabled: false,
+    },
+  );
+  assert.equal(card.a2a.transport, 'https+jsonrpc');
+  assert.equal(card.a2a.capabilities.streaming, false);
+});
+
+test('buildMentionableCard surfaces device-flow oauth2 auth when configured', () => {
+  // Mirrors the AgentCardV03 the bridge generates for a callable agent when
+  // Google device-flow is mounted: an oauth2 scheme with a `deviceCode` flow.
+  const card = buildMentionableCard(
+    baseCard({
+      securitySchemes: {
+        bridge: {
+          type: 'oauth2',
+          flows: {
+            deviceCode: {
+              deviceAuthorizationUrl: 'https://bridge.example.com/oauth/device/code',
+              tokenUrl: 'https://bridge.example.com/oauth/token',
+              scopes: {},
+            },
+          },
+        },
+      } as unknown as AgentCardV03['securitySchemes'],
+    }),
+    {
+      local: 'foo',
+      domain: 'bridge.example.com',
+      baseUrl: 'https://bridge.example.com',
+      publicUrl: 'https://bridge.example.com',
+      deviceFlowEnabled: true,
+    },
+  );
+  assert.deepEqual(card.a2a.auth, {
+    scheme: 'oauth2',
+    issuer: 'https://bridge.example.com',
+    authorization_endpoint: 'https://bridge.example.com/oauth/device/code',
+    token_endpoint: 'https://bridge.example.com/oauth/token',
+    scopes: [],
+  });
+});
+
+test('buildMentionableCard falls back to scheme:none when device flow is not enabled', () => {
+  const card = buildMentionableCard(
+    baseCard({
+      // Even if the wire card carries an oauth2 scheme, deviceFlowEnabled=false
+      // means this deployment does not actually mount the token endpoints —
+      // advertising oauth2 would point clients at non-existent URLs.
+      securitySchemes: {
+        bridge: {
+          type: 'oauth2',
+          flows: {
+            deviceCode: {
+              deviceAuthorizationUrl: 'https://bridge.example.com/oauth/device/code',
+              tokenUrl: 'https://bridge.example.com/oauth/token',
+              scopes: {},
+            },
+          },
+        },
+      } as unknown as AgentCardV03['securitySchemes'],
+    }),
+    {
+      local: 'foo',
+      domain: 'bridge.example.com',
+      baseUrl: 'https://bridge.example.com',
+      publicUrl: 'https://bridge.example.com',
+      deviceFlowEnabled: false,
+    },
+  );
+  assert.deepEqual(card.a2a.auth, { scheme: 'none' });
+});
+
+test('buildAgentDirectory emits Schema.org Organization with one ContactPoint per entry', () => {
+  const dir = buildAgentDirectory({
+    baseUrl: 'https://bridge.example.com',
+    domain: 'bridge.example.com',
+    organizationName: 'Vicoop Bridge',
+    entries: [
+      { local: 'foo', name: 'Foo Agent', description: 'foo desc' },
+      { local: 'bar', name: 'Bar Agent' },
+    ],
+  });
+  assert.equal(dir['@context'], 'https://schema.org');
+  assert.equal(dir['@type'], 'Organization');
+  assert.equal(dir.name, 'Vicoop Bridge');
+  assert.equal(dir.contactPoint.length, 2);
+  const [foo, bar] = dir.contactPoint;
+  assert.equal(foo!.email, 'foo@bridge.example.com');
+  assert.equal(foo!.url, 'https://bridge.example.com/.well-known/agent-card/foo');
+  assert.equal(foo!.description, 'foo desc');
+  assert.deepEqual(foo!['https://mentionable.dev/ns/v1#protocols'], ['a2a']);
+  assert.equal(
+    foo!['https://mentionable.dev/ns/v1#webfinger'],
+    'https://bridge.example.com/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+  );
+  // Optional `description` is omitted when not provided rather than serialized
+  // as `description: undefined`.
+  assert.equal('description' in bar!, false);
+});

--- a/packages/server/src/mentionable.ts
+++ b/packages/server/src/mentionable.ts
@@ -1,0 +1,217 @@
+import type { AgentCardV03 } from '@a2x/sdk';
+
+export const MENTIONABLE_PROTOCOL_VERSION = '0.1' as const;
+export const MENTIONABLE_AGENT_CARD_REL = 'https://mentionable.dev/agent-card';
+
+// RFC 5321 §4.1.2 allows a wider local-part charset, but agentIds at this
+// layer are unconstrained client-supplied strings (see registry.ts). Restrict
+// the Mentionable surface to a safe subset — letter, digit, dot, hyphen,
+// underscore — so a client cannot smuggle path/CRLF/`@` characters into the
+// `acct:` URI we render. Length cap mirrors typical local-part limits.
+const LOCAL_RE = /^[A-Za-z0-9._-]{1,64}$/;
+
+export function isValidMentionableLocal(local: string): boolean {
+  return LOCAL_RE.test(local);
+}
+
+// Mentionable v0.1 §1 also defines an 'artifact' mode (mime + optional
+// artifact_type). A2A `defaultInputModes`/`defaultOutputModes` are bare
+// strings with no `artifact` form, so this mapper never produces it.
+export type Mode =
+  | { kind: 'text'; mime: 'text/plain' | 'text/markdown' | 'text/html' }
+  | { kind: 'link' }
+  | { kind: 'file'; mime: string };
+
+export function toMode(m: string): Mode {
+  if (m === 'text' || m === 'text/plain') return { kind: 'text', mime: 'text/plain' };
+  if (m === 'text/markdown') return { kind: 'text', mime: 'text/markdown' };
+  if (m === 'text/html') return { kind: 'text', mime: 'text/html' };
+  if (m === 'link') return { kind: 'link' };
+  return { kind: 'file', mime: m };
+}
+
+export type MentionableAuth =
+  | { scheme: 'none' }
+  | {
+      scheme: 'oauth2';
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      scopes: string[];
+    };
+
+export interface MentionableCard {
+  address: string;
+  name: string;
+  description?: string;
+  version: string;
+  protocol_version: typeof MENTIONABLE_PROTOCOL_VERSION;
+  a2a: {
+    endpoint: string;
+    transport: 'https+sse' | 'https+jsonrpc';
+    capabilities: {
+      streaming: boolean;
+      push_notifications: boolean;
+      extensions: unknown[];
+    };
+    skills: Array<{
+      id: string;
+      name: string;
+      description?: string;
+      examples?: string[];
+      input_modes?: Mode[];
+      output_modes?: Mode[];
+    }>;
+    input_modes: Mode[];
+    output_modes: Mode[];
+    auth: MentionableAuth;
+  };
+  mentionable: {
+    supported_inbound: ['a2a'];
+    homepage?: string;
+  };
+}
+
+export interface MentionableCardOptions {
+  local: string;
+  domain: string;
+  baseUrl?: string;
+  deviceFlowEnabled: boolean;
+  publicUrl?: string;
+}
+
+// Pull the device-code flow off whatever security scheme the underlying card
+// declared. The SDK's OAuthFlows shape doesn't include `deviceCode` (RFC 8628
+// is an A2A-spec extension), so we read it through an `unknown` cast.
+function findDeviceFlow(
+  card: AgentCardV03,
+): { deviceAuthorizationUrl: string; tokenUrl: string; scopes?: Record<string, string> } | undefined {
+  const schemes = card.securitySchemes ?? {};
+  for (const scheme of Object.values(schemes)) {
+    if (!scheme || (scheme as { type?: string }).type !== 'oauth2') continue;
+    const flows = (scheme as { flows?: Record<string, unknown> }).flows ?? {};
+    const dc = flows.deviceCode as
+      | { deviceAuthorizationUrl?: string; tokenUrl?: string; scopes?: Record<string, string> }
+      | undefined;
+    if (dc?.deviceAuthorizationUrl && dc?.tokenUrl) {
+      return {
+        deviceAuthorizationUrl: dc.deviceAuthorizationUrl,
+        tokenUrl: dc.tokenUrl,
+        scopes: dc.scopes,
+      };
+    }
+  }
+  return undefined;
+}
+
+export function buildMentionableCard(
+  card: AgentCardV03,
+  opts: MentionableCardOptions,
+): MentionableCard {
+  const streaming = card.capabilities?.streaming ?? false;
+  const deviceFlow = opts.deviceFlowEnabled ? findDeviceFlow(card) : undefined;
+  const auth: MentionableAuth = deviceFlow
+    ? {
+        scheme: 'oauth2',
+        issuer: opts.publicUrl ?? `https://${opts.domain}`,
+        authorization_endpoint: deviceFlow.deviceAuthorizationUrl,
+        token_endpoint: deviceFlow.tokenUrl,
+        scopes: Object.keys(deviceFlow.scopes ?? {}),
+      }
+    : { scheme: 'none' };
+
+  return {
+    address: `@${opts.local}@${opts.domain}`,
+    name: card.name,
+    description: card.description,
+    version: card.version,
+    protocol_version: MENTIONABLE_PROTOCOL_VERSION,
+    a2a: {
+      endpoint: card.url,
+      transport: streaming ? 'https+sse' : 'https+jsonrpc',
+      capabilities: {
+        streaming,
+        push_notifications: card.capabilities?.pushNotifications ?? false,
+        extensions: card.capabilities?.extensions ?? [],
+      },
+      skills: (card.skills ?? []).map((s) => ({
+        id: s.id,
+        name: s.name,
+        description: s.description ?? undefined,
+        examples: s.examples ?? undefined,
+        input_modes: s.inputModes ? s.inputModes.map(toMode) : undefined,
+        output_modes: s.outputModes ? s.outputModes.map(toMode) : undefined,
+      })),
+      input_modes: (card.defaultInputModes ?? ['text/plain']).map(toMode),
+      output_modes: (card.defaultOutputModes ?? ['text/plain']).map(toMode),
+      auth,
+    },
+    mentionable: {
+      supported_inbound: ['a2a'],
+      homepage: opts.baseUrl,
+    },
+  };
+}
+
+// Schema.org `Organization` payload as defined in mentionable's
+// agent-directory.md. Each ContactPoint is one publicly addressable agent.
+export interface OrganizationContactPoint {
+  '@type': 'ContactPoint';
+  contactType: 'AI assistant';
+  name: string;
+  email: string;
+  url: string;
+  description?: string;
+  'https://mentionable.dev/ns/v1#protocols'?: string[];
+  'https://mentionable.dev/ns/v1#webfinger'?: string;
+}
+
+export interface AgentDirectoryOrganization {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  url: string;
+  name: string;
+  contactPoint: OrganizationContactPoint[];
+}
+
+export interface DirectoryEntry {
+  local: string;
+  name: string;
+  description?: string;
+}
+
+export function buildAgentDirectory(opts: {
+  baseUrl: string;
+  domain: string;
+  organizationName: string;
+  entries: DirectoryEntry[];
+}): AgentDirectoryOrganization {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    url: `${opts.baseUrl}/`,
+    name: opts.organizationName,
+    contactPoint: opts.entries.map((e) => ({
+      '@type': 'ContactPoint',
+      contactType: 'AI assistant',
+      name: e.name,
+      email: `${e.local}@${opts.domain}`,
+      url: `${opts.baseUrl}/.well-known/agent-card/${e.local}`,
+      ...(e.description !== undefined ? { description: e.description } : {}),
+      'https://mentionable.dev/ns/v1#protocols': ['a2a'],
+      'https://mentionable.dev/ns/v1#webfinger': `${opts.baseUrl}/.well-known/webfinger?resource=acct:${e.local}@${opts.domain}`,
+    })),
+  };
+}
+
+export interface ParsedAcct {
+  local: string;
+  domain: string;
+}
+
+export function parseAcct(resource: string): ParsedAcct | null {
+  // RFC 7565 acct: URI; scheme is case-insensitive (RFC 3986 §3.1).
+  const match = /^acct:([^@]+)@(.+)$/i.exec(resource);
+  if (!match) return null;
+  return { local: match[1]!, domain: match[2]! };
+}

--- a/packages/server/src/mentionable.ts
+++ b/packages/server/src/mentionable.ts
@@ -3,6 +3,11 @@ import type { AgentCardV03 } from '@a2x/sdk';
 export const MENTIONABLE_PROTOCOL_VERSION = '0.1' as const;
 export const MENTIONABLE_AGENT_CARD_REL = 'https://mentionable.dev/agent-card';
 
+// Local-part for the bridge's built-in admin agent. Reserved at every
+// agentId intake point (see reserved-agent-ids.ts) so a connected client
+// cannot shadow it.
+export const MENTIONABLE_ADMIN_LOCAL = 'admin';
+
 // RFC 5321 §4.1.2 allows a wider local-part charset, but agentIds at this
 // layer are unconstrained client-supplied strings (see registry.ts). Restrict
 // the Mentionable surface to a safe subset — letter, digit, dot, hyphen,

--- a/packages/server/src/mentionable.ts
+++ b/packages/server/src/mentionable.ts
@@ -16,6 +16,7 @@ export const MENTIONABLE_ADMIN_LOCAL = 'admin';
 const LOCAL_RE = /^[A-Za-z0-9._-]{1,64}$/;
 
 export function isValidMentionableLocal(local: string): boolean {
+  if (local === '.' || local === '..') return false;
   return LOCAL_RE.test(local);
 }
 

--- a/packages/server/src/reserved-agent-ids.test.ts
+++ b/packages/server/src/reserved-agent-ids.test.ts
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  RESERVED_AGENT_IDS,
+  findReservedAgentId,
+  isReservedAgentId,
+} from './reserved-agent-ids.js';
+
+test('admin is reserved', () => {
+  assert.equal(isReservedAgentId('admin'), true);
+});
+
+test('reservation is case-insensitive', () => {
+  // Don't let a caller bypass by sending Admin / ADMIN / aDmIn.
+  for (const variant of ['Admin', 'ADMIN', 'aDmIn']) {
+    assert.equal(isReservedAgentId(variant), true, variant);
+  }
+});
+
+test('typical client agentIds are not reserved', () => {
+  for (const id of ['echo-agent', 'foo', 'bar.baz', 'agent_7', 'admin-tools']) {
+    assert.equal(isReservedAgentId(id), false, id);
+  }
+});
+
+test('findReservedAgentId returns the first reserved entry, in input case', () => {
+  // Returning the offending value (not just a boolean) lets callers surface
+  // it in error_description without having to re-walk the array.
+  assert.equal(findReservedAgentId(['foo', 'Admin', 'bar']), 'Admin');
+  assert.equal(findReservedAgentId(['foo', 'bar']), undefined);
+});
+
+test('RESERVED_AGENT_IDS is non-empty (the SQL mirror would silently no-op otherwise)', () => {
+  assert.ok(RESERVED_AGENT_IDS.size > 0);
+  assert.ok(RESERVED_AGENT_IDS.has('admin'));
+});

--- a/packages/server/src/reserved-agent-ids.test.ts
+++ b/packages/server/src/reserved-agent-ids.test.ts
@@ -31,6 +31,6 @@ test('findReservedAgentId returns the first reserved entry, in input case', () =
 });
 
 test('RESERVED_AGENT_IDS is non-empty (the SQL mirror would silently no-op otherwise)', () => {
-  assert.ok(RESERVED_AGENT_IDS.size > 0);
-  assert.ok(RESERVED_AGENT_IDS.has('admin'));
+  assert.ok(RESERVED_AGENT_IDS.length > 0);
+  assert.ok(RESERVED_AGENT_IDS.includes('admin'));
 });

--- a/packages/server/src/reserved-agent-ids.ts
+++ b/packages/server/src/reserved-agent-ids.ts
@@ -1,0 +1,24 @@
+// Agent ids the bridge reserves for itself. A client cannot register one,
+// list one in `clients.allowed_agent_ids`, nor send a hello frame with one
+// — all three intake points enforce this set.
+//
+// `admin` is reserved because the bridge surfaces its built-in admin agent
+// at `@admin@<host>` via Mentionable WebFinger; letting a client register
+// the same local-part would silently shadow it.
+//
+// Mirrored in schema.sql `assert_no_reserved_agent_ids()`. Keep both lists
+// in sync — a divergence between the SQL gate and the TS gate creates a
+// bypass: the SQL function signature is stable, so when adding a new
+// reserved id, edit both files in the same commit.
+export const RESERVED_AGENT_IDS: ReadonlySet<string> = new Set(['admin']);
+
+export function isReservedAgentId(id: string): boolean {
+  return RESERVED_AGENT_IDS.has(id.toLowerCase());
+}
+
+export function findReservedAgentId(ids: readonly string[]): string | undefined {
+  for (const id of ids) {
+    if (isReservedAgentId(id)) return id;
+  }
+  return undefined;
+}

--- a/packages/server/src/reserved-agent-ids.ts
+++ b/packages/server/src/reserved-agent-ids.ts
@@ -10,10 +10,12 @@
 // in sync — a divergence between the SQL gate and the TS gate creates a
 // bypass: the SQL function signature is stable, so when adding a new
 // reserved id, edit both files in the same commit.
-export const RESERVED_AGENT_IDS: ReadonlySet<string> = new Set(['admin']);
+export const RESERVED_AGENT_IDS = ['admin'] as const;
+
+const RESERVED_AGENT_ID_SET = new Set<string>(RESERVED_AGENT_IDS);
 
 export function isReservedAgentId(id: string): boolean {
-  return RESERVED_AGENT_IDS.has(id.toLowerCase());
+  return RESERVED_AGENT_ID_SET.has(id.toLowerCase());
 }
 
 export function findReservedAgentId(ids: readonly string[]): string | undefined {

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -205,6 +205,29 @@ test('agent-card: 404 when two registry entries differ only in case (ambiguous)'
   assert.equal(res.status, 404);
 });
 
+test('webfinger: avoids card synthesis when local lookup is ambiguous', async () => {
+  const calls: string[] = [];
+  const app = new Hono();
+  mountWellKnown(app, {
+    listAgents: () => [fakeConn('Foo'), fakeConn('foo')],
+    getAgentCard: (conn) => {
+      calls.push(conn.agentId);
+      return fakeCardV03(conn.agentId);
+    },
+    adminCard: fakeAdminCard(),
+    publicUrl: 'https://bridge.example.com',
+    domain: 'bridge.example.com',
+    deviceFlowEnabled: false,
+    organizationName: 'Vicoop Bridge',
+  });
+
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+  assert.deepEqual(calls, []);
+});
+
 test('mentionable-agents.json: drops case-insensitive collisions to match resolveLocal', async () => {
   // listDirectoryEntries must mirror resolveLocal's ambiguous-→-404 rule;
   // otherwise the directory advertises addresses that immediately fail to

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -64,6 +64,10 @@ function makeApp(opts: {
   // When omitted, defaults to a typical deploy with publicUrl / domain set.
   // Pass `noPublicUrl: true` to simulate a bridge with no PUBLIC_URL config.
   noPublicUrl?: boolean;
+  // Override the publicUrl/domain pair to test ineligible deployments
+  // (http://, single-label hostnames). Both must be set together.
+  publicUrl?: string;
+  domain?: string;
   deviceFlowEnabled?: boolean;
 }) {
   const app = new Hono();
@@ -71,8 +75,12 @@ function makeApp(opts: {
     listAgents: () => opts.agents,
     getAgentCard: (conn) => fakeCardV03(conn.agentId),
     adminCard: fakeAdminCard(),
-    publicUrl: opts.noPublicUrl ? undefined : 'https://bridge.example.com',
-    domain: opts.noPublicUrl ? undefined : 'bridge.example.com',
+    publicUrl: opts.noPublicUrl
+      ? undefined
+      : (opts.publicUrl ?? 'https://bridge.example.com'),
+    domain: opts.noPublicUrl
+      ? undefined
+      : (opts.domain ?? 'bridge.example.com'),
     deviceFlowEnabled: opts.deviceFlowEnabled ?? false,
     organizationName: 'Vicoop Bridge',
   };
@@ -318,4 +326,60 @@ test('mentionable-agents.json: 404 when bridge has no PUBLIC_URL configured', as
   const app = makeApp({ agents: [fakeConn('foo')], noPublicUrl: true });
   const res = await app.request('/.well-known/mentionable-agents.json');
   assert.equal(res.status, 404);
+});
+
+test('all routes 404 when PUBLIC_URL is http:// (Mentionable §2 requires HTTPS)', async () => {
+  // A bridge deployed at http://bridge.example.com would publish self-
+  // referential http:// URLs in the JRD/agent-card/directory, which no
+  // conformant resolver will accept. Refuse to serve at all rather than
+  // ship spec-non-conformant payloads.
+  const app = makeApp({
+    agents: [fakeConn('foo')],
+    publicUrl: 'http://bridge.example.com',
+    domain: 'bridge.example.com',
+  });
+  for (const path of [
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+    '/.well-known/agent-card/foo',
+    '/.well-known/mentionable-agents.json',
+  ]) {
+    const res = await app.request(path);
+    assert.equal(res.status, 404, path);
+  }
+});
+
+test('all routes 404 when domain is single-label (Mentionable §1 rejects bare localhost)', async () => {
+  // The spec validation ladder makes a bare `localhost` unverifiable in
+  // the subject step, so a deployment at https://localhost:8787 cannot
+  // serve a conformant Mentionable surface. Local dev should use a
+  // reserved-TLD subdomain (https://agent.localhost / https://agent.test)
+  // — those have a dot and pass.
+  const app = makeApp({
+    agents: [fakeConn('foo')],
+    publicUrl: 'https://localhost:8787',
+    domain: 'localhost',
+  });
+  for (const path of [
+    '/.well-known/webfinger?resource=acct:foo@localhost',
+    '/.well-known/agent-card/foo',
+    '/.well-known/mentionable-agents.json',
+  ]) {
+    const res = await app.request(path);
+    assert.equal(res.status, 404, path);
+  }
+});
+
+test('all routes serve when PUBLIC_URL is https with a multi-label hostname', async () => {
+  // Sanity check the positive path: agent.localhost (RFC 6761 reserved
+  // TLD subdomain) is the canonical local-dev form per Mentionable §1
+  // and passes the multi-label check.
+  const app = makeApp({
+    agents: [fakeConn('foo')],
+    publicUrl: 'https://agent.localhost',
+    domain: 'agent.localhost',
+  });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@agent.localhost',
+  );
+  assert.equal(res.status, 200);
 });

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -193,6 +193,17 @@ test('agent-card: 404 when two registry entries differ only in case (ambiguous)'
   assert.equal(res.status, 404);
 });
 
+test('mentionable-agents.json: drops case-insensitive collisions to match resolveLocal', async () => {
+  // listDirectoryEntries must mirror resolveLocal's ambiguous-→-404 rule;
+  // otherwise the directory advertises addresses that immediately fail to
+  // resolve. The unambiguous `bar` survives; admin is always present.
+  const app = makeApp({ agents: [fakeConn('Foo'), fakeConn('foo'), fakeConn('bar')] });
+  const res = await app.request('/.well-known/mentionable-agents.json');
+  const body = (await res.json()) as { contactPoint: Array<{ email: string }> };
+  const emails = body.contactPoint.map((p) => p.email);
+  assert.deepEqual(emails, ['admin@bridge.example.com', 'bar@bridge.example.com']);
+});
+
 test('webfinger: 404 when local-part contains unsafe chars (path separator)', async () => {
   // Defends against an attacker crafting an agentId that smuggles `..` /
   // `@` / CRLF into the JRD subject. isValidMentionableLocal rejects them

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -3,7 +3,11 @@ import assert from 'node:assert/strict';
 import { Hono } from 'hono';
 import type { AgentCardV03 } from '@a2x/sdk';
 import type { ClientConnection } from './registry.js';
-import { mountWellKnown, type WellKnownDeps } from './well-known.js';
+import {
+  buildLandingDirectory,
+  mountWellKnown,
+  type WellKnownDeps,
+} from './well-known.js';
 
 function fakeConn(agentId: string, card: Partial<AgentCardV03> = {}): ClientConnection {
   return {
@@ -210,6 +214,35 @@ test('mentionable-agents.json: drops case-insensitive collisions to match resolv
   const body = (await res.json()) as { contactPoint: Array<{ email: string }> };
   const emails = body.contactPoint.map((p) => p.email);
   assert.deepEqual(emails, ['admin@bridge.example.com', 'bar@bridge.example.com']);
+});
+
+test('mentionable-agents.json: avoids card synthesis for invalid and colliding locals', () => {
+  const calls: string[] = [];
+  const deps: WellKnownDeps = {
+    listAgents: () => [
+      fakeConn('Foo'),
+      fakeConn('foo'),
+      fakeConn('bad@id'),
+      fakeConn('bar'),
+    ],
+    getAgentCard: (conn) => {
+      calls.push(conn.agentId);
+      return fakeCardV03(conn.agentId);
+    },
+    adminCard: fakeAdminCard(),
+    publicUrl: 'https://bridge.example.com',
+    domain: 'bridge.example.com',
+    deviceFlowEnabled: false,
+    organizationName: 'Vicoop Bridge',
+  };
+
+  const directory = buildLandingDirectory(deps);
+  assert.ok(directory);
+  assert.deepEqual(calls, ['bar']);
+  assert.deepEqual(
+    directory.contactPoint.map((p) => p.email),
+    ['admin@bridge.example.com', 'bar@bridge.example.com'],
+  );
 });
 
 test('webfinger: 404 when local-part contains unsafe chars (path separator)', async () => {

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -1,0 +1,206 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import type { AgentCardV03 } from '@a2x/sdk';
+import type { ClientConnection } from './registry.js';
+import { mountWellKnown, type WellKnownDeps } from './well-known.js';
+
+function fakeConn(agentId: string, card: Partial<AgentCardV03> = {}): ClientConnection {
+  return {
+    agentId,
+    clientId: `c-${agentId}`,
+    ownerPrincipal: 'eth:0x0',
+    agentCard: {
+      name: card.name ?? `Agent ${agentId}`,
+      description: card.description ?? `desc ${agentId}`,
+      version: card.version ?? '0.0.1',
+      protocolVersion: '0.3.0',
+      capabilities: { streaming: false },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
+    },
+    allowedCallers: [],
+    // Registry only ever calls .close() / equality on this; the well-known
+    // routes don't touch ws at all.
+    ws: { close: () => undefined } as unknown as ClientConnection['ws'],
+    connectedAt: 0,
+  };
+}
+
+function fakeCardV03(agentId: string, overrides: Partial<AgentCardV03> = {}): AgentCardV03 {
+  return {
+    name: `Agent ${agentId}`,
+    description: `desc ${agentId}`,
+    version: '0.0.1',
+    protocolVersion: '0.3',
+    url: `https://bridge.example.com/agents/${agentId}`,
+    capabilities: { streaming: false, pushNotifications: false },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    ...overrides,
+  } as AgentCardV03;
+}
+
+function makeApp(opts: {
+  agents: ClientConnection[];
+  // When omitted, defaults to a typical deploy with publicUrl / domain set.
+  // Pass `noPublicUrl: true` to simulate a bridge with no PUBLIC_URL config.
+  noPublicUrl?: boolean;
+  deviceFlowEnabled?: boolean;
+}) {
+  const app = new Hono();
+  const deps: WellKnownDeps = {
+    listAgents: () => opts.agents,
+    getAgentCard: (conn) => fakeCardV03(conn.agentId),
+    publicUrl: opts.noPublicUrl ? undefined : 'https://bridge.example.com',
+    domain: opts.noPublicUrl ? undefined : 'bridge.example.com',
+    deviceFlowEnabled: opts.deviceFlowEnabled ?? false,
+    organizationName: 'Vicoop Bridge',
+  };
+  mountWellKnown(app, deps);
+  return app;
+}
+
+test('webfinger: 400 when resource is missing', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request('/.well-known/webfinger');
+  assert.equal(res.status, 400);
+});
+
+test('webfinger: returns JRD with the agent-card rel for a connected agent', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') ?? '', /application\/jrd\+json/);
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.equal(body.subject, 'acct:foo@bridge.example.com');
+  const links = body.links as Array<Record<string, string>>;
+  assert.ok(
+    links.some(
+      (l) =>
+        l.rel === 'https://mentionable.dev/agent-card' &&
+        l.href === 'https://bridge.example.com/.well-known/agent-card/foo',
+    ),
+    `agent-card rel missing: ${JSON.stringify(links)}`,
+  );
+  // SHOULD include a profile-page rel per Mentionable §3.
+  assert.ok(
+    links.some((l) => l.rel === 'http://webfinger.net/rel/profile-page'),
+  );
+});
+
+test('webfinger: matches case-insensitively on scheme + domain + local', async () => {
+  // RFC 3986 §3.1 (scheme), RFC 1035 §2.3.3 (domain), RFC 5321 §2.4 (local
+  // SHOULD be treated case-insensitively in practice).
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=ACCT:FOO@BRIDGE.EXAMPLE.COM',
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Record<string, unknown>;
+  // Subject is rendered with the live agentId (preserves its actual case)
+  // and a lowercased domain.
+  assert.equal(body.subject, 'acct:foo@bridge.example.com');
+});
+
+test('webfinger: 404 on unknown local-part', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:bar@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('webfinger: 404 on foreign domain', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@other.example',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('webfinger: 404 on malformed resource (no acct: scheme)', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=foo@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('webfinger: 404 when local-part contains unsafe chars (path separator)', async () => {
+  // Defends against an attacker crafting an agentId that smuggles `..` /
+  // `@` / CRLF into the JRD subject. isValidMentionableLocal rejects them
+  // at the layer that builds the URL, so the well-known routes never see
+  // them — and a query asking for one resolves to 404 too.
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:..%2Fevil@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('webfinger: 404 when bridge has no PUBLIC_URL configured (no domain)', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')], noPublicUrl: true });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('agent-card: returns Mentionable v0.1 shape for a connected local', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request('/.well-known/agent-card/foo');
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as Record<string, unknown>;
+  assert.equal(body.address, '@foo@bridge.example.com');
+  assert.equal(body.protocol_version, '0.1');
+  const a2a = body.a2a as Record<string, unknown>;
+  assert.equal(a2a.endpoint, 'https://bridge.example.com/agents/foo');
+});
+
+test('agent-card: matches local-part case-insensitively (parity with WebFinger)', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request('/.well-known/agent-card/FOO');
+  assert.equal(res.status, 200);
+});
+
+test('agent-card: 404 for an unknown local', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const res = await app.request('/.well-known/agent-card/bar');
+  assert.equal(res.status, 404);
+});
+
+test('mentionable-agents.json: lists every connected client with a safe local-part', async () => {
+  // The third agent has `bad@id` which fails isValidMentionableLocal and
+  // must be silently dropped so we never render an `acct:bad@id@host` URI.
+  const app = makeApp({
+    agents: [fakeConn('foo'), fakeConn('bar'), fakeConn('bad@id')],
+  });
+  const res = await app.request('/.well-known/mentionable-agents.json');
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as {
+    '@type': string;
+    contactPoint: Array<{ email: string }>;
+  };
+  assert.equal(body['@type'], 'Organization');
+  const emails = body.contactPoint.map((p) => p.email).sort();
+  assert.deepEqual(emails, ['bar@bridge.example.com', 'foo@bridge.example.com']);
+});
+
+test('mentionable-agents.json: empty contactPoint when no clients connected', async () => {
+  const app = makeApp({ agents: [] });
+  const res = await app.request('/.well-known/mentionable-agents.json');
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { contactPoint: unknown[] };
+  assert.equal(body.contactPoint.length, 0);
+});
+
+test('mentionable-agents.json: 404 when bridge has no PUBLIC_URL configured', async () => {
+  const app = makeApp({ agents: [fakeConn('foo')], noPublicUrl: true });
+  const res = await app.request('/.well-known/mentionable-agents.json');
+  assert.equal(res.status, 404);
+});

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -86,6 +86,33 @@ test('webfinger: 400 when resource is missing', async () => {
   assert.equal(res.status, 400);
 });
 
+test('every well-known response (200, 400, 404) carries Cache-Control: no-store', async () => {
+  // The data tracks live WS connections, so a 404 for an offline agent
+  // must NOT be cached — when the agent reconnects, an intermediate
+  // shared cache holding the old 404 would keep advertising it as
+  // unreachable. Same logic for the success paths.
+  const app = makeApp({ agents: [fakeConn('foo')] });
+  const cases = [
+    // success
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+    '/.well-known/agent-card/foo',
+    '/.well-known/mentionable-agents.json',
+    // 400
+    '/.well-known/webfinger',
+    // 404 — unknown local-part
+    '/.well-known/webfinger?resource=acct:nope@bridge.example.com',
+    '/.well-known/agent-card/nope',
+  ];
+  for (const path of cases) {
+    const res = await app.request(path);
+    assert.equal(
+      res.headers.get('cache-control'),
+      'no-store',
+      `${path} → status=${res.status} cache-control="${res.headers.get('cache-control')}"`,
+    );
+  }
+});
+
 test('webfinger: returns JRD with the agent-card rel for a connected agent', async () => {
   const app = makeApp({ agents: [fakeConn('foo')] });
   const res = await app.request(

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -175,6 +175,24 @@ test('webfinger: 404 on malformed resource (no acct: scheme)', async () => {
   assert.equal(res.status, 404);
 });
 
+test('webfinger: 404 when two registry entries differ only in case (ambiguous)', async () => {
+  // Mentionable lookups are case-insensitive but the registry is
+  // case-sensitive, so `Foo` and `foo` could both register concurrently.
+  // The lookup MUST refuse to pick — silently routing a mention to
+  // whichever connected first would be misdelivery.
+  const app = makeApp({ agents: [fakeConn('Foo'), fakeConn('foo')] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@bridge.example.com',
+  );
+  assert.equal(res.status, 404);
+});
+
+test('agent-card: 404 when two registry entries differ only in case (ambiguous)', async () => {
+  const app = makeApp({ agents: [fakeConn('Foo'), fakeConn('foo')] });
+  const res = await app.request('/.well-known/agent-card/foo');
+  assert.equal(res.status, 404);
+});
+
 test('webfinger: 404 when local-part contains unsafe chars (path separator)', async () => {
   // Defends against an attacker crafting an agentId that smuggles `..` /
   // `@` / CRLF into the JRD subject. isValidMentionableLocal rejects them

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -43,6 +43,22 @@ function fakeCardV03(agentId: string, overrides: Partial<AgentCardV03> = {}): Ag
   } as AgentCardV03;
 }
 
+function fakeAdminCard(): AgentCardV03 {
+  return {
+    name: 'Vicoop Bridge Server Admin',
+    description: 'Bridge admin agent',
+    version: '0.1.0',
+    protocolVersion: '0.3',
+    url: 'https://bridge.example.com/',
+    capabilities: { streaming: false, pushNotifications: false },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [
+      { id: 'client-management', name: 'Client Management', description: 'admin tools' },
+    ],
+  } as AgentCardV03;
+}
+
 function makeApp(opts: {
   agents: ClientConnection[];
   // When omitted, defaults to a typical deploy with publicUrl / domain set.
@@ -54,6 +70,7 @@ function makeApp(opts: {
   const deps: WellKnownDeps = {
     listAgents: () => opts.agents,
     getAgentCard: (conn) => fakeCardV03(conn.agentId),
+    adminCard: fakeAdminCard(),
     publicUrl: opts.noPublicUrl ? undefined : 'https://bridge.example.com',
     domain: opts.noPublicUrl ? undefined : 'bridge.example.com',
     deviceFlowEnabled: opts.deviceFlowEnabled ?? false,
@@ -174,9 +191,10 @@ test('agent-card: 404 for an unknown local', async () => {
   assert.equal(res.status, 404);
 });
 
-test('mentionable-agents.json: lists every connected client with a safe local-part', async () => {
+test('mentionable-agents.json: lists admin first, then every safe-local-part client', async () => {
   // The third agent has `bad@id` which fails isValidMentionableLocal and
   // must be silently dropped so we never render an `acct:bad@id@host` URI.
+  // Admin is always advertised — it's the bridge itself.
   const app = makeApp({
     agents: [fakeConn('foo'), fakeConn('bar'), fakeConn('bad@id')],
   });
@@ -187,16 +205,57 @@ test('mentionable-agents.json: lists every connected client with a safe local-pa
     contactPoint: Array<{ email: string }>;
   };
   assert.equal(body['@type'], 'Organization');
-  const emails = body.contactPoint.map((p) => p.email).sort();
-  assert.deepEqual(emails, ['bar@bridge.example.com', 'foo@bridge.example.com']);
+  const emails = body.contactPoint.map((p) => p.email);
+  // Admin first by convention; client order follows registry insertion.
+  assert.deepEqual(emails, [
+    'admin@bridge.example.com',
+    'foo@bridge.example.com',
+    'bar@bridge.example.com',
+  ]);
 });
 
-test('mentionable-agents.json: empty contactPoint when no clients connected', async () => {
+test('mentionable-agents.json: contains only admin when no clients connected', async () => {
+  // The bridge itself is always addressable — directory is never empty
+  // on a configured deployment.
   const app = makeApp({ agents: [] });
   const res = await app.request('/.well-known/mentionable-agents.json');
   assert.equal(res.status, 200);
-  const body = (await res.json()) as { contactPoint: unknown[] };
-  assert.equal(body.contactPoint.length, 0);
+  const body = (await res.json()) as { contactPoint: Array<{ email: string }> };
+  assert.equal(body.contactPoint.length, 1);
+  assert.equal(body.contactPoint[0]!.email, 'admin@bridge.example.com');
+});
+
+test('webfinger: resolves admin even when no clients are connected', async () => {
+  const app = makeApp({ agents: [] });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:admin@bridge.example.com',
+  );
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { subject: string; aliases: string[] };
+  assert.equal(body.subject, 'acct:admin@bridge.example.com');
+  // Admin lives at the bridge root, NOT under /agents/admin.
+  assert.deepEqual(body.aliases, ['https://bridge.example.com/']);
+});
+
+test('agent-card: returns admin Mentionable card with admin endpoint at root', async () => {
+  const app = makeApp({ agents: [] });
+  const res = await app.request('/.well-known/agent-card/admin');
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as {
+    address: string;
+    a2a: { endpoint: string };
+  };
+  assert.equal(body.address, '@admin@bridge.example.com');
+  assert.equal(body.a2a.endpoint, 'https://bridge.example.com/');
+});
+
+test('agent-card: matches admin local-part case-insensitively', async () => {
+  const app = makeApp({ agents: [] });
+  const res = await app.request('/.well-known/agent-card/ADMIN');
+  assert.equal(res.status, 200);
+  const body = (await res.json()) as { address: string };
+  // Canonical local-part is rendered in lowercase regardless of input case.
+  assert.equal(body.address, '@admin@bridge.example.com');
 });
 
 test('mentionable-agents.json: 404 when bridge has no PUBLIC_URL configured', async () => {

--- a/packages/server/src/well-known.test.ts
+++ b/packages/server/src/well-known.test.ts
@@ -383,3 +383,15 @@ test('all routes serve when PUBLIC_URL is https with a multi-label hostname', as
   );
   assert.equal(res.status, 200);
 });
+
+test('all routes serve when PUBLIC_URL is https with an IPv6 literal hostname', async () => {
+  const app = makeApp({
+    agents: [fakeConn('foo')],
+    publicUrl: 'https://[::1]',
+    domain: '[::1]',
+  });
+  const res = await app.request(
+    '/.well-known/webfinger?resource=acct:foo@[::1]',
+  );
+  assert.equal(res.status, 200);
+});

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -98,6 +98,36 @@ function collectPairs(deps: WellKnownDeps): ConnectionPair[] {
   return deps.listAgents().map((conn) => ({ conn, card: deps.getAgentCard(conn) }));
 }
 
+// Mentionable v0.1 has two hard requirements that constrain when the
+// well-known surface can serve at all:
+//   • §2 requires HTTPS at the .well-known URL ("Plain HTTP is not
+//     supported"). A bridge running on http:// would publish addresses
+//     that no conformant resolver will accept.
+//   • §1 requires a multi-label domain ("Single-label hostnames (e.g.
+//     `localhost`) are rejected"). The `subject` field of the JRD must
+//     match the queried `acct:` URI and §2's domain validation makes a
+//     bare `localhost` unverifiable.
+// Bridges deployed for local development with PUBLIC_URL=http://localhost
+// fail both checks; the Mentionable surface returns 404 for them while
+// every other route continues to work, so smoke-testing Mentionable
+// requires either a real HTTPS deployment or a multi-label dev domain
+// (e.g. `https://agent.localhost` behind a reverse proxy with a
+// self-signed cert — see Mentionable §1 for the recommended forms).
+// Type predicate so call sites that pass the check can use deps.publicUrl
+// and deps.domain as `string` without re-asserting.
+function isMentionableEligible(
+  deps: WellKnownDeps,
+): deps is WellKnownDeps & { publicUrl: string; domain: string } {
+  if (!deps.publicUrl || !deps.domain) return false;
+  if (!deps.publicUrl.toLowerCase().startsWith('https://')) return false;
+  // Quick multi-label test: must contain at least one dot. IP literals
+  // (e.g. 192.168.1.1) pass — they're not globally meaningful but the
+  // spec validation ladders are not blocked by them either, so we accept
+  // them rather than introducing a fragile hostname-classifier here.
+  if (!deps.domain.includes('.')) return false;
+  return true;
+}
+
 function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undefined {
   const lower = local.toLowerCase();
   if (lower === MENTIONABLE_ADMIN_LOCAL.toLowerCase()) {
@@ -156,8 +186,8 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
   app.use('/.well-known/mentionable-agents.json', noStoreOnAllResponses);
 
   app.get('/.well-known/webfinger', (c) => {
-    if (!deps.domain || !deps.publicUrl) {
-      return c.json({ error: 'webfinger not available (no PUBLIC_URL configured)' }, 404);
+    if (!isMentionableEligible(deps)) {
+      return c.json({ error: 'webfinger not available (PUBLIC_URL must be HTTPS with a multi-label hostname)' }, 404);
     }
     const resource = c.req.query('resource');
     if (!resource) {
@@ -207,8 +237,8 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
   });
 
   app.get('/.well-known/agent-card/:local', (c) => {
-    if (!deps.domain || !deps.publicUrl) {
-      return c.json({ error: 'agent-card not available (no PUBLIC_URL configured)' }, 404);
+    if (!isMentionableEligible(deps)) {
+      return c.json({ error: 'agent-card not available (PUBLIC_URL must be HTTPS with a multi-label hostname)' }, 404);
     }
     const local = c.req.param('local');
     if (!isValidMentionableLocal(local)) {
@@ -227,8 +257,8 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
   });
 
   app.get('/.well-known/mentionable-agents.json', (c) => {
-    if (!deps.domain || !deps.publicUrl) {
-      return c.json({ error: 'directory not available (no PUBLIC_URL configured)' }, 404);
+    if (!isMentionableEligible(deps)) {
+      return c.json({ error: 'directory not available (PUBLIC_URL must be HTTPS with a multi-label hostname)' }, 404);
     }
     const directory = buildAgentDirectory({
       baseUrl: deps.publicUrl,
@@ -250,8 +280,10 @@ export function buildLandingDirectory(
   deps: WellKnownDeps,
   pairs?: readonly ConnectionPair[],
 ) {
-  if (!deps.domain || !deps.publicUrl) return undefined;
+  if (!isMentionableEligible(deps)) return undefined;
   return buildAgentDirectory({
+    // isMentionableEligible's type predicate narrows publicUrl/domain
+    // from `string | undefined` to `string` here.
     baseUrl: deps.publicUrl,
     domain: deps.domain.toLowerCase(),
     organizationName: deps.organizationName,

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -45,38 +45,57 @@ interface ResolvedLocal {
   card: AgentCardV03;
 }
 
-function listDirectoryEntries(deps: WellKnownDeps): DirectoryEntry[] {
+// Pair shape used by both the directory route (which collects internally)
+// and the / HTML handler (which already walks the registry to render its
+// own client list — passing the snapshot in saves a second listAgents()
+// call plus a re-fetch of every AgentCardV03).
+export interface ConnectionPair {
+  conn: ClientConnection;
+  card: AgentCardV03;
+}
+
+function entriesFromPairs(
+  pairs: readonly ConnectionPair[],
+  adminCard: AgentCardV03,
+): DirectoryEntry[] {
   // Admin always appears first so a casual reader of the directory finds
   // the bridge itself before the connected clients.
   const entries: DirectoryEntry[] = [
     {
       local: MENTIONABLE_ADMIN_LOCAL,
-      name: deps.adminCard.name,
-      description: deps.adminCard.description ?? undefined,
+      name: adminCard.name,
+      description: adminCard.description ?? undefined,
     },
   ];
   // Drop case-insensitive collisions consistently with resolveLocal: if
   // two connected agents fold to the same local, resolveLocal returns 404
-  // for the lookup — listing them in the directory would advertise an
-  // address that immediately fails to resolve. Better to omit both than to
-  // ship broken links downstream.
-  const lowerCounts = new Map<string, number>();
-  for (const conn of deps.listAgents()) {
+  // — listing them here would advertise an address that immediately fails
+  // to resolve. Single pass: candidate map keyed on the lowercased local,
+  // a second occurrence flips it to 'collision' and neither variant is
+  // emitted. Insertion order is preserved (Map iteration order = insertion
+  // order), so the directory mirrors the registry's connect order.
+  const candidates = new Map<string, DirectoryEntry | 'collision'>();
+  for (const { conn, card } of pairs) {
     if (!isValidMentionableLocal(conn.agentId)) continue;
     const k = conn.agentId.toLowerCase();
-    lowerCounts.set(k, (lowerCounts.get(k) ?? 0) + 1);
-  }
-  for (const conn of deps.listAgents()) {
-    if (!isValidMentionableLocal(conn.agentId)) continue;
-    if ((lowerCounts.get(conn.agentId.toLowerCase()) ?? 0) > 1) continue;
-    const card = deps.getAgentCard(conn);
-    entries.push({
+    if (candidates.has(k)) {
+      candidates.set(k, 'collision');
+      continue;
+    }
+    candidates.set(k, {
       local: conn.agentId,
       name: card.name,
       description: card.description ?? undefined,
     });
   }
+  for (const v of candidates.values()) {
+    if (v !== 'collision') entries.push(v);
+  }
   return entries;
+}
+
+function collectPairs(deps: WellKnownDeps): ConnectionPair[] {
+  return deps.listAgents().map((conn) => ({ conn, card: deps.getAgentCard(conn) }));
 }
 
 function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undefined {
@@ -215,21 +234,27 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
       baseUrl: deps.publicUrl,
       domain: deps.domain.toLowerCase(),
       organizationName: deps.organizationName,
-      entries: listDirectoryEntries(deps),
+      entries: entriesFromPairs(collectPairs(deps), deps.adminCard),
     });
     return c.json(directory);
   });
 }
 
 // Re-exported so the HTTP layer can also embed the same payload as JSON-LD
-// in the landing page (Layer 1 source of truth per Mentionable's
-// Agent Directory spec).
-export function buildLandingDirectory(deps: WellKnownDeps) {
+// in the landing page (Layer 1 source of truth per Mentionable's Agent
+// Directory spec). Accepts a pre-collected `pairs` snapshot — the / handler
+// already walks the registry to render its own client list, so passing the
+// same snapshot in saves a redundant listAgents() + per-agent getAgentCard
+// round on every landing-page hit.
+export function buildLandingDirectory(
+  deps: WellKnownDeps,
+  pairs?: readonly ConnectionPair[],
+) {
   if (!deps.domain || !deps.publicUrl) return undefined;
   return buildAgentDirectory({
     baseUrl: deps.publicUrl,
     domain: deps.domain.toLowerCase(),
     organizationName: deps.organizationName,
-    entries: listDirectoryEntries(deps),
+    entries: entriesFromPairs(pairs ?? collectPairs(deps), deps.adminCard),
   });
 }

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -1,4 +1,4 @@
-import type { Hono } from 'hono';
+import type { Hono, MiddlewareHandler } from 'hono';
 import type { AgentCardV03 } from '@a2x/sdk';
 import type { ClientConnection } from './registry.js';
 import {
@@ -96,7 +96,24 @@ function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undef
  *   `Organization` payload listing every connected client whose agentId is
  *   a Mentionable-safe local-part.
  */
+// Mentionable §3 encourages aggressive caching ("card changes are expected
+// to be infrequent"), but our payloads track live WS connections — a client
+// that disconnects (or that hasn't connected yet, producing a 404) must not
+// be cached, otherwise shared caches keep returning unreachable / stale
+// addressability for the TTL window. 404s are cacheable by HTTP defaults
+// too, so the header has to apply uniformly across every status. Until we
+// add ETag/Last-Modified for conditional revalidation, no-store is the
+// only honest answer.
+const noStoreOnAllResponses: MiddlewareHandler = async (c, next) => {
+  await next();
+  c.header('Cache-Control', 'no-store');
+};
+
 export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
+  app.use('/.well-known/webfinger', noStoreOnAllResponses);
+  app.use('/.well-known/agent-card/:local', noStoreOnAllResponses);
+  app.use('/.well-known/mentionable-agents.json', noStoreOnAllResponses);
+
   app.get('/.well-known/webfinger', (c) => {
     if (!deps.domain || !deps.publicUrl) {
       return c.json({ error: 'webfinger not available (no PUBLIC_URL configured)' }, 404);
@@ -138,16 +155,12 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
         },
       ],
     };
-    // Mentionable §3 encourages aggressive caching ("card changes are
-    // expected to be infrequent"), but our payload tracks live WS
-    // connections — a client that disconnects must stop being addressable
-    // immediately, not 5 minutes later. Until we add ETag/Last-Modified
-    // for conditional revalidation, no-store is the only honest answer
-    // for both private and shared caches.
+    // Cache-Control: no-store is applied uniformly by the route-scoped
+    // middleware above, so every status (including the 400/404 errors)
+    // carries it.
     return new Response(JSON.stringify(jrd), {
       headers: {
         'Content-Type': 'application/jrd+json; charset=utf-8',
-        'Cache-Control': 'no-store',
       },
     });
   });
@@ -169,10 +182,6 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
       publicUrl: deps.publicUrl,
       deviceFlowEnabled: deps.deviceFlowEnabled,
     });
-    // See WebFinger above — the underlying AgentCardV03 is rebuilt on
-    // every connect/disconnect/policy change, so shared caches must not
-    // hold it.
-    c.header('Cache-Control', 'no-store');
     return c.json(mentionable);
   });
 
@@ -186,10 +195,6 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
       organizationName: deps.organizationName,
       entries: listDirectoryEntries(deps),
     });
-    // Same reasoning as WebFinger: the entry list is the live registry
-    // snapshot, so shared caches holding it across connect/disconnect
-    // events would advertise unreachable agents.
-    c.header('Cache-Control', 'no-store');
     return c.json(directory);
   });
 }

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -1,0 +1,171 @@
+import type { Hono } from 'hono';
+import type { AgentCardV03 } from '@a2x/sdk';
+import type { ClientConnection } from './registry.js';
+import {
+  MENTIONABLE_AGENT_CARD_REL,
+  buildAgentDirectory,
+  buildMentionableCard,
+  isValidMentionableLocal,
+  parseAcct,
+  type DirectoryEntry,
+} from './mentionable.js';
+
+export interface WellKnownDeps {
+  // Snapshot of currently connected client agents. Called per-request so
+  // connect/disconnect changes are reflected immediately (no caching here —
+  // the registry is already in-memory).
+  listAgents: () => ClientConnection[];
+  // Resolves a connection's runtime AgentCardV03 (post-auth synthesis,
+  // streaming/extensions/security all reflected). The HTTP layer hands us
+  // a closure over its per-agent cache so we don't rebuild cards here.
+  getAgentCard: (conn: ClientConnection) => AgentCardV03;
+  // Bridge's external HTTPS base, e.g. `https://bridge.example.com`. When
+  // unset, every Mentionable route degrades to 404 — RFC 7033 requires HTTPS
+  // and we can't render a self-referential URL without knowing our origin.
+  publicUrl?: string;
+  // Bridge's external hostname (URL.hostname of publicUrl). Carried
+  // separately because callers already derive it once for SIWE.
+  domain?: string;
+  // Whether the deployment actually mounts the device-flow token endpoints.
+  // SIWE-only deployments advertise `auth.scheme: 'none'` instead of
+  // pointing clients at oauth2 URLs that aren't served.
+  deviceFlowEnabled: boolean;
+  // Display name for the Schema.org Organization payload. Typically the
+  // admin agent card's `name`.
+  organizationName: string;
+}
+
+function listDirectoryEntries(deps: WellKnownDeps): DirectoryEntry[] {
+  const entries: DirectoryEntry[] = [];
+  for (const conn of deps.listAgents()) {
+    if (!isValidMentionableLocal(conn.agentId)) continue;
+    const card = deps.getAgentCard(conn);
+    entries.push({
+      local: conn.agentId,
+      name: card.name,
+      description: card.description ?? undefined,
+    });
+  }
+  return entries;
+}
+
+function findConnByLocal(deps: WellKnownDeps, local: string): ClientConnection | undefined {
+  const lower = local.toLowerCase();
+  for (const conn of deps.listAgents()) {
+    if (
+      isValidMentionableLocal(conn.agentId) &&
+      conn.agentId.toLowerCase() === lower
+    ) {
+      return conn;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Mount the Mentionable v0.1 surface — WebFinger, the agent-card document,
+ * and the Agent Directory accelerator — on `app`.
+ *
+ * - `GET /.well-known/webfinger?resource=acct:<local>@<domain>` resolves to
+ *   any connected client whose agentId matches `<local>` (case-insensitive,
+ *   per RFC 1035 + a practical reading of RFC 5321).
+ * - `GET /.well-known/agent-card/<local>` returns the Mentionable-shaped
+ *   card (wraps the per-client A2A AgentCardV03).
+ * - `GET /.well-known/mentionable-agents.json` returns the Schema.org
+ *   `Organization` payload listing every connected client whose agentId is
+ *   a Mentionable-safe local-part.
+ */
+export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
+  app.get('/.well-known/webfinger', (c) => {
+    if (!deps.domain || !deps.publicUrl) {
+      return c.json({ error: 'webfinger not available (no PUBLIC_URL configured)' }, 404);
+    }
+    const resource = c.req.query('resource');
+    if (!resource) {
+      return c.json({ error: 'missing resource parameter' }, 400);
+    }
+    const parsed = parseAcct(resource);
+    if (
+      !parsed ||
+      parsed.domain.toLowerCase() !== deps.domain.toLowerCase() ||
+      !isValidMentionableLocal(parsed.local)
+    ) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const conn = findConnByLocal(deps, parsed.local);
+    if (!conn) return c.json({ error: 'not found' }, 404);
+
+    const subject = `acct:${conn.agentId}@${deps.domain.toLowerCase()}`;
+    const jrd = {
+      subject,
+      aliases: [`${deps.publicUrl}/agents/${conn.agentId}`],
+      links: [
+        {
+          rel: MENTIONABLE_AGENT_CARD_REL,
+          type: 'application/json',
+          href: `${deps.publicUrl}/.well-known/agent-card/${conn.agentId}`,
+        },
+        {
+          rel: 'http://webfinger.net/rel/profile-page',
+          type: 'text/html',
+          href: `${deps.publicUrl}/`,
+        },
+      ],
+    };
+    return new Response(JSON.stringify(jrd), {
+      headers: {
+        'Content-Type': 'application/jrd+json; charset=utf-8',
+        'Cache-Control': 'public, max-age=300, s-maxage=300',
+      },
+    });
+  });
+
+  app.get('/.well-known/agent-card/:local', (c) => {
+    if (!deps.domain || !deps.publicUrl) {
+      return c.json({ error: 'agent-card not available (no PUBLIC_URL configured)' }, 404);
+    }
+    const local = c.req.param('local');
+    if (!isValidMentionableLocal(local)) {
+      return c.json({ error: 'not found' }, 404);
+    }
+    const conn = findConnByLocal(deps, local);
+    if (!conn) return c.json({ error: 'not found' }, 404);
+    const card = deps.getAgentCard(conn);
+    const mentionable = buildMentionableCard(card, {
+      local: conn.agentId,
+      domain: deps.domain.toLowerCase(),
+      baseUrl: deps.publicUrl,
+      publicUrl: deps.publicUrl,
+      deviceFlowEnabled: deps.deviceFlowEnabled,
+    });
+    c.header('Cache-Control', 'public, max-age=300, s-maxage=300');
+    return c.json(mentionable);
+  });
+
+  app.get('/.well-known/mentionable-agents.json', (c) => {
+    if (!deps.domain || !deps.publicUrl) {
+      return c.json({ error: 'directory not available (no PUBLIC_URL configured)' }, 404);
+    }
+    const directory = buildAgentDirectory({
+      baseUrl: deps.publicUrl,
+      domain: deps.domain.toLowerCase(),
+      organizationName: deps.organizationName,
+      entries: listDirectoryEntries(deps),
+    });
+    c.header('Cache-Control', 'public, max-age=60, s-maxage=60');
+    return c.json(directory);
+  });
+}
+
+// Re-exported so the HTTP layer can also embed the same payload as JSON-LD
+// in the landing page (Layer 1 source of truth per Mentionable's
+// Agent Directory spec).
+export function buildLandingDirectory(deps: WellKnownDeps) {
+  if (!deps.domain || !deps.publicUrl) return undefined;
+  return buildAgentDirectory({
+    baseUrl: deps.publicUrl,
+    domain: deps.domain.toLowerCase(),
+    organizationName: deps.organizationName,
+    entries: listDirectoryEntries(deps),
+  });
+}

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -164,7 +164,7 @@ function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undef
   // first; refuse the lookup instead so the ambiguity surfaces as a 404
   // rather than misdelivery. The right long-term fix is to enforce
   // case-insensitive uniqueness at registration time.
-  let match: ResolvedLocal | undefined;
+  let match: ClientConnection | undefined;
   for (const conn of deps.listAgents()) {
     if (
       !isValidMentionableLocal(conn.agentId) ||
@@ -173,9 +173,11 @@ function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undef
       continue;
     }
     if (match) return undefined;
-    match = { local: conn.agentId, card: deps.getAgentCard(conn) };
+    match = conn;
   }
-  return match;
+  return match
+    ? { local: match.agentId, card: deps.getAgentCard(match) }
+    : undefined;
 }
 
 /**

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -138,10 +138,16 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
         },
       ],
     };
+    // Mentionable §3 encourages aggressive caching ("card changes are
+    // expected to be infrequent"), but our payload tracks live WS
+    // connections — a client that disconnects must stop being addressable
+    // immediately, not 5 minutes later. Until we add ETag/Last-Modified
+    // for conditional revalidation, no-store is the only honest answer
+    // for both private and shared caches.
     return new Response(JSON.stringify(jrd), {
       headers: {
         'Content-Type': 'application/jrd+json; charset=utf-8',
-        'Cache-Control': 'public, max-age=300, s-maxage=300',
+        'Cache-Control': 'no-store',
       },
     });
   });
@@ -163,7 +169,10 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
       publicUrl: deps.publicUrl,
       deviceFlowEnabled: deps.deviceFlowEnabled,
     });
-    c.header('Cache-Control', 'public, max-age=300, s-maxage=300');
+    // See WebFinger above — the underlying AgentCardV03 is rebuilt on
+    // every connect/disconnect/policy change, so shared caches must not
+    // hold it.
+    c.header('Cache-Control', 'no-store');
     return c.json(mentionable);
   });
 
@@ -177,7 +186,10 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
       organizationName: deps.organizationName,
       entries: listDirectoryEntries(deps),
     });
-    c.header('Cache-Control', 'public, max-age=60, s-maxage=60');
+    // Same reasoning as WebFinger: the entry list is the live registry
+    // snapshot, so shared caches holding it across connect/disconnect
+    // events would advertise unreachable agents.
+    c.header('Cache-Control', 'no-store');
     return c.json(directory);
   });
 }

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -55,8 +55,20 @@ function listDirectoryEntries(deps: WellKnownDeps): DirectoryEntry[] {
       description: deps.adminCard.description ?? undefined,
     },
   ];
+  // Drop case-insensitive collisions consistently with resolveLocal: if
+  // two connected agents fold to the same local, resolveLocal returns 404
+  // for the lookup — listing them in the directory would advertise an
+  // address that immediately fails to resolve. Better to omit both than to
+  // ship broken links downstream.
+  const lowerCounts = new Map<string, number>();
   for (const conn of deps.listAgents()) {
     if (!isValidMentionableLocal(conn.agentId)) continue;
+    const k = conn.agentId.toLowerCase();
+    lowerCounts.set(k, (lowerCounts.get(k) ?? 0) + 1);
+  }
+  for (const conn of deps.listAgents()) {
+    if (!isValidMentionableLocal(conn.agentId)) continue;
+    if ((lowerCounts.get(conn.agentId.toLowerCase()) ?? 0) > 1) continue;
     const card = deps.getAgentCard(conn);
     entries.push({
       local: conn.agentId,

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -2,6 +2,7 @@ import type { Hono } from 'hono';
 import type { AgentCardV03 } from '@a2x/sdk';
 import type { ClientConnection } from './registry.js';
 import {
+  MENTIONABLE_ADMIN_LOCAL,
   MENTIONABLE_AGENT_CARD_REL,
   buildAgentDirectory,
   buildMentionableCard,
@@ -19,6 +20,10 @@ export interface WellKnownDeps {
   // streaming/extensions/security all reflected). The HTTP layer hands us
   // a closure over its per-agent cache so we don't rebuild cards here.
   getAgentCard: (conn: ClientConnection) => AgentCardV03;
+  // Bridge's own admin agent card. Listed under @admin@<host> in every
+  // well-known surface — does not depend on a WS connection (it's the
+  // bridge itself).
+  adminCard: AgentCardV03;
   // Bridge's external HTTPS base, e.g. `https://bridge.example.com`. When
   // unset, every Mentionable route degrades to 404 — RFC 7033 requires HTTPS
   // and we can't render a self-referential URL without knowing our origin.
@@ -35,8 +40,21 @@ export interface WellKnownDeps {
   organizationName: string;
 }
 
+interface ResolvedLocal {
+  local: string; // canonical local-part as it appears in addresses
+  card: AgentCardV03;
+}
+
 function listDirectoryEntries(deps: WellKnownDeps): DirectoryEntry[] {
-  const entries: DirectoryEntry[] = [];
+  // Admin always appears first so a casual reader of the directory finds
+  // the bridge itself before the connected clients.
+  const entries: DirectoryEntry[] = [
+    {
+      local: MENTIONABLE_ADMIN_LOCAL,
+      name: deps.adminCard.name,
+      description: deps.adminCard.description ?? undefined,
+    },
+  ];
   for (const conn of deps.listAgents()) {
     if (!isValidMentionableLocal(conn.agentId)) continue;
     const card = deps.getAgentCard(conn);
@@ -49,14 +67,17 @@ function listDirectoryEntries(deps: WellKnownDeps): DirectoryEntry[] {
   return entries;
 }
 
-function findConnByLocal(deps: WellKnownDeps, local: string): ClientConnection | undefined {
+function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undefined {
   const lower = local.toLowerCase();
+  if (lower === MENTIONABLE_ADMIN_LOCAL.toLowerCase()) {
+    return { local: MENTIONABLE_ADMIN_LOCAL, card: deps.adminCard };
+  }
   for (const conn of deps.listAgents()) {
     if (
       isValidMentionableLocal(conn.agentId) &&
       conn.agentId.toLowerCase() === lower
     ) {
-      return conn;
+      return { local: conn.agentId, card: deps.getAgentCard(conn) };
     }
   }
   return undefined;
@@ -92,18 +113,23 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
     ) {
       return c.json({ error: 'not found' }, 404);
     }
-    const conn = findConnByLocal(deps, parsed.local);
-    if (!conn) return c.json({ error: 'not found' }, 404);
+    const resolved = resolveLocal(deps, parsed.local);
+    if (!resolved) return c.json({ error: 'not found' }, 404);
 
-    const subject = `acct:${conn.agentId}@${deps.domain.toLowerCase()}`;
+    // Admin lives at the bridge root; clients live under /agents/<id>.
+    const isAdmin = resolved.local === MENTIONABLE_ADMIN_LOCAL;
+    const aliasUrl = isAdmin
+      ? `${deps.publicUrl}/`
+      : `${deps.publicUrl}/agents/${resolved.local}`;
+    const subject = `acct:${resolved.local}@${deps.domain.toLowerCase()}`;
     const jrd = {
       subject,
-      aliases: [`${deps.publicUrl}/agents/${conn.agentId}`],
+      aliases: [aliasUrl],
       links: [
         {
           rel: MENTIONABLE_AGENT_CARD_REL,
           type: 'application/json',
-          href: `${deps.publicUrl}/.well-known/agent-card/${conn.agentId}`,
+          href: `${deps.publicUrl}/.well-known/agent-card/${resolved.local}`,
         },
         {
           rel: 'http://webfinger.net/rel/profile-page',
@@ -128,11 +154,10 @@ export function mountWellKnown(app: Hono, deps: WellKnownDeps): void {
     if (!isValidMentionableLocal(local)) {
       return c.json({ error: 'not found' }, 404);
     }
-    const conn = findConnByLocal(deps, local);
-    if (!conn) return c.json({ error: 'not found' }, 404);
-    const card = deps.getAgentCard(conn);
-    const mentionable = buildMentionableCard(card, {
-      local: conn.agentId,
+    const resolved = resolveLocal(deps, local);
+    if (!resolved) return c.json({ error: 'not found' }, 404);
+    const mentionable = buildMentionableCard(resolved.card, {
+      local: resolved.local,
       domain: deps.domain.toLowerCase(),
       baseUrl: deps.publicUrl,
       publicUrl: deps.publicUrl,

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -72,15 +72,25 @@ function resolveLocal(deps: WellKnownDeps, local: string): ResolvedLocal | undef
   if (lower === MENTIONABLE_ADMIN_LOCAL.toLowerCase()) {
     return { local: MENTIONABLE_ADMIN_LOCAL, card: deps.adminCard };
   }
+  // Mentionable lookups are case-insensitive (RFC 1035 / RFC 5321), but the
+  // registry treats `agentId` as case-sensitive at the moment, so two
+  // distinct connections like `Foo` and `foo` could both fold to the same
+  // local. Picking one would silently route mentions to whichever connected
+  // first; refuse the lookup instead so the ambiguity surfaces as a 404
+  // rather than misdelivery. The right long-term fix is to enforce
+  // case-insensitive uniqueness at registration time.
+  let match: ResolvedLocal | undefined;
   for (const conn of deps.listAgents()) {
     if (
-      isValidMentionableLocal(conn.agentId) &&
-      conn.agentId.toLowerCase() === lower
+      !isValidMentionableLocal(conn.agentId) ||
+      conn.agentId.toLowerCase() !== lower
     ) {
-      return { local: conn.agentId, card: deps.getAgentCard(conn) };
+      continue;
     }
+    if (match) return undefined;
+    match = { local: conn.agentId, card: deps.getAgentCard(conn) };
   }
-  return undefined;
+  return match;
 }
 
 /**

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import type { Hono, MiddlewareHandler } from 'hono';
 import type { AgentCardV03 } from '@a2x/sdk';
 import type { ClientConnection } from './registry.js';
@@ -98,6 +99,14 @@ function collectPairs(deps: WellKnownDeps): ConnectionPair[] {
   return deps.listAgents().map((conn) => ({ conn, card: deps.getAgentCard(conn) }));
 }
 
+function isIpLiteral(hostname: string): boolean {
+  const unbracketed =
+    hostname.startsWith('[') && hostname.endsWith(']')
+      ? hostname.slice(1, -1)
+      : hostname;
+  return isIP(unbracketed) !== 0;
+}
+
 // Mentionable v0.1 has two hard requirements that constrain when the
 // well-known surface can serve at all:
 //   • §2 requires HTTPS at the .well-known URL ("Plain HTTP is not
@@ -120,11 +129,11 @@ function isMentionableEligible(
 ): deps is WellKnownDeps & { publicUrl: string; domain: string } {
   if (!deps.publicUrl || !deps.domain) return false;
   if (!deps.publicUrl.toLowerCase().startsWith('https://')) return false;
-  // Quick multi-label test: must contain at least one dot. IP literals
-  // (e.g. 192.168.1.1) pass — they're not globally meaningful but the
-  // spec validation ladders are not blocked by them either, so we accept
-  // them rather than introducing a fragile hostname-classifier here.
-  if (!deps.domain.includes('.')) return false;
+  // Quick multi-label test: must contain at least one dot, unless the host
+  // is an IP literal. IPs are not globally meaningful but the spec validation
+  // ladders are not blocked by them either, so we allow IPv4 and bracketed
+  // IPv6 literals for private deployments and smoke tests.
+  if (!deps.domain.includes('.') && !isIpLiteral(deps.domain)) return false;
   return true;
 }
 

--- a/packages/server/src/well-known.ts
+++ b/packages/server/src/well-known.ts
@@ -96,7 +96,22 @@ function entriesFromPairs(
 }
 
 function collectPairs(deps: WellKnownDeps): ConnectionPair[] {
-  return deps.listAgents().map((conn) => ({ conn, card: deps.getAgentCard(conn) }));
+  const candidates = new Map<string, ClientConnection | 'collision'>();
+  for (const conn of deps.listAgents()) {
+    if (!isValidMentionableLocal(conn.agentId)) continue;
+    const key = conn.agentId.toLowerCase();
+    if (candidates.has(key)) {
+      candidates.set(key, 'collision');
+      continue;
+    }
+    candidates.set(key, conn);
+  }
+
+  const pairs: ConnectionPair[] = [];
+  for (const conn of candidates.values()) {
+    if (conn !== 'collision') pairs.push({ conn, card: deps.getAgentCard(conn) });
+  }
+  return pairs;
 }
 
 function isIpLiteral(hostname: string): boolean {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -99,10 +99,12 @@ async function authenticateAndRegister(
   opts: ServerWsOptions,
 ): Promise<AuthResult> {
   // Reserved agent ids (e.g. "admin") are owned by the bridge itself —
-  // exposed at @admin@<host> via Mentionable. The schema assert makes it
-  // impossible for a client row to legally carry "admin" in its allowlist,
-  // but a manually-inserted row or a future schema regression must still
-  // be refused at the wire. Belt and suspenders.
+  // exposed at @admin@<host> via Mentionable. The SQL trigger
+  // clients_assert_no_reserved_agent_ids covers every mutation path on the
+  // `clients` table (wrapper functions, PostGraphile auto-mutations, direct
+  // SQL), but a manually-inserted row from psql before the trigger landed,
+  // or any future schema regression, must still be refused at the wire.
+  // Belt and suspenders — and cheaper to deny here than after the DB lookup.
   if (isReservedAgentId(frame.agentId)) {
     logEvent('client_rejected', { reason: 'agent id reserved', agentId: frame.agentId });
     return { ok: false, code: 4011, reason: 'agent id reserved by the bridge' };

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -13,6 +13,7 @@ import type { Registry } from './registry.js';
 import type { Sql } from './db.js';
 import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
+import { isReservedAgentId } from './reserved-agent-ids.js';
 
 interface ClientRow {
   id: string;
@@ -97,6 +98,15 @@ async function authenticateAndRegister(
   frame: import('@vicoop-bridge/protocol').HelloFrame,
   opts: ServerWsOptions,
 ): Promise<AuthResult> {
+  // Reserved agent ids (e.g. "admin") are owned by the bridge itself —
+  // exposed at @admin@<host> via Mentionable. The schema assert makes it
+  // impossible for a client row to legally carry "admin" in its allowlist,
+  // but a manually-inserted row or a future schema regression must still
+  // be refused at the wire. Belt and suspenders.
+  if (isReservedAgentId(frame.agentId)) {
+    logEvent('client_rejected', { reason: 'agent id reserved', agentId: frame.agentId });
+    return { ok: false, code: 4011, reason: 'agent id reserved by the bridge' };
+  }
   const hash = hashToken(frame.token);
   const client = await lookupByTokenHash(opts.db, hash);
   if (!client) {


### PR DESCRIPTION
## Summary

- Adds `/.well-known/webfinger`, `/.well-known/agent-card/<local>`, and `/.well-known/mentionable-agents.json` following [planetarium/mentionable v0.1](https://github.com/planetarium/mentionable/blob/main/docs/spec/webfinger.md), so every currently-connected client agent becomes addressable as `@<agentId>@<bridge-host>` from any Mentionable-aware client (Slack adapter, Fediverse, REST, email).
- The bridge's own admin agent is exposed alongside connected clients as `@admin@<bridge-host>` — and the agentId `admin` is reserved at every intake point (SQL `register_client` + `update_client_allowed_agents`, the device-flow `client_register` intent, and the WS hello handshake) so a connected client cannot shadow it.
- Each Mentionable card is built by wrapping the underlying A2A `AgentCardV03` — device-flow OAuth2 maps onto `a2a.auth` when the deployment actually mounts those endpoints, otherwise `scheme: 'none'` (SIWE-bearer is not advertised through Mentionable's narrow auth union).
- The same Schema.org `Organization` payload is published two ways per the Agent Directory spec: embedded as JSON-LD in the landing-page `<head>` (Layer 1, source of truth) and served by `/.well-known/mentionable-agents.json` (Layer 2 accelerator). The directory always lists admin first.

## Design notes

- **Reserved agentIds** (currently `admin`) live in `packages/server/src/reserved-agent-ids.ts` with a mirrored SQL function `assert_no_reserved_agent_ids()`. Both lists must be kept in sync; both are case-insensitive. WS hello rejects with close code 4011 before consulting the client allowlist as a defense against manually-inserted DB rows or future schema regressions.
- **Local-parts** are restricted to `[A-Za-z0-9._-]{1,64}` so client-supplied `agentId`s cannot smuggle `@` / `/` / CRLF into the rendered `acct:` URI; clients with unsafe ids are silently dropped from the directory and return 404 on lookup.
- **Cache-Control: no-store** on every response from the three Mentionable routes (200, 400, and 404 alike). The data is a live WS-registry snapshot, so any caching above the bridge would keep advertising disconnected agents — and 404s for not-yet-connected agents are themselves stale by HTTP defaults. Applied via a route-scoped Hono middleware so the header is uniform across status codes. ETag/Last-Modified for conditional revalidation is a future improvement.
- **No PUBLIC_URL ⇒ 404** on every Mentionable route — RFC 7033 requires HTTPS and the bridge can't render a self-referential URL without knowing its own origin.
- **Case-insensitive matching** on scheme + domain + local (RFC 3986 §3.1, RFC 1035 §2.3.3, practical reading of RFC 5321 §2.4); the rendered `subject` normalizes the domain to lowercase.

## Files

- `packages/server/src/mentionable.ts` — pure builders (`buildMentionableCard`, `buildAgentDirectory`, `parseAcct`, `isValidMentionableLocal`, `MENTIONABLE_ADMIN_LOCAL`).
- `packages/server/src/well-known.ts` — `mountWellKnown(app, deps)` route bundle with the no-store middleware. Resolves `local==='admin'` against the bridge's own admin card; everything else against the registry.
- `packages/server/src/reserved-agent-ids.ts` — `RESERVED_AGENT_IDS = {'admin'}`, mirrored by `assert_no_reserved_agent_ids()` in `schema.sql`.
- `packages/server/src/{mentionable,well-known,reserved-agent-ids}.test.ts` — `node:test` coverage of card shape, JRD shape, case-insensitivity, reservation enforcement, admin-only directory, no-store on every status.
- `packages/server/src/ws.ts` — WS hello layer rejects reserved agentIds with close code 4011 (defense in depth above the SQL gate).
- `packages/server/src/auth/device-flow.ts` — `parseClientRegisterParams` rejects reserved entries before issuing the token.
- `packages/server/schema.sql` — adds `assert_no_reserved_agent_ids()` and threads it through `register_client()` + `update_client_allowed_agents()`.
- `packages/server/src/http.tsx` — hoists `siweDomain`, wires `mountWellKnown`, threads the directory into the landing.
- `packages/server/src/landing.tsx` — accepts an optional `directory` prop and renders it as `<script type="application/ld+json">` (with `</script>` escape).

## Test plan

- [x] `pnpm --filter @vicoop-bridge/server typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/server test` — 135 tests, 115 pass, 20 skipped (DB-required), 0 fail
- [x] `pnpm -r build` clean across the workspace
- [x] Local smoke (run twice across iterations):
      `curl /.well-known/webfinger?resource=acct:<connected-agent>@<host>` returns JRD with the agent-card rel
      `curl /.well-known/mentionable-agents.json` lists admin first, then every connected client
      WS hello with `agentId='admin'` is rejected with close code 4011
      `SELECT register_client('x', ARRAY['admin'], …)` raises `agent id "admin" is reserved by the bridge`
- [ ] Mention `@<agentId>@<host>` from the Mentionable Slack adapter and confirm the A2A round-trip on a deployed bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)