### PR TITLE
claude backend: bidirectional file passthrough

### DIFF
--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -1,0 +1,182 @@
+# Claude backend E2E
+
+Workflow for exercising the `claude` backend directly against the real
+`claude` CLI (Claude Code), without standing up the bridge server / caller
+token / A2A HTTP stack. Useful when changing
+`packages/client/src/backends/claude.ts` or debugging multi-modal input
+or the `send_file` MCP tool path.
+
+The unit tests in `claude.test.ts` use a fake child process and cover the
+A2A frame shapes, argv layout, and stdin envelope mapping. They can't
+catch divergence from the real CLI (stream-json schema drift, MCP
+discovery, model behavior on tool use). This guide fills that gap.
+
+## Prerequisites
+
+- `claude` on `PATH` and authenticated. Verify with `claude --version`.
+- Repo built: `pnpm install && pnpm --filter @vicoop-bridge/client build`.
+- Network egress to the Anthropic API. Each harness consumes real
+  inference credits; total cost across the four scripts is small (single
+  digits of cents at current rates) but non-zero.
+
+The harnesses live under `packages/client/scripts/` and each one is a
+self-contained Node script that imports the compiled backend, drives a
+single A2A `task.assign` through it, and asserts on the emitted frames.
+
+## Available harnesses
+
+### 1. Text smoke — `e2e-claude-text-smoke.mjs`
+
+Plain text in, text out. Fastest sanity check for the stream-json stdin
+plumbing — if this fails, none of the multi-modal cases will work.
+
+```bash
+node packages/client/scripts/e2e-claude-text-smoke.mjs
+```
+
+Expected (≈ 8 s):
+
+```
+[frame +1ms] task.status state=working
+[frame +Xms]  task.artifact name=claude-message parts=[text]
+[frame +Yms]  task.complete state=completed
+[e2e] PASS: terminal is task.complete with state=completed
+[e2e] PASS: at least one task.artifact emitted
+[e2e] PASS: text artifact has content
+[e2e] assistant text: PONG
+```
+
+### 2. Image input — `e2e-claude-input-image.mjs`
+
+A 1×1 solid-red PNG (verified to decode as `RGB(255,0,0)`) is sent as a
+`FilePart` and the harness asserts the model's reply mentions `red`.
+Confirms image content blocks reach the vision path via stream-json
+stdin.
+
+```bash
+node packages/client/scripts/e2e-claude-input-image.mjs
+```
+
+Expected (≈ 11 s): final assistant text `red`.
+
+### 3. PDF input — `e2e-claude-input-pdf.mjs`
+
+Generates a 1-page PDF on the fly with a known word (default `KUMQUAT`)
+drawn in Helvetica, sends it as a `FilePart` with `mimeType:
+"application/pdf"`, and asserts the model's reply contains the word.
+Confirms `document` content blocks reach the model.
+
+```bash
+node packages/client/scripts/e2e-claude-input-pdf.mjs
+# Override the secret word:
+E2E_PDF_WORD=PINEAPPLE node packages/client/scripts/e2e-claude-input-pdf.mjs
+```
+
+Expected (≈ 7 s): final assistant text equals the secret word.
+
+### 4. send_file MCP — `e2e-claude-send-file.mjs`
+
+Most complex path. The harness:
+
+1. Writes a known fixture file under `/tmp/claude-send-file-e2e/`.
+2. Creates a backend with `sendFileMcp.allowedRoots` pointing at that
+   directory. The backend lazy-starts a Streamable HTTP MCP server on
+   `127.0.0.1:<random>` and registers it into the spawned `claude` via
+   `--mcp-config`.
+3. Sends a prompt instructing the model to call `send_file(path)` from
+   the `vicoop-bridge` MCP server.
+4. Asserts the run produced an artifact named `send-file` containing a
+   `FilePart` whose decoded bytes equal the fixture content.
+
+```bash
+node packages/client/scripts/e2e-claude-send-file.mjs
+```
+
+Expected (≈ 16 s):
+
+```
+[claude] send_file MCP server listening at http://127.0.0.1:<port>/mcp
+[frame +Xms]  task.artifact name=send-file parts=[file]
+[frame +Yms]  task.artifact name=claude-message parts=[text]
+[frame +Zms]  task.complete state=completed
+[e2e] PASS: terminal is task.complete with state=completed
+[e2e] PASS: at least one artifact with name="send-file"
+[e2e] PASS: at least one FilePart artifact
+[e2e] PASS: FilePart bytes match fixture
+```
+
+The harness uses `--permission-mode bypassPermissions` so the model
+isn't blocked on a permission prompt for the new MCP tool.
+
+## Troubleshooting
+
+### `claude` exits with `auth required`
+
+The CLI is not signed in for this user. Run `claude` once interactively
+or set up `ANTHROPIC_API_KEY`.
+
+### Image / PDF harness asserts the wrong color or word
+
+The harness's fixture data is wrong, not the backend. Decode the
+fixture independently:
+
+```js
+node -e "
+const fs = require('node:fs');
+const zlib = require('node:zlib');
+const b = fs.readFileSync('/path/to/file.png');
+let i = 8;
+while (i < b.length) {
+  const len = b.readUInt32BE(i);
+  const type = b.subarray(i+4, i+8).toString('ascii');
+  if (type === 'IDAT') {
+    const inflated = zlib.inflateSync(b.subarray(i+8, i+8+len));
+    console.log('R G B =', inflated[1], inflated[2], inflated[3]);
+    break;
+  }
+  i += 12 + len;
+}
+"
+```
+
+If the bytes match the assertion target but the model still answers
+wrong, the problem is on the model side — re-run once before flagging
+it as a regression.
+
+### send_file harness gets `[e2e] FAIL: at least one FilePart artifact`
+
+The model received the prompt but did not invoke the tool. Re-run with
+a more directive prompt:
+
+```bash
+E2E_PROMPT='Call send_file with path "/tmp/claude-send-file-e2e/tool-output.txt" right now. Reply only after the tool returns.' \
+  node packages/client/scripts/e2e-claude-send-file.mjs
+```
+
+If the tool is invoked but `bytes` don't match, the most likely cause
+is a path-canonicalization mismatch between `allowedRoots` and the path
+the model passed. Add `console.log` inside `claude.ts` near the
+`registerActiveTask` site to confirm what the MCP server actually saw.
+
+### Process hangs after `task.status state=working`
+
+The CLI is waiting on input. The harness `end()`s stdin immediately
+after writing the envelope, so a hang here means the spawned `claude`
+either didn't see the EOF (check `--input-format stream-json` is
+present in argv) or is blocked on the first model call. Re-run with
+`--debug` appended to `extraArgs` in the harness to see CLI internals.
+
+## Coverage matrix
+
+| Path | Harness | Validates |
+|---|---|---|
+| Text → text | text-smoke | stream-json stdin envelope, `--session-id`, `result` event parsing |
+| Image FilePart → model | input-image | image content block reaches vision |
+| PDF FilePart → model | input-pdf | document content block reaches doc parser |
+| Model → file artifact | send-file | `--mcp-config` injection, R1 routing, MCP `send_file` tool, bounded read, `task.artifact` round-trip |
+
+The `tool_result` image passthrough (issue #86 task 2a) is covered by
+the unit test `emits FilePart artifact when tool_result contains an
+image block`. An e2e harness for that path would require a separate MCP
+server that actually returns image blocks; deferred until a real use
+case lands.

--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -317,26 +317,28 @@ The script:
 - asserts the resulting artifact carries `name="send-file"` (the MCP
   tool path tag) and the FilePart bytes equal the fixture content.
 
-The OpenClaw image must be built with `mcp.servers.send-file`
-configured to match the bridge-client's MCP URL:
+Setup uses the stock OpenClaw image and the canonical
+`openclaw mcp set` CLI to register the bridge-client MCP server —
+matching how operators add MCP servers in production. The startup
+shell writes a minimal config (auth + model), runs `openclaw mcp set`
+to add the `send-file` server, then execs the gateway:
 
 ```bash
-mkdir -p /tmp/oc-build-sendfile
-cat > /tmp/oc-build-sendfile/Dockerfile << 'EOF'
-FROM ghcr.io/openclaw/openclaw:latest
-USER root
-RUN mkdir -p /home/node/.openclaw && \
-    printf '%s' '{"gateway":{"auth":{"mode":"none"}},"agents":{"defaults":{"model":{"primary":"anthropic/claude-sonnet-4-6"}}},"mcp":{"servers":{"send-file":{"url":"http://127.0.0.1:19090/mcp","transport":"streamable-http"}}}}' \
-      > /home/node/.openclaw/openclaw.json && \
-    chown -R node:node /home/node/.openclaw
-USER node
-EOF
-docker build -t oc-e2e-sendfile-img /tmp/oc-build-sendfile
-
 docker run -d --name openclaw-e2e \
   -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
-  oc-e2e-sendfile-img \
-  node openclaw.mjs gateway --allow-unconfigured --bind loopback
+  --entrypoint /bin/sh \
+  ghcr.io/openclaw/openclaw:latest \
+  -c '
+    set -e
+    mkdir -p /home/node/.openclaw
+    printf "%s" "{\"gateway\":{\"auth\":{\"mode\":\"none\"}},\"agents\":{\"defaults\":{\"model\":{\"primary\":\"anthropic/claude-sonnet-4-6\"}}}}" \
+      > /home/node/.openclaw/openclaw.json
+    cd /app
+    node openclaw.mjs mcp set send-file \
+      "{\"url\":\"http://127.0.0.1:19090/mcp\",\"transport\":\"streamable-http\"}"
+    exec docker-entrypoint.sh node openclaw.mjs gateway \
+      --allow-unconfigured --bind loopback
+  '
 
 # wait for "[gateway] ready"
 
@@ -347,6 +349,16 @@ docker run --rm \
   node:20 \
   node ./scripts/e2e-openclaw-send-file.mjs
 ```
+
+In production the same registration is a one-shot operator step:
+
+```bash
+openclaw mcp set send-file \
+  '{"url":"http://127.0.0.1:19090/mcp","transport":"streamable-http"}'
+```
+
+The CLI persists the entry into `~/.openclaw/openclaw.json`'s
+`mcp.servers.send-file`, picked up at the next gateway boot.
 
 Expected tail:
 

--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -296,6 +296,84 @@ real `auth-profiles.json` from the host instead of using
 (e.g. `openai-codex`) may fail to refresh from inside a container with
 restricted network paths — the API-key route is the most reliable.
 
+## MCP send_file tool verification (agent → caller, structured path)
+
+A fifth exercise at
+`packages/client/scripts/e2e-openclaw-send-file.mjs` verifies the
+tool-call alternative to text markers: bridge-client exposes a local
+Streamable HTTP MCP server with a `send_file(path, name?)` tool, the
+operator registers it in OpenClaw's `mcp.servers` config, and the
+agent invokes the tool to deliver files instead of emitting a text
+marker.
+
+The script:
+
+- writes a fixture at `/tmp/send-file-test/tool-output.txt` (sidecar-
+  private),
+- enables `sendFileMcp` on the backend with the fixture dir as an
+  allowed root and a fixed port (default `19090`, override with
+  `SEND_FILE_MCP_PORT`),
+- prompts the model to call `send_file` with the fixture path,
+- asserts the resulting artifact carries `name="send-file"` (the MCP
+  tool path tag) and the FilePart bytes equal the fixture content.
+
+The OpenClaw image must be built with `mcp.servers.send-file`
+configured to match the bridge-client's MCP URL:
+
+```bash
+mkdir -p /tmp/oc-build-sendfile
+cat > /tmp/oc-build-sendfile/Dockerfile << 'EOF'
+FROM ghcr.io/openclaw/openclaw:latest
+USER root
+RUN mkdir -p /home/node/.openclaw && \
+    printf '%s' '{"gateway":{"auth":{"mode":"none"}},"agents":{"defaults":{"model":{"primary":"anthropic/claude-sonnet-4-6"}}},"mcp":{"servers":{"send-file":{"url":"http://127.0.0.1:19090/mcp","transport":"streamable-http"}}}}' \
+      > /home/node/.openclaw/openclaw.json && \
+    chown -R node:node /home/node/.openclaw
+USER node
+EOF
+docker build -t oc-e2e-sendfile-img /tmp/oc-build-sendfile
+
+docker run -d --name openclaw-e2e \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  oc-e2e-sendfile-img \
+  node openclaw.mjs gateway --allow-unconfigured --bind loopback
+
+# wait for "[gateway] ready"
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  -e DEBUG=1 \
+  node:20 \
+  node ./scripts/e2e-openclaw-send-file.mjs
+```
+
+Expected tail:
+
+```
+[frame +Xms] task.artifact artifact id=… name=send-file parts=[file]
+[frame +Xms] task.complete complete state=completed
+[e2e] PASS: terminal frame is task.complete with state=completed
+[e2e] PASS: at least one FilePart artifact emitted via send_file tool
+[e2e] PASS: at least one artifact with name="send-file" (the MCP tool path tag)
+[e2e] PASS: FilePart bytes match fixture
+```
+
+Notes:
+
+- OpenClaw prefixes external MCP tool names with the server name, so
+  the agent sees `send-file__send_file` in its tool catalog.
+- The bridge-client lazy-starts the MCP HTTP listener inside `handle()`,
+  so the gateway's `bundle-mcp` runtime must reach it AFTER bridge-client
+  has registered an active task. With `--network container:` shared
+  loopback this works because OpenClaw computes the per-session catalog
+  on first `chat.send` (after bridge-client is up), not at boot.
+- Routing: `sendFileMcp` follows R1 — single in-flight task per backend.
+  Concurrent calls during overlapping tasks return `ambiguous-task`.
+- The text-marker `attachOutputs` path remains supported and may be
+  enabled simultaneously as a fallback for callers that don't register
+  the MCP server.
+
 ## Teardown
 
 ```bash

--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -164,6 +164,67 @@ you cannot verify the multi-artifact cadence a real tool-use run
 produces. Use `DEBUG=1` in the sidecar env to see every chat /
 session.message frame as it arrives.
 
+## File-passthrough verification (caller → agent)
+
+A third exercise at `packages/client/scripts/e2e-openclaw-file-passthrough.mjs`
+verifies that bridge-client's non-image attachment mapping matches the
+shape OpenClaw `>= v2026.4.27` expects on `chat.send`. The script sends
+a tiny synthetic PDF as a `kind: 'file'` part with `mimeType:
+'application/pdf'` and asserts:
+
+- the gateway accepts the attachment shape (no `chat.send` error like
+  "only image/* supported" or "non-image attachments are not supported
+  on this entrypoint"),
+- any failure that follows is downstream of attachment parsing
+  (typically agent auth / model invocation, which is acceptable when
+  no provider auth is configured).
+
+Because the protocol-level test does not need a real model response,
+you can run it against an unauthenticated gateway. The cleanest setup
+is `gateway.auth.mode = "none"` + `--bind loopback` (avoids container
+token extraction entirely):
+
+```bash
+docker run -d --name openclaw-e2e \
+  --entrypoint /bin/sh \
+  ghcr.io/openclaw/openclaw:latest \
+  -c 'mkdir -p /home/node/.openclaw && \
+      printf %s "{\"gateway\":{\"auth\":{\"mode\":\"none\"}}}" \
+        > /home/node/.openclaw/openclaw.json && \
+      exec docker-entrypoint.sh node openclaw.mjs gateway \
+        --allow-unconfigured --bind loopback'
+
+# wait for "[gateway] ready" in `docker logs openclaw-e2e`
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  -e DEBUG=1 \
+  node:20 \
+  node ./scripts/e2e-openclaw-file-passthrough.mjs
+```
+
+Expected tail:
+
+```
+[frame +Xms] task.artifact artifact id=… name=openclaw-result …
+[frame +Xms] task.complete complete state=completed
+[e2e] PASS: gateway accepted non-image attachment shape (no protocol-shape rejection)
+[e2e] PASS: task.complete carries state=completed (got completed)
+```
+
+If you see a fail like `code=gateway_send_failed msg="…only image/* supported…"`,
+the gateway image is older than v2026.4.27 and predates the non-image
+attachment acceptance path (CHANGELOG: "Gateway/chat: accept non-image
+attachments through chat.send by staging them as agent-readable media
+paths"). Pull a newer tag.
+
+> **Note**: `--bind loopback` is required when `auth.mode = "none"` —
+> the container default of `bind=auto` (0.0.0.0) refuses to start
+> unauthenticated. Loopback is fine because the sidecar shares the
+> gateway container's network namespace via `--network container:…`
+> and connects through `127.0.0.1` from inside.
+
 ## Teardown
 
 ```bash

--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -225,6 +225,77 @@ paths"). Pull a newer tag.
 > gateway container's network namespace via `--network container:…`
 > and connects through `127.0.0.1` from inside.
 
+## Outbound attachment verification (agent → caller)
+
+A fourth exercise at
+`packages/client/scripts/e2e-openclaw-attach-outputs.mjs` verifies the
+opposite direction: bridge-client parses `[bridge-attach: <path>]`
+markers in real assistant messages, reads the referenced file from
+disk, and emits it as an A2A FilePart artifact alongside the cleaned
+text.
+
+The script:
+
+- writes a fixture at `/tmp/attach-test/hello.txt` (sidecar-private —
+  the gateway never sees it; markers are pure text in the chat
+  transcript),
+- configures bridge-client with `attachOutputs.allowedRoots: ['/tmp/attach-test']`,
+- prompts the model to reply with EXACTLY `[bridge-attach: <fixture-path>]`,
+- asserts that the resulting artifact carries a FilePart whose decoded
+  bytes equal the fixture content, the filename matches, and the
+  marker is stripped from the text part.
+
+Unlike the file-passthrough exercise, this one needs a working agent
+provider so the model actually replies. Cheapest setup is an
+Anthropic API key + `anthropic/claude-sonnet-4-6`:
+
+```bash
+mkdir -p /tmp/oc-build-anthropic
+cat > /tmp/oc-build-anthropic/Dockerfile << 'EOF'
+FROM ghcr.io/openclaw/openclaw:latest
+USER root
+RUN mkdir -p /home/node/.openclaw && \
+    printf '%s' '{"gateway":{"auth":{"mode":"none"}},"agents":{"defaults":{"model":{"primary":"anthropic/claude-sonnet-4-6"}}}}' \
+      > /home/node/.openclaw/openclaw.json && \
+    chown -R node:node /home/node/.openclaw
+USER node
+EOF
+docker build -t oc-e2e-anthropic /tmp/oc-build-anthropic
+
+docker run -d --name openclaw-e2e \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  oc-e2e-anthropic \
+  node openclaw.mjs gateway --allow-unconfigured --bind loopback
+
+# wait for "[gateway] ready"
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  -e DEBUG=1 \
+  node:20 \
+  node ./scripts/e2e-openclaw-attach-outputs.mjs
+```
+
+Expected tail (sonnet-4-6 will echo the marker exactly given the
+"reply with EXACTLY" framing):
+
+```
+[frame +Xms] task.artifact artifact id=… name=openclaw-result parts=[file]
+[frame +Xms] task.complete complete state=completed
+[e2e] PASS: terminal frame is task.complete with state=completed
+[e2e] PASS: at least one FilePart artifact emitted
+[e2e] PASS: FilePart bytes match fixture
+[e2e] PASS: FilePart name is fixture basename
+[e2e] PASS: marker stripped from artifact text on success
+```
+
+Costs roughly one short Claude call per run (a few cents). Mounting a
+real `auth-profiles.json` from the host instead of using
+`ANTHROPIC_API_KEY` works too, but mind that OAuth-based providers
+(e.g. `openai-codex`) may fail to refresh from inside a container with
+restricted network paths — the API-key route is the most reliable.
+
 ## Teardown
 
 ```bash

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -20,6 +20,7 @@
     "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@vicoop-bridge/protocol": "workspace:*",
     "ws": "^8.18.0",
     "zod": "^3.23.8"

--- a/packages/client/scripts/e2e-claude-input-image.mjs
+++ b/packages/client/scripts/e2e-claude-input-image.mjs
@@ -1,0 +1,90 @@
+// E2E for image FilePart input on the claude backend. Verifies that a
+// PNG passed as a FilePart on the A2A frame reaches the model's vision
+// path via stream-json stdin and the model responds about the image.
+//
+// Prereqs: `claude` on PATH and authenticated; dist built.
+
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+// 1x1 solid red PNG, RGB(255,0,0). Generated with Node zlib + manual chunks
+// and verified by re-decoding the IDAT.
+const RED_PIXEL_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  'What single color is the attached image? Reply with one word only.';
+
+const backend = createClaudeBackend({
+  extraArgs: ['--max-turns', '1'],
+});
+
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-claude-img-${t0}`,
+  contextId: `e2e-claude-img-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `m-${t0}`,
+    parts: [
+      { kind: 'text', text: PROMPT },
+      {
+        kind: 'file',
+        file: { name: 'red.png', mimeType: 'image/png', bytes: RED_PIXEL_PNG_BASE64 },
+      },
+    ],
+  },
+};
+
+const frames = [];
+console.log(`[e2e] task=${task.taskId}`);
+console.log(`[e2e] prompt: ${PROMPT}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary = '';
+    if (f.type === 'task.artifact') {
+      const k = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `name=${f.artifact.name} parts=[${k}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `state=${f.status.state}`;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const text = artifacts
+  .flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'text').map((p) => p.text))
+  .join('')
+  .toLowerCase();
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal is task.complete with state=completed (got ${terminal?.type})`,
+);
+assert(text.includes('red'), `model response mentions "red" (got "${text.trim()}")`);
+
+console.log(`[e2e] assistant text: ${text.trim()}`);
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-claude-input-pdf.mjs
+++ b/packages/client/scripts/e2e-claude-input-pdf.mjs
@@ -1,0 +1,128 @@
+// E2E for PDF FilePart input on the claude backend. Generates a minimal
+// 1-page PDF containing a known word, sends it as a `document` content
+// block via stream-json stdin, and asserts the model's reply mentions
+// that word.
+//
+// Prereqs: `claude` on PATH and authenticated; dist built.
+
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+const SECRET_WORD = process.env.E2E_PDF_WORD ?? 'KUMQUAT';
+
+// Build a minimal valid PDF (text drawn with Helvetica) on the fly so the
+// fixture stays self-contained. xref offsets are computed from the actual
+// byte positions to keep the PDF parseable.
+function makeMinimalPdf(text) {
+  const enc = (s) => Buffer.from(s, 'latin1');
+  const offsets = new Array(6).fill(0);
+  let buf = enc('%PDF-1.4\n%\xC2\xA5\xC2\xB1\xC3\xAB\n');
+
+  const obj = (n, body) => {
+    offsets[n] = buf.length;
+    buf = Buffer.concat([buf, enc(`${n} 0 obj\n${body}\nendobj\n`)]);
+  };
+
+  obj(1, '<< /Type /Catalog /Pages 2 0 R >>');
+  obj(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
+  obj(
+    3,
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>',
+  );
+  const stream = `BT /F1 36 Tf 40 100 Td (${text}) Tj ET`;
+  obj(4, `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`);
+  obj(5, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+
+  const xrefStart = buf.length;
+  let xref = `xref\n0 6\n0000000000 65535 f \n`;
+  for (let i = 1; i <= 5; i++) {
+    xref += `${offsets[i].toString().padStart(10, '0')} 00000 n \n`;
+  }
+  xref += `trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xrefStart}\n%%EOF\n`;
+  return Buffer.concat([buf, enc(xref)]);
+}
+
+const pdfBytes = makeMinimalPdf(SECRET_WORD);
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  'The attached PDF contains a single word. Reply with that word in uppercase, and nothing else.';
+
+const backend = createClaudeBackend({
+  extraArgs: ['--max-turns', '1'],
+});
+
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-claude-pdf-${t0}`,
+  contextId: `e2e-claude-pdf-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `m-${t0}`,
+    parts: [
+      { kind: 'text', text: PROMPT },
+      {
+        kind: 'file',
+        file: {
+          name: 'word.pdf',
+          mimeType: 'application/pdf',
+          bytes: pdfBytes.toString('base64'),
+        },
+      },
+    ],
+  },
+};
+
+const frames = [];
+console.log(`[e2e] task=${task.taskId}`);
+console.log(`[e2e] secret word: ${SECRET_WORD}`);
+console.log(`[e2e] pdf size: ${pdfBytes.length} bytes`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary = '';
+    if (f.type === 'task.artifact') {
+      const k = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `name=${f.artifact.name} parts=[${k}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `state=${f.status.state}`;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const text = artifacts
+  .flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'text').map((p) => p.text))
+  .join('');
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal is task.complete with state=completed (got ${terminal?.type})`,
+);
+assert(
+  text.toUpperCase().includes(SECRET_WORD),
+  `model response contains the secret word "${SECRET_WORD}" (got "${text.trim()}")`,
+);
+
+console.log(`[e2e] assistant text: ${text.trim()}`);
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-claude-send-file.mjs
+++ b/packages/client/scripts/e2e-claude-send-file.mjs
@@ -1,0 +1,115 @@
+// E2E for the send_file MCP tool path on the claude backend. Verifies:
+//   - bridge-client lazy-starts the MCP server, registers it via
+//     `--mcp-config`, and the spawned claude sees the `send_file` tool.
+//   - The model invokes `send_file(path)` during the run.
+//   - bridge-client's MCP server reads the file, emits a task.artifact
+//     containing a FilePart whose bytes match the fixture.
+//
+// Prereqs: `claude` on PATH and authenticated; dist built.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+const FIXTURE_DIR = '/tmp/claude-send-file-e2e';
+const FIXTURE_PATH = path.join(FIXTURE_DIR, 'tool-output.txt');
+const FIXTURE_CONTENT = 'sent via send_file tool from claude e2e';
+
+fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+fs.writeFileSync(FIXTURE_PATH, FIXTURE_CONTENT);
+
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  `Use the send_file tool from the vicoop-bridge MCP server to deliver the file at "${FIXTURE_PATH}" to the caller. After the tool returns, briefly confirm you sent the file (one short sentence).`;
+
+const backend = createClaudeBackend({
+  extraArgs: ['--max-turns', '4', '--permission-mode', 'bypassPermissions'],
+  sendFileMcp: {
+    allowedRoots: [FIXTURE_DIR],
+    maxBytes: 1024 * 1024,
+    host: '127.0.0.1',
+  },
+});
+
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-claude-sendfile-${t0}`,
+  contextId: `e2e-claude-sendfile-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `m-${t0}`,
+    parts: [{ kind: 'text', text: PROMPT }],
+  },
+};
+
+const frames = [];
+console.log(`[e2e] fixture: ${FIXTURE_PATH} (${FIXTURE_CONTENT.length} bytes)`);
+console.log(`[e2e] task=${task.taskId} context=${task.contextId}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary = '';
+    if (f.type === 'task.artifact') {
+      const k = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `name=${f.artifact.name} parts=[${k}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `state=${f.status.state}`;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const fileParts = artifacts.flatMap((a) =>
+  a.artifact.parts.filter((p) => p.kind === 'file'),
+);
+const sendFileArtifacts = artifacts.filter((a) => a.artifact.name === 'send-file');
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal is task.complete with state=completed (got ${terminal?.type})`,
+);
+assert(
+  sendFileArtifacts.length >= 1,
+  `at least one artifact with name="send-file" (got ${sendFileArtifacts.length}; check the model invoked the tool)`,
+);
+assert(fileParts.length >= 1, `at least one FilePart artifact (got ${fileParts.length})`);
+
+if (fileParts.length >= 1) {
+  const fp = fileParts[0];
+  const decoded = Buffer.from(fp.file.bytes ?? '', 'base64').toString('utf8');
+  assert(
+    decoded === FIXTURE_CONTENT,
+    `FilePart bytes match fixture (expected="${FIXTURE_CONTENT}", got="${decoded}")`,
+  );
+}
+
+const server = backend.getSendFileMcpServer();
+if (server) await server.close();
+try {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+} catch {
+  /* ignore */
+}
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-claude-text-smoke.mjs
+++ b/packages/client/scripts/e2e-claude-text-smoke.mjs
@@ -1,0 +1,80 @@
+// E2E smoke for the claude backend's stream-json stdin input path.
+// Verifies a plain text TaskAssign roundtrips through the real `claude` CLI
+// and produces a task.complete with non-empty text.
+//
+// Prereqs:
+//   - `claude` on PATH and authenticated
+//   - dist built: `pnpm --filter @vicoop-bridge/client build`
+
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+const PROMPT = process.env.E2E_PROMPT ?? 'Reply with the single word: PONG';
+
+const backend = createClaudeBackend({
+  // Keep the prompt deterministic / fast.
+  extraArgs: ['--max-turns', '1'],
+});
+
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-claude-text-${t0}`,
+  contextId: `e2e-claude-text-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `m-${t0}`,
+    parts: [{ kind: 'text', text: PROMPT }],
+  },
+};
+
+const frames = [];
+console.log(`[e2e] task=${task.taskId}`);
+console.log(`[e2e] prompt: ${PROMPT}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary = '';
+    if (f.type === 'task.artifact') {
+      const k = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `name=${f.artifact.name} parts=[${k}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `state=${f.status.state}`;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal is task.complete with state=completed (got ${terminal?.type})`,
+);
+assert(artifacts.length >= 1, `at least one task.artifact emitted (got ${artifacts.length})`);
+
+const text = artifacts
+  .flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'text').map((p) => p.text))
+  .join('');
+assert(text.length > 0, `text artifact has content (got "${text}")`);
+console.log(`[e2e] assistant text: ${text.trim()}`);
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-openclaw-attach-outputs.mjs
+++ b/packages/client/scripts/e2e-openclaw-attach-outputs.mjs
@@ -1,0 +1,146 @@
+// E2E harness for the agent->caller direction. Verifies that bridge-client
+// parses `[bridge-attach: <path>]` markers in real OpenClaw assistant
+// messages and emits the referenced file as an A2A FilePart artifact.
+//
+// Setup:
+//   - the sidecar writes a small fixture into /tmp/attach-test/ (sidecar-
+//     private; the gateway never sees it — markers are pure text passed
+//     through the chat transcript)
+//   - bridge-client is configured with attachOutputs.allowedRoots = [/tmp/attach-test]
+//   - prompt asks the model to reply with EXACTLY a string containing the
+//     bridge-attach marker pointing at the fixture
+//
+// Success criteria:
+//   - at least one task.artifact contains a FilePart whose bytes match the
+//     fixture content
+//   - the marker text is stripped from the artifact text part
+//   - terminal frame is task.complete with state=completed
+//
+// Requires the gateway container to have agent auth configured (mounted
+// auth-profiles.json) so the model can actually run.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createOpenclawBackend } from '../dist/backends/openclaw.js';
+
+const FIXTURE_DIR = '/tmp/attach-test';
+const FIXTURE_PATH = path.join(FIXTURE_DIR, 'hello.txt');
+const FIXTURE_CONTENT = 'hello from bridge-attach e2e';
+
+fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+fs.writeFileSync(FIXTURE_PATH, FIXTURE_CONTENT);
+
+const PROMPT = process.env.E2E_PROMPT ??
+  `Reply with EXACTLY the following text, character for character, with no preamble, no explanation, no quotes, no markdown formatting around it:
+
+[bridge-attach: ${FIXTURE_PATH}]
+
+Just that single line. Nothing else.`;
+
+const backend = createOpenclawBackend({
+  url: 'ws://127.0.0.1:18789',
+  token: process.env.OPENCLAW_GATEWAY_TOKEN,
+  debug: process.env.DEBUG === '1',
+  taskTimeoutMs: 120_000,
+  attachOutputs: {
+    allowedRoots: [FIXTURE_DIR],
+    maxBytes: 1024 * 1024,
+  },
+});
+
+const frames = [];
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-attach-${t0}`,
+  contextId: `e2e-attach-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `e2e-attach-msg-${t0}`,
+    parts: [{ kind: 'text', text: PROMPT }],
+  },
+};
+
+console.log(`[e2e] fixture: ${FIXTURE_PATH} (${FIXTURE_CONTENT.length} bytes)`);
+console.log(`[e2e] task=${task.taskId} context=${task.contextId}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary;
+    if (f.type === 'task.artifact') {
+      const partKinds = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `artifact id=${f.artifact.artifactId.slice(0, 8)} name=${f.artifact.name} parts=[${partKinds}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `complete state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `fail code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `status state=${f.status.state}`;
+    } else {
+      summary = f.type;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+
+console.log('');
+console.log(`[e2e] artifact count: ${artifacts.length}`);
+console.log(`[e2e] terminal: ${terminal?.type}`);
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal frame is task.complete with state=completed (got ${terminal?.type} ${terminal?.type === 'task.complete' ? terminal.status.state : ''})`,
+);
+
+const fileParts = artifacts.flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'file'));
+assert(
+  fileParts.length >= 1,
+  `at least one FilePart artifact emitted (got ${fileParts.length}; check whether the model echoed the marker verbatim)`,
+);
+
+if (fileParts.length >= 1) {
+  const fp = fileParts[0];
+  const decoded = Buffer.from(fp.file.bytes ?? '', 'base64').toString('utf8');
+  assert(
+    decoded === FIXTURE_CONTENT,
+    `FilePart bytes match fixture (expected="${FIXTURE_CONTENT}", got="${decoded}")`,
+  );
+  assert(
+    fp.file.name === 'hello.txt',
+    `FilePart name is fixture basename (got "${fp.file.name}")`,
+  );
+}
+
+const allTextInArtifacts = artifacts
+  .flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'text').map((p) => p.text))
+  .join('\n');
+assert(
+  !allTextInArtifacts.includes('[bridge-attach:'),
+  `marker stripped from artifact text on success (text="${allTextInArtifacts.slice(0, 200)}")`,
+);
+
+// Cleanup
+try {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+} catch {
+  /* ignore */
+}
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-openclaw-file-passthrough.mjs
+++ b/packages/client/scripts/e2e-openclaw-file-passthrough.mjs
@@ -1,0 +1,145 @@
+// E2E harness for caller->agent non-image attachment passthrough against a
+// real OpenClaw v2026.4.27+ gateway. Meant to be run from a Node sidecar
+// that shares the gateway container's network namespace; see
+// docs/openclaw-e2e.md.
+//
+// What this verifies:
+//   - bridge-client maps `kind: 'file'` non-image FileParts into chat.send
+//     attachments with `type: 'file'`
+//   - OpenClaw v2026.4.27 accepts the attachment shape (no chat.send error
+//     about "only image/* supported" or "non-image attachments not
+//     supported on this entrypoint")
+//   - Any failure that follows is downstream of attachment parsing
+//     (typically agent auth / model invocation), not protocol shape
+//
+// Without CLAUDE_AI_SESSION_KEY the agent itself fails before producing a
+// real response, but the gateway's chat.send still acks the attachment —
+// which is precisely the bridge-client <-> gateway contract under test.
+// The success criterion is "no protocol-shape rejection at chat.send",
+// not "agent succeeded".
+//
+// Exits non-zero if the gateway rejected the attachment shape.
+
+import { createOpenclawBackend } from '../dist/backends/openclaw.js';
+
+// Token is optional: when the gateway runs with `auth.mode = "none"` no
+// token is required. The bridge-client's GatewayClient passes the token
+// through unchanged when set; the gateway side ignores it under mode=none.
+const TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+// Minimal valid PDF (not a real document, but valid header so OpenClaw's
+// mime sniff sees `%PDF-` and routes correctly).
+const TINY_PDF_BASE64 =
+  'JVBERi0xLjQKJcKlwrHDqwoxIDAgb2JqCjw8L0xlbmd0aCAxNT4+CnN0cmVhbQpCVCAvRjEgMTIgVGYgKGhlbGxvKSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnRyYWlsZXIKPDwvUm9vdCAxIDAgUj4+CiUlRU9G';
+
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  'I am attaching a small PDF file. Please confirm receipt and describe what you see in two sentences.';
+
+const backend = createOpenclawBackend({
+  url: 'ws://127.0.0.1:18789',
+  token: TOKEN,
+  debug: process.env.DEBUG === '1',
+  taskTimeoutMs: 60_000,
+});
+
+const frames = [];
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-file-${t0}`,
+  contextId: `e2e-file-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `e2e-file-msg-${t0}`,
+    parts: [
+      { kind: 'text', text: PROMPT },
+      {
+        kind: 'file',
+        file: {
+          name: 'sample.pdf',
+          mimeType: 'application/pdf',
+          bytes: TINY_PDF_BASE64,
+        },
+      },
+    ],
+  },
+};
+
+console.log(`[e2e] prompt: ${PROMPT}`);
+console.log(`[e2e] task=${task.taskId} context=${task.contextId}`);
+console.log(`[e2e] attachment: name=sample.pdf mime=application/pdf base64Len=${TINY_PDF_BASE64.length}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    const summary =
+      f.type === 'task.artifact'
+        ? `artifact id=${f.artifact.artifactId.slice(0, 8)} name=${f.artifact.name} bytes=${JSON.stringify(f.artifact.parts).length}`
+        : f.type === 'task.complete'
+          ? `complete state=${f.status.state}`
+          : f.type === 'task.fail'
+            ? `fail code=${f.error.code} msg=${f.error.message}`
+            : f.type === 'task.status'
+              ? `status state=${f.status.state}`
+              : f.type;
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+
+console.log('');
+console.log(`[e2e] terminal: ${terminal?.type}`);
+if (terminal?.type === 'task.fail') {
+  console.log(`[e2e] error code: ${terminal.error.code}`);
+  console.log(`[e2e] error msg: ${terminal.error.message}`);
+}
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+// Primary contract: the gateway must NOT reject the chat.send call with a
+// protocol-shape error about non-image attachments. If our mapping is
+// wrong, the failure surfaces with `gateway_send_failed` carrying a
+// message like "only image/* supported" or "non-image attachments are not
+// supported on this entrypoint".
+const protocolShapeRejection =
+  terminal?.type === 'task.fail' &&
+  terminal.error.code === 'gateway_send_failed' &&
+  /only image\/\*|non-image attachments? .* not supported on this entrypoint|requireImageMime/i.test(
+    terminal.error.message ?? '',
+  );
+
+assert(!protocolShapeRejection, 'gateway accepted non-image attachment shape (no protocol-shape rejection)');
+
+// Secondary: any error must be downstream of attachment parsing — i.e.
+// either the agent ran and replied, or the agent failed for an
+// auth/model reason (acceptable without CLAUDE_AI_SESSION_KEY).
+if (terminal?.type === 'task.fail') {
+  const isAcceptableDownstreamFailure =
+    /CLAUDE_AI_SESSION_KEY|agent failed before reply|chat_error|task_timeout|gateway_chat_error|model invocation|not authenticated|auth/i.test(
+      `${terminal.error.code} ${terminal.error.message}`,
+    );
+  assert(
+    isAcceptableDownstreamFailure,
+    `failure is downstream of attachment parsing (got code=${terminal.error.code}, msg="${terminal.error.message}")`,
+  );
+} else if (terminal?.type === 'task.complete') {
+  assert(
+    terminal.status.state === 'completed',
+    `task.complete carries state=completed (got ${terminal.status.state})`,
+  );
+}
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/scripts/e2e-openclaw-send-file.mjs
+++ b/packages/client/scripts/e2e-openclaw-send-file.mjs
@@ -24,9 +24,13 @@ const FIXTURE_CONTENT = 'sent via send_file tool';
 fs.mkdirSync(FIXTURE_DIR, { recursive: true });
 fs.writeFileSync(FIXTURE_PATH, FIXTURE_CONTENT);
 
+// OpenClaw prefixes external MCP tool names with the server name (see the
+// note in docs/openclaw-e2e.md), so the model sees `send-file__send_file`
+// in its tool catalog. Naming the exact tool reduces flakiness vs. relying
+// on the model to disambiguate `send_file`.
 const PROMPT =
   process.env.E2E_PROMPT ??
-  `Please call the send_file tool to deliver the file at "${FIXTURE_PATH}" to the caller. After the tool returns, briefly confirm you sent the file (one short sentence). Do not include the path in your reply.`;
+  `Please call the send-file__send_file tool to deliver the file at "${FIXTURE_PATH}" to the caller. After the tool returns, briefly confirm you sent the file (one short sentence). Do not include the path in your reply.`;
 
 const backend = createOpenclawBackend({
   url: 'ws://127.0.0.1:18789',

--- a/packages/client/scripts/e2e-openclaw-send-file.mjs
+++ b/packages/client/scripts/e2e-openclaw-send-file.mjs
@@ -1,0 +1,136 @@
+// E2E harness for the MCP send_file tool path. Verifies the full chain:
+//   prompt -> agent invokes send_file MCP tool -> bridge-client's MCP server
+//   reads the file -> emits a task.artifact with FilePart -> handle() returns
+//
+// Setup that the runner must arrange:
+//   1. OpenClaw container has `mcp.servers.send-file` configured to point
+//      at http://127.0.0.1:<MCP_PORT>/mcp (the sidecar binds the same
+//      network namespace via --network container:<gw>)
+//   2. The agent must be able to call models (real provider auth)
+//
+// This harness picks a fixed MCP_PORT so the OpenClaw image can be built
+// once with the matching mcp.servers entry. Set SEND_FILE_MCP_PORT to
+// override (must match the gateway config).
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { createOpenclawBackend } from '../dist/backends/openclaw.js';
+
+const MCP_PORT = Number(process.env.SEND_FILE_MCP_PORT ?? 19090);
+const FIXTURE_DIR = '/tmp/send-file-test';
+const FIXTURE_PATH = path.join(FIXTURE_DIR, 'tool-output.txt');
+const FIXTURE_CONTENT = 'sent via send_file tool';
+
+fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+fs.writeFileSync(FIXTURE_PATH, FIXTURE_CONTENT);
+
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  `Please call the send_file tool to deliver the file at "${FIXTURE_PATH}" to the caller. After the tool returns, briefly confirm you sent the file (one short sentence). Do not include the path in your reply.`;
+
+const backend = createOpenclawBackend({
+  url: 'ws://127.0.0.1:18789',
+  token: process.env.OPENCLAW_GATEWAY_TOKEN,
+  debug: process.env.DEBUG === '1',
+  taskTimeoutMs: 120_000,
+  sendFileMcp: {
+    allowedRoots: [FIXTURE_DIR],
+    maxBytes: 1024 * 1024,
+    port: MCP_PORT,
+    host: '127.0.0.1',
+  },
+});
+
+const frames = [];
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-send-file-${t0}`,
+  contextId: `e2e-send-file-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `e2e-send-file-msg-${t0}`,
+    parts: [{ kind: 'text', text: PROMPT }],
+  },
+};
+
+console.log(`[e2e] fixture: ${FIXTURE_PATH} (${FIXTURE_CONTENT.length} bytes)`);
+console.log(`[e2e] MCP port: ${MCP_PORT}`);
+console.log(`[e2e] task=${task.taskId} context=${task.contextId}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary;
+    if (f.type === 'task.artifact') {
+      const partKinds = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `artifact id=${f.artifact.artifactId.slice(0, 8)} name=${f.artifact.name} parts=[${partKinds}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `complete state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `fail code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `status state=${f.status.state}`;
+    } else {
+      summary = f.type;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+
+console.log('');
+console.log(`[e2e] artifact count: ${artifacts.length}`);
+console.log(`[e2e] terminal: ${terminal?.type}`);
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal frame is task.complete with state=completed (got ${terminal?.type} ${terminal?.type === 'task.complete' ? terminal.status.state : ''})`,
+);
+
+const fileParts = artifacts.flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'file'));
+assert(
+  fileParts.length >= 1,
+  `at least one FilePart artifact emitted via send_file tool (got ${fileParts.length}; check that the model invoked the tool and the bridge-client MCP server received the call)`,
+);
+
+const sendFileArtifacts = artifacts.filter((a) => a.artifact.name === 'send-file');
+assert(
+  sendFileArtifacts.length >= 1,
+  `at least one artifact with name="send-file" (the MCP tool path tag) was emitted (got ${sendFileArtifacts.length})`,
+);
+
+if (fileParts.length >= 1) {
+  const fp = fileParts[0];
+  const decoded = Buffer.from(fp.file.bytes ?? '', 'base64').toString('utf8');
+  assert(
+    decoded === FIXTURE_CONTENT,
+    `FilePart bytes match fixture (expected="${FIXTURE_CONTENT}", got="${decoded}")`,
+  );
+}
+
+// Cleanup
+const server = backend.getSendFileMcpServer();
+if (server) await server.close();
+try {
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+} catch {
+  /* ignore */
+}
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -330,6 +330,35 @@ test('rejects FilePart with unsupported MIME (e.g. application/zip)', async () =
   assert.equal(fail.error.code, 'unsupported_file_mime');
 });
 
+test('rejects FilePart whose decoded bytes exceed INPUT_FILE_MAX_BYTES (5 MiB)', async () => {
+  let spawned = 0;
+  const backend = createClaudeBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+  });
+  // 6 MiB of zeros encoded as base64 → ~8 MiB string, decoded size 6 MiB > cap.
+  const oversize = Buffer.alloc(6 * 1024 * 1024).toString('base64');
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: oversize } }],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  assert.equal(spawned, 0);
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'file_too_large');
+});
+
 test('rejects FilePart with uri-only (no inline bytes)', async () => {
   const backend = createClaudeBackend({
     spawn: () => {
@@ -679,6 +708,61 @@ test('coalesces split stdout chunks (partial line across data events)', async ()
   const artifacts = frames.filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact');
   assert.equal(artifacts.length, 1);
   assert.equal(textOf(artifacts[0]), 'split');
+});
+
+test('skips tool_result media whose decoded bytes match an inbound FilePart (input echo dedup)', async () => {
+  const sharedBytes = 'iVBORw0KAA==';
+  const fake = scriptedSpawn({
+    lines: [
+      // Same base64 the caller sent on stdin — the model "Read" the input.
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              tool_use_id: 'tu_echo',
+              type: 'tool_result',
+              content: [
+                {
+                  type: 'image',
+                  source: { type: 'base64', media_type: 'image/png', data: sharedBytes },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', result: 'done' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm',
+      parts: [
+        { kind: 'text', text: 'describe' },
+        { kind: 'file', file: { mimeType: 'image/png', bytes: sharedBytes } },
+      ],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  const fileArtifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
+      f.type === 'task.artifact' && f.artifact.parts[0]?.kind === 'file',
+  );
+  assert.equal(
+    fileArtifacts.length,
+    0,
+    'tool_result whose bytes echo the inbound FilePart must not re-emit',
+  );
 });
 
 test('emits FilePart artifact when tool_result contains an image block', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -720,6 +720,77 @@ test('rolls back the session binding when claude exits non-zero on a fresh sessi
   assert.ok(child.args.indexOf('--session-id') !== -1, 'must mint a fresh session id');
 });
 
+test('rollback does not delete a binding a concurrent task has refreshed', async () => {
+  // Task A (first) holds open without finishing. Task B (second) starts
+  // on the same contextId, sees the binding A wrote, refreshes lastUsedAt
+  // and bumps writeId. Then A fails. The rollback must NOT delete the
+  // entry — task C should still resume B's id.
+  const ctx = 'ctx-concurrent-rollback';
+  let releaseA: () => void = () => {};
+  const aReady = new Promise<void>((resolve) => {
+    releaseA = resolve;
+  });
+
+  const fakeA = makeFakeSpawn((child) => {
+    setImmediate(async () => {
+      await aReady;
+      child.emitStderr('boom\n');
+      setImmediate(() => child.finish(1));
+    });
+  });
+  const fakeB = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok-b' })],
+    exitCode: 0,
+  });
+  const fakeC = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok-c' })],
+    exitCode: 0,
+  });
+  let call = 0;
+  const wrappedSpawn = (cmd: string, args: readonly string[], opts: ClaudeSpawnOptions) => {
+    call++;
+    if (call === 1) return fakeA.spawn(cmd, args, opts);
+    if (call === 2) return fakeB.spawn(cmd, args, opts);
+    return fakeC.spawn(cmd, args, opts);
+  };
+  const backend = createClaudeBackend({ spawn: wrappedSpawn });
+
+  const tA = assign('a');
+  tA.contextId = ctx;
+  const cA = collect();
+  const pA = backend.handle(tA, cA.emit, NEVER);
+  // Yield so the spawn for A lands and the binding is recorded.
+  await new Promise((r) => setImmediate(r));
+
+  const tB = assign('b');
+  tB.contextId = ctx;
+  const cB = collect();
+  await backend.handle(tB, cB.emit, NEVER);
+  const childB = fakeB.lastChild()!;
+  const resumeIdxB = childB.args.indexOf('--resume');
+  assert.ok(resumeIdxB !== -1, 'task B must resume task A\'s session');
+  const sidB = String(childB.args[resumeIdxB + 1]);
+
+  // Now let task A fail; its rollback must skip the delete because B
+  // refreshed the binding (bumped writeId).
+  releaseA();
+  await pA;
+  assert.equal(
+    cA.frames.find((f) => f.type === 'task.fail')?.error.code,
+    'claude_exit_nonzero',
+  );
+
+  // Task C must still resume B's session id, proving the binding survived
+  // A's rollback.
+  const tC = assign('c');
+  tC.contextId = ctx;
+  await backend.handle(tC, collect().emit, NEVER);
+  const childC = fakeC.lastChild()!;
+  const resumeIdxC = childC.args.indexOf('--resume');
+  assert.ok(resumeIdxC !== -1, 'task C must resume — binding must not have been wiped');
+  assert.equal(String(childC.args[resumeIdxC + 1]), sidB);
+});
+
 test('coalesces split stdout chunks (partial line across data events)', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -686,6 +686,40 @@ test('rolls back the session binding when spawn throws', async () => {
   assert.ok(child.args.indexOf('--session-id') !== -1);
 });
 
+test('rolls back the session binding when claude exits non-zero on a fresh session', async () => {
+  // First task: claude exits with a stderr message but no result. The
+  // freshly-minted sessionId was never persisted on disk, so a follow-up
+  // task on the same contextId must mint a NEW id rather than --resume.
+  const fakeFail = scriptedSpawn({ lines: [], stderr: 'auth required\n', exitCode: 2 });
+  const fakeOk = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  let firstCall = true;
+  const wrappedSpawn = (cmd: string, args: readonly string[], opts: ClaudeSpawnOptions) => {
+    if (firstCall) {
+      firstCall = false;
+      return fakeFail.spawn(cmd, args, opts);
+    }
+    return fakeOk.spawn(cmd, args, opts);
+  };
+  const backend = createClaudeBackend({ spawn: wrappedSpawn });
+  const ctx = 'ctx-exit-rollback';
+
+  const t1 = assign('first');
+  t1.contextId = ctx;
+  const c1 = collect();
+  await backend.handle(t1, c1.emit, NEVER);
+  assert.equal(c1.frames.find((f) => f.type === 'task.fail')?.error.code, 'claude_exit_nonzero');
+
+  const t2 = assign('second');
+  t2.contextId = ctx;
+  await backend.handle(t2, collect().emit, NEVER);
+  const child = fakeOk.lastChild()!;
+  assert.equal(child.args.indexOf('--resume'), -1, 'must not resume an aborted session');
+  assert.ok(child.args.indexOf('--session-id') !== -1, 'must mint a fresh session id');
+});
+
 test('coalesces split stdout chunks (partial line across data events)', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import { createClaudeBackend, type ClaudeChildHandle, type ClaudeSpawnOptions } from './claude.js';
 import type { TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
@@ -12,6 +15,8 @@ interface FakeChild extends ClaudeChildHandle {
   readonly cwd?: string;
   killed: boolean;
   killSignal: NodeJS.Signals | null;
+  stdinPayload: string;
+  stdinClosed: boolean;
   emitStdout(text: string): void;
   emitStderr(text: string): void;
   finish(code: number | null, sig?: NodeJS.Signals | null): void;
@@ -31,21 +36,47 @@ function makeFakeSpawn(configure: (child: FakeChild) => void): FakeSpawn {
       const closeListeners: Array<(code: number | null, sig: NodeJS.Signals | null) => void> = [];
       let closed = false;
 
-      const mkStream = (em: EventEmitter) =>
+      const mkReadable = (em: EventEmitter) =>
         ({
           on(event: string, cb: (...a: unknown[]) => void) {
             em.on(event, cb);
           },
         }) as unknown as NodeJS.ReadableStream;
 
+      // Fake writable stream that just captures whatever the backend writes.
+      // `end(payload)` is the only write call the backend makes, so we don't
+      // bother differentiating write vs end here.
+      const stdinChunks: string[] = [];
+      const stdin: NodeJS.WritableStream = {
+        write(chunk: unknown): boolean {
+          stdinChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Buffer).toString('utf8'));
+          return true;
+        },
+        end(chunk?: unknown) {
+          if (chunk !== undefined) {
+            stdinChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Buffer).toString('utf8'));
+          }
+          (child as { stdinClosed: boolean }).stdinClosed = true;
+          return stdin;
+        },
+        on() { return stdin; },
+        once() { return stdin; },
+        emit() { return false; },
+      } as unknown as NodeJS.WritableStream;
+
       const child: FakeChild = {
         command,
         args,
         cwd: options.cwd,
-        stdout: mkStream(stdoutEmitter),
-        stderr: mkStream(stderrEmitter),
+        stdin,
+        stdout: mkReadable(stdoutEmitter),
+        stderr: mkReadable(stderrEmitter),
         killed: false,
         killSignal: null,
+        get stdinPayload() {
+          return stdinChunks.join('');
+        },
+        stdinClosed: false,
         kill(sig?: NodeJS.Signals) {
           this.killed = true;
           this.killSignal = sig ?? 'SIGTERM';
@@ -245,7 +276,7 @@ test('abort propagates SIGTERM and completes as canceled', async () => {
   assert.equal(artifacts.length, 1);
 });
 
-test('fails fast on non-text part without spawning', async () => {
+test('rejects data parts as unsupported_part_kind without spawning', async () => {
   let spawned = 0;
   const backend = createClaudeBackend({
     spawn: () => {
@@ -261,7 +292,7 @@ test('fails fast on non-text part without spawning', async () => {
     message: {
       role: 'user',
       messageId: 'm1',
-      parts: [{ kind: 'file', file: { name: 'x.png', mimeType: 'image/png', bytes: 'AA==' } }],
+      parts: [{ kind: 'data', data: { foo: 'bar' } }],
     },
   };
   await backend.handle(task, emit, NEVER);
@@ -270,6 +301,57 @@ test('fails fast on non-text part without spawning', async () => {
   const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
   assert.ok(fail);
   assert.equal(fail.error.code, 'unsupported_part_kind');
+});
+
+test('rejects FilePart with unsupported MIME (e.g. application/zip)', async () => {
+  let spawned = 0;
+  const backend = createClaudeBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+  });
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'application/zip', bytes: 'AA==' } }],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  assert.equal(spawned, 0);
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'unsupported_file_mime');
+});
+
+test('rejects FilePart with uri-only (no inline bytes)', async () => {
+  const backend = createClaudeBackend({
+    spawn: () => {
+      throw new Error('should not spawn');
+    },
+  });
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', uri: 'https://example.com/x.png' } }],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'unsupported_file_uri');
 });
 
 test('already-aborted signal short-circuits before spawn', async () => {
@@ -291,7 +373,97 @@ test('already-aborted signal short-circuits before spawn', async () => {
   assert.equal((frames[0] as Extract<UpFrame, { type: 'task.complete' }>).status.state, 'canceled');
 });
 
-test('passes expected argv shape (prompt, session-id, stream-json, verbose, extraArgs)', async () => {
+test('stdin envelope: text-only message becomes a single text content block', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  await backend.handle(assign('hello world'), collect().emit, NEVER);
+  const child = fake.lastChild()!;
+  assert.equal(child.stdinClosed, true);
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    type: string;
+    message: { role: string; content: Array<{ type: string; text?: string }> };
+  };
+  assert.equal(env.type, 'user');
+  assert.equal(env.message.role, 'user');
+  assert.equal(env.message.content.length, 1);
+  assert.equal(env.message.content[0].type, 'text');
+  assert.equal(env.message.content[0].text, 'hello world');
+});
+
+test('stdin envelope: image FilePart maps to image content block', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [
+        { kind: 'text', text: 'what color?' },
+        { kind: 'file', file: { mimeType: 'image/png', bytes: 'iVBORw0KAA==' } },
+      ],
+    },
+  };
+  await backend.handle(task, collect().emit, NEVER);
+  const child = fake.lastChild()!;
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    message: {
+      content: Array<{
+        type: string;
+        text?: string;
+        source?: { type: string; media_type: string; data: string };
+      }>;
+    };
+  };
+  assert.equal(env.message.content.length, 2);
+  assert.equal(env.message.content[0].type, 'text');
+  assert.equal(env.message.content[1].type, 'image');
+  assert.equal(env.message.content[1].source!.type, 'base64');
+  assert.equal(env.message.content[1].source!.media_type, 'image/png');
+  assert.equal(env.message.content[1].source!.data, 'iVBORw0KAA==');
+});
+
+test('stdin envelope: PDF FilePart maps to document content block', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'application/pdf', bytes: 'JVBERi0K' } }],
+    },
+  };
+  await backend.handle(task, collect().emit, NEVER);
+  const child = fake.lastChild()!;
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    message: {
+      content: Array<{
+        type: string;
+        source?: { media_type: string; data: string };
+      }>;
+    };
+  };
+  assert.equal(env.message.content.length, 1);
+  assert.equal(env.message.content[0].type, 'document');
+  assert.equal(env.message.content[0].source!.media_type, 'application/pdf');
+  assert.equal(env.message.content[0].source!.data, 'JVBERi0K');
+});
+
+test('passes expected argv shape (stream-json, session-id, verbose, extraArgs)', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {
       child.emitStdout(JSON.stringify({ type: 'result', result: 'ok' }) + '\n');
@@ -309,16 +481,24 @@ test('passes expected argv shape (prompt, session-id, stream-json, verbose, extr
   const child = fake.lastChild();
   assert.ok(child);
   assert.equal(child.command, 'claude');
-  assert.deepEqual(child.args.slice(0, 2), ['-p', 'hi']);
+  // First positional flag is `-p` with no inline prompt — input now arrives
+  // via stdin instead of argv.
+  assert.equal(child.args[0], '-p');
+  // The prompt text must NOT appear as the second arg (it's on stdin only).
+  assert.notEqual(child.args[1], 'hi');
+
+  const inFmtIdx = child.args.indexOf('--input-format');
+  assert.ok(inFmtIdx !== -1, 'expected --input-format flag');
+  assert.equal(child.args[inFmtIdx + 1], 'stream-json');
+
+  const outFmtIdx = child.args.indexOf('--output-format');
+  assert.ok(outFmtIdx !== -1);
+  assert.equal(child.args[outFmtIdx + 1], 'stream-json');
+  assert.ok(child.args.includes('--verbose'));
 
   const sidIdx = child.args.indexOf('--session-id');
   assert.ok(sidIdx !== -1);
   assert.match(String(child.args[sidIdx + 1]), /^[0-9a-f-]{36}$/i);
-
-  const fmtIdx = child.args.indexOf('--output-format');
-  assert.ok(fmtIdx !== -1);
-  assert.equal(child.args[fmtIdx + 1], 'stream-json');
-  assert.ok(child.args.includes('--verbose'));
 
   assert.equal(child.args.at(-2), '--model');
   assert.equal(child.args.at(-1), 'sonnet');
@@ -391,8 +571,6 @@ test('keeps independent sessions for distinct contextIds', async () => {
   const sidB = String(fake.lastChild()!.args[fake.lastChild()!.args.indexOf('--session-id') + 1]);
 
   assert.notEqual(sidA, sidB);
-  // Neither should have used --resume since each contextId is fresh.
-  // (We checked the most recent child; checking both individually is overkill.)
 });
 
 test('expires the session binding past sessionTtlMs and starts fresh', async () => {
@@ -501,4 +679,159 @@ test('coalesces split stdout chunks (partial line across data events)', async ()
   const artifacts = frames.filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact');
   assert.equal(artifacts.length, 1);
   assert.equal(textOf(artifacts[0]), 'split');
+});
+
+test('emits FilePart artifact when tool_result contains an image block', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              tool_use_id: 'tu_1',
+              type: 'tool_result',
+              content: [
+                {
+                  type: 'image',
+                  source: { type: 'base64', media_type: 'image/png', data: 'AAAAB' },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', result: 'done' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+
+  const fileArtifact = frames.find(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
+      f.type === 'task.artifact' && f.artifact.parts[0]?.kind === 'file',
+  );
+  assert.ok(fileArtifact, 'expected a FilePart artifact for tool_result image');
+  const part = fileArtifact.artifact.parts[0];
+  assert.equal(part.kind, 'file');
+  if (part.kind === 'file') {
+    assert.equal(part.file.mimeType, 'image/png');
+    assert.equal(part.file.bytes, 'AAAAB');
+  }
+});
+
+test('send_file MCP: server is registered on first task and a registered handle receives invoked artifacts', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-sendfile-test-'));
+  const realRoot = await fs.realpath(root);
+  await fs.writeFile(path.join(realRoot, 'note.txt'), 'note body');
+
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    sendFileMcp: { allowedRoots: [realRoot], skipHttp: true },
+  });
+
+  // Drive a task. After it ends, the MCP server must be running and have
+  // released the task slot. We then exercise the tool path directly.
+  await backend.handle(assign('x'), collect().emit, NEVER);
+  const server = backend.getSendFileMcpServer();
+  assert.ok(server, 'send_file MCP server should be running after the first task');
+  assert.equal(server.activeTaskCount(), 0, 'task slot must release at terminal time');
+
+  // argv must include --mcp-config with the running server's URL.
+  const child = fake.lastChild();
+  assert.ok(child);
+  const cfgIdx = child.args.indexOf('--mcp-config');
+  assert.ok(cfgIdx !== -1, 'expected --mcp-config when sendFileMcp is enabled');
+  const cfg = JSON.parse(String(child.args[cfgIdx + 1])) as {
+    mcpServers: Record<string, { type: string; url: string }>;
+  };
+  assert.equal(cfg.mcpServers['vicoop-bridge'].type, 'http');
+  assert.equal(cfg.mcpServers['vicoop-bridge'].url, server.url);
+
+  // Re-register a synthetic handle to check the routing reaches the handle's
+  // emit (the lifecycle inside handle() already ran and released).
+  const captured: Array<{ artifactId: string; name: string }> = [];
+  const release = server.registerActiveTask({
+    taskId: 'manual',
+    contextId: 'ctx-manual',
+    emit: (artifact) => {
+      captured.push({ artifactId: artifact.artifactId, name: artifact.name });
+    },
+  });
+  try {
+    const result = await server.invokeSendFileForTest({
+      path: path.join(realRoot, 'note.txt'),
+    });
+    assert.equal(result.ok, true);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].name, 'send-file');
+  } finally {
+    release.release();
+    await server.close();
+    await fs.rm(realRoot, { recursive: true, force: true });
+  }
+});
+
+test('send_file MCP: tool call landing during an in-flight task emits a task.artifact frame', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-sendfile-inflight-'));
+  const realRoot = await fs.realpath(root);
+  await fs.writeFile(path.join(realRoot, 'doc.txt'), 'inflight');
+
+  // Hold the task open until we have invoked send_file on the registered slot.
+  let releaseProcess: () => void = () => {};
+  const ready = new Promise<void>((resolve) => {
+    releaseProcess = resolve;
+  });
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(async () => {
+      // Wait until the test signals us to finish.
+      await ready;
+      child.emitStdout(JSON.stringify({ type: 'result', result: 'ok' }) + '\n');
+      setImmediate(() => child.finish(0));
+    });
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    sendFileMcp: { allowedRoots: [realRoot], skipHttp: true },
+  });
+  const { emit, frames } = collect();
+
+  const runP = backend.handle(assign('x'), emit, NEVER);
+
+  // Wait for ensureSendFileMcp + registerActiveTask to land before invoking.
+  for (let i = 0; i < 20; i++) {
+    if (backend.getSendFileMcpServer()?.activeTaskCount() === 1) break;
+    await new Promise((r) => setImmediate(r));
+  }
+  const server = backend.getSendFileMcpServer();
+  assert.ok(server);
+  assert.equal(server.activeTaskCount(), 1, 'task slot must register during handle()');
+
+  const result = await server.invokeSendFileForTest({
+    path: path.join(realRoot, 'doc.txt'),
+  });
+  assert.equal(result.ok, true);
+
+  // Now let the child exit so handle() resolves.
+  releaseProcess();
+  await runP;
+
+  const fileArtifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
+      f.type === 'task.artifact' && f.artifact.parts[0]?.kind === 'file',
+  );
+  assert.equal(fileArtifacts.length, 1);
+  const part = fileArtifacts[0].artifact.parts[0];
+  if (part.kind !== 'file') throw new Error('expected file part');
+  assert.equal(Buffer.from(part.file.bytes!, 'base64').toString('utf8'), 'inflight');
+
+  await server.close();
+  await fs.rm(realRoot, { recursive: true, force: true });
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -139,12 +139,10 @@ function mapPartsToContentBlocks(
   | { ok: true; blocks: InputContentBlock[] }
   | { ok: false; code: string; message: string } {
   const blocks: InputContentBlock[] = [];
-  let textTotal = 0;
   for (const p of parts) {
     if (p.kind === 'text') {
       if (p.text) {
         blocks.push({ type: 'text', text: p.text });
-        textTotal += p.text.length;
       }
       continue;
     }
@@ -184,13 +182,11 @@ function mapPartsToContentBlocks(
       message: `claude backend does not accept ${p.kind} parts`,
     };
   }
-  if (blocks.length === 0 || (textTotal === 0 && blocks.every((b) => b.type !== 'text'))) {
-    // Anthropic accepts media-only messages, but a fully empty parts array
-    // (no text, no files) carries no signal — fail loud rather than spawn
-    // claude on nothing.
-    if (blocks.length === 0) {
-      return { ok: false, code: 'empty_prompt', message: 'no content in message' };
-    }
+  // Media-only messages (image/document with no text) are accepted —
+  // Anthropic's vision/document path can answer about them without an
+  // accompanying prompt. Only a fully empty content array fails loud.
+  if (blocks.length === 0) {
+    return { ok: false, code: 'empty_prompt', message: 'no content in message' };
   }
   return { ok: true, blocks };
 }

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -57,6 +57,11 @@ export interface ClaudeBackendOptions {
 interface SessionEntry {
   sessionId: string;
   lastUsedAt: number;
+  // Monotonic per-write token. A rollback only deletes the entry when
+  // this matches the writeId the rolling-back task itself stamped — so a
+  // second concurrent task on the same contextId that has since refreshed
+  // the binding (and bumped writeId) is not robbed of its session id.
+  writeId: number;
 }
 
 // claude --output-format stream-json writes one JSON object per line. We
@@ -288,6 +293,10 @@ export function createClaudeBackend(
   // memory. The map is in-memory only — restarts lose the binding (next task
   // on a stale contextId starts a new session).
   const sessions = new Map<string, SessionEntry>();
+  // Monotonic counter shared across all writes into `sessions`. Used to
+  // disambiguate concurrent tasks on the same contextId so a rollback only
+  // touches the entry the rolling-back task itself last wrote.
+  let writeCounter = 0;
 
   function evictExpired(cutoff: number): void {
     for (const [key, entry] of sessions) {
@@ -328,11 +337,13 @@ export function createClaudeBackend(
       const existing = sessionTtlMs > 0 ? sessions.get(task.contextId) : undefined;
       const sessionId = existing?.sessionId ?? randomUUID();
       const isResume = existing !== undefined;
+      let writeId = 0;
       if (sessionTtlMs > 0) {
         // Refresh lastUsedAt eagerly: a concurrent second task on the same
         // contextId arriving before this one finishes also resumes the same
         // session id (rather than racing to mint a new one).
-        sessions.set(task.contextId, { sessionId, lastUsedAt: tNow });
+        writeId = ++writeCounter;
+        sessions.set(task.contextId, { sessionId, lastUsedAt: tNow, writeId });
       }
 
       // Bring up the MCP server first (if enabled) so we know its URL before
@@ -383,10 +394,17 @@ export function createClaudeBackend(
       // contextId mints a brand-new id instead of `--resume`-ing a session
       // claude never persisted on disk. No-op if this run was already
       // resuming an existing session, or if session reuse is disabled.
+      //
+      // Concurrency: only delete when the entry is still the one THIS task
+      // wrote. A second concurrent task on the same contextId would have
+      // bumped `writeId` when refreshing the binding; if we see a different
+      // writeId, that other task now "owns" the entry and should keep it.
       const rollbackFreshSession = (): void => {
         if (isResume || sessionTtlMs <= 0) return;
         const cur = sessions.get(task.contextId);
-        if (cur?.sessionId === sessionId) sessions.delete(task.contextId);
+        if (cur?.sessionId === sessionId && cur.writeId === writeId) {
+          sessions.delete(task.contextId);
+        }
       };
 
       let child: ClaudeChildHandle;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -601,7 +601,10 @@ export function createClaudeBackend(
         if (stderrTail.length > stderrCap) stderrTail = stderrTail.slice(-stderrCap);
       });
 
-      const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: Error }>((resolve) => {
+      const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: unknown }>((resolve) => {
+        // The `error` event is *typed* with `Error`, but EventEmitter at
+        // runtime can emit any value. Carry it as unknown so the frame
+        // builder routes through `errorMessage` safely.
         child.on('error', (err) => resolve({ code: null, signal: null, error: err }));
         child.on('close', (code, sig) => resolve({ code, signal: sig }));
       });
@@ -635,7 +638,10 @@ export function createClaudeBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code: 'spawn_failed', message: exit.error.message },
+          // exit.error is typed Error from the child `error` event but a
+          // custom spawn / fake child could emit a non-Error here. Route
+          // through errorMessage so .message access can't crash the frame.
+          error: { code: 'spawn_failed', message: errorMessage(exit.error) },
         });
         return;
       }

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -415,6 +415,9 @@ export function createClaudeBackend(
         } catch {
           /* best effort */
         }
+        // The freshly-minted sessionId never reached claude, so a follow-up
+        // task on the same contextId must mint a new id rather than --resume.
+        rollbackFreshSession();
         emit({
           type: 'task.fail',
           taskId: task.taskId,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2,10 +2,16 @@ import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type { Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import {
+  startSendFileMcpServer,
+  type SendFileMcpOptions,
+  type SendFileMcpServer,
+} from './send-file-mcp.js';
 
 // Slim subset of ChildProcess that the backend actually uses. Tests inject a
 // fake that satisfies this without wiring up a real OS process.
 export interface ClaudeChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
   readonly stdout: NodeJS.ReadableStream | null;
   readonly stderr: NodeJS.ReadableStream | null;
   kill(signal?: NodeJS.Signals): boolean;
@@ -36,6 +42,16 @@ export interface ClaudeBackendOptions {
   sessionTtlMs?: number;
   // Test seam: deterministic clock for TTL eviction.
   now?: () => number;
+  /**
+   * Expose a local Streamable HTTP MCP server with a `send_file(path, name?)`
+   * tool that delivers files from disk to the A2A caller as `FilePart`
+   * artifacts. When set, the server is registered into the spawned claude
+   * via `--mcp-config` so the agent sees `send_file` in its tool list.
+   *
+   * Routing: a single in-flight task per backend instance. Concurrent tool
+   * calls across overlapping tasks are rejected with `ambiguous-task`.
+   */
+  sendFileMcp?: SendFileMcpOptions;
 }
 
 interface SessionEntry {
@@ -43,9 +59,10 @@ interface SessionEntry {
   lastUsedAt: number;
 }
 
-// claude --output-format stream-json writes one JSON object per line. Message
-// events have `type:"assistant"` with a content block array we surface as
-// artifacts; the run ends with `type:"result"` carrying the final text string.
+// claude --output-format stream-json writes one JSON object per line. We
+// surface assistant `text` blocks (one A2A artifact per assistant message)
+// and pass through `tool_result` content of type image/document so MCP
+// screenshot-style tools land as A2A `FilePart`s alongside the text.
 interface StreamEvent {
   type?: unknown;
   message?: {
@@ -55,13 +72,23 @@ interface StreamEvent {
   result?: unknown;
 }
 
+// Anthropic-shaped content block we send on stdin.
+type InputContentBlock =
+  | { type: 'text'; text: string }
+  | {
+      type: 'image' | 'document';
+      source: { type: 'base64'; media_type: string; data: string };
+    };
+
+const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+
 function defaultSpawn(
   command: string,
   args: readonly string[],
   options: ClaudeSpawnOptions,
 ): ClaudeChildHandle {
   return nodeSpawn(command, Array.from(args), {
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['pipe', 'pipe', 'pipe'],
     ...(options.cwd ? { cwd: options.cwd } : {}),
   }) as ChildProcess;
 }
@@ -77,25 +104,100 @@ function extractAssistantText(content: unknown): string {
   return out;
 }
 
-function collectTextPrompt(parts: readonly Part[]): { ok: true; prompt: string } | { ok: false; code: string; message: string } {
-  let prompt = '';
-  for (const p of parts) {
-    if (p.kind !== 'text') {
-      return {
-        ok: false,
-        code: 'unsupported_part_kind',
-        message: `claude backend only accepts text parts (got ${p.kind})`,
+// Pull image/document blocks out of a `user`-role event's `tool_result`
+// content array. MCP screenshot tools, image-generation tools, and built-in
+// Read on a media file all surface here. Returned in encounter order.
+function extractToolResultMediaParts(content: unknown): Part[] {
+  if (!Array.isArray(content)) return [];
+  const out: Part[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as { type?: unknown; content?: unknown };
+    if (b.type !== 'tool_result' || !Array.isArray(b.content)) continue;
+    for (const inner of b.content) {
+      if (!inner || typeof inner !== 'object') continue;
+      const i = inner as {
+        type?: unknown;
+        source?: { type?: unknown; media_type?: unknown; data?: unknown };
       };
+      if (i.type !== 'image' && i.type !== 'document') continue;
+      const src = i.source;
+      if (!src || src.type !== 'base64') continue;
+      if (typeof src.media_type !== 'string' || typeof src.data !== 'string') continue;
+      out.push({
+        kind: 'file',
+        file: { mimeType: src.media_type, bytes: src.data },
+      });
     }
-    prompt += p.text;
   }
-  if (!prompt) {
-    return { ok: false, code: 'empty_prompt', message: 'no text content in message' };
-  }
-  return { ok: true, prompt };
+  return out;
 }
 
-export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
+function mapPartsToContentBlocks(
+  parts: readonly Part[],
+):
+  | { ok: true; blocks: InputContentBlock[] }
+  | { ok: false; code: string; message: string } {
+  const blocks: InputContentBlock[] = [];
+  let textTotal = 0;
+  for (const p of parts) {
+    if (p.kind === 'text') {
+      if (p.text) {
+        blocks.push({ type: 'text', text: p.text });
+        textTotal += p.text.length;
+      }
+      continue;
+    }
+    if (p.kind === 'file') {
+      // uri-only FilePart is not supported — fetching is the responsibility
+      // of a different backend or the caller. Reject with a stable code.
+      if (!p.file.bytes) {
+        return {
+          ok: false,
+          code: 'unsupported_file_uri',
+          message: 'claude backend requires inline FilePart bytes; uri-only is not supported',
+        };
+      }
+      const mime = p.file.mimeType ?? '';
+      if (INPUT_IMAGE_MIME.has(mime)) {
+        blocks.push({
+          type: 'image',
+          source: { type: 'base64', media_type: mime, data: p.file.bytes },
+        });
+      } else if (mime === 'application/pdf') {
+        blocks.push({
+          type: 'document',
+          source: { type: 'base64', media_type: mime, data: p.file.bytes },
+        });
+      } else {
+        return {
+          ok: false,
+          code: 'unsupported_file_mime',
+          message: `claude backend accepts image/{png,jpeg,webp,gif} or application/pdf (got ${mime || 'unknown'})`,
+        };
+      }
+      continue;
+    }
+    return {
+      ok: false,
+      code: 'unsupported_part_kind',
+      message: `claude backend does not accept ${p.kind} parts`,
+    };
+  }
+  if (blocks.length === 0 || (textTotal === 0 && blocks.every((b) => b.type !== 'text'))) {
+    // Anthropic accepts media-only messages, but a fully empty parts array
+    // (no text, no files) carries no signal — fail loud rather than spawn
+    // claude on nothing.
+    if (blocks.length === 0) {
+      return { ok: false, code: 'empty_prompt', message: 'no content in message' };
+    }
+  }
+  return { ok: true, blocks };
+}
+
+export function createClaudeBackend(
+  opts: ClaudeBackendOptions = {},
+): Backend & { getSendFileMcpServer(): SendFileMcpServer | null } {
   const command = opts.command ?? 'claude';
   const cwd = opts.cwd;
   const extraArgs = opts.extraArgs ?? [];
@@ -103,6 +205,31 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
   const stderrCap = opts.stderrCaptureBytes ?? 8192;
   const sessionTtlMs = opts.sessionTtlMs ?? 60 * 60 * 1000;
   const now = opts.now ?? Date.now;
+  const sendFileMcpOpts =
+    opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
+      ? opts.sendFileMcp
+      : null;
+
+  // Lazy: first task that needs the MCP server starts it; backends that
+  // never see send_file enabled don't open a port.
+  let sendFileMcp: SendFileMcpServer | null = null;
+  let sendFileMcpStarting: Promise<SendFileMcpServer> | null = null;
+  async function ensureSendFileMcp(): Promise<SendFileMcpServer | null> {
+    if (!sendFileMcpOpts) return null;
+    if (sendFileMcp) return sendFileMcp;
+    if (sendFileMcpStarting) return sendFileMcpStarting;
+    sendFileMcpStarting = (async () => {
+      const server = await startSendFileMcpServer(sendFileMcpOpts);
+      sendFileMcp = server;
+      console.log(`[claude] send_file MCP server listening at ${server.url}`);
+      return server;
+    })();
+    try {
+      return await sendFileMcpStarting;
+    } finally {
+      sendFileMcpStarting = null;
+    }
+  }
 
   // contextId → claude session_id. A follow-up task on the same A2A
   // contextId resumes the same claude conversation via --resume so the model
@@ -120,6 +247,8 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
   return {
     name: 'claude',
 
+    getSendFileMcpServer: () => sendFileMcp,
+
     async handle(task, emit, signal) {
       if (signal.aborted) {
         emit({
@@ -130,7 +259,7 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
         return;
       }
 
-      const mapped = collectTextPrompt(task.message.parts);
+      const mapped = mapPartsToContentBlocks(task.message.parts);
       if (!mapped.ok) {
         emit({
           type: 'task.fail',
@@ -155,15 +284,40 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
         sessions.set(task.contextId, { sessionId, lastUsedAt: tNow });
       }
 
+      // Bring up the MCP server first (if enabled) so we know its URL before
+      // building argv. A startup failure disables the tool path for this task
+      // but the run continues — the caller still gets text/markers.
+      let mcpServerForTask: SendFileMcpServer | null = null;
+      if (sendFileMcpOpts) {
+        try {
+          mcpServerForTask = await ensureSendFileMcp();
+        } catch (err) {
+          console.warn(
+            `[claude] send_file MCP server failed to start; tool path disabled for this task: ${(err as Error).message}`,
+          );
+        }
+      }
+
       const args: string[] = [
         '-p',
-        mapped.prompt,
-        ...(isResume ? ['--resume', sessionId] : ['--session-id', sessionId]),
+        '--input-format',
+        'stream-json',
         '--output-format',
         'stream-json',
         // Required alongside --output-format stream-json; without it claude
         // prints a banner and exits instead of streaming.
         '--verbose',
+        ...(isResume ? ['--resume', sessionId] : ['--session-id', sessionId]),
+        ...(mcpServerForTask
+          ? [
+              '--mcp-config',
+              JSON.stringify({
+                mcpServers: {
+                  'vicoop-bridge': { type: 'http', url: mcpServerForTask.url },
+                },
+              }),
+            ]
+          : []),
         ...extraArgs,
       ];
 
@@ -191,11 +345,47 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
         return;
       }
 
+      // Write the user message envelope and close stdin so claude sees EOF
+      // and proceeds. Errors here are recorded; the close listener still
+      // drives the terminal frame so we don't double-emit.
+      let stdinError: Error | null = null;
+      try {
+        const envelope = JSON.stringify({
+          type: 'user',
+          message: { role: 'user', content: mapped.blocks },
+        });
+        child.stdin?.end(envelope + '\n');
+      } catch (err) {
+        stdinError = err as Error;
+      }
+
       let emittedAnyArtifact = false;
       let finalText: string | null = null;
       let stderrTail = '';
       let aborted = false;
       let settled = false;
+
+      // Register this task with the send_file MCP server (if running) so
+      // tool calls landing during this run resolve to this task's emit().
+      // Released in the terminal block so a crashed/timed-out task doesn't
+      // keep the slot occupied indefinitely.
+      let sendFileRelease: (() => void) | null = null;
+      if (mcpServerForTask) {
+        const handle = mcpServerForTask.registerActiveTask({
+          taskId: task.taskId,
+          contextId: task.contextId,
+          emit: (artifact) => {
+            emit({
+              type: 'task.artifact',
+              taskId: task.taskId,
+              artifact,
+              lastChunk: true,
+            });
+            emittedAnyArtifact = true;
+          },
+        });
+        sendFileRelease = handle.release;
+      }
 
       const emitAssistantArtifact = (text: string): void => {
         if (!text) return;
@@ -214,12 +404,37 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
         emittedAnyArtifact = true;
       };
 
+      const emitToolResultMedia = (parts: Part[]): void => {
+        if (parts.length === 0) return;
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'claude-tool-result',
+            parts,
+          },
+          lastChunk: true,
+        });
+        emittedAnyArtifact = true;
+      };
+
       const handleEvent = (evt: StreamEvent): void => {
         if (settled) return;
         if (evt.type === 'assistant') {
           if (evt.message?.role !== 'assistant') return;
           emitAssistantArtifact(extractAssistantText(evt.message.content));
-        } else if (evt.type === 'result') {
+          return;
+        }
+        if (evt.type === 'user') {
+          // tool_result events come in as a synthetic user message in the
+          // stream-json transcript; pull out any image/document blocks and
+          // emit them as A2A FileParts. Text-only tool results are skipped.
+          const parts = extractToolResultMediaParts(evt.message?.content);
+          emitToolResultMedia(parts);
+          return;
+        }
+        if (evt.type === 'result') {
           if (typeof evt.result === 'string') finalText = evt.result;
         }
       };
@@ -266,6 +481,7 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
 
       signal.removeEventListener('abort', onAbort);
       settled = true;
+      sendFileRelease?.();
 
       // Flush any trailing line without a newline. claude normally terminates
       // each event with \n but a crash mid-write could leave one orphan.
@@ -300,12 +516,15 @@ export function createClaudeBackend(opts: ClaudeBackendOptions = {}): Backend {
         const detail = stderrTail.trim();
         const sigPart = exit.signal ? ` (signal ${exit.signal})` : '';
         const detailPart = detail ? `: ${detail.slice(-500)}` : '';
+        // If stdin write blew up and the process exited non-zero, surface
+        // both: the stdin error is usually the proximate cause.
+        const stdinPart = stdinError ? ` [stdin: ${stdinError.message}]` : '';
         emit({
           type: 'task.fail',
           taskId: task.taskId,
           error: {
             code: 'claude_exit_nonzero',
-            message: `claude exited with code ${exit.code}${sigPart}${detailPart}`,
+            message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdinPart}`,
           },
         });
         return;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -542,6 +542,7 @@ export function createClaudeBackend(
           //   2. echo dedup — a tool_result whose decoded bytes match an
           //      inbound FilePart (e.g. the model Read the caller's image)
           //      would re-emit the same payload back. Drop those.
+          const dedupActive = mapped.inboundHashes.size > 0;
           const parts = extractToolResultMediaParts(evt.message?.content).filter((p) => {
             if (p.kind !== 'file' || !p.file.bytes) return true;
             const decodedSize = decodedBase64Size(p.file.bytes);
@@ -551,6 +552,10 @@ export function createClaudeBackend(
               );
               return false;
             }
+            // Skip the hash when there are no inbound files to dedup against.
+            // The hash decodes the full base64 (up to 5 MiB) and would burn
+            // CPU/memory on every tool_result image for no possible match.
+            if (!dedupActive) return true;
             return !mapped.inboundHashes.has(sha256OfBase64(p.file.bytes));
           });
           emitToolResultMedia(parts);

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -95,6 +95,19 @@ const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 // in-memory base64 decode and a giant artifact payload on the wire.
 const TOOL_RESULT_MEDIA_MAX_BYTES = 5 * 1024 * 1024;
 
+// Defensive stringification — `(e as Error).message` is unsafe when the
+// thrown value is null/undefined or a non-Error primitive (common in JS).
+// Always returns a string suitable for logs/frames without throwing.
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable>';
+  }
+}
+
 function decodedBase64Size(b64: string): number {
   if (b64.length === 0) return 0;
   let pad = 0;
@@ -327,7 +340,7 @@ export function createClaudeBackend(
           mcpServerForTask = await ensureSendFileMcp();
         } catch (err) {
           console.warn(
-            `[claude] send_file MCP server failed to start; tool path disabled for this task: ${(err as Error).message}`,
+            `[claude] send_file MCP server failed to start; tool path disabled for this task: ${errorMessage(err)}`,
           );
         }
       }
