### PR TITLE
[codex] Fix install client onboarding guide

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -2,9 +2,10 @@
 
 Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code,
 with `echo` available for testing) to a deployed vicoop-bridge server. The
-end state is a long-running `vicoop-client` process on your host that bridges
-inbound A2A traffic at `POST <bridge>/agents/<your-agent-id>` to your local
-backend.
+first target is a verified foreground `vicoop-client` process on your host
+that bridges inbound A2A traffic at `POST <bridge>/agents/<your-agent-id>` to
+your local backend. Persistent service setup is optional once the foreground
+run works.
 
 Additional backends (Codex, ...) are described in `docs/design.md` §5 but are
 not in the published client bundle yet. The released client currently
@@ -75,7 +76,7 @@ would still default to `/data/vicoop-bridge-client`.
 | `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
 | `VERSION` | latest `client-v*` | Pin a specific tag, e.g. `client-v0.1.1`. |
 | `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
-| `INSTALL_SKIP_SERVICE` | `0` | If `1`, skip the systemd unit + env template even on systemd hosts. |
+| `INSTALL_SKIP_SERVICE` | `0` | If `1`, skip the optional systemd unit + env template even on systemd hosts. |
 | `INSTALL_SERVICE_SCOPE` | `auto` | Force `user`, `system`, or `none` instead of auto-detecting by `id -u`. `system` requires root; an explicit `system` without root is refused with a warning. |
 
 What you get after extraction:
