### PR TITLE
fix(client): claude+openclaw cards advertise image and file I/O (#94)

### DIFF
--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -1,16 +1,30 @@
 {
   "name": "claude",
-  "description": "Anthropic Claude Code CLI agent. Spawns the local `claude` binary per task and streams each assistant message back as an A2A artifact. Text input only.",
+  "description": "Anthropic Claude Code CLI agent. Spawns the local `claude` binary per task and streams each assistant message back as an A2A artifact. Accepts text, image, and PDF inputs; can return text plus image/PDF outputs from tool results.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": { "streaming": true },
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["text/plain"],
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
+  "defaultOutputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
   "skills": [
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text.",
+      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`.",
       "tags": ["chat", "assistant", "claude"]
     }
   ]

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -1,16 +1,35 @@
 {
   "name": "openclaw",
-  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text and inline image attachments.",
+  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; can return text plus image/PDF/structured-data outputs when the operator enables outbound file delivery.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": { "streaming": true },
-  "defaultInputModes": ["text/plain", "image/png", "image/jpeg", "image/gif", "image/webp"],
-  "defaultOutputModes": ["text/plain"],
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
+  "defaultOutputModes": [
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf",
+    "application/json",
+    "application/zip",
+    "application/octet-stream"
+  ],
   "skills": [
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image parts (file.bytes with image/* mimeType).",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. Outputs may include text plus operator-enabled file deliveries.",
       "tags": ["chat", "assistant"]
     }
   ]

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -16,14 +16,24 @@
     "text/plain",
     "text/markdown",
     "text/csv",
+    "text/html",
     "image/png",
     "image/jpeg",
     "image/gif",
     "image/webp",
+    "image/svg+xml",
+    "image/bmp",
     "application/pdf",
     "application/json",
+    "application/xml",
     "application/zip",
-    "application/octet-stream"
+    "application/octet-stream",
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+    "video/mp4",
+    "video/quicktime",
+    "video/webm"
   ],
   "skills": [
     {

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; can return text plus image/PDF/structured-data outputs when the operator enables outbound file delivery.",
+  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; when the operator enables outbound file delivery, can also return file artifacts spanning images, PDFs, structured data (JSON/XML/CSV/HTML/Markdown), archives, audio, video, and other binary types.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": { "streaming": true },
@@ -39,7 +39,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. Outputs may include text plus operator-enabled file deliveries.",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
       "tags": ["chat", "assistant"]
     }
   ]

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Closes #94 (claude card) and applies the same correction to the openclaw card, which had the dual problem in a smaller form.

**claude card** (`packages/client/cards/claude.json`)
- `defaultInputModes` now lists `image/{png,jpeg,gif,webp}` and `application/pdf` alongside `text/plain` — matching what `packages/client/src/backends/claude.ts` actually accepts (`INPUT_IMAGE_MIME` set + `application/pdf` document blocks at L88, L224).
- `defaultOutputModes` likewise expanded — the backend passes through tool_result image/document blocks as outbound `FilePart` (see `extractToolResultMediaParts`, L157-181).
- Description drops the misleading "Text input only.", chat skill description calls out image/PDF.

**openclaw card** (`packages/client/cards/openclaw.json`)
- `defaultInputModes` adds `application/pdf` (mime is not pre-filtered in `mapPartsToChatInput`; OpenClaw ≥ v2026.4.27 accepts non-image via `media://inbound/`).
- `defaultOutputModes` expanded from `text/plain` only to the common set `inferMimeFromPath` produces (`file-attach.ts:368`) plus `application/octet-stream` for the unknown-extension fallback. Both `attachOutputs` (bridge-attach markers) and `sendFileMcp` can deliver across this set.
- Description and chat skill description updated.

## Why
A2A clients that trust `defaultInputModes` (e.g. a2a-inspector) blocked image/PDF attachments client-side with "File type ... is not supported by this agent" even though the backends handle them. The cards were advertising narrower than reality, so users couldn't even try working flows.

## Test plan
- [ ] `node -e 'JSON.parse(require("fs").readFileSync("packages/client/cards/claude.json","utf8"))'` — JSON parses
- [ ] `node -e 'JSON.parse(require("fs").readFileSync("packages/client/cards/openclaw.json","utf8"))'` — JSON parses
- [ ] Manual: connect a2a-inspector to a bridge instance running these cards; confirm PNG/PDF attachments are no longer pre-blocked and round-trip through both backends
- [ ] Manual: openclaw — agent emits `[bridge-attach: ...]` marker for a PDF and confirm caller sees a `FilePart` with `application/pdf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)