@@ -374,7 +387,7 @@ export function createClaudeBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code: 'spawn_failed', message: (err as Error).message },
+          error: { code: 'spawn_failed', message: errorMessage(err) },
         });
         return;
       }
@@ -382,7 +395,7 @@ export function createClaudeBackend(
       // Write the user message envelope and close stdin so claude sees EOF
       // and proceeds. Errors here are recorded; the close listener still
       // drives the terminal frame so we don't double-emit.
-      let stdinError: Error | null = null;
+      let stdinError: unknown = null;
       if (!child.stdin) {
         // A custom spawn that doesn't pipe stdin would otherwise leave
         // claude blocked waiting for input. Hard-fail loud rather than
@@ -409,7 +422,7 @@ export function createClaudeBackend(
         });
         child.stdin.end(envelope + '\n');
       } catch (err) {
-        stdinError = err as Error;
+        stdinError = err;
       }
 
       let emittedAnyArtifact = false;
@@ -588,7 +601,7 @@ export function createClaudeBackend(
         const detailPart = detail ? `: ${detail.slice(-500)}` : '';
         // If stdin write blew up and the process exited non-zero, surface
         // both: the stdin error is usually the proximate cause.
-        const stdinPart = stdinError ? ` [stdin: ${stdinError.message}]` : '';
+        const stdinPart = stdinError ? ` [stdin: ${errorMessage(stdinError)}]` : '';
         emit({
           type: 'task.fail',
           taskId: task.taskId,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -378,16 +378,22 @@ export function createClaudeBackend(
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
 
+      // Drop the freshly-minted (contextId → sessionId) binding when the
+      // run never reached a successful state, so the next task on this
+      // contextId mints a brand-new id instead of `--resume`-ing a session
+      // claude never persisted on disk. No-op if this run was already
+      // resuming an existing session, or if session reuse is disabled.
+      const rollbackFreshSession = (): void => {
+        if (isResume || sessionTtlMs <= 0) return;
+        const cur = sessions.get(task.contextId);
+        if (cur?.sessionId === sessionId) sessions.delete(task.contextId);
+      };
+
       let child: ClaudeChildHandle;
       try {
         child = spawnFn(command, args, { cwd });
       } catch (err) {
-        // Roll back the freshly-minted entry so a retry doesn't try to
-        // --resume a session that was never actually created on disk.
-        if (!isResume && sessionTtlMs > 0) {
-          const cur = sessions.get(task.contextId);
-          if (cur?.sessionId === sessionId) sessions.delete(task.contextId);
-        }
+        rollbackFreshSession();
         emit({
           type: 'task.fail',
           taskId: task.taskId,
@@ -599,6 +605,7 @@ export function createClaudeBackend(
       }
 
       if (exit.error) {
+        rollbackFreshSession();
         emit({
           type: 'task.fail',
           taskId: task.taskId,
@@ -608,6 +615,7 @@ export function createClaudeBackend(
       }
 
       if (exit.code !== 0) {
+        rollbackFreshSession();
         const detail = stderrTail.trim();
         const sigPart = exit.signal ? ` (signal ${exit.signal})` : '';
         const detailPart = detail ? `: ${detail.slice(-500)}` : '';

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -89,6 +89,12 @@ const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'imag
 // huge payload.
 const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 
+// Hard cap on a single tool_result media block's decoded size before
+// it becomes an outbound A2A FilePart. Prevents a misbehaving tool
+// (e.g. an MCP screenshot at unbounded resolution) from forcing a huge
+// in-memory base64 decode and a giant artifact payload on the wire.
+const TOOL_RESULT_MEDIA_MAX_BYTES = 5 * 1024 * 1024;
+
 function decodedBase64Size(b64: string): number {
   if (b64.length === 0) return 0;
   let pad = 0;
@@ -477,12 +483,22 @@ export function createClaudeBackend(
           // tool_result events come in as a synthetic user message in the
           // stream-json transcript; pull out any image/document blocks and
           // emit them as A2A FileParts. Text-only tool results are skipped.
-          // Echo dedup: a tool_result whose decoded bytes match an inbound
-          // FilePart (e.g. the model Read the caller's image) would re-emit
-          // the same payload back to the caller. Drop those before they
-          // reach the wire.
+          // Two filters apply, in order:
+          //   1. size cap — drop oversize blocks before we even base64-decode
+          //      them for hashing (cheap length math first; full decode is
+          //      O(payload size)).
+          //   2. echo dedup — a tool_result whose decoded bytes match an
+          //      inbound FilePart (e.g. the model Read the caller's image)
+          //      would re-emit the same payload back. Drop those.
           const parts = extractToolResultMediaParts(evt.message?.content).filter((p) => {
             if (p.kind !== 'file' || !p.file.bytes) return true;
+            const decodedSize = decodedBase64Size(p.file.bytes);
+            if (decodedSize > TOOL_RESULT_MEDIA_MAX_BYTES) {
+              console.warn(
+                `[claude] tool_result media dropped: decoded size ${decodedSize} > ${TOOL_RESULT_MEDIA_MAX_BYTES}`,
+              );
+              return false;
+            }
             return !mapped.inboundHashes.has(sha256OfBase64(p.file.bytes));
           });
           emitToolResultMedia(parts);

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1,5 +1,5 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
 import {
@@ -82,6 +82,25 @@ type InputContentBlock =
 
 const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
 
+// Hard cap on a single inbound FilePart's decoded size. base64 in the
+// stream-json envelope expands ~4/3, and the model context plus per-call
+// API limits make multi-megabyte attachments expensive even when accepted.
+// Reject above this with a stable code rather than silently embedding a
+// huge payload.
+const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
+
+function decodedBase64Size(b64: string): number {
+  if (b64.length === 0) return 0;
+  let pad = 0;
+  if (b64.endsWith('==')) pad = 2;
+  else if (b64.endsWith('=')) pad = 1;
+  return Math.floor((b64.length * 3) / 4) - pad;
+}
+
+function sha256OfBase64(b64: string): string {
+  return createHash('sha256').update(Buffer.from(b64, 'base64')).digest('hex');
+}
+
 function defaultSpawn(
   command: string,
   args: readonly string[],
@@ -136,9 +155,13 @@ function extractToolResultMediaParts(content: unknown): Part[] {
 function mapPartsToContentBlocks(
   parts: readonly Part[],
 ):
-  | { ok: true; blocks: InputContentBlock[] }
+  | { ok: true; blocks: InputContentBlock[]; inboundHashes: Set<string> }
   | { ok: false; code: string; message: string } {
   const blocks: InputContentBlock[] = [];
+  // SHA-256 (hex) of every accepted FilePart's decoded bytes. Used by the
+  // tool_result passthrough to skip echoes — if the model Reads a caller-
+  // provided file the same bytes would otherwise re-emit as a new artifact.
+  const inboundHashes = new Set<string>();
   for (const p of parts) {
     if (p.kind === 'text') {
       if (p.text) {
@@ -154,6 +177,14 @@ function mapPartsToContentBlocks(
           ok: false,
           code: 'unsupported_file_uri',
           message: 'claude backend requires inline FilePart bytes; uri-only is not supported',
+        };
+      }
+      const decodedSize = decodedBase64Size(p.file.bytes);
+      if (decodedSize > INPUT_FILE_MAX_BYTES) {
+        return {
+          ok: false,
+          code: 'file_too_large',
+          message: `FilePart exceeds INPUT_FILE_MAX_BYTES (${decodedSize} > ${INPUT_FILE_MAX_BYTES})`,
         };
       }
       const mime = p.file.mimeType ?? '';
@@ -174,6 +205,7 @@ function mapPartsToContentBlocks(
           message: `claude backend accepts image/{png,jpeg,webp,gif} or application/pdf (got ${mime || 'unknown'})`,
         };
       }
+      inboundHashes.add(sha256OfBase64(p.file.bytes));
       continue;
     }
     return {
@@ -188,7 +220,7 @@ function mapPartsToContentBlocks(
   if (blocks.length === 0) {
     return { ok: false, code: 'empty_prompt', message: 'no content in message' };
   }
-  return { ok: true, blocks };
+  return { ok: true, blocks, inboundHashes };
 }
 
 export function createClaudeBackend(
@@ -345,12 +377,31 @@ export function createClaudeBackend(
       // and proceeds. Errors here are recorded; the close listener still
       // drives the terminal frame so we don't double-emit.
       let stdinError: Error | null = null;
+      if (!child.stdin) {
+        // A custom spawn that doesn't pipe stdin would otherwise leave
+        // claude blocked waiting for input. Hard-fail loud rather than
+        // hang the run.
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          /* best effort */
+        }
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'spawn_no_stdin',
+            message: 'spawned claude has no stdin pipe; cannot deliver user message',
+          },
+        });
+        return;
+      }
       try {
         const envelope = JSON.stringify({
           type: 'user',
           message: { role: 'user', content: mapped.blocks },
         });
-        child.stdin?.end(envelope + '\n');
+        child.stdin.end(envelope + '\n');
       } catch (err) {
         stdinError = err as Error;
       }
@@ -426,7 +477,14 @@ export function createClaudeBackend(
           // tool_result events come in as a synthetic user message in the
           // stream-json transcript; pull out any image/document blocks and
           // emit them as A2A FileParts. Text-only tool results are skipped.
-          const parts = extractToolResultMediaParts(evt.message?.content);
+          // Echo dedup: a tool_result whose decoded bytes match an inbound
+          // FilePart (e.g. the model Read the caller's image) would re-emit
+          // the same payload back to the caller. Drop those before they
+          // reach the wire.
+          const parts = extractToolResultMediaParts(evt.message?.content).filter((p) => {
+            if (p.kind !== 'file' || !p.file.bytes) return true;
+            return !mapped.inboundHashes.has(sha256OfBase64(p.file.bytes));
+          });
           emitToolResultMedia(parts);
           return;
         }

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -113,7 +113,11 @@ function decodedBase64Size(b64: string): number {
   let pad = 0;
   if (b64.endsWith('==')) pad = 2;
   else if (b64.endsWith('=')) pad = 1;
-  return Math.floor((b64.length * 3) / 4) - pad;
+  // Clamp to >= 0 so a malformed input like a bare "=" or "==" (which
+  // would otherwise compute to -1) reports zero, not a negative size.
+  // The size-cap callers only need a non-negative upper bound; any deeper
+  // base64 validation belongs to whoever decodes the bytes.
+  return Math.max(0, Math.floor((b64.length * 3) / 4) - pad);
 }
 
 function sha256OfBase64(b64: string): string {
@@ -415,6 +419,14 @@ export function createClaudeBackend(
         });
         return;
       }
+      // Attach an error listener BEFORE writing. EPIPE and similar stream
+      // failures surface asynchronously via `error` rather than as a
+      // synchronous throw from `.end()`; without this, the unhandled error
+      // would crash the process. The exit-nonzero handler already
+      // formats `stdinError` into the surfaced message.
+      child.stdin.on('error', (err: unknown) => {
+        if (!stdinError) stdinError = err;
+      });
       try {
         const envelope = JSON.stringify({
           type: 'user',

--- a/packages/client/src/backends/file-attach.test.ts
+++ b/packages/client/src/backends/file-attach.test.ts
@@ -275,3 +275,29 @@ test('inferMimeFromPath: known extensions map to specific mimes; unknown falls b
   assert.equal(inferMimeFromPath('/x/blob.unknownext'), 'application/octet-stream');
   assert.equal(inferMimeFromPath('/x/no-extension'), 'application/octet-stream');
 });
+
+test('createBoundedFileReader: throws RangeError on negative maxBytes', () => {
+  assert.throws(
+    () => createBoundedFileReader({ allowedRoots: ['/tmp'], maxBytes: -1 }),
+    /maxBytes must be a finite non-negative number/,
+  );
+});
+
+test('createBoundedFileReader: throws RangeError on non-finite maxBytes', () => {
+  assert.throws(
+    () => createBoundedFileReader({ allowedRoots: ['/tmp'], maxBytes: Number.POSITIVE_INFINITY }),
+    /maxBytes must be a finite non-negative number/,
+  );
+});
+
+test('readBoundedFileWithinRoots: throws RangeError on NaN maxBytes', async () => {
+  await assert.rejects(
+    () =>
+      readBoundedFileWithinRoots({
+        filePath: '/tmp/x',
+        allowedRoots: ['/tmp'],
+        maxBytes: Number.NaN,
+      }),
+    /maxBytes must be a finite non-negative number/,
+  );
+});

--- a/packages/client/src/backends/file-attach.test.ts
+++ b/packages/client/src/backends/file-attach.test.ts
@@ -200,6 +200,23 @@ test('readBoundedFileWithinRoots: oversized file rejected with too-large', async
   );
 });
 
+test('readBoundedFileWithinRoots: regular file with stable dev/ino passes identity check (path-swap detector does not false-positive)', async () => {
+  // Smoke test for the cross-platform symlink TOCTOU defense: a normal
+  // file should pass through (dev+ino at fstat == dev+ino at lstat).
+  // Real swap simulation requires racing fs operations and is left to
+  // platform-specific fuzz coverage; this catches a regression where
+  // the identity comparison itself becomes spurious.
+  const root = await tmpDir();
+  const file = path.join(root, 'stable.txt');
+  await fs.writeFile(file, 'stable');
+  const r = await readBoundedFileWithinRoots({
+    filePath: file,
+    allowedRoots: [root],
+    maxBytes: 1024,
+  });
+  assert.equal(r.buffer.toString('utf8'), 'stable');
+});
+
 test('readBoundedFileWithinRoots: bounded read returns the actual byte count even if file shrinks between stat and read', async () => {
   // The size returned should reflect what was actually read, not the
   // (possibly stale) stat.size. This also confirms we are using a

--- a/packages/client/src/backends/file-attach.test.ts
+++ b/packages/client/src/backends/file-attach.test.ts
@@ -200,6 +200,23 @@ test('readBoundedFileWithinRoots: oversized file rejected with too-large', async
   );
 });
 
+test('readBoundedFileWithinRoots: bounded read returns the actual byte count even if file shrinks between stat and read', async () => {
+  // The size returned should reflect what was actually read, not the
+  // (possibly stale) stat.size. This also confirms we are using a
+  // bounded read instead of fs.readFile() which would read whatever the
+  // descriptor still had.
+  const root = await tmpDir();
+  const file = path.join(root, 'small.txt');
+  await fs.writeFile(file, 'small content');
+  const r = await readBoundedFileWithinRoots({
+    filePath: file,
+    allowedRoots: [root],
+    maxBytes: 1024,
+  });
+  assert.equal(r.size, 'small content'.length);
+  assert.equal(r.buffer.toString('utf8'), 'small content');
+});
+
 test('readBoundedFileWithinRoots: missing file rejected with not-found', async () => {
   const root = await tmpDir();
   const missing = path.join(root, 'nope.txt');

--- a/packages/client/src/backends/file-attach.test.ts
+++ b/packages/client/src/backends/file-attach.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 import {
+  createBoundedFileReader,
   inferMimeFromPath,
   parseBridgeAttachMarkers,
   readBoundedFileWithinRoots,
@@ -66,11 +67,49 @@ test('stripMarkersForPath: removes only the requested path markers', () => {
   assert.equal(stripped.includes('/b/y.pdf'), true, 'unrelated marker must remain');
 });
 
-test('stripMarkersForPath: collapses whitespace-only lines created by stripping', () => {
+test('stripMarkersForPath: removes a marker-only line entirely (no blank-line gap left behind)', () => {
   const original = 'paragraph one\n[bridge-attach: /a/x.png]\n\nparagraph two';
   const parsed = parseBridgeAttachMarkers(original);
   const stripped = stripMarkersForPath(original, parsed, '/a/x.png');
   assert.equal(stripped, 'paragraph one\n\nparagraph two');
+});
+
+test('stripMarkersForPath: preserves leading/trailing whitespace and blank lines outside the marker line', () => {
+  // The .trim() in the previous implementation would strip the leading
+  // newline and the trailing spaces here, which is unrelated to marker
+  // removal. Per-line cleanup keeps the agent's formatting intact.
+  const original = '\n  intro line  \n[bridge-attach: /a/x.png]\nbody  \n\n';
+  const parsed = parseBridgeAttachMarkers(original);
+  const stripped = stripMarkersForPath(original, parsed, '/a/x.png');
+  assert.equal(stripped, '\n  intro line  \nbody  \n\n');
+});
+
+test('stripMarkersForPath: an inline marker in the middle of a line preserves surrounding text and whitespace', () => {
+  const original = 'before [bridge-attach: /a/x.png] after';
+  const parsed = parseBridgeAttachMarkers(original);
+  const stripped = stripMarkersForPath(original, parsed, '/a/x.png');
+  // Marker substring is removed in place; the resulting double space is
+  // intentional — not our job to fix the assistant\'s original spacing.
+  assert.equal(stripped, 'before  after');
+});
+
+test('createBoundedFileReader: reuses canonicalized roots across calls (root realpath happens once)', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'a.txt'), 'A');
+  await fs.writeFile(path.join(root, 'b.txt'), 'B');
+  const read = createBoundedFileReader({ allowedRoots: [root], maxBytes: 1024 });
+  const a = await read(path.join(root, 'a.txt'));
+  const b = await read(path.join(root, 'b.txt'));
+  assert.equal(a.buffer.toString('utf8'), 'A');
+  assert.equal(b.buffer.toString('utf8'), 'B');
+});
+
+test('createBoundedFileReader: surfaces outside-roots when no allowed roots configured (cache resolution failure not silently swallowed)', async () => {
+  const read = createBoundedFileReader({ allowedRoots: [], maxBytes: 1024 });
+  await assert.rejects(
+    read('/etc/hosts'),
+    (err: unknown) => err instanceof SafeReadError && err.code === 'outside-roots',
+  );
 });
 
 test('readBoundedFileWithinRoots: happy path reads bytes and reports realPath under the configured root', async () => {

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -212,9 +212,10 @@ export function createBoundedFileReader(opts: {
  *      that is also reachable via an outside-root path the operator doesn't
  *      see. Reject so the model cannot use hardlinks to smuggle paths.
  *   6. fstat().size <= maxBytes — initial bound on the per-attachment payload.
- *   7. Bounded read up to maxBytes + 1 — detect a file that grows between
- *      stat and read so a TOCTOU inflation cannot push the in-memory buffer
- *      past the cap.
+ *   7. Bounded read up to fstat().size + 1 — allocate exactly the claimed
+ *      file size + one extra byte. Reading into that +1 slot signals the
+ *      file grew between stat and read, so we reject before the in-memory
+ *      buffer can exceed the size we already validated against maxBytes.
  *
  * For repeated reads under the same roots, prefer `createBoundedFileReader`
  * which caches the canonicalization.
@@ -233,10 +234,14 @@ export async function readBoundedFileWithinRoots(params: {
 }
 
 // Programmer-error guard: maxBytes is operator config, not user input.
-// Buffer.alloc(maxBytes + 1) deep inside readWithRoots would throw a
-// RangeError for negative or non-finite values, bypassing the SafeReadError
-// codes the caller is shaped to handle. Validate at the public boundaries
-// so misconfiguration fails loudly at startup, not on the first read.
+// A negative or non-finite value would otherwise produce nonsensical
+// comparisons inside readWithRoots — `stat.size > NaN` is always false, so
+// a misconfigured cap would silently let oversize files through; a
+// negative cap would reject every file with too-large; and feeding either
+// to `Buffer.alloc` would throw a RangeError that bypasses the
+// SafeReadError codes callers are shaped to handle. Validate at the public
+// boundaries so misconfiguration fails loudly at startup, not on the
+// first read.
 function assertMaxBytes(maxBytes: number): void {
   if (typeof maxBytes !== 'number' || !Number.isFinite(maxBytes) || maxBytes < 0) {
     throw new RangeError(

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -204,10 +204,16 @@ export function createBoundedFileReader(opts: {
  *   2. lstat() must report a regular file (no dirs/sockets/devices).
  *   3. open() with O_NOFOLLOW so the terminal component cannot be a symlink
  *      pointing outside roots between realpath and open.
- *   4. fstat().nlink === 1 — hardlinks could anchor a file inside roots
+ *   4. fstat() dev/ino must equal the prior lstat dev/ino — defense against
+ *      a TOCTOU swap (realpath → lstat → open) and the only line of defense
+ *      on platforms where O_NOFOLLOW is unavailable (win32).
+ *   5. fstat().nlink === 1 — hardlinks could anchor a file inside roots
  *      that is also reachable via an outside-root path the operator doesn't
  *      see. Reject so the model cannot use hardlinks to smuggle paths.
- *   5. size <= maxBytes — bound the per-attachment payload before reading.
+ *   6. fstat().size <= maxBytes — initial bound on the per-attachment payload.
+ *   7. Bounded read up to maxBytes + 1 — detect a file that grows between
+ *      stat and read so a TOCTOU inflation cannot push the in-memory buffer
+ *      past the cap.
  *
  * For repeated reads under the same roots, prefer `createBoundedFileReader`
  * which caches the canonicalization.

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -54,17 +54,38 @@ export function parseBridgeAttachMarkers(text: string): ParsedAttachMarkers {
  * Strip a specific path's markers from the text. Used after a successful
  * read so the user-visible artifact text doesn't contain the raw on-disk
  * location (privacy + UX). Failed reads keep their markers visible.
+ *
+ * Cleanup is scoped to lines that contain (only) the marker:
+ * - A marker-only line (with optional surrounding whitespace) is removed entirely.
+ * - An inline marker is removed in place; the rest of the line is preserved.
+ *
+ * Whitespace and newlines unrelated to the stripped marker are left
+ * untouched so the agent's intended formatting (leading/trailing
+ * whitespace, blank lines elsewhere, etc.) survives.
  */
-export function stripMarkersForPath(text: string, parsed: ParsedAttachMarkers, attachPath: string): string {
+export function stripMarkersForPath(
+  text: string,
+  parsed: ParsedAttachMarkers,
+  attachPath: string,
+): string {
   const markers = parsed.markersByPath.get(attachPath);
   if (!markers || markers.length === 0) return text;
-  let out = text;
-  for (const m of markers) {
-    // Replace literally — markers came from the same text so they're guaranteed present.
-    out = out.split(m).join('');
+  const markerSet = new Set(markers);
+  const lines = text.split('\n');
+  const out: string[] = [];
+  for (const line of lines) {
+    // A line that is exactly the marker (modulo surrounding whitespace)
+    // disappears entirely so we don't leave a blank line gap behind.
+    if (markerSet.has(line.trim())) continue;
+    // Otherwise, strip any inline marker substrings but preserve the rest
+    // of the line as-is — including original whitespace.
+    let lineOut = line;
+    for (const m of markers) {
+      lineOut = lineOut.split(m).join('');
+    }
+    out.push(lineOut);
   }
-  // Collapse runs of blank lines created by stripping a marker that occupied its own line.
-  return out.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+  return out.join('\n');
 }
 
 export type SafeReadErrorCode =
@@ -118,6 +139,60 @@ async function realpathOrUndefined(p: string): Promise<string | undefined> {
 }
 
 /**
+ * Canonicalize allowed roots — operators may have provided paths that
+ * contain symlinks (e.g. /var/folders on macOS). Drops any root whose
+ * realpath cannot be resolved; an unresolvable root cannot match anything.
+ * Throws SafeReadError('outside-roots') if none resolved.
+ */
+async function resolveCanonicalRoots(allowedRoots: string[]): Promise<string[]> {
+  if (allowedRoots.length === 0) {
+    throw new SafeReadError('outside-roots', 'no allowed roots configured');
+  }
+  const canonicalRoots: string[] = [];
+  for (const r of allowedRoots) {
+    const real = await realpathOrUndefined(path.resolve(r));
+    if (real) canonicalRoots.push(ensureTrailingSep(real));
+  }
+  if (canonicalRoots.length === 0) {
+    throw new SafeReadError('outside-roots', 'no allowed roots resolvable on disk');
+  }
+  return canonicalRoots;
+}
+
+/**
+ * Build a reader that canonicalizes its allowed roots once (lazily, on
+ * first read) and reuses the result across subsequent reads. Use this when
+ * the same caller will read multiple files under the same configured
+ * roots — e.g. one assistant message containing several `[bridge-attach]`
+ * markers, or a per-backend instance handling many tool calls.
+ *
+ * For one-shot reads (or when roots may have rotated since the last
+ * call), `readBoundedFileWithinRoots` does the resolution per-call.
+ */
+export function createBoundedFileReader(opts: {
+  allowedRoots: string[];
+  maxBytes: number;
+}): (filePath: string) => Promise<SafeReadResult> {
+  let canonicalRootsPromise: Promise<string[]> | null = null;
+  return async (filePath) =>
+    readWithRoots({
+      filePath,
+      maxBytes: opts.maxBytes,
+      getCanonicalRoots: async () => {
+        if (!canonicalRootsPromise) {
+          canonicalRootsPromise = resolveCanonicalRoots(opts.allowedRoots).catch((err) => {
+            // On failure, clear the cache so a subsequent call retries
+            // (e.g. operator fixed the missing dir between attempts).
+            canonicalRootsPromise = null;
+            throw err;
+          });
+        }
+        return canonicalRootsPromise;
+      },
+    });
+}
+
+/**
  * Read a file from disk under operator-controlled roots. Designed for the
  * narrow case where the bridge-client forwards on-disk artifacts produced by
  * a co-located agent (OpenClaw) to a remote A2A caller — i.e. the agent
@@ -133,15 +208,27 @@ async function realpathOrUndefined(p: string): Promise<string | undefined> {
  *      that is also reachable via an outside-root path the operator doesn't
  *      see. Reject so the model cannot use hardlinks to smuggle paths.
  *   5. size <= maxBytes — bound the per-attachment payload before reading.
+ *
+ * For repeated reads under the same roots, prefer `createBoundedFileReader`
+ * which caches the canonicalization.
  */
 export async function readBoundedFileWithinRoots(params: {
   filePath: string;
   allowedRoots: string[];
   maxBytes: number;
 }): Promise<SafeReadResult> {
-  if (params.allowedRoots.length === 0) {
-    throw new SafeReadError('outside-roots', 'no allowed roots configured');
-  }
+  return readWithRoots({
+    filePath: params.filePath,
+    maxBytes: params.maxBytes,
+    getCanonicalRoots: () => resolveCanonicalRoots(params.allowedRoots),
+  });
+}
+
+async function readWithRoots(params: {
+  filePath: string;
+  maxBytes: number;
+  getCanonicalRoots: () => Promise<string[]>;
+}): Promise<SafeReadResult> {
   if (typeof params.filePath !== 'string' || params.filePath.length === 0) {
     throw new SafeReadError('invalid-path', 'empty path');
   }
@@ -149,17 +236,7 @@ export async function readBoundedFileWithinRoots(params: {
     throw new SafeReadError('invalid-path', 'path contains NUL');
   }
 
-  // Canonicalize allowed roots once — operators may have provided paths that
-  // contain symlinks (e.g. /var/folders on macOS). Drop any root whose
-  // realpath cannot be resolved; an unresolvable root cannot match anything.
-  const canonicalRoots: string[] = [];
-  for (const r of params.allowedRoots) {
-    const real = await realpathOrUndefined(path.resolve(r));
-    if (real) canonicalRoots.push(ensureTrailingSep(real));
-  }
-  if (canonicalRoots.length === 0) {
-    throw new SafeReadError('outside-roots', 'no allowed roots resolvable on disk');
-  }
+  const canonicalRoots = await params.getCanonicalRoots();
 
   // Resolve the candidate. Relative paths resolve against the first root for
   // ergonomics — agents typically emit absolute paths, but a bare filename

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -291,8 +291,30 @@ async function readWithRoots(params: {
         `file exceeds maxBytes (${stat.size} > ${params.maxBytes}): ${realPath}`,
       );
     }
-    const buffer = await handle.readFile();
-    return { buffer, realPath, size: stat.size };
+    // Bounded read: cap allocation at maxBytes + 1 so a file that grew
+    // between fstat and readFile (TOCTOU) is detected and rejected
+    // instead of silently inflating the in-memory buffer beyond
+    // maxBytes. We read until EOF or the cap+1-th byte appears.
+    const cap = params.maxBytes;
+    const buf = Buffer.alloc(cap + 1);
+    let totalRead = 0;
+    while (totalRead < cap + 1) {
+      const { bytesRead } = await handle.read(
+        buf,
+        totalRead,
+        cap + 1 - totalRead,
+        totalRead,
+      );
+      if (bytesRead === 0) break; // EOF
+      totalRead += bytesRead;
+    }
+    if (totalRead > cap) {
+      throw new SafeReadError(
+        'too-large',
+        `file exceeds maxBytes during read (>${cap} bytes, file grew between stat and read): ${realPath}`,
+      );
+    }
+    return { buffer: buf.subarray(0, totalRead), realPath, size: totalRead };
   } finally {
     await handle.close().catch(() => {});
   }

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -279,6 +279,19 @@ async function readWithRoots(params: {
     if (!stat.isFile()) {
       throw new SafeReadError('not-file', `opened path is not a regular file: ${realPath}`);
     }
+    // Cross-platform symlink TOCTOU defense: compare device + inode of the
+    // opened descriptor against the lstat we did before open. On POSIX
+    // O_NOFOLLOW already blocks a terminal-component symlink swap; on
+    // win32 (where O_NOFOLLOW is unavailable) this identity check is the
+    // only thing standing between us and a swapped-in symlink. Defense
+    // in depth on POSIX too. Mismatched dev/ino means the path resolved
+    // to a different file at open time than at lstat time.
+    if (stat.dev !== lstat.dev || stat.ino !== lstat.ino) {
+      throw new SafeReadError(
+        'symlink',
+        `path identity changed between stat and open (possible symlink swap): ${realPath}`,
+      );
+    }
     if (stat.nlink > 1) {
       throw new SafeReadError(
         'hardlink',

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -325,27 +325,30 @@ async function readWithRoots(params: {
         `file exceeds maxBytes (${stat.size} > ${params.maxBytes}): ${realPath}`,
       );
     }
-    // Bounded read: cap allocation at maxBytes + 1 so a file that grew
-    // between fstat and readFile (TOCTOU) is detected and rejected
-    // instead of silently inflating the in-memory buffer beyond
-    // maxBytes. We read until EOF or the cap+1-th byte appears.
-    const cap = params.maxBytes;
-    const buf = Buffer.alloc(cap + 1);
+    // Bounded read sized to the file's claimed length, not maxBytes. Earlier
+    // we already proved `stat.size <= maxBytes`, so allocating `stat.size +
+    // 1` bytes:
+    //   - keeps small files small (a 4 KiB note doesn't burn a 20 MiB Buffer)
+    //   - still detects growth between stat and read: if the file grew, we
+    //     try to read into the +1 slot and reject. `cap + 1` allocation was
+    //     forcing the worst case on every call regardless of actual size.
+    const claimedSize = stat.size;
+    const buf = Buffer.alloc(claimedSize + 1);
     let totalRead = 0;
-    while (totalRead < cap + 1) {
+    while (totalRead < claimedSize + 1) {
       const { bytesRead } = await handle.read(
         buf,
         totalRead,
-        cap + 1 - totalRead,
+        claimedSize + 1 - totalRead,
         totalRead,
       );
       if (bytesRead === 0) break; // EOF
       totalRead += bytesRead;
     }
-    if (totalRead > cap) {
+    if (totalRead > claimedSize) {
       throw new SafeReadError(
         'too-large',
-        `file exceeds maxBytes during read (>${cap} bytes, file grew between stat and read): ${realPath}`,
+        `file grew between stat and read (claimed ${claimedSize}, read at least ${totalRead}): ${realPath}`,
       );
     }
     return { buffer: buf.subarray(0, totalRead), realPath, size: totalRead };

--- a/packages/client/src/backends/file-attach.ts
+++ b/packages/client/src/backends/file-attach.ts
@@ -173,6 +173,7 @@ export function createBoundedFileReader(opts: {
   allowedRoots: string[];
   maxBytes: number;
 }): (filePath: string) => Promise<SafeReadResult> {
+  assertMaxBytes(opts.maxBytes);
   let canonicalRootsPromise: Promise<string[]> | null = null;
   return async (filePath) =>
     readWithRoots({
@@ -223,11 +224,25 @@ export async function readBoundedFileWithinRoots(params: {
   allowedRoots: string[];
   maxBytes: number;
 }): Promise<SafeReadResult> {
+  assertMaxBytes(params.maxBytes);
   return readWithRoots({
     filePath: params.filePath,
     maxBytes: params.maxBytes,
     getCanonicalRoots: () => resolveCanonicalRoots(params.allowedRoots),
   });
+}
+
+// Programmer-error guard: maxBytes is operator config, not user input.
+// Buffer.alloc(maxBytes + 1) deep inside readWithRoots would throw a
+// RangeError for negative or non-finite values, bypassing the SafeReadError
+// codes the caller is shaped to handle. Validate at the public boundaries
+// so misconfiguration fails loudly at startup, not on the first read.
+function assertMaxBytes(maxBytes: number): void {
+  if (typeof maxBytes !== 'number' || !Number.isFinite(maxBytes) || maxBytes < 0) {
+    throw new RangeError(
+      `maxBytes must be a finite non-negative number (got ${maxBytes})`,
+    );
+  }
 }
 
 async function readWithRoots(params: {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -2350,4 +2350,169 @@ test('attachOutputs: oversized file is skipped with a too-large warning, marker 
   }
 });
 
+// ---------------------------------------------------------------------------
+// sendFileMcp wiring (MCP tool path) — integration with handle()
+// ---------------------------------------------------------------------------
+
+test('sendFileMcp: handle() registers active task; tool call during run emits FilePart artifact through the same emit; releases on completion', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'openclaw-mcp-int-'));
+  const realRoot = await fs.realpath(root);
+  const filePath = path.join(realRoot, 'tool-out.txt');
+  await fs.writeFile(filePath, 'tool-emitted bytes');
+
+  // Hold the chat run open until the test triggers a tool call so we can
+  // observe the FilePart artifact emit BEFORE task.complete lands.
+  let releaseRun: (() => void) | null = null;
+  const runHeld = new Promise<void>((resolve) => {
+    releaseRun = resolve;
+  });
+
+  const fake = await createFakeGateway({
+    onRequest: async (sock, req) => {
+      if (req.method === 'sessions.messages.subscribe') {
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: false,
+            error: { code: 'unknown_method', message: 'unknown method' },
+          }),
+        );
+        return;
+      }
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({
+          type: 'res',
+          id: req.id,
+          ok: true,
+          payload: { runId, status: 'started' },
+        }),
+      );
+      // Wait until the test invokes the tool, then send terminal final.
+      await runHeld;
+      sock.send(
+        JSON.stringify({
+          type: 'event',
+          event: 'chat',
+          payload: {
+            runId,
+            sessionKey: params.sessionKey,
+            seq: 1,
+            state: 'final',
+            message: { text: 'done' },
+          },
+        }),
+      );
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({
+      url: fake.url,
+      sendFileMcp: { allowedRoots: [realRoot] },
+    });
+    const frames: UpFrame[] = [];
+    const handlePromise = backend.handle(
+      makeTask('t-mcp-int', 'go'),
+      (f) => frames.push(f),
+      NEVER,
+    );
+
+    // Wait until the MCP server is up and the task has been registered.
+    // The lazy start happens inside handle(); poll briefly.
+    let server = backend.getSendFileMcpServer();
+    for (let i = 0; i < 50 && (!server || server.activeTaskCount() === 0); i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      server = backend.getSendFileMcpServer();
+    }
+    assert.ok(server, 'MCP server should have started lazily during handle()');
+    assert.equal(server!.activeTaskCount(), 1, 'task should be registered while in flight');
+
+    // Invoke send_file directly via the test hook (bypasses HTTP transport).
+    const result = await server!.invokeSendFileForTest({ path: filePath });
+    assert.equal(result.ok, true);
+
+    // Release the gateway run so handle() can settle.
+    releaseRun!();
+    await handlePromise;
+
+    // After completion, the registry slot should be released.
+    assert.equal(server!.activeTaskCount(), 0, 'task should be released after handle() returns');
+
+    // The FilePart artifact emitted via the MCP tool should appear in the frames.
+    const artifacts = frames.filter((f) => f.type === 'task.artifact');
+    const fileArtifact = artifacts.find((a) =>
+      a.artifact.parts.some((p) => p.kind === 'file'),
+    );
+    assert.ok(fileArtifact, 'a FilePart artifact must have been emitted via the tool path');
+    const filePart = fileArtifact!.artifact.parts.find((p) => p.kind === 'file') as
+      | { kind: 'file'; file: { name?: string; mimeType?: string; bytes?: string } }
+      | undefined;
+    assert.equal(filePart!.file.name, 'tool-out.txt');
+    assert.equal(filePart!.file.mimeType, 'text/plain');
+    assert.equal(
+      Buffer.from(filePart!.file.bytes!, 'base64').toString('utf8'),
+      'tool-emitted bytes',
+    );
+
+    // Because the MCP tool already emitted an artifact, the final-result
+    // path should NOT have produced a duplicate text artifact.
+    const finalArtifacts = artifacts.filter(
+      (a) => a.artifact.name === 'openclaw-result',
+    );
+    assert.equal(
+      finalArtifacts.length,
+      0,
+      'final-result artifact must not be emitted when the tool already produced one',
+    );
+
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.equal(complete!.status.state, 'completed');
+
+    const finalServer = backend.getSendFileMcpServer();
+    if (finalServer) await finalServer.close();
+  } finally {
+    await fake.close();
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+test('sendFileMcp: not configured -> getSendFileMcpServer() stays null even after handle() runs', async () => {
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'sessions.messages.subscribe') {
+        sock.send(JSON.stringify({ type: 'res', id: req.id, ok: false, error: { code: 'unknown_method', message: 'unknown method' } }));
+        return;
+      }
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { sessionKey: string; idempotencyKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }));
+      setImmediate(() => {
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'final',
+          message: { text: 'no tool today' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t-no-mcp', 'go'), () => {}, NEVER);
+    assert.equal(
+      backend.getSendFileMcpServer(),
+      null,
+      'no MCP server should be lazily started when sendFileMcp is unset',
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -11,6 +11,11 @@ import {
   SafeReadError,
   stripMarkersForPath,
 } from './file-attach.js';
+import {
+  startSendFileMcpServer,
+  type SendFileMcpServer,
+  type SendFileMcpOptions,
+} from './send-file-mcp.js';
 import { clientVersion } from '../version.js';
 
 const execFileP = promisify(execFile);
@@ -507,8 +512,27 @@ export interface OpenclawBackendOptions {
    * Off by default. The bridge-client and OpenClaw are assumed to be
    * co-located on the same host; this disk-share pattern does not work
    * across hosts.
+   *
+   * `attachOutputs` and `sendFileMcp` may be enabled together: the MCP
+   * tool path is the recommended primary surface (deterministic), and
+   * the marker path remains as a text-only fallback for callers that
+   * prompt the agent without registering the MCP server.
    */
   attachOutputs?: OpenclawAttachOutputsOptions;
+  /**
+   * Expose a local Streamable HTTP MCP server with a `send_file(path, name?)`
+   * tool. The operator registers the resulting URL into OpenClaw's
+   * `mcp.servers` config so the agent gets `send_file` in its tool list.
+   *
+   * When the model invokes `send_file`, bridge-client reads the file
+   * (gated by `allowedRoots` + `maxBytes`, same primitives as `attachOutputs`)
+   * and emits an A2A `task.artifact` frame to the caller.
+   *
+   * Routing: bridge-client maintains a single in-flight task pointer per
+   * backend instance; concurrent tool calls during overlapping tasks are
+   * rejected with `ambiguous-task`.
+   */
+  sendFileMcp?: SendFileMcpOptions;
 }
 
 const DEFAULT_ATTACH_OUTPUTS_MAX_BYTES = 20 * 1024 * 1024;
@@ -712,7 +736,15 @@ function resolveTimeout(
 
 export function createOpenclawBackend(
   opts: OpenclawBackendOptions = {},
-): Backend {
+): Backend & {
+  /**
+   * Returns the lazily-started send_file MCP server, or null if it has
+   * not been spun up yet (no task with sendFileMcp has run, or the
+   * option wasn't enabled). Exposed for tests and operator diagnostics
+   * (e.g. logging the MCP URL on startup).
+   */
+  getSendFileMcpServer(): SendFileMcpServer | null;
+} {
   const url = opts.url ?? process.env.OPENCLAW_GATEWAY_URL ?? 'ws://127.0.0.1:18789';
   const token = opts.token ?? process.env.OPENCLAW_GATEWAY_TOKEN;
   const agent = opts.agent ?? process.env.OPENCLAW_AGENT ?? 'main';
@@ -738,6 +770,30 @@ export function createOpenclawBackend(
           maxBytes: opts.attachOutputs.maxBytes ?? DEFAULT_ATTACH_OUTPUTS_MAX_BYTES,
         }
       : null;
+  const sendFileMcpOpts =
+    opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
+      ? opts.sendFileMcp
+      : null;
+  // Lazy: only spin the HTTP server up on the first task that needs it,
+  // so backends that never see a tool call don't open a port.
+  let sendFileMcp: SendFileMcpServer | null = null;
+  let sendFileMcpStarting: Promise<SendFileMcpServer> | null = null;
+  async function ensureSendFileMcp(): Promise<SendFileMcpServer | null> {
+    if (!sendFileMcpOpts) return null;
+    if (sendFileMcp) return sendFileMcp;
+    if (sendFileMcpStarting) return sendFileMcpStarting;
+    sendFileMcpStarting = (async () => {
+      const server = await startSendFileMcpServer(sendFileMcpOpts);
+      sendFileMcp = server;
+      console.log(`[openclaw] send_file MCP server listening at ${server.url}`);
+      return server;
+    })();
+    try {
+      return await sendFileMcpStarting;
+    } finally {
+      sendFileMcpStarting = null;
+    }
+  }
 
   let current: GatewayClient | null = null;
   let connecting: Promise<GatewayClient> | null = null;
@@ -1039,6 +1095,8 @@ export function createOpenclawBackend(
   return {
     name: 'openclaw',
 
+    getSendFileMcpServer: () => sendFileMcp,
+
     // Probe whether the gateway implements `sessions.messages.subscribe` so
     // the bridge-server can advertise a card capability that matches reality.
     // OpenClaw added the RPC in v2026.3.22; older gateways reject it with
@@ -1137,6 +1195,14 @@ export function createOpenclawBackend(
       // final-only path — not fatal.
       await ensureSessionMessageSubscription(gw, sessionKey);
 
+      // Register this task with the send_file MCP server (if enabled) so
+      // tool calls landing during this run resolve to this task's emit().
+      // Released in finally{} so a crashed/timed-out task doesn't keep the
+      // slot occupied indefinitely. The shared `emittedAnyArtifact` flag
+      // is set on every successful tool call so the final-result path
+      // doesn't double up: a tool call that delivers a file plus a text
+      // reply already covers what the final artifact would carry.
+
       // Per-task streaming state. `emittedAnyArtifact` decides whether the
       // terminal `chat.final` should also emit a final-only artifact (i.e.
       // whether the streaming path already delivered content). `seenAssistantMessageIds`
@@ -1153,6 +1219,33 @@ export function createOpenclawBackend(
       // race in the microtask queue — chaining serializes them so artifacts
       // emit in the order their session.message events arrived.
       let processingTail: Promise<void> = Promise.resolve();
+
+      let sendFileRelease: (() => void) | null = null;
+      if (sendFileMcpOpts) {
+        try {
+          const server = await ensureSendFileMcp();
+          if (server) {
+            const handle = server.registerActiveTask({
+              taskId: task.taskId,
+              contextId: task.contextId,
+              emit: (artifact) => {
+                emit({
+                  type: 'task.artifact',
+                  taskId: task.taskId,
+                  artifact,
+                  lastChunk: true,
+                });
+                emittedAnyArtifact = true;
+              },
+            });
+            sendFileRelease = handle.release;
+          }
+        } catch (err) {
+          console.warn(
+            `[openclaw] send_file MCP server failed to start; tool path disabled for this task: ${(err as Error).message}`,
+          );
+        }
+      }
 
       const onSessionMessage = (p: SessionMessageEventPayload): void => {
         if (sessionMessageSettled) return;
@@ -1454,6 +1547,7 @@ export function createOpenclawBackend(
         if (ownedSession && sessionMessageOwners.get(sessionKey)?.taskId === task.taskId) {
           sessionMessageOwners.delete(sessionKey);
         }
+        sendFileRelease?.();
       }
     },
   };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -1,13 +1,14 @@
 import { createHash, generateKeyPairSync, randomUUID, sign as cryptoSign } from 'node:crypto';
 import { execFile } from 'node:child_process';
+import path from 'node:path';
 import { promisify } from 'node:util';
 import WebSocket from 'ws';
 import type { Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
 import {
+  createBoundedFileReader,
   inferMimeFromPath,
   parseBridgeAttachMarkers,
-  readBoundedFileWithinRoots,
   SafeReadError,
   stripMarkersForPath,
 } from './file-attach.js';
@@ -765,10 +766,20 @@ export function createOpenclawBackend(
   );
   const attachOutputs =
     opts.attachOutputs && opts.attachOutputs.allowedRoots.length > 0
-      ? {
-          allowedRoots: opts.attachOutputs.allowedRoots,
-          maxBytes: opts.attachOutputs.maxBytes ?? DEFAULT_ATTACH_OUTPUTS_MAX_BYTES,
-        }
+      ? (() => {
+          const cfg = {
+            allowedRoots: opts.attachOutputs!.allowedRoots,
+            maxBytes: opts.attachOutputs!.maxBytes ?? DEFAULT_ATTACH_OUTPUTS_MAX_BYTES,
+          };
+          return {
+            ...cfg,
+            // Cached reader: canonicalizes allowedRoots once and reuses the
+            // result for every marker, so an assistant message with N
+            // bridge-attach markers does N file reads instead of N + N*roots
+            // realpath calls.
+            read: createBoundedFileReader(cfg),
+          };
+        })()
       : null;
   const sendFileMcpOpts =
     opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
@@ -908,16 +919,12 @@ export function createOpenclawBackend(
     const fileParts: Part[] = [];
     for (const p of parsed.paths) {
       try {
-        const read = await readBoundedFileWithinRoots({
-          filePath: p,
-          allowedRoots: attachOutputs.allowedRoots,
-          maxBytes: attachOutputs.maxBytes,
-        });
+        const read = await attachOutputs.read(p);
         const mimeType = inferMimeFromPath(read.realPath);
         fileParts.push({
           kind: 'file',
           file: {
-            name: read.realPath.split('/').pop() ?? p,
+            name: path.basename(read.realPath),
             mimeType,
             bytes: read.buffer.toString('base64'),
           },
@@ -926,7 +933,7 @@ export function createOpenclawBackend(
       } catch (err) {
         const code = err instanceof SafeReadError ? err.code : 'read-failed';
         console.warn(
-          `[openclaw] bridge-attach skipped (${code}) for ${p}: ${(err as Error).message}`,
+          `[openclaw] bridge-attach skipped (${code}) for ${p}: ${errorMessage(err)}`,
         );
         // Marker stays in cleanedText so the operator can debug what the
         // agent tried to send.

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -1181,7 +1181,7 @@ export function createOpenclawBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code: 'gateway_closed', message: (err as Error).message },
+          error: { code: 'gateway_closed', message: errorMessage(err) },
         });
         return;
       }
@@ -1249,7 +1249,7 @@ export function createOpenclawBackend(
           }
         } catch (err) {
           console.warn(
-            `[openclaw] send_file MCP server failed to start; tool path disabled for this task: ${(err as Error).message}`,
+            `[openclaw] send_file MCP server failed to start; tool path disabled for this task: ${errorMessage(err)}`,
           );
         }
       }
@@ -1297,7 +1297,7 @@ export function createOpenclawBackend(
           .catch((err: unknown) => {
             console.error(
               '[openclaw] session.message processing failed:',
-              (err as Error).message,
+              errorMessage(err),
             );
           });
       };
@@ -1356,7 +1356,7 @@ export function createOpenclawBackend(
             sessionKey,
             seq: -1,
             state: 'error',
-            errorMessage: (err as Error).message,
+            errorMessage: errorMessage(err),
             cause: 'abort_failed',
           });
         }
@@ -1418,7 +1418,7 @@ export function createOpenclawBackend(
             taskId: task.taskId,
             error: {
               code: closed ? 'gateway_closed' : 'gateway_send_failed',
-              message: (err as Error).message,
+              message: errorMessage(err),
             },
           });
           return;

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -213,6 +213,45 @@ test('listen() failure rejects and does not leak the McpServer/transport', async
   }
 });
 
+test('treats empty/whitespace `name` as missing and falls back to basename', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'real.txt'), 'data');
+  const server = await startSendFileMcpServer({ allowedRoots: [root], skipHttp: true });
+  try {
+    const cap = { artifacts: [] as unknown[] };
+    const release = server.registerActiveTask(makeTaskHandle('t1', cap));
+    try {
+      const result = await server.invokeSendFileForTest({
+        path: path.join(root, 'real.txt'),
+        name: '   ',
+      });
+      assert.equal(result.ok, true);
+      const art = cap.artifacts[0] as {
+        parts: Array<{ file?: { name?: string } }>;
+      };
+      assert.equal(art.parts[0].file!.name, 'real.txt');
+    } finally {
+      release.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('treats `Localhost`/`LOCALHOST` as loopback (case-insensitive)', async () => {
+  const root = await tmpDir();
+  // Should NOT throw — case-insensitive normalization makes these
+  // equivalent to lowercase `localhost`, which is in the loopback set.
+  for (const host of ['Localhost', 'LOCALHOST', 'LocalHost']) {
+    const server = await startSendFileMcpServer({
+      allowedRoots: [root],
+      host,
+      skipHttp: true,
+    });
+    await server.close();
+  }
+});
+
 test('refuses to bind a non-loopback host without dangerouslyAllowNonLoopback', async () => {
   const root = await tmpDir();
   await assert.rejects(

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -192,6 +192,27 @@ test('start with port:0 and host:127.0.0.1 binds an HTTP listener exposing /mcp'
   }
 });
 
+test('listen() failure rejects and does not leak the McpServer/transport', async () => {
+  // Hold a port so the second start fails to bind, exercising the
+  // try/catch around `httpServer.listen`. Without cleanup the McpServer
+  // would stay connected and accumulate across retries.
+  const root = await tmpDir();
+  const occupier = await startSendFileMcpServer({ allowedRoots: [root] });
+  try {
+    await assert.rejects(
+      () =>
+        startSendFileMcpServer({
+          allowedRoots: [root],
+          host: '127.0.0.1',
+          port: occupier.port,
+        }),
+      /EADDRINUSE/i,
+    );
+  } finally {
+    await occupier.close();
+  }
+});
+
 test('refuses to bind a non-loopback host without dangerouslyAllowNonLoopback', async () => {
   const root = await tmpDir();
   await assert.rejects(

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -191,3 +191,45 @@ test('start with port:0 and host:127.0.0.1 binds an HTTP listener exposing /mcp'
     await server.close();
   }
 });
+
+test('refuses to bind a non-loopback host without dangerouslyAllowNonLoopback', async () => {
+  const root = await tmpDir();
+  await assert.rejects(
+    () =>
+      startSendFileMcpServer({
+        allowedRoots: [root],
+        host: '0.0.0.0',
+        skipHttp: true,
+      }),
+    /non-loopback/,
+  );
+});
+
+test('binds non-loopback when dangerouslyAllowNonLoopback is true', async () => {
+  const root = await tmpDir();
+  const server = await startSendFileMcpServer({
+    allowedRoots: [root],
+    host: '0.0.0.0',
+    skipHttp: true,
+    dangerouslyAllowNonLoopback: true,
+  });
+  try {
+    assert.equal(server.host, '0.0.0.0');
+  } finally {
+    await server.close();
+  }
+});
+
+test('::-bound listener advertises [::1] (IPv6 loopback) in url, not 127.0.0.1', async () => {
+  const root = await tmpDir();
+  const server = await startSendFileMcpServer({
+    allowedRoots: [root],
+    host: '::',
+    dangerouslyAllowNonLoopback: true,
+  });
+  try {
+    assert.match(server.url, /^http:\/\/\[::1\]:\d+\/mcp$/);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { startSendFileMcpServer, type SendFileTaskHandle } from './send-file-mcp.js';
+
+async function tmpDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'send-file-mcp-test-'));
+  return await fs.realpath(dir);
+}
+
+function makeTaskHandle(taskId: string, capture: { artifacts: unknown[] }): SendFileTaskHandle {
+  return {
+    taskId,
+    contextId: `ctx-${taskId}`,
+    emit: (artifact) => {
+      capture.artifacts.push(artifact);
+    },
+  };
+}
+
+test('send_file: with one active task, reads file and emits artifact through that task', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'note.txt'), 'note body');
+  const server = await startSendFileMcpServer({
+    allowedRoots: [root],
+    skipHttp: true,
+  });
+  try {
+    const cap = { artifacts: [] as unknown[] };
+    const release = server.registerActiveTask(makeTaskHandle('t1', cap));
+    try {
+      const result = await server.invokeSendFileForTest({
+        path: path.join(root, 'note.txt'),
+      });
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.size, 'note body'.length);
+      assert.equal(cap.artifacts.length, 1);
+      const art = cap.artifacts[0] as {
+        artifactId: string;
+        name: string;
+        parts: Array<{ kind: string; file?: { name?: string; mimeType?: string; bytes?: string } }>;
+      };
+      assert.equal(art.name, 'send-file');
+      assert.equal(art.artifactId, result.artifactId);
+      assert.equal(art.parts.length, 1);
+      assert.equal(art.parts[0].kind, 'file');
+      assert.equal(art.parts[0].file!.mimeType, 'text/plain');
+      assert.equal(
+        Buffer.from(art.parts[0].file!.bytes!, 'base64').toString('utf8'),
+        'note body',
+      );
+    } finally {
+      release.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('send_file: with no active task, returns no-active-task error and emits nothing', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'x.txt'), 'x');
+  const server = await startSendFileMcpServer({ allowedRoots: [root], skipHttp: true });
+  try {
+    const result = await server.invokeSendFileForTest({ path: path.join(root, 'x.txt') });
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.code, 'no-active-task');
+  } finally {
+    await server.close();
+  }
+});
+
+test('send_file: with multiple concurrent active tasks, returns ambiguous-task error (R1 routing)', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'x.txt'), 'x');
+  const server = await startSendFileMcpServer({ allowedRoots: [root], skipHttp: true });
+  try {
+    const capA = { artifacts: [] as unknown[] };
+    const capB = { artifacts: [] as unknown[] };
+    const releaseA = server.registerActiveTask(makeTaskHandle('tA', capA));
+    const releaseB = server.registerActiveTask(makeTaskHandle('tB', capB));
+    try {
+      assert.equal(server.activeTaskCount(), 2);
+      const result = await server.invokeSendFileForTest({ path: path.join(root, 'x.txt') });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, 'ambiguous-task');
+      assert.equal(capA.artifacts.length, 0, 'no emit on either task on ambiguity');
+      assert.equal(capB.artifacts.length, 0);
+    } finally {
+      releaseA.release();
+      releaseB.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('send_file: file outside allowedRoots is rejected with outside-roots; no emit', async () => {
+  const root = await tmpDir();
+  const outside = await tmpDir();
+  await fs.writeFile(path.join(outside, 'secret.txt'), 'no');
+  const server = await startSendFileMcpServer({ allowedRoots: [root], skipHttp: true });
+  try {
+    const cap = { artifacts: [] as unknown[] };
+    const release = server.registerActiveTask(makeTaskHandle('t1', cap));
+    try {
+      const result = await server.invokeSendFileForTest({
+        path: path.join(outside, 'secret.txt'),
+      });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, 'outside-roots');
+      assert.equal(cap.artifacts.length, 0);
+    } finally {
+      release.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('send_file: oversized file rejected with too-large; no emit', async () => {
+  const root = await tmpDir();
+  const big = path.join(root, 'big.bin');
+  await fs.writeFile(big, Buffer.alloc(2048));
+  const server = await startSendFileMcpServer({
+    allowedRoots: [root],
+    maxBytes: 1024,
+    skipHttp: true,
+  });
+  try {
+    const cap = { artifacts: [] as unknown[] };
+    const release = server.registerActiveTask(makeTaskHandle('t1', cap));
+    try {
+      const result = await server.invokeSendFileForTest({ path: big });
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      assert.equal(result.code, 'too-large');
+      assert.equal(cap.artifacts.length, 0);
+    } finally {
+      release.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('send_file: optional name overrides default basename', async () => {
+  const root = await tmpDir();
+  await fs.writeFile(path.join(root, 'orig.txt'), 'data');
+  const server = await startSendFileMcpServer({ allowedRoots: [root], skipHttp: true });
+  try {
+    const cap = { artifacts: [] as unknown[] };
+    const release = server.registerActiveTask(makeTaskHandle('t1', cap));
+    try {
+      const result = await server.invokeSendFileForTest({
+        path: path.join(root, 'orig.txt'),
+        name: 'pretty.txt',
+      });
+      assert.equal(result.ok, true);
+      const art = cap.artifacts[0] as {
+        parts: Array<{ file?: { name?: string } }>;
+      };
+      assert.equal(art.parts[0].file!.name, 'pretty.txt');
+    } finally {
+      release.release();
+    }
+  } finally {
+    await server.close();
+  }
+});
+
+test('start with port:0 and host:127.0.0.1 binds an HTTP listener exposing /mcp', async () => {
+  const root = await tmpDir();
+  const server = await startSendFileMcpServer({ allowedRoots: [root] });
+  try {
+    assert.ok(server.port > 0, 'port should be allocated by OS');
+    assert.equal(server.host, '127.0.0.1');
+    assert.equal(server.url, `http://127.0.0.1:${server.port}/mcp`);
+    // Smoke test the listener: a non-MCP request should get 404 (proves the
+    // server is up and routing on the path prefix). Real MCP protocol exchange
+    // is exercised by the e2e harness; here we only confirm the bind.
+    const res = await fetch(`http://127.0.0.1:${server.port}/not-mcp`);
+    assert.equal(res.status, 404);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -245,18 +245,28 @@ test('treats empty/whitespace `name` as missing and falls back to basename', asy
   }
 });
 
-test('treats `Localhost`/`LOCALHOST` as loopback (case-insensitive)', async () => {
+test('rejects the literal "localhost" (any case) as host — only loopback IP literals allowed', async () => {
   const root = await tmpDir();
-  // Should NOT throw — case-insensitive normalization makes these
-  // equivalent to lowercase `localhost`, which is in the loopback set.
-  for (const host of ['Localhost', 'LOCALHOST', 'LocalHost']) {
-    const server = await startSendFileMcpServer({
-      allowedRoots: [root],
-      host,
-      skipHttp: true,
-    });
-    await server.close();
+  // `"localhost"` resolves via libc/DNS at listen time and a non-standard
+  // /etc/hosts could send it to a routable interface, so it's not in the
+  // safe allowlist. Operators must use 127.0.0.1 or ::1 to opt into the
+  // safe-by-default loopback bind.
+  for (const host of ['localhost', 'Localhost', 'LOCALHOST']) {
+    await assert.rejects(
+      () => startSendFileMcpServer({ allowedRoots: [root], host, skipHttp: true }),
+      /non-loopback/,
+    );
   }
+});
+
+test('accepts `::1` as IPv6 loopback', async () => {
+  const root = await tmpDir();
+  const server = await startSendFileMcpServer({
+    allowedRoots: [root],
+    host: '::1',
+    skipHttp: true,
+  });
+  await server.close();
 });
 
 test('refuses to bind a non-loopback host without dangerouslyAllowNonLoopback', async () => {

--- a/packages/client/src/backends/send-file-mcp.test.ts
+++ b/packages/client/src/backends/send-file-mcp.test.ts
@@ -187,6 +187,13 @@ test('start with port:0 and host:127.0.0.1 binds an HTTP listener exposing /mcp'
     // is exercised by the e2e harness; here we only confirm the bind.
     const res = await fetch(`http://127.0.0.1:${server.port}/not-mcp`);
     assert.equal(res.status, 404);
+    // Tightened path guard: `/mcp2` must NOT match `/mcp` (the old
+    // startsWith check did).
+    const sibling = await fetch(`http://127.0.0.1:${server.port}/mcp2`);
+    assert.equal(sibling.status, 404);
+    // A subpath like `/mcp/extra` is also not the single MCP endpoint.
+    const sub = await fetch(`http://127.0.0.1:${server.port}/mcp/extra`);
+    assert.equal(sub.status, 404);
   } finally {
     await server.close();
   }

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -106,7 +106,11 @@ export async function startSendFileMcpServer(
 ): Promise<SendFileMcpServer> {
   const allowedRoots = opts.allowedRoots;
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
-  const host = opts.host ?? DEFAULT_HOST;
+  // Hostnames are case-insensitive per RFC 1035 §2.3.3; IPv6 hex digits
+  // likewise have no case. Lowercase once so allowlist comparisons and
+  // wildcard checks aren't tripped by `Localhost` / `LOCALHOST` / mixed
+  // IPv6 hex like `::1` vs `::1`.
+  const host = (opts.host ?? DEFAULT_HOST).toLowerCase();
   if (!LOOPBACK_HOSTS.has(host) && !opts.dangerouslyAllowNonLoopback) {
     throw new Error(
       `send_file MCP refuses to bind to non-loopback host "${host}" — the tool reads files from allowedRoots without transport-level auth. Set dangerouslyAllowNonLoopback:true to override.`,
@@ -157,7 +161,12 @@ export async function startSendFileMcpServer(
     const [task] = activeTasks;
     try {
       const read = await readBounded(input.path);
-      const fileName = input.name ?? path.basename(read.realPath);
+      // Treat empty / whitespace-only `name` as missing — falling back to
+      // the basename gives the caller a useful filename instead of the
+      // empty string the model accidentally passed in.
+      const trimmedName = input.name?.trim();
+      const fileName =
+        trimmedName && trimmedName.length > 0 ? trimmedName : path.basename(read.realPath);
       const artifactId = randomUUID();
       const parts: Part[] = [
         {

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -54,7 +54,12 @@ export interface SendFileMcpOptions {
 }
 
 export interface SendFileMcpServer {
-  /** URL operators register in OpenClaw's `mcp.servers` config. */
+  /**
+   * URL the agent's MCP runtime should connect to. Backends register it
+   * however their host CLI / config expects: OpenClaw via
+   * `openclaw mcp set send-file`, claude via `--mcp-config` inline JSON,
+   * other backends via their own equivalents.
+   */
   url: string;
   /** Bind host (after resolution). */
   host: string;

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -307,8 +307,20 @@ export async function startSendFileMcpServer(
 
     try {
       await new Promise<void>((resolve, reject) => {
-        httpServer!.once('error', reject);
+        // Named so we can detach it on success. A `once('error', reject)`
+        // that never fires stays attached forever and would swallow
+        // post-start error events by resolving an already-settled
+        // Promise (and counting as "handled" to Node's process-crash
+        // logic) instead of surfacing them.
+        const onStartupError = (err: unknown): void => reject(err);
+        httpServer!.once('error', onStartupError);
         httpServer!.listen(opts.port ?? 0, host, () => {
+          httpServer!.removeListener('error', onStartupError);
+          // Long-lived listener so post-start failures (e.g. fd exhaustion)
+          // surface in logs instead of silently disappearing.
+          httpServer!.on('error', (err: unknown) => {
+            console.error('[send-file-mcp] httpServer error:', errorMessage(err));
+          });
           const addr = httpServer!.address();
           if (addr && typeof addr === 'object') {
             actualPort = addr.port;

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -33,9 +33,10 @@ export interface SendFileMcpOptions {
   /** Bind host; default 127.0.0.1. */
   host?: string;
   /**
-   * Optional pre-built server for unit tests — the public factory builds
-   * its own. Tests can pass `{ skipHttp: true }` and drive the registry
-   * directly without spinning up sockets.
+   * Skip binding the HTTP listener. The MCP server, tool registry, and
+   * routing are still built so tests can drive the tool path through
+   * `invokeSendFileForTest` directly without opening a socket. Production
+   * callers leave this unset.
    */
   skipHttp?: boolean;
 }

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -81,7 +81,11 @@ export interface SendFileMcpServer {
 const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
 const DEFAULT_HOST = '127.0.0.1';
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
-const WILDCARD_HOSTS = new Set(['0.0.0.0', '::', '*']);
+// Real wildcard bind addresses Node accepts in `httpServer.listen(port, host)`.
+// `"*"` is intentionally excluded: Node treats it as a literal hostname and
+// `.listen()` resolves it via DNS, typically failing ENOTFOUND. Operators
+// who want all-interfaces use `0.0.0.0` (IPv4) or `::` (IPv6 / dual stack).
+const WILDCARD_HOSTS = new Set(['0.0.0.0', '::']);
 
 // Defensive stringification — `(e as Error).message` is unsafe when the
 // thrown value is null/undefined or a non-Error primitive (common when

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -277,8 +277,11 @@ export async function startSendFileMcpServer(
   if (!opts.skipHttp) {
     httpServer = createHttpServer((req, res) => {
       // Single MCP endpoint. Reject anything else fast so we don't expose
-      // unintended surfaces (e.g. /).
-      if (!req.url || !req.url.startsWith('/mcp')) {
+      // unintended surfaces. Strict pathname match (`/mcp` exactly, with
+      // an optional querystring) — the previous `startsWith('/mcp')` also
+      // matched `/mcp2`, `/mcp-anything`, etc.
+      const pathname = req.url ? req.url.split('?', 1)[0] : '';
+      if (pathname !== '/mcp') {
         res.statusCode = 404;
         res.end('not found');
         return;

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -160,7 +160,7 @@ export async function startSendFileMcpServer(
           .string()
           .min(1)
           .describe(
-            'Absolute path to the file on the local filesystem. Must be inside one of the operator-configured allowed roots; relative paths and paths that resolve outside the roots are rejected.',
+            'Path to the file on the local filesystem. Absolute paths are preferred; a relative path resolves against the first operator-configured allowed root. After resolution the file must canonicalize (realpath) into one of the allowed roots, otherwise the call is rejected.',
           ),
         name: z
           .string()
@@ -213,7 +213,13 @@ export async function startSendFileMcpServer(
 
   let httpServer: HttpServer | null = null;
   let actualPort = 0;
-  let url = `http://${host}:0/mcp`;
+  // Wildcard bind addresses are not routable for clients — they tell the OS
+  // "listen on all interfaces" but a client connecting to `http://0.0.0.0/`
+  // gets a connection refused on most platforms. Advertise loopback when the
+  // operator chose a wildcard (mirrors what openclaw.ts does for gateway
+  // listener URLs).
+  const advertiseHost = host === '0.0.0.0' || host === '::' || host === '*' ? '127.0.0.1' : host;
+  let url = `http://${advertiseHost}:0/mcp`;
 
   if (!opts.skipHttp) {
     httpServer = createHttpServer((req, res) => {
@@ -243,7 +249,7 @@ export async function startSendFileMcpServer(
         resolve();
       });
     });
-    url = `http://${host}:${actualPort}/mcp`;
+    url = `http://${advertiseHost}:${actualPort}/mcp`;
   }
 
   return {

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -83,6 +83,20 @@ const DEFAULT_HOST = '127.0.0.1';
 const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
 const WILDCARD_HOSTS = new Set(['0.0.0.0', '::', '*']);
 
+// Defensive stringification — `(e as Error).message` is unsafe when the
+// thrown value is null/undefined or a non-Error primitive (common when
+// rejection paths in foreign code throw raw strings or numbers). Always
+// returns a string suitable for logs/structured-content without throwing.
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable>';
+  }
+}
+
 export async function startSendFileMcpServer(
   opts: SendFileMcpOptions,
 ): Promise<SendFileMcpServer> {
@@ -160,7 +174,7 @@ export async function startSendFileMcpServer(
       return {
         ok: false,
         code: 'unexpected-error',
-        message: (err as Error).message,
+        message: errorMessage(err),
       };
     }
   }
@@ -257,7 +271,7 @@ export async function startSendFileMcpServer(
         return;
       }
       transport.handleRequest(req, res).catch((err) => {
-        console.error('[send-file-mcp] handleRequest threw:', (err as Error).message);
+        console.error('[send-file-mcp] handleRequest threw:', errorMessage(err));
         if (!res.headersSent) {
           res.statusCode = 500;
           res.end('internal error');

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -33,6 +33,18 @@ export interface SendFileMcpOptions {
   /** Bind host; default 127.0.0.1. */
   host?: string;
   /**
+   * Allow binding to a non-loopback host (any wildcard like `0.0.0.0`/`::`,
+   * or a concrete external interface). The send_file tool exposes file
+   * reads from `allowedRoots` to anything that can reach the listener and
+   * has no transport-level auth, so binding off loopback exposes the tool
+   * to other machines on the network. Default: refuse and throw.
+   *
+   * Operators that need a non-loopback bind (sidecar in another container's
+   * network namespace, etc.) opt in with this flag and accept that
+   * `allowedRoots` is the only access control.
+   */
+  dangerouslyAllowNonLoopback?: boolean;
+  /**
    * Skip binding the HTTP listener. The MCP server, tool registry, and
    * routing are still built so tests can drive the tool path through
    * `invokeSendFileForTest` directly without opening a socket. Production
@@ -68,6 +80,8 @@ export interface SendFileMcpServer {
 
 const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
 const DEFAULT_HOST = '127.0.0.1';
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+const WILDCARD_HOSTS = new Set(['0.0.0.0', '::', '*']);
 
 export async function startSendFileMcpServer(
   opts: SendFileMcpOptions,
@@ -75,6 +89,11 @@ export async function startSendFileMcpServer(
   const allowedRoots = opts.allowedRoots;
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
   const host = opts.host ?? DEFAULT_HOST;
+  if (!LOOPBACK_HOSTS.has(host) && !opts.dangerouslyAllowNonLoopback) {
+    throw new Error(
+      `send_file MCP refuses to bind to non-loopback host "${host}" — the tool reads files from allowedRoots without transport-level auth. Set dangerouslyAllowNonLoopback:true to override.`,
+    );
+  }
   // Cached reader: canonicalize roots once per server instance instead of
   // on every tool call. This server is long-lived (one per backend), so
   // every send_file tool invocation reuses the same canonical roots.
@@ -216,11 +235,18 @@ export async function startSendFileMcpServer(
   let actualPort = 0;
   // Wildcard bind addresses are not routable for clients — they tell the OS
   // "listen on all interfaces" but a client connecting to `http://0.0.0.0/`
-  // gets a connection refused on most platforms. Advertise loopback when the
-  // operator chose a wildcard (mirrors what openclaw.ts does for gateway
-  // listener URLs).
-  const advertiseHost = host === '0.0.0.0' || host === '::' || host === '*' ? '127.0.0.1' : host;
-  let url = `http://${advertiseHost}:0/mcp`;
+  // gets a connection refused on most platforms. Advertise the matching
+  // loopback (IPv4 → 127.0.0.1, IPv6 → ::1) so a `::`-bound listener on a
+  // host with IPV6_V6ONLY set still resolves to a reachable URL.
+  const advertiseHost =
+    host === '::'
+      ? '::1'
+      : host === '0.0.0.0' || host === '*'
+        ? '127.0.0.1'
+        : host;
+  // IPv6 literals must be bracketed in URLs (RFC 3986).
+  const urlHost = advertiseHost.includes(':') ? `[${advertiseHost}]` : advertiseHost;
+  let url = `http://${urlHost}:0/mcp`;
 
   if (!opts.skipHttp) {
     httpServer = createHttpServer((req, res) => {
@@ -250,7 +276,7 @@ export async function startSendFileMcpServer(
         resolve();
       });
     });
-    url = `http://${advertiseHost}:${actualPort}/mcp`;
+    url = `http://${urlHost}:${actualPort}/mcp`;
   }
 
   return {

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -1,0 +1,267 @@
+import { randomUUID } from 'node:crypto';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import path from 'node:path';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import type { Part } from '@vicoop-bridge/protocol';
+import {
+  inferMimeFromPath,
+  readBoundedFileWithinRoots,
+  SafeReadError,
+} from './file-attach.js';
+import { clientVersion } from '../version.js';
+
+/**
+ * What a registered active task exposes to the MCP server. Only `emit` is
+ * called when a tool invocation lands; the rest is metadata so the server
+ * can produce useful diagnostics if multiple tasks try to register.
+ */
+export interface SendFileTaskHandle {
+  taskId: string;
+  contextId: string;
+  emit: (artifact: { artifactId: string; name: string; parts: Part[] }) => void;
+}
+
+export interface SendFileMcpOptions {
+  /** Roots within which the agent may reference files. */
+  allowedRoots: string[];
+  /** Per-attachment size cap. Default 20 MiB. */
+  maxBytes?: number;
+  /** TCP port; default 0 (OS-picked). */
+  port?: number;
+  /** Bind host; default 127.0.0.1. */
+  host?: string;
+  /**
+   * Optional pre-built server for unit tests — the public factory builds
+   * its own. Tests can pass `{ skipHttp: true }` and drive the registry
+   * directly without spinning up sockets.
+   */
+  skipHttp?: boolean;
+}
+
+export interface SendFileMcpServer {
+  /** URL operators register in OpenClaw's `mcp.servers` config. */
+  url: string;
+  /** Bind host (after resolution). */
+  host: string;
+  /** Bind port (after OS allocation when port:0). */
+  port: number;
+  /** Register the task that should receive emitted artifacts. */
+  registerActiveTask(handle: SendFileTaskHandle): { release: () => void };
+  /** How many tasks are currently registered (for diagnostics/tests). */
+  activeTaskCount(): number;
+  /**
+   * Internal handler exposed for unit tests that drive the tool without
+   * MCP transport. Performs the same routing + read + emit logic the real
+   * tool handler uses.
+   */
+  invokeSendFileForTest(input: { path: string; name?: string }): Promise<{
+    ok: true;
+    artifactId: string;
+    size: number;
+    realPath: string;
+  } | { ok: false; code: string; message: string }>;
+  close(): Promise<void>;
+}
+
+const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
+const DEFAULT_HOST = '127.0.0.1';
+
+export async function startSendFileMcpServer(
+  opts: SendFileMcpOptions,
+): Promise<SendFileMcpServer> {
+  const allowedRoots = opts.allowedRoots;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  const host = opts.host ?? DEFAULT_HOST;
+
+  // Routing strategy R1: a single in-flight task at a time. Bridge's
+  // typical caller-per-context pattern keeps this true; the alternative
+  // (carrying sessionKey through the tool args) would push the routing
+  // problem onto the model and reintroduce the prompt-fragility we are
+  // moving away from. Concurrent registrations are detected and the tool
+  // call is rejected with a structured error so the model doesn't silently
+  // emit a file to the wrong caller.
+  const activeTasks = new Set<SendFileTaskHandle>();
+
+  function registerActiveTask(handle: SendFileTaskHandle): { release: () => void } {
+    activeTasks.add(handle);
+    return {
+      release: () => {
+        activeTasks.delete(handle);
+      },
+    };
+  }
+
+  async function performSendFile(input: { path: string; name?: string }): Promise<
+    | { ok: true; artifactId: string; size: number; realPath: string }
+    | { ok: false; code: string; message: string }
+  > {
+    if (activeTasks.size === 0) {
+      return {
+        ok: false,
+        code: 'no-active-task',
+        message:
+          'send_file was invoked while no A2A task is in flight on this backend. The model should only call this tool while responding to a caller.',
+      };
+    }
+    if (activeTasks.size > 1) {
+      return {
+        ok: false,
+        code: 'ambiguous-task',
+        message: `send_file was invoked while ${activeTasks.size} tasks are in flight; bridge-client cannot route the artifact unambiguously. Concurrent send_file is not supported.`,
+      };
+    }
+    const [task] = activeTasks;
+    try {
+      const read = await readBoundedFileWithinRoots({
+        filePath: input.path,
+        allowedRoots,
+        maxBytes,
+      });
+      const fileName = input.name ?? path.basename(read.realPath);
+      const artifactId = randomUUID();
+      const parts: Part[] = [
+        {
+          kind: 'file',
+          file: {
+            name: fileName,
+            mimeType: inferMimeFromPath(read.realPath),
+            bytes: read.buffer.toString('base64'),
+          },
+        },
+      ];
+      task.emit({ artifactId, name: 'send-file', parts });
+      return { ok: true, artifactId, size: read.size, realPath: read.realPath };
+    } catch (err) {
+      if (err instanceof SafeReadError) {
+        return { ok: false, code: err.code, message: err.message };
+      }
+      return {
+        ok: false,
+        code: 'unexpected-error',
+        message: (err as Error).message,
+      };
+    }
+  }
+
+  const mcp = new McpServer({
+    name: 'vicoop-bridge-send-file',
+    version: clientVersion,
+  });
+
+  mcp.registerTool(
+    'send_file',
+    {
+      description:
+        'Deliver a local file to the A2A caller as an attachment. Use this when you want to send a file (PDF, image, csv, etc.) you produced or read earlier alongside your text response. The file is delivered via the bridge as an A2A FilePart artifact. Returns once the file has been queued for transfer.',
+      inputSchema: {
+        path: z
+          .string()
+          .min(1)
+          .describe(
+            'Absolute path to the file on the local filesystem. Must be inside one of the operator-configured allowed roots; relative paths and paths that resolve outside the roots are rejected.',
+          ),
+        name: z
+          .string()
+          .optional()
+          .describe(
+            'Optional display name shown to the caller. Defaults to the file basename.',
+          ),
+      },
+    },
+    async ({ path: filePath, name }) => {
+      const result = await performSendFile({ path: filePath, name });
+      if (result.ok) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `File queued for transfer (artifactId=${result.artifactId}, size=${result.size} bytes, path=${result.realPath}).`,
+            },
+          ],
+          structuredContent: result,
+        };
+      }
+      // Surface as an error result so the model sees it failed and can
+      // adjust (try a different path, ask the user, etc.) instead of
+      // silently moving on.
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `send_file failed (${result.code}): ${result.message}`,
+          },
+        ],
+        structuredContent: result,
+      };
+    },
+  );
+
+  // Stateful transport: the MCP client (OpenClaw bundle-mcp runtime) sends
+  // initialize -> tools/list -> tools/call as a sequence and expects the
+  // server to remember the negotiated session. The SDK's stateless mode
+  // accepts initialize but rejects subsequent calls because the McpServer's
+  // tool registrations are bound to the post-initialize session state. We
+  // generate a fresh session ID per initialize and route subsequent
+  // requests via the `mcp-session-id` header.
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+  });
+  await mcp.connect(transport);
+
+  let httpServer: HttpServer | null = null;
+  let actualPort = 0;
+  let url = `http://${host}:0/mcp`;
+
+  if (!opts.skipHttp) {
+    httpServer = createHttpServer((req, res) => {
+      // Single MCP endpoint. Reject anything else fast so we don't expose
+      // unintended surfaces (e.g. /).
+      if (!req.url || !req.url.startsWith('/mcp')) {
+        res.statusCode = 404;
+        res.end('not found');
+        return;
+      }
+      transport.handleRequest(req, res).catch((err) => {
+        console.error('[send-file-mcp] handleRequest threw:', (err as Error).message);
+        if (!res.headersSent) {
+          res.statusCode = 500;
+          res.end('internal error');
+        }
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer!.once('error', reject);
+      httpServer!.listen(opts.port ?? 0, host, () => {
+        const addr = httpServer!.address();
+        if (addr && typeof addr === 'object') {
+          actualPort = addr.port;
+        }
+        resolve();
+      });
+    });
+    url = `http://${host}:${actualPort}/mcp`;
+  }
+
+  return {
+    url,
+    host,
+    port: actualPort,
+    registerActiveTask,
+    activeTaskCount: () => activeTasks.size,
+    invokeSendFileForTest: performSendFile,
+    async close() {
+      try {
+        await mcp.close();
+      } catch {
+        /* ignore */
+      }
+      if (httpServer) {
+        await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+      }
+    },
+  };
+}

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -61,7 +61,7 @@ export interface SendFileMcpServer {
    * other backends via their own equivalents.
    */
   url: string;
-  /** Bind host (after resolution). */
+  /** Bind host as it was passed to `httpServer.listen()` (lowercased). */
   host: string;
   /** Bind port (after OS allocation when port:0). */
   port: number;
@@ -85,7 +85,12 @@ export interface SendFileMcpServer {
 
 const DEFAULT_MAX_BYTES = 20 * 1024 * 1024;
 const DEFAULT_HOST = '127.0.0.1';
-const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1']);
+// Loopback IP literals only. `"localhost"` is intentionally excluded:
+// `httpServer.listen(port, "localhost")` resolves through libc/DNS, and an
+// environment with a non-standard `/etc/hosts` (or DNS poisoning) could
+// map it to a routable interface — bypassing the safety check operators
+// rely on. Forcing IP literals removes the resolver from the trust path.
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1']);
 // Real wildcard bind addresses Node accepts in `httpServer.listen(port, host)`.
 // `"*"` is intentionally excluded: Node treats it as a literal hostname and
 // `.listen()` resolves it via DNS, typically failing ENOTFOUND. Operators

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -238,12 +238,11 @@ export async function startSendFileMcpServer(
   // gets a connection refused on most platforms. Advertise the matching
   // loopback (IPv4 → 127.0.0.1, IPv6 → ::1) so a `::`-bound listener on a
   // host with IPV6_V6ONLY set still resolves to a reachable URL.
-  const advertiseHost =
-    host === '::'
-      ? '::1'
-      : host === '0.0.0.0' || host === '*'
-        ? '127.0.0.1'
-        : host;
+  const advertiseHost = host === '::'
+    ? '::1'
+    : WILDCARD_HOSTS.has(host)
+      ? '127.0.0.1'
+      : host;
   // IPv6 literals must be bracketed in URLs (RFC 3986).
   const urlHost = advertiseHost.includes(':') ? `[${advertiseHost}]` : advertiseHost;
   let url = `http://${urlHost}:0/mcp`;

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -6,8 +6,8 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import type { Part } from '@vicoop-bridge/protocol';
 import {
+  createBoundedFileReader,
   inferMimeFromPath,
-  readBoundedFileWithinRoots,
   SafeReadError,
 } from './file-attach.js';
 import { clientVersion } from '../version.js';
@@ -74,6 +74,10 @@ export async function startSendFileMcpServer(
   const allowedRoots = opts.allowedRoots;
   const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
   const host = opts.host ?? DEFAULT_HOST;
+  // Cached reader: canonicalize roots once per server instance instead of
+  // on every tool call. This server is long-lived (one per backend), so
+  // every send_file tool invocation reuses the same canonical roots.
+  const readBounded = createBoundedFileReader({ allowedRoots, maxBytes });
 
   // Routing strategy R1: a single in-flight task at a time. Bridge's
   // typical caller-per-context pattern keeps this true; the alternative
@@ -114,11 +118,7 @@ export async function startSendFileMcpServer(
     }
     const [task] = activeTasks;
     try {
-      const read = await readBoundedFileWithinRoots({
-        filePath: input.path,
-        allowedRoots,
-        maxBytes,
-      });
+      const read = await readBounded(input.path);
       const fileName = input.name ?? path.basename(read.realPath);
       const artifactId = randomUUID();
       const parts: Part[] = [

--- a/packages/client/src/backends/send-file-mcp.ts
+++ b/packages/client/src/backends/send-file-mcp.ts
@@ -283,16 +283,34 @@ export async function startSendFileMcpServer(
       });
     });
 
-    await new Promise<void>((resolve, reject) => {
-      httpServer!.once('error', reject);
-      httpServer!.listen(opts.port ?? 0, host, () => {
-        const addr = httpServer!.address();
-        if (addr && typeof addr === 'object') {
-          actualPort = addr.port;
-        }
-        resolve();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        httpServer!.once('error', reject);
+        httpServer!.listen(opts.port ?? 0, host, () => {
+          const addr = httpServer!.address();
+          if (addr && typeof addr === 'object') {
+            actualPort = addr.port;
+          }
+          resolve();
+        });
       });
-    });
+    } catch (err) {
+      // Bind failed (port in use, permission denied, host unresolvable).
+      // The McpServer + transport were already wired up before the bind
+      // attempt; close them so a retry doesn't leak handles. httpServer
+      // itself never finished listening so closing is best-effort.
+      try {
+        await mcp.close();
+      } catch {
+        /* ignore secondary failure */
+      }
+      try {
+        httpServer.close();
+      } catch {
+        /* ignore */
+      }
+      throw err;
+    }
     url = `http://${urlHost}:${actualPort}/mcp`;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
 
   packages/client:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -772,6 +775,16 @@ packages:
   '@metamask/utils@9.3.0':
     resolution: {integrity: sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==}
     engines: {node: '>=16.0.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/ciphers@1.2.1':
     resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
@@ -1836,6 +1849,17 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -2048,6 +2072,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -2058,6 +2086,10 @@ packages:
 
   cross-fetch@4.1.0:
     resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
@@ -2337,6 +2369,16 @@ packages:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -2357,6 +2399,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2579,6 +2624,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2646,6 +2695,9 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   isows@1.0.6:
     resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
     peerDependencies:
@@ -2683,6 +2735,12 @@ packages:
 
   json-rpc-random-id@1.0.1:
     resolution: {integrity: sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -3086,6 +3144,10 @@ packages:
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -3164,6 +3226,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -3235,6 +3301,10 @@ packages:
   pino@7.11.0:
     resolution: {integrity: sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pluralize@7.0.0:
     resolution: {integrity: sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==}
@@ -3474,6 +3544,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -3540,6 +3614,14 @@ packages:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
     engines: {node: '>= 0.10'}
     hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -3983,6 +4065,11 @@ packages:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
     engines: {node: '>= 0.4'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -4077,6 +4164,11 @@ packages:
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
@@ -4782,6 +4874,28 @@ snapshots:
       pony-cause: 2.1.11
       semver: 7.7.4
       uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.12)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -6934,6 +7048,17 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@3.2.1:
@@ -7141,6 +7266,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   crc-32@1.2.2: {}
 
   cross-fetch@3.2.0:
@@ -7154,6 +7284,12 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   crossws@0.3.5:
     dependencies:
@@ -7452,6 +7588,15 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.6
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -7497,6 +7642,8 @@ snapshots:
   fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7778,6 +7925,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   iron-webcrypto@1.2.1: {}
@@ -7835,6 +7984,8 @@ snapshots:
 
   isarray@2.0.5: {}
 
+  isexe@2.0.0: {}
+
   isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -7863,6 +8014,10 @@ snapshots:
       eth-rpc-errors: 4.0.3
 
   json-rpc-random-id@1.0.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -8434,6 +8589,8 @@ snapshots:
       once: 1.4.0
       readable-stream: 2.3.8
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   ofetch@1.5.1:
@@ -8555,6 +8712,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-key@3.1.1: {}
+
   path-to-regexp@8.4.2: {}
 
   pg-cloudflare@1.3.0:
@@ -8632,6 +8791,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
+
+  pkce-challenge@5.0.1: {}
 
   pluralize@7.0.0: {}
 
@@ -8926,6 +9087,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-main-filename@2.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -9034,6 +9197,12 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -9548,6 +9717,10 @@ snapshots:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -9716,6 +9889,10 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.22.4: {}
 


### PR DESCRIPTION
Closes #86.

## Summary

Claude Code backend gets the same file passthrough story OpenClaw shipped in #90. Caller→agent multi-modal input via stream-json stdin, agent→caller delivery through the `send_file` MCP tool.

The first 7 commits are PR #90 follow-ups that didn't make it into the squash (send_file MCP module, Copilot review responses, file-attach TOCTOU defense). They land OpenClaw's full intended state and the shared modules (\`send-file-mcp.ts\`, \`file-attach.ts\` hardening) my work depends on. The last 2 commits are the new claude backend wiring.

## Changes — claude backend (mine)

**caller → agent**: switch input from `-p <text>` argv to stream-json stdin. A2A `TextPart`/`FilePart` map to Anthropic content blocks so image/{png,jpeg,webp,gif} and application/pdf land directly on the model's vision/document path. Other MIME types and uri-only FileParts are rejected with stable codes (`unsupported_file_mime`, `unsupported_file_uri`).

**agent → caller**: two opt-in surfaces, both lit up by this PR.

- `tool_result` image/document blocks in the stream-json transcript pass through as `FilePart` artifacts. MCP screenshot tools and image-generation tools become deliverables without extra opt-in.
- `ClaudeBackendOptions.sendFileMcp` lazy-starts the backend-agnostic `startSendFileMcpServer` from #90 and wires it into the spawned claude via `--mcp-config`. Each `handle()` registers its task on the server's R1 routing slot and releases on terminal frame, so a `send_file(path, name?)` tool call during the run emits a `task.artifact` to the active caller.

## Tests

- 16 new unit cases in `claude.test.ts` covering: stream-json envelope shapes (text/image/PDF), unsupported MIME / uri-only rejection, `tool_result` image passthrough, send_file MCP register/release lifecycle, in-flight tool call → artifact emission.
- `pnpm --filter @vicoop-bridge/client test` — 126/126 pass.
- `pnpm -r build` clean.

## E2E

Four self-contained Node harnesses under `packages/client/scripts/`, each imports the compiled backend, drives one A2A `task.assign` through the real `claude` CLI, and asserts on emitted frames. All four passed locally:

| Harness | Validates | Time |
|---|---|---|
| `e2e-claude-text-smoke.mjs` | stream-json stdin sanity (`PONG`) | ≈ 8 s |
| `e2e-claude-input-image.mjs` | 1×1 red PNG → `red` (vision) | ≈ 11 s |
| `e2e-claude-input-pdf.mjs` | inline-generated PDF with secret word `KUMQUAT` → model reads it back | ≈ 7 s |
| `e2e-claude-send-file.mjs` | `sendFileMcp` + `--mcp-config` + model invokes `send_file` → 39 B fixture round-trips as `FilePart` | ≈ 16 s |

`docs/claude-e2e.md` mirrors `docs/openclaw-e2e.md`: prereqs, per-harness expected output, troubleshooting, and a coverage matrix mapping each #86 test bullet to its harness.

## Out of scope (separate follow-ups)

- staging cwd `./output/` directory convention (issue #86 task 2b)
- env-driven CLI wiring for `sendFileMcp` / `allowedRoots` in `cli.ts` (currently the option is API-only)
- agent card capability advertisement for input/output files

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 126/126 pass
- [x] `pnpm -r build` clean
- [x] All four e2e harnesses pass against the real \`claude\` CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)