@@ -95,13 +96,13 @@ The script targets Linux (Fly.io persistent volumes are the original target
 deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
 background.
 
-When systemd is the host init, `install.sh` also writes a
+When systemd is the host init, `install.sh` may also write an optional
 `vicoop-client.service` unit plus a `vicoop-client.env` template (scope
 auto-detected: `system` as root, `user` otherwise). It does not enable or
-start the service — env values are populated by Steps 3-5 below, and the
-operator runs the `systemctl enable --now` command from the installer's
-output once they're filled in. Opt out with `INSTALL_SKIP_SERVICE=1`, or
-force a scope with `INSTALL_SERVICE_SCOPE=user|system|none`.
+start the service. Use the foreground run in Step 6 first; enable the service
+later only if this host should keep the client online unattended. Opt out with
+`INSTALL_SKIP_SERVICE=1`, or force a scope with
+`INSTALL_SERVICE_SCOPE=user|system|none`.
 
 ## Step 2 — Verify the installed bundle
 
@@ -174,7 +175,7 @@ CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
   --bridge "$BRIDGE_URL" \
   --client-name "$CLIENT_NAME" \
   --agent-ids "$AGENT_ID" \
-  --env-file "$INSTALL_DIR/vicoop-client.env"
+  --write-env-file "$INSTALL_DIR/vicoop-client.env"
 ```
 
 The CLI prints a verification URL to stderr — open it in **any** browser
@@ -197,8 +198,8 @@ AGENT_ID=<your agent id>
 > `intent=owner_session` — the rotation surfaces a new CLIENT_TOKEN, also
 > one-time).
 
-Drop `--env-file` and pass `--json` instead if you want to compose with
-shell tooling:
+Drop `--write-env-file` and pass `--json` instead if you want to compose
+with shell tooling:
 
 ```sh
 "$INSTALL_DIR/bin/vicoop-client" login \
@@ -207,6 +208,11 @@ shell tooling:
   | tee /tmp/vicoop-login.json
 CLIENT_TOKEN=$(jq -r .client_token /tmp/vicoop-login.json)
 ```
+
+`--write-env-file` replaces the older `--env-file` spelling. The old alias is
+still accepted by current bundles, but avoid it on Node 24 or newer unless the
+bundle wrapper has been updated to invoke `node -- dist/cli.js`; otherwise
+Node may consume `--env-file` before the CLI sees it.
 
 `--agent-ids` is a comma-separated allowlist. Include every id you plan to
 run under this single token if you know them up front; amend later via
@@ -268,21 +274,12 @@ JSON
 
 ## Step 6 — Run the client
 
-All flags also accept env vars, which is usually cleaner for long-running
-services:
+Run the client in the foreground first. All flags also accept env vars, so the
+file written by Step 4 can be loaded directly:
 
 ```sh
-# The client appends /connect to SERVER_URL, so it must be a bare origin
-# (scheme+host+port only, no path). Derive via URL parsing and map the
-# scheme to its WS counterpart.
-SERVER_URL=$(BRIDGE_URL="$BRIDGE_URL" node -p '
-  const u = new URL(process.env.BRIDGE_URL);
-  (u.protocol === "https:" ? "wss:" : "ws:") + "//" + u.host
-')
+. "$INSTALL_DIR/vicoop-client.env"
 
-SERVER_URL="$SERVER_URL" \
-SERVER_TOKEN="$CLIENT_TOKEN" \
-AGENT_ID="$AGENT_ID" \
 AGENT_CARD="$INSTALL_DIR/cards/openclaw.json" \
 BACKEND=openclaw \
   "$INSTALL_DIR/bin/vicoop-client"
@@ -324,9 +321,47 @@ CLAUDE_CWD="$HOME/vicoop-bridge" \
   "$INSTALL_DIR/bin/vicoop-client"
 ```
 
+If you used `--write-env-file` in Step 4, load it first and omit the
+already-populated `SERVER_URL`, `SERVER_TOKEN`, and `AGENT_ID` assignments:
+
+```sh
+. "$INSTALL_DIR/vicoop-client.env"
+
+AGENT_CARD="$INSTALL_DIR/cards/claude.json" \
+BACKEND=claude \
+CLAUDE_CWD="$HOME/vicoop-bridge" \
+  "$INSTALL_DIR/bin/vicoop-client"
+```
+
 `CLAUDE_CWD` defaults to the current working directory of the client
 process. Set it when the released bundle lives outside the repository you
 want Claude to edit.
+
+## Optional: persistence
+
+Only set up persistence after the foreground run connects and the agent
+endpoint responds. For local Claude/OpenClaw onboarding, a foreground process
+is often enough for first success.
+
+On systemd hosts where `install.sh` wrote a unit, update the generated env
+file with the same values used for the foreground run:
+
+```sh
+AGENT_CARD="$INSTALL_DIR/cards/openclaw.json"
+BACKEND=openclaw
+```
+
+Then reload and start the service using the exact commands printed by the
+installer, for example:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now vicoop-client
+```
+
+For macOS or ad hoc local testing, use the foreground command above or your
+normal process supervisor. The bridge does not require systemd; it only needs
+one live `vicoop-client` process connected for the agent id.
 
 ### Restrict who can call your agent
 

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,11 @@
 #   2. Resolves the latest (or pinned) client-v* GitHub release.
 #   3. Downloads the .tgz + .sha256 and verifies integrity.
 #   4. Extracts the bundle into INSTALL_DIR.
-#   5. On systemd hosts, drops a vicoop-client.service unit + env template
-#      (does NOT enable/start — the owner must populate env first). The
+#   5. On systemd hosts, drops an optional vicoop-client.service unit + env
+#      template (does NOT enable/start — verify a foreground run first). The
 #      shipped bundle already contains cards/openclaw.json, so the env
 #      template points AGENT_CARD at that file by default.
-#   6. Prints next-step instructions (populate env, reload, enable).
+#   6. Prints next-step instructions for login and a foreground first run.
 
 set -eu
 
@@ -187,7 +187,7 @@ register_service() {
   # systemd must be the init (PID 1) — otherwise systemctl may exist but the
   # unit will never actually run (common in Docker, WSL1, macOS with homebrew).
   if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
-    log "systemd not detected — skipping service registration (set up a supervisor manually; see docs/install-client.md §6)"
+    log "systemd not detected — skipping optional service registration"
     return
   fi
 
@@ -392,14 +392,22 @@ cat <<EOF
 
 Next steps (the agent that owns this client should perform these):
 
-  1. Obtain SERVER_TOKEN, AGENT_ID, and an agent card — see
-     docs/install-client.md steps 2-4 for the SIWE + registerClient flow.
+  1. Verify the installed bundle and register with device flow:
+
+       "$INSTALL_DIR/bin/vicoop-client" -v
+       "$INSTALL_DIR/bin/vicoop-client" login --help
+
+     Then follow docs/install-client.md steps 3-5 to pick AGENT_ID, run
+     login, and choose an agent card.
 EOF
 
 if [ -n "$SERVICE_INSTALLED" ]; then
   cat <<EOF
-  2. Fill in $SERVICE_ENV_FILE with SERVER_URL / SERVER_TOKEN / AGENT_ID / AGENT_CARD / BACKEND.
-  3. Reload systemd and enable + start the service:
+  2. First run the client in the foreground with SERVER_URL / SERVER_TOKEN /
+     AGENT_ID / AGENT_CARD / BACKEND. See docs/install-client.md step 6.
+
+  3. Optional: after the foreground run works, fill in $SERVICE_ENV_FILE,
+     then reload systemd and enable + start the service:
 
        $SERVICE_RELOAD_CMD
        $SERVICE_ENABLE_CMD
@@ -423,7 +431,8 @@ EOF
   fi
 else
   cat <<EOF
-  2. Run the client (supply config via env or flags). Paths are quoted so
+  2. Run the client in the foreground (supply config via env or flags).
+     Paths are quoted so
      the snippet works even when \$INSTALL_DIR contains whitespace:
 
        SERVER_URL=wss://your-server-host \\
@@ -433,8 +442,8 @@ else
        BACKEND=openclaw \\
          "$INSTALL_DIR/bin/vicoop-client"
 
-     For persistent operation, see docs/install-client.md §6
-     (launchd on macOS, systemd user unit, tmux).
+     Persistent operation is optional after the foreground run works; see
+     docs/install-client.md "Optional: persistence".
 
   Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
   to re-run this installer. Pass --check to see if a newer release is

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -49,7 +49,7 @@ function usage(): void {
   process.stderr.write(
     [
       'usage: vicoop-client login --bridge <https://...> --client-name <name>',
-      '                          --agent-ids <id1,id2> [--env-file <path>] [--json]',
+      '                          --agent-ids <id1,id2> [--write-env-file <path>] [--json]',
       '',
       'Drives Google OAuth device flow against the bridge to register a new client.',
       'Prints the resulting CLIENT_TOKEN once — save it immediately, it is unrecoverable.',
@@ -58,8 +58,11 @@ function usage(): void {
       '  --bridge          Bridge HTTP URL (e.g. https://vicoop-bridge-server.fly.dev)',
       '  --client-name     Human-readable client name shown in admin tooling',
       '  --agent-ids       CSV of agent ids this client is allowed to register as',
-      '  --env-file PATH   Write SERVER_URL / SERVER_TOKEN / AGENT_ID env block to PATH',
+      '  --write-env-file PATH',
+      '                    Write SERVER_URL / SERVER_TOKEN / AGENT_ID env block to PATH',
       '                    (chmod 600). When omitted, the env block is printed to stdout.',
+      '  --env-file PATH   Deprecated alias for --write-env-file. Avoid on Node 24+',
+      '                    unless your wrapper invokes node with "--" before the script.',
       '  --json            Print the token endpoint response as JSON to stdout instead.',
       '',
     ].join('\n'),
@@ -103,6 +106,7 @@ function parseArgs(args: string[]): LoginArgs | null {
       case '--agent-ids':
         out.allowedAgentIds = v.split(',').map((s) => s.trim()).filter(Boolean);
         break;
+      case '--write-env-file':
       case '--env-file':
         out.envFile = v;
         break;

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -31,7 +31,7 @@ cat > "$BUNDLE_DIR/bin/vicoop-client" <<'EOF'
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec node "$SCRIPT_DIR/../dist/cli.js" "$@"
+exec node -- "$SCRIPT_DIR/../dist/cli.js" "$@"
 EOF
 
 chmod +x "$BUNDLE_DIR/bin/vicoop-client"
@@ -51,7 +51,7 @@ export AGENT_ID=my-agent
   --bridge "\$BRIDGE_URL" \\
   --client-name "my client" \\
   --agent-ids "\$AGENT_ID" \\
-  --env-file ./vicoop-client.env
+  --write-env-file ./vicoop-client.env
 \`\`\`
 
 Then start the client with env vars from \`./vicoop-client.env\` and a backend card


### PR DESCRIPTION
## Summary

Fixes #92 and #93.

- Add `--write-env-file` as the documented login flag and keep `--env-file` as a deprecated alias.
- Update the release bundle wrapper to invoke `node -- dist/cli.js` so Node 24 does not consume app flags such as `--env-file`.
- Rework `docs/install-client.md` and installer next steps around a minimal foreground first-run path, with persistence moved to an optional follow-up section.

## Validation

- `git diff --check`
- `sh -n install.sh`
- `dash -n install.sh`
- `shellcheck -s sh install.sh`
- `bash -n scripts/package-client-release.sh`
- `shellcheck -s bash scripts/package-client-release.sh`
- Isolated temp-dir installer simulations with fake `curl` and local tarball/checksum for non-systemd/no-service and user-systemd paths
- `node -- /tmp/argv.js --env-file /tmp/nope`
- `node /tmp/argv.js --write-env-file /tmp/nope`
- Node 24 wrapper check with CLI-looking args such as `--run`, `--watch`, and `--inspect=0` delivered to script argv instead of being consumed by Node

## Known validation gap

`pnpm --filter @vicoop-bridge/client typecheck` and `pnpm --filter @vicoop-bridge/client test` currently fail before reaching this change because `@modelcontextprotocol/sdk` is missing from the local install/package metadata, producing module resolution errors from `packages/client/src/backends/send-file-mcp.ts`.