### PR TITLE
feat(client): log task lifecycle events with configurable level

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -22,6 +22,13 @@ test('summarizeParts: file part without mimeType falls back to octet-stream', ()
   assert.equal(summarizeParts(parts), 'application/octet-stream');
 });
 
+test('summarizeParts: file part with empty/whitespace mimeType falls back to octet-stream', () => {
+  const empty: Part[] = [{ kind: 'file', file: { name: 'a.bin', mimeType: '' } }];
+  assert.equal(summarizeParts(empty), 'application/octet-stream');
+  const whitespace: Part[] = [{ kind: 'file', file: { name: 'a.bin', mimeType: '   \t' } }];
+  assert.equal(summarizeParts(whitespace), 'application/octet-stream');
+});
+
 test('summarizeParts: data part reports application/json', () => {
   const parts: Part[] = [{ kind: 'data', data: { foo: 'bar' } }];
   assert.equal(summarizeParts(parts), 'application/json');

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -231,6 +231,31 @@ test('processTask: backend throws without emit -> emits backend_error fail and l
   assert.match(failLog, /code=backend_error/);
 });
 
+test('processTask: late-throw debug log preserves long error messages (not truncated at 200)', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const longMessage = 'x'.repeat(1500);
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+    throw new Error(longMessage);
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  const debugLine = c.log.find((l) =>
+    /backend threw after terminal taskId=T1.*message=/.test(l),
+  );
+  assert.ok(debugLine, `expected debug late-throw line, got: ${c.log.join(' | ')}`);
+  // The full 1500-char message must be present (default lifecycle-token
+  // limit of 200 would truncate it; this debug log uses a generous cap).
+  assert.ok(
+    debugLine.includes(longMessage),
+    `expected full error message, got debug line of length ${debugLine.length}`,
+  );
+});
+
 test('processTask: backend emits complete then throws -> does not double-emit, warns with errorClass only', async () => {
   const c = makeSink();
   const s = captureSend();
@@ -315,7 +340,14 @@ test('processTask: backend throws after abort -> emits canceled task.complete, l
   const s = captureSend();
   const controller = new AbortController();
   controller.abort();
-  const backend = backendOf('stub', async (_t, _emit, signal) => {
+  const backend = backendOf('stub', async (_t, emit, signal) => {
+    // Backend may have streamed an artifact before observing the abort —
+    // the canceled log should still surface the artifact count.
+    emit({
+      type: 'task.artifact',
+      taskId: 'T1',
+      artifact: { artifactId: 'A', parts: [{ kind: 'text', text: 'partial' }] },
+    });
     if (signal.aborted) throw new Error('aborted');
   });
   await processTask(makeAssign('T1'), controller.signal, {
@@ -323,17 +355,18 @@ test('processTask: backend throws after abort -> emits canceled task.complete, l
     send: s.send,
     logger: createLogger('debug', c.sink),
   });
-  // Wire saw a canceled-state task.complete — not a backend_error fail.
-  assert.equal(s.sent.length, 1);
-  const sent = s.sent[0];
+  // Wire saw the artifact + a canceled-state task.complete — not a backend_error fail.
+  assert.equal(s.sent.length, 2);
+  assert.equal(s.sent[0].type, 'task.artifact');
+  const sent = s.sent[1];
   assert.equal(sent.type, 'task.complete');
   if (sent.type === 'task.complete') {
     assert.equal(sent.status.state, 'canceled');
     assert.ok(typeof sent.status.timestamp === 'string' && sent.status.timestamp.length > 0);
   }
   assert.ok(
-    c.log.some((l) => /task\.canceled taskId=T1 elapsedMs=\d+/.test(l)),
-    `expected task.canceled log, got: ${c.log.join(' | ')}`,
+    c.log.some((l) => /task\.canceled taskId=T1 elapsedMs=\d+ artifacts=1/.test(l)),
+    `expected task.canceled log with artifacts=1, got: ${c.log.join(' | ')}`,
   );
   assert.ok(
     !c.log.some((l) => /task\.fail/.test(l)),

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Part } from '@vicoop-bridge/protocol';
+import { summarizeParts } from './client.js';
+
+test('summarizeParts: empty', () => {
+  assert.equal(summarizeParts([]), '(none)');
+});
+
+test('summarizeParts: text part reports text/plain', () => {
+  const parts: Part[] = [{ kind: 'text', text: 'hi' }];
+  assert.equal(summarizeParts(parts), 'text/plain');
+});
+
+test('summarizeParts: file part uses declared mimeType', () => {
+  const parts: Part[] = [{ kind: 'file', file: { name: 'a.png', mimeType: 'image/png' } }];
+  assert.equal(summarizeParts(parts), 'image/png');
+});
+
+test('summarizeParts: file part without mimeType falls back to octet-stream', () => {
+  const parts: Part[] = [{ kind: 'file', file: { name: 'a.bin' } }];
+  assert.equal(summarizeParts(parts), 'application/octet-stream');
+});
+
+test('summarizeParts: data part reports application/json', () => {
+  const parts: Part[] = [{ kind: 'data', data: { foo: 'bar' } }];
+  assert.equal(summarizeParts(parts), 'application/json');
+});
+
+test('summarizeParts: dedupes mime types and preserves first-seen order', () => {
+  const parts: Part[] = [
+    { kind: 'text', text: 'one' },
+    { kind: 'file', file: { name: 'a.png', mimeType: 'image/png' } },
+    { kind: 'text', text: 'two' },
+    { kind: 'file', file: { name: 'b.png', mimeType: 'image/png' } },
+    { kind: 'data', data: {} },
+  ];
+  assert.equal(summarizeParts(parts), 'text/plain,image/png,application/json');
+});
+
+test('summarizeParts: does not include user-supplied content', () => {
+  const secret = 'super-secret-token';
+  const parts: Part[] = [
+    { kind: 'text', text: secret },
+    { kind: 'file', file: { name: secret, mimeType: 'image/png', bytes: secret } },
+    { kind: 'data', data: { token: secret } },
+  ];
+  const summary = summarizeParts(parts);
+  assert.equal(summary.includes(secret), false);
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,7 +1,57 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { Part } from '@vicoop-bridge/protocol';
-import { summarizeParts } from './client.js';
+import type { Part, TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
+import type { Backend, Emit } from './backend.js';
+import { processTask, summarizeParts } from './client.js';
+import { type ConsoleSink, createLogger } from './logger.js';
+
+interface CapturedSink {
+  log: string[];
+  warn: string[];
+  error: string[];
+  sink: ConsoleSink;
+}
+
+function makeSink(): CapturedSink {
+  const log: string[] = [];
+  const warn: string[] = [];
+  const error: string[] = [];
+  const join = (a: unknown[]): string =>
+    a.map((x) => (typeof x === 'string' ? x : String(x))).join(' ');
+  return {
+    log,
+    warn,
+    error,
+    sink: {
+      log: (...a: unknown[]) => log.push(join(a)),
+      warn: (...a: unknown[]) => warn.push(join(a)),
+      error: (...a: unknown[]) => error.push(join(a)),
+    },
+  };
+}
+
+function captureSend(): { sent: UpFrame[]; send: (f: UpFrame) => void } {
+  const sent: UpFrame[] = [];
+  return {
+    sent,
+    send: (f) => {
+      sent.push(f);
+    },
+  };
+}
+
+function makeAssign(taskId: string): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId,
+    contextId: 'ctx',
+    message: { role: 'user', parts: [{ kind: 'text', text: 'hi' }], messageId: 'm1' },
+  };
+}
+
+function backendOf(name: string, handle: Backend['handle']): Backend {
+  return { name, handle };
+}
 
 test('summarizeParts: empty', () => {
   assert.equal(summarizeParts([]), '(none)');
@@ -54,4 +104,205 @@ test('summarizeParts: does not include user-supplied content', () => {
   ];
   const summary = summarizeParts(parts);
   assert.equal(summary.includes(secret), false);
+});
+
+// processTask lifecycle tests — exercise the runTask body directly with
+// stub backends and a capturing send/logger so we don't need a real ws.
+
+test('processTask: backend emits task.complete -> logs backend.start and task.complete', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit: Emit) => {
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.equal(s.sent.length, 1);
+  assert.equal(s.sent[0].type, 'task.complete');
+  assert.equal(c.log.length, 2);
+  assert.match(c.log[0], /backend\.start taskId=T1 backend=stub/);
+  assert.match(c.log[1], /task\.complete taskId=T1 elapsedMs=\d+ artifacts=0/);
+});
+
+test('processTask: artifacts are deduped by artifactId across chunks', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({
+      type: 'task.artifact',
+      taskId: 'T1',
+      artifact: { artifactId: 'A', parts: [{ kind: 'text', text: 'p1' }] },
+    });
+    emit({
+      type: 'task.artifact',
+      taskId: 'T1',
+      artifact: { artifactId: 'A', parts: [{ kind: 'text', text: 'p2' }] },
+      lastChunk: true,
+    });
+    emit({
+      type: 'task.artifact',
+      taskId: 'T1',
+      artifact: { artifactId: 'B', parts: [{ kind: 'text', text: 'b' }] },
+      lastChunk: true,
+    });
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  const completeLog = c.log.find((l) => l.includes('task.complete'));
+  assert.ok(completeLog, 'task.complete log should be emitted');
+  assert.match(completeLog, /artifacts=2/);
+});
+
+test('processTask: backend emits task.fail -> logs task.fail with code', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({
+      type: 'task.fail',
+      taskId: 'T1',
+      error: { code: 'rate_limited', message: 'slow down' },
+    });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  const failLog = c.log.find((l) => l.includes('task.fail'));
+  assert.ok(failLog);
+  assert.match(failLog, /code=rate_limited/);
+});
+
+test('processTask: backend resolves silently -> warns about missing terminal', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async () => {
+    /* no emits */
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.equal(s.sent.length, 0);
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], /backend\.end taskId=T1 .* \(no terminal frame\)/);
+});
+
+test('processTask: backend throws without emit -> emits backend_error fail and logs task.fail', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async () => {
+    throw new Error('boom');
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.equal(s.sent.length, 1);
+  const sent = s.sent[0];
+  assert.equal(sent.type, 'task.fail');
+  if (sent.type === 'task.fail') {
+    assert.equal(sent.error.code, 'backend_error');
+    assert.equal(sent.error.message, 'boom');
+  }
+  const failLog = c.log.find((l) => l.includes('task.fail'));
+  assert.ok(failLog);
+  assert.match(failLog, /code=backend_error/);
+});
+
+test('processTask: backend emits complete then throws -> does not double-emit, warns', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+    throw new Error('late boom');
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  // Wire saw only the original task.complete; no fallback fail was sent.
+  assert.equal(s.sent.length, 1);
+  assert.equal(s.sent[0].type, 'task.complete');
+  assert.ok(
+    c.warn.some((l) =>
+      /backend threw after terminal taskId=T1 .*terminal=complete .*message=late boom/.test(l),
+    ),
+    `expected late-throw warn, got: ${c.warn.join(' | ')}`,
+  );
+});
+
+test('processTask: backend emits fail then throws -> does not double-emit, warns', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({
+      type: 'task.fail',
+      taskId: 'T1',
+      error: { code: 'upstream', message: 'gateway 500' },
+    });
+    throw new Error('post-fail boom');
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.equal(s.sent.length, 1);
+  const sent = s.sent[0];
+  assert.equal(sent.type, 'task.fail');
+  if (sent.type === 'task.fail') assert.equal(sent.error.code, 'upstream');
+  assert.ok(
+    c.warn.some((l) =>
+      /backend threw after terminal taskId=T1 .*terminal=fail .*message=post-fail boom/.test(l),
+    ),
+    `expected late-throw warn, got: ${c.warn.join(' | ')}`,
+  );
+});
+
+test('processTask: backend.start log uses the backend name', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('my-special-backend', async (_t, emit) => {
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.match(c.log[0], /backend\.start taskId=T1 backend=my-special-backend/);
+});
+
+test('processTask: forwards non-terminal frames (e.g. task.artifact, task.status) to send', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({ type: 'task.status', taskId: 'T1', status: { state: 'working' } });
+    emit({
+      type: 'task.artifact',
+      taskId: 'T1',
+      artifact: { artifactId: 'A', parts: [{ kind: 'text', text: 'a' }] },
+    });
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.deepEqual(
+    s.sent.map((f) => f.type),
+    ['task.status', 'task.artifact', 'task.complete'],
+  );
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -95,6 +95,18 @@ test('summarizeParts: dedupes mime types and preserves first-seen order', () => 
   assert.equal(summarizeParts(parts), 'text/plain,image/png,application/json');
 });
 
+test('summarizeParts: sanitizes hostile mimeType so it cannot inject newlines', () => {
+  const parts: Part[] = [
+    {
+      kind: 'file',
+      file: { name: 'a.png', mimeType: 'image/png\n[client] FAKE INJECTED LINE' },
+    },
+  ];
+  const summary = summarizeParts(parts);
+  assert.equal(summary.includes('\n'), false, 'summary must not contain raw newlines');
+  assert.match(summary, /image\/png\\n\[client\] FAKE INJECTED LINE/);
+});
+
 test('summarizeParts: does not include user-supplied content', () => {
   const secret = 'super-secret-token';
   const parts: Part[] = [
@@ -367,6 +379,39 @@ test('processTask: backend emits canceled task.complete on abort -> uses backend
   assert.ok(
     !c.log.some((l) => /task\.complete taskId=T1/.test(l)),
     'should not log task.complete for a canceled-state completion',
+  );
+});
+
+test('processTask: sanitizes hostile taskId so wire data cannot inject log lines', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const hostileTaskId = 'T1\n[client] FAKE INJECTED LINE';
+  const backend = backendOf('stub', async (_t, emit) => {
+    emit({ type: 'task.complete', taskId: hostileTaskId, status: { state: 'completed' } });
+  });
+  await processTask(
+    { ...makeAssign(hostileTaskId), taskId: hostileTaskId },
+    new AbortController().signal,
+    {
+      backend,
+      send: s.send,
+      logger: createLogger('debug', c.sink),
+    },
+  );
+  // Every log line must remain single-line — no line should contain a raw
+  // newline carried over from the taskId interpolation.
+  for (const line of [...c.log, ...c.warn, ...c.error]) {
+    assert.equal(
+      line.includes('\n'),
+      false,
+      `log line contained a raw newline (log injection): ${JSON.stringify(line)}`,
+    );
+  }
+  // The hostile suffix must appear escaped — operators can still see what
+  // arrived, but it cannot break out of the line.
+  assert.ok(
+    c.log.some((l) => /backend\.start taskId=T1\\n\[client\] FAKE INJECTED LINE/.test(l)),
+    `expected escaped taskId in backend.start, got: ${c.log.join(' | ')}`,
   );
 });
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -284,6 +284,68 @@ test('processTask: backend.start log uses the backend name', async () => {
   assert.match(c.log[0], /backend\.start taskId=T1 backend=my-special-backend/);
 });
 
+test('processTask: backend throws after abort -> emits canceled task.complete, logs task.canceled (not task.fail)', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const controller = new AbortController();
+  controller.abort();
+  const backend = backendOf('stub', async (_t, _emit, signal) => {
+    if (signal.aborted) throw new Error('aborted');
+  });
+  await processTask(makeAssign('T1'), controller.signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  // Wire saw a canceled-state task.complete — not a backend_error fail.
+  assert.equal(s.sent.length, 1);
+  const sent = s.sent[0];
+  assert.equal(sent.type, 'task.complete');
+  if (sent.type === 'task.complete') {
+    assert.equal(sent.status.state, 'canceled');
+    assert.ok(typeof sent.status.timestamp === 'string' && sent.status.timestamp.length > 0);
+  }
+  assert.ok(
+    c.log.some((l) => /task\.canceled taskId=T1 elapsedMs=\d+/.test(l)),
+    `expected task.canceled log, got: ${c.log.join(' | ')}`,
+  );
+  assert.ok(
+    !c.log.some((l) => /task\.fail/.test(l)),
+    'should not log task.fail when the throw is from cancellation',
+  );
+});
+
+test('processTask: backend emits canceled task.complete on abort -> uses backend frame, no fallback', async () => {
+  // Well-behaved backend (like claude.ts): observes signal and emits its
+  // own canceled-state task.complete instead of throwing. processTask
+  // must use that frame as-is and not synthesize a fallback.
+  const c = makeSink();
+  const s = captureSend();
+  const controller = new AbortController();
+  controller.abort();
+  const backend = backendOf('stub', async (_t, emit, signal) => {
+    if (signal.aborted) {
+      emit({
+        type: 'task.complete',
+        taskId: 'T1',
+        status: { state: 'canceled', timestamp: '2026-01-01T00:00:00Z' },
+      });
+    }
+  });
+  await processTask(makeAssign('T1'), controller.signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  assert.equal(s.sent.length, 1);
+  const sent = s.sent[0];
+  assert.equal(sent.type, 'task.complete');
+  if (sent.type === 'task.complete') {
+    assert.equal(sent.status.state, 'canceled');
+    assert.equal(sent.status.timestamp, '2026-01-01T00:00:00Z');
+  }
+});
+
 test('processTask: forwards non-terminal frames (e.g. task.artifact, task.status) to send', async () => {
   const c = makeSink();
   const s = captureSend();

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -219,12 +219,19 @@ test('processTask: backend throws without emit -> emits backend_error fail and l
   assert.match(failLog, /code=backend_error/);
 });
 
-test('processTask: backend emits complete then throws -> does not double-emit, warns', async () => {
+test('processTask: backend emits complete then throws -> does not double-emit, warns with errorClass only', async () => {
   const c = makeSink();
   const s = captureSend();
+  // Use a custom Error subclass so we can assert the class name in the warn.
+  class LateBoom extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'LateBoom';
+    }
+  }
   const backend = backendOf('stub', async (_t, emit) => {
     emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
-    throw new Error('late boom');
+    throw new LateBoom('user-prompt-secret-leak');
   });
   await processTask(makeAssign('T1'), new AbortController().signal, {
     backend,
@@ -234,15 +241,23 @@ test('processTask: backend emits complete then throws -> does not double-emit, w
   // Wire saw only the original task.complete; no fallback fail was sent.
   assert.equal(s.sent.length, 1);
   assert.equal(s.sent[0].type, 'task.complete');
+  // warn: includes terminal kind + errorClass, but NOT the raw message.
+  const warnLine = c.warn.find((l) => /backend threw after terminal taskId=T1/.test(l));
+  assert.ok(warnLine, `expected late-throw warn, got: ${c.warn.join(' | ')}`);
+  assert.match(warnLine, /terminal=complete/);
+  assert.match(warnLine, /errorClass=LateBoom/);
+  assert.equal(
+    warnLine.includes('user-prompt-secret-leak'),
+    false,
+    'warn line must not include the raw error message',
+  );
+  // debug: full message available for opt-in operators.
   assert.ok(
-    c.warn.some((l) =>
-      /backend threw after terminal taskId=T1 .*terminal=complete .*message=late boom/.test(l),
-    ),
-    `expected late-throw warn, got: ${c.warn.join(' | ')}`,
+    c.log.some((l) => /backend threw after terminal taskId=T1.*message=user-prompt-secret-leak/.test(l)),
   );
 });
 
-test('processTask: backend emits fail then throws -> does not double-emit, warns', async () => {
+test('processTask: backend emits fail then throws -> does not double-emit, warns with errorClass only', async () => {
   const c = makeSink();
   const s = captureSend();
   const backend = backendOf('stub', async (_t, emit) => {
@@ -262,12 +277,11 @@ test('processTask: backend emits fail then throws -> does not double-emit, warns
   const sent = s.sent[0];
   assert.equal(sent.type, 'task.fail');
   if (sent.type === 'task.fail') assert.equal(sent.error.code, 'upstream');
-  assert.ok(
-    c.warn.some((l) =>
-      /backend threw after terminal taskId=T1 .*terminal=fail .*message=post-fail boom/.test(l),
-    ),
-    `expected late-throw warn, got: ${c.warn.join(' | ')}`,
-  );
+  const warnLine = c.warn.find((l) => /backend threw after terminal taskId=T1/.test(l));
+  assert.ok(warnLine, `expected late-throw warn, got: ${c.warn.join(' | ')}`);
+  assert.match(warnLine, /terminal=fail/);
+  assert.match(warnLine, /errorClass=Error/);
+  assert.equal(warnLine.includes('post-fail boom'), false, 'warn must not include raw message');
 });
 
 test('processTask: backend.start log uses the backend name', async () => {
@@ -315,10 +329,12 @@ test('processTask: backend throws after abort -> emits canceled task.complete, l
   );
 });
 
-test('processTask: backend emits canceled task.complete on abort -> uses backend frame, no fallback', async () => {
+test('processTask: backend emits canceled task.complete on abort -> uses backend frame, logs task.canceled', async () => {
   // Well-behaved backend (like claude.ts): observes signal and emits its
   // own canceled-state task.complete instead of throwing. processTask
-  // must use that frame as-is and not synthesize a fallback.
+  // must use that frame as-is, not synthesize a fallback, and log it as
+  // `task.canceled` (not `task.complete`) so the lifecycle log clearly
+  // distinguishes a successful completion from a cancel.
   const c = makeSink();
   const s = captureSend();
   const controller = new AbortController();
@@ -344,6 +360,14 @@ test('processTask: backend emits canceled task.complete on abort -> uses backend
     assert.equal(sent.status.state, 'canceled');
     assert.equal(sent.status.timestamp, '2026-01-01T00:00:00Z');
   }
+  assert.ok(
+    c.log.some((l) => /task\.canceled taskId=T1 elapsedMs=\d+ artifacts=\d+/.test(l)),
+    `expected task.canceled log, got: ${c.log.join(' | ')}`,
+  );
+  assert.ok(
+    !c.log.some((l) => /task\.complete taskId=T1/.test(l)),
+    'should not log task.complete for a canceled-state completion',
+  );
 });
 
 test('processTask: forwards non-terminal frames (e.g. task.artifact, task.status) to send', async () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -320,6 +320,21 @@ export async function processTask(
       deps.logger.warn(
         `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} message=${message}`,
       );
+    } else if (signal.aborted) {
+      // The throw is plausibly the backend reacting to the AbortSignal it
+      // was handed (an incoming `task.cancel` aborted the controller).
+      // Emit a canceled-state task.complete — the codebase's existing
+      // convention for cancellation (see backends/claude.ts) — instead of
+      // misclassifying the cancel as a `backend_error` fail and racing
+      // the bridge server's own cancel path.
+      deps.send({
+        type: 'task.complete',
+        taskId: frame.taskId,
+        status: { state: 'canceled', timestamp: new Date().toISOString() },
+      });
+      deps.logger.info(
+        `task.canceled taskId=${frame.taskId} elapsedMs=${elapsedMs}`,
+      );
     } else {
       const code = 'backend_error';
       deps.send({

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -93,8 +93,13 @@ export class Client {
       const probePromise = Promise.resolve()
         .then(() => probe.call(this.opts.backend))
         .catch((err: unknown) => {
+          // Sanitize the message — even a probe error path can carry text
+          // derived from upstream, and a stray newline in an error message
+          // would let a non-fatal probe failure split the warn into two
+          // log lines (or appear to inject a fake `[client] …` entry).
+          const message = err instanceof Error ? err.message : String(err);
           this.logger.warn(
-            `backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
+            `backend capability probe threw (${safeToken(message)}); using declared card capabilities`,
           );
           return null;
         });
@@ -173,8 +178,9 @@ export class Client {
       this.resolveEffectiveCard()
         .then(sendHello)
         .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
           this.logger.warn(
-            `effectiveCard promise rejected unexpectedly (${err instanceof Error ? err.message : String(err)}); sending hello with declared card`,
+            `effectiveCard promise rejected unexpectedly (${safeToken(message)}); sending hello with declared card`,
           );
           sendHello(this.opts.agentCard);
         });
@@ -185,7 +191,11 @@ export class Client {
       try {
         frame = parseDownFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
       } catch (err) {
-        this.logger.error('invalid frame:', err);
+        // Stringify+sanitize before passing to the logger so a frame parse
+        // error (Zod or otherwise) carrying newlines / control chars in
+        // its message can't split the log into multiple lines.
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error(`invalid frame: ${safeToken(message)}`);
         return;
       }
 
@@ -227,7 +237,10 @@ export class Client {
     });
 
     ws.on('error', (err) => {
-      this.logger.error('ws error:', err.message);
+      // Sanitize: ws error messages can include URLs, hostnames, or
+      // upstream text and we want the same single-line invariant we
+      // applied to the close `reason` and lifecycle logs.
+      this.logger.error(`ws error: ${safeToken(err.message)}`);
     });
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -347,8 +347,12 @@ export async function processTask(
       deps.logger.warn(
         `backend threw after terminal taskId=${taskTok} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} errorClass=${safeToken(errorClass)}`,
       );
+      // Use a generous limit so the full backend message is preserved at
+      // debug — the default 200-char ceiling on lifecycle tokens is too
+      // tight for an exception's text. Still escape line breaks so the
+      // log line stays single-line.
       deps.logger.debug(
-        `backend threw after terminal taskId=${taskTok} message=${safeToken(message)}`,
+        `backend threw after terminal taskId=${taskTok} message=${safeToken(message, 4000)}`,
       );
     } else if (signal.aborted) {
       // The throw is plausibly the backend reacting to the AbortSignal it
@@ -362,7 +366,9 @@ export async function processTask(
         taskId: frame.taskId,
         status: { state: 'canceled', timestamp: new Date().toISOString() },
       });
-      deps.logger.info(`task.canceled taskId=${taskTok} elapsedMs=${elapsedMs}`);
+      deps.logger.info(
+        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+      );
     } else {
       const code = 'backend_error';
       deps.send({

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -325,6 +325,12 @@ export function summarizeParts(parts: readonly Part[]): string {
 
 function mimeForPart(part: Part): string {
   if (part.kind === 'text') return 'text/plain';
-  if (part.kind === 'file') return part.file.mimeType ?? 'application/octet-stream';
+  if (part.kind === 'file') {
+    // The protocol allows `mimeType` to be any string (or absent).
+    // Normalize empty / whitespace-only values to the octet-stream
+    // fallback so log lines don't end up with empty `parts=,` segments.
+    const mime = part.file.mimeType?.trim();
+    return mime || 'application/octet-stream';
+  }
   return 'application/json';
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -27,8 +27,10 @@ export interface ClientOptions {
   probeDeadlineMs?: number;
   // Verbosity for client-emitted logs. Falls back to the
   // `VICOOP_CLIENT_LOG_LEVEL` env var, then to `info`. Lifecycle events
-  // (task.assign / backend.start / task.complete / task.fail / task.cancel)
-  // surface at `info`; `debug` adds messageId and per-part detail.
+  // (task.assign / backend.start / task.complete / task.canceled /
+  // task.fail / task.cancel) surface at `info`; `debug` adds the
+  // task.assign detail line (`messageId`, `role`, `partsCount`) and the
+  // full backend exception message on the late-throw path.
   logLevel?: LogLevel;
 }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,6 +5,7 @@ import {
   parseDownFrame,
   type AgentCard,
   type Part,
+  type TaskAssignFrame,
   type UpFrame,
 } from '@vicoop-bridge/protocol';
 import type { Backend, Emit } from './backend.js';
@@ -231,77 +232,104 @@ export class Client {
     if (frame.type !== 'task.assign') return;
     const controller = new AbortController();
     this.inflight.set(frame.taskId, controller);
-    const startedAt = Date.now();
-    // Track lifecycle state through an object so reads after `await` aren't
-    // narrowed back to the initial `null` by control-flow analysis — TS
-    // doesn't follow assignments made inside the `emit` closure below.
-    //
-    // `artifactIds` counts *distinct* artifacts via their `artifactId`
-    // rather than counting raw `task.artifact` frames: the protocol allows
-    // a single artifact to be streamed across multiple chunks (`lastChunk`),
-    // so a per-frame counter would over-report.
-    const state: {
-      artifactIds: Set<string>;
-      terminal: { kind: 'complete' } | { kind: 'fail'; code: string } | null;
-    } = { artifactIds: new Set(), terminal: null };
-
-    // Wrap emit so the client can observe terminal frames the backend sends
-    // and report taskId/elapsedMs/artifacts/code from the same code path,
-    // without changing the wire-level frames or inspecting their payloads.
-    const emit: Emit = (f) => {
-      if (f.type === 'task.artifact') state.artifactIds.add(f.artifact.artifactId);
-      else if (f.type === 'task.complete') state.terminal = { kind: 'complete' };
-      else if (f.type === 'task.fail') state.terminal = { kind: 'fail', code: f.error.code };
-      this.send(f);
-    };
-
-    this.logger.info(`backend.start taskId=${frame.taskId} backend=${this.opts.backend.name}`);
     try {
-      await this.opts.backend.handle(frame, emit, controller.signal);
-      const elapsedMs = Date.now() - startedAt;
-      const terminal = state.terminal;
-      if (terminal === null) {
-        // Backend resolved without emitting task.complete or task.fail. The
-        // bridge server will likely time the task out; surface it at warn so
-        // operators see the broken contract instead of a silent gap.
-        this.logger.warn(
-          `backend.end taskId=${frame.taskId} elapsedMs=${elapsedMs} (no terminal frame)`,
-        );
-      } else if (terminal.kind === 'complete') {
-        this.logger.info(
-          `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
-        );
-      } else {
-        this.logger.info(
-          `task.fail taskId=${frame.taskId} code=${terminal.code} elapsedMs=${elapsedMs}`,
-        );
-      }
-    } catch (err) {
-      const elapsedMs = Date.now() - startedAt;
-      const message = err instanceof Error ? err.message : String(err);
-      if (state.terminal !== null) {
-        // The backend already emitted a terminal frame and then threw. Do
-        // *not* send a second terminal — the bridge server treats a second
-        // task.complete/task.fail for the same taskId as a protocol
-        // violation. Surface the late throw at warn so operators notice
-        // the backend's broken contract instead of seeing it silently
-        // swallowed.
-        this.logger.warn(
-          `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} message=${message}`,
-        );
-      } else {
-        const code = 'backend_error';
-        this.send({
-          type: 'task.fail',
-          taskId: frame.taskId,
-          error: { code, message },
-        });
-        this.logger.info(
-          `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
-        );
-      }
+      await processTask(frame, controller.signal, {
+        backend: this.opts.backend,
+        send: (f) => this.send(f),
+        logger: this.logger,
+      });
     } finally {
       this.inflight.delete(frame.taskId);
+    }
+  }
+}
+
+export interface ProcessTaskDeps {
+  backend: Backend;
+  // Wire send. Receives every frame the backend emits, plus a fallback
+  // task.fail emitted by `processTask` itself when the backend throws
+  // without having emitted a terminal.
+  send: (frame: UpFrame) => void;
+  logger: Logger;
+}
+
+// Run a single A2A task through the backend and emit the lifecycle logs
+// described in vicoop-bridge issue #98. Extracted from `Client.runTask` so
+// the lifecycle logic is unit-testable without a real WebSocket — tests
+// pass stub backends and a capturing send/logger.
+export async function processTask(
+  frame: TaskAssignFrame,
+  signal: AbortSignal,
+  deps: ProcessTaskDeps,
+): Promise<void> {
+  const startedAt = Date.now();
+  // Track lifecycle state through an object so reads after `await` aren't
+  // narrowed back to the initial `null` by control-flow analysis — TS
+  // doesn't follow assignments made inside the `emit` closure below.
+  //
+  // `artifactIds` counts *distinct* artifacts via their `artifactId`
+  // rather than counting raw `task.artifact` frames: the protocol allows
+  // a single artifact to be streamed across multiple chunks (`lastChunk`),
+  // so a per-frame counter would over-report.
+  const state: {
+    artifactIds: Set<string>;
+    terminal: { kind: 'complete' } | { kind: 'fail'; code: string } | null;
+  } = { artifactIds: new Set(), terminal: null };
+
+  // Wrap emit so we can observe terminal frames the backend sends and
+  // report taskId/elapsedMs/artifacts/code from the same code path,
+  // without changing the wire-level frames or inspecting their payloads.
+  const emit: Emit = (f) => {
+    if (f.type === 'task.artifact') state.artifactIds.add(f.artifact.artifactId);
+    else if (f.type === 'task.complete') state.terminal = { kind: 'complete' };
+    else if (f.type === 'task.fail') state.terminal = { kind: 'fail', code: f.error.code };
+    deps.send(f);
+  };
+
+  deps.logger.info(`backend.start taskId=${frame.taskId} backend=${deps.backend.name}`);
+  try {
+    await deps.backend.handle(frame, emit, signal);
+    const elapsedMs = Date.now() - startedAt;
+    const terminal = state.terminal;
+    if (terminal === null) {
+      // Backend resolved without emitting task.complete or task.fail. The
+      // bridge server will likely time the task out; surface it at warn so
+      // operators see the broken contract instead of a silent gap.
+      deps.logger.warn(
+        `backend.end taskId=${frame.taskId} elapsedMs=${elapsedMs} (no terminal frame)`,
+      );
+    } else if (terminal.kind === 'complete') {
+      deps.logger.info(
+        `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+      );
+    } else {
+      deps.logger.info(
+        `task.fail taskId=${frame.taskId} code=${terminal.code} elapsedMs=${elapsedMs}`,
+      );
+    }
+  } catch (err) {
+    const elapsedMs = Date.now() - startedAt;
+    const message = err instanceof Error ? err.message : String(err);
+    if (state.terminal !== null) {
+      // The backend already emitted a terminal frame and then threw. Do
+      // *not* send a second terminal — the bridge server treats a second
+      // task.complete/task.fail for the same taskId as a protocol
+      // violation. Surface the late throw at warn so operators notice
+      // the backend's broken contract instead of seeing it silently
+      // swallowed.
+      deps.logger.warn(
+        `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} message=${message}`,
+      );
+    } else {
+      const code = 'backend_error';
+      deps.send({
+        type: 'task.fail',
+        taskId: frame.taskId,
+        error: { code, message },
+      });
+      deps.logger.info(
+        `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
+      );
     }
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -273,16 +273,27 @@ export async function processTask(
   // so a per-frame counter would over-report.
   const state: {
     artifactIds: Set<string>;
-    terminal: { kind: 'complete' } | { kind: 'fail'; code: string } | null;
+    terminal:
+      | { kind: 'complete' }
+      | { kind: 'canceled' }
+      | { kind: 'fail'; code: string }
+      | null;
   } = { artifactIds: new Set(), terminal: null };
 
   // Wrap emit so we can observe terminal frames the backend sends and
   // report taskId/elapsedMs/artifacts/code from the same code path,
   // without changing the wire-level frames or inspecting their payloads.
+  // A `task.complete` with `status.state === 'canceled'` is the codebase's
+  // existing cancellation convention (see backends/claude.ts); record it
+  // distinctly so the lifecycle log doesn't mislabel cancels as completions.
   const emit: Emit = (f) => {
     if (f.type === 'task.artifact') state.artifactIds.add(f.artifact.artifactId);
-    else if (f.type === 'task.complete') state.terminal = { kind: 'complete' };
-    else if (f.type === 'task.fail') state.terminal = { kind: 'fail', code: f.error.code };
+    else if (f.type === 'task.complete') {
+      state.terminal =
+        f.status.state === 'canceled' ? { kind: 'canceled' } : { kind: 'complete' };
+    } else if (f.type === 'task.fail') {
+      state.terminal = { kind: 'fail', code: f.error.code };
+    }
     deps.send(f);
   };
 
@@ -302,6 +313,10 @@ export async function processTask(
       deps.logger.info(
         `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
       );
+    } else if (terminal.kind === 'canceled') {
+      deps.logger.info(
+        `task.canceled taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+      );
     } else {
       deps.logger.info(
         `task.fail taskId=${frame.taskId} code=${terminal.code} elapsedMs=${elapsedMs}`,
@@ -310,15 +325,22 @@ export async function processTask(
   } catch (err) {
     const elapsedMs = Date.now() - startedAt;
     const message = err instanceof Error ? err.message : String(err);
+    const errorClass = err instanceof Error ? err.constructor.name : typeof err;
     if (state.terminal !== null) {
       // The backend already emitted a terminal frame and then threw. Do
       // *not* send a second terminal — the bridge server treats a second
       // task.complete/task.fail for the same taskId as a protocol
       // violation. Surface the late throw at warn so operators notice
       // the backend's broken contract instead of seeing it silently
-      // swallowed.
+      // swallowed. The raw error message can include user content
+      // (prompts, file paths, upstream payloads) and stays out of the
+      // default-visible warn line; debug carries the full text for
+      // operators who opt in.
       deps.logger.warn(
-        `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} message=${message}`,
+        `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} errorClass=${errorClass}`,
+      );
+      deps.logger.debug(
+        `backend threw after terminal taskId=${frame.taskId} message=${message}`,
       );
     } else if (signal.aborted) {
       // The throw is plausibly the backend reacting to the AbortSignal it

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -235,16 +235,21 @@ export class Client {
     // Track lifecycle state through an object so reads after `await` aren't
     // narrowed back to the initial `null` by control-flow analysis — TS
     // doesn't follow assignments made inside the `emit` closure below.
+    //
+    // `artifactIds` counts *distinct* artifacts via their `artifactId`
+    // rather than counting raw `task.artifact` frames: the protocol allows
+    // a single artifact to be streamed across multiple chunks (`lastChunk`),
+    // so a per-frame counter would over-report.
     const state: {
-      artifactCount: number;
+      artifactIds: Set<string>;
       terminal: { kind: 'complete' } | { kind: 'fail'; code: string } | null;
-    } = { artifactCount: 0, terminal: null };
+    } = { artifactIds: new Set(), terminal: null };
 
     // Wrap emit so the client can observe terminal frames the backend sends
     // and report taskId/elapsedMs/artifacts/code from the same code path,
     // without changing the wire-level frames or inspecting their payloads.
     const emit: Emit = (f) => {
-      if (f.type === 'task.artifact') state.artifactCount++;
+      if (f.type === 'task.artifact') state.artifactIds.add(f.artifact.artifactId);
       else if (f.type === 'task.complete') state.terminal = { kind: 'complete' };
       else if (f.type === 'task.fail') state.terminal = { kind: 'fail', code: f.error.code };
       this.send(f);
@@ -264,7 +269,7 @@ export class Client {
         );
       } else if (terminal.kind === 'complete') {
         this.logger.info(
-          `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactCount}`,
+          `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
         );
       } else {
         this.logger.info(

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -191,8 +191,13 @@ export class Client {
 
       switch (frame.type) {
         case 'task.assign':
+          // `summarizeParts` already sanitizes each MIME via safeToken, so
+          // the `parts=` token here intentionally does NOT wrap the whole
+          // summary again — that would double-escape backslashes (a `\n`
+          // sanitized to `\\n` would become `\\\\n`) and make the field
+          // harder to read for operators.
           this.logger.info(
-            `task.assign taskId=${safeToken(frame.taskId)} contextId=${safeToken(frame.contextId)} parts=${safeToken(summarizeParts(frame.message.parts))}`,
+            `task.assign taskId=${safeToken(frame.taskId)} contextId=${safeToken(frame.contextId)} parts=${summarizeParts(frame.message.parts)}`,
           );
           this.logger.debug(
             `task.assign detail taskId=${safeToken(frame.taskId)} messageId=${safeToken(frame.message.messageId)} role=${frame.message.role} partsCount=${frame.message.parts.length}`,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -278,18 +278,28 @@ export class Client {
       }
     } catch (err) {
       const elapsedMs = Date.now() - startedAt;
-      const code = 'backend_error';
-      this.send({
-        type: 'task.fail',
-        taskId: frame.taskId,
-        error: {
-          code,
-          message: err instanceof Error ? err.message : String(err),
-        },
-      });
-      this.logger.info(
-        `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      if (state.terminal !== null) {
+        // The backend already emitted a terminal frame and then threw. Do
+        // *not* send a second terminal — the bridge server treats a second
+        // task.complete/task.fail for the same taskId as a protocol
+        // violation. Surface the late throw at warn so operators notice
+        // the backend's broken contract instead of seeing it silently
+        // swallowed.
+        this.logger.warn(
+          `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} message=${message}`,
+        );
+      } else {
+        const code = 'backend_error';
+        this.send({
+          type: 'task.fail',
+          taskId: frame.taskId,
+          error: { code, message },
+        });
+        this.logger.info(
+          `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
+        );
+      }
     } finally {
       this.inflight.delete(frame.taskId);
     }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -4,9 +4,11 @@ import {
   encodeFrame,
   parseDownFrame,
   type AgentCard,
+  type Part,
   type UpFrame,
 } from '@vicoop-bridge/protocol';
-import type { Backend } from './backend.js';
+import type { Backend, Emit } from './backend.js';
+import { createLogger, type LogLevel, type Logger } from './logger.js';
 
 export interface ClientOptions {
   serverUrl: string;
@@ -22,6 +24,11 @@ export interface ClientOptions {
   // server's 10s hello deadline so a slow or hung probe cannot push us
   // into the 4001 "hello timeout" close and a reconnect loop.
   probeDeadlineMs?: number;
+  // Verbosity for client-emitted logs. Falls back to the
+  // `VICOOP_CLIENT_LOG_LEVEL` env var, then to `info`. Lifecycle events
+  // (task.assign / backend.start / task.complete / task.fail / task.cancel)
+  // surface at `info`; `debug` adds messageId and per-part detail.
+  logLevel?: LogLevel;
 }
 
 const DEFAULT_PROBE_DEADLINE_MS = 3000;
@@ -36,8 +43,11 @@ export class Client {
   // don't re-probe on every bridge WS reconnect — the underlying upstream
   // doesn't change mid-process.
   private effectiveCardPromise: Promise<AgentCard> | null = null;
+  private readonly logger: Logger;
 
-  constructor(private readonly opts: ClientOptions) {}
+  constructor(private readonly opts: ClientOptions) {
+    this.logger = createLogger(opts.logLevel);
+  }
 
   start(): void {
     // Kick off the capability probe before opening the bridge WS so it runs
@@ -82,16 +92,16 @@ export class Client {
       const probePromise = Promise.resolve()
         .then(() => probe.call(this.opts.backend))
         .catch((err: unknown) => {
-          console.warn(
-            `[client] backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
+          this.logger.warn(
+            `backend capability probe threw (${err instanceof Error ? err.message : String(err)}); using declared card capabilities`,
           );
           return null;
         });
       try {
         const outcome = await Promise.race([probePromise, timeoutPromise]);
         if (outcome === TIMEOUT) {
-          console.warn(
-            `[client] backend capability probe did not complete within ${deadlineMs}ms; sending hello with declared card capabilities`,
+          this.logger.warn(
+            `backend capability probe did not complete within ${deadlineMs}ms; sending hello with declared card capabilities`,
           );
           return base;
         }
@@ -144,7 +154,7 @@ export class Client {
       // will issue its own hello.
       const sendHello = (agentCard: AgentCard): void => {
         if (ws.readyState !== WebSocket.OPEN) return;
-        console.log('[client] connected, sending hello');
+        this.logger.info('connected, sending hello');
         ws.send(
           encodeFrame({
             type: 'hello',
@@ -162,8 +172,8 @@ export class Client {
       this.resolveEffectiveCard()
         .then(sendHello)
         .catch((err: unknown) => {
-          console.warn(
-            `[client] effectiveCard promise rejected unexpectedly (${err instanceof Error ? err.message : String(err)}); sending hello with declared card`,
+          this.logger.warn(
+            `effectiveCard promise rejected unexpectedly (${err instanceof Error ? err.message : String(err)}); sending hello with declared card`,
           );
           sendHello(this.opts.agentCard);
         });
@@ -174,15 +184,22 @@ export class Client {
       try {
         frame = parseDownFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
       } catch (err) {
-        console.error('[client] invalid frame:', err);
+        this.logger.error('invalid frame:', err);
         return;
       }
 
       switch (frame.type) {
         case 'task.assign':
+          this.logger.info(
+            `task.assign taskId=${frame.taskId} contextId=${frame.contextId} parts=${summarizeParts(frame.message.parts)}`,
+          );
+          this.logger.debug(
+            `task.assign detail taskId=${frame.taskId} messageId=${frame.message.messageId} role=${frame.message.role} partsCount=${frame.message.parts.length}`,
+          );
           this.runTask(frame);
           break;
         case 'task.cancel':
+          this.logger.info(`task.cancel taskId=${frame.taskId}`);
           this.inflight.get(frame.taskId)?.abort();
           break;
         case 'ping':
@@ -192,7 +209,7 @@ export class Client {
     });
 
     ws.on('close', (code, reason) => {
-      console.log(`[client] disconnected: ${code} ${reason.toString()}`);
+      this.logger.info(`disconnected: ${code} ${reason.toString()}`);
       this.ws = null;
       if (!this.stopped) {
         const delay = this.opts.reconnectDelayMs ?? 3000;
@@ -201,7 +218,7 @@ export class Client {
     });
 
     ws.on('error', (err) => {
-      console.error('[client] ws error:', err.message);
+      this.logger.error('ws error:', err.message);
     });
   }
 
@@ -214,19 +231,85 @@ export class Client {
     if (frame.type !== 'task.assign') return;
     const controller = new AbortController();
     this.inflight.set(frame.taskId, controller);
+    const startedAt = Date.now();
+    // Track lifecycle state through an object so reads after `await` aren't
+    // narrowed back to the initial `null` by control-flow analysis — TS
+    // doesn't follow assignments made inside the `emit` closure below.
+    const state: {
+      artifactCount: number;
+      terminal: { kind: 'complete' } | { kind: 'fail'; code: string } | null;
+    } = { artifactCount: 0, terminal: null };
+
+    // Wrap emit so the client can observe terminal frames the backend sends
+    // and report taskId/elapsedMs/artifacts/code from the same code path,
+    // without changing the wire-level frames or inspecting their payloads.
+    const emit: Emit = (f) => {
+      if (f.type === 'task.artifact') state.artifactCount++;
+      else if (f.type === 'task.complete') state.terminal = { kind: 'complete' };
+      else if (f.type === 'task.fail') state.terminal = { kind: 'fail', code: f.error.code };
+      this.send(f);
+    };
+
+    this.logger.info(`backend.start taskId=${frame.taskId} backend=${this.opts.backend.name}`);
     try {
-      await this.opts.backend.handle(frame, (f) => this.send(f), controller.signal);
+      await this.opts.backend.handle(frame, emit, controller.signal);
+      const elapsedMs = Date.now() - startedAt;
+      const terminal = state.terminal;
+      if (terminal === null) {
+        // Backend resolved without emitting task.complete or task.fail. The
+        // bridge server will likely time the task out; surface it at warn so
+        // operators see the broken contract instead of a silent gap.
+        this.logger.warn(
+          `backend.end taskId=${frame.taskId} elapsedMs=${elapsedMs} (no terminal frame)`,
+        );
+      } else if (terminal.kind === 'complete') {
+        this.logger.info(
+          `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactCount}`,
+        );
+      } else {
+        this.logger.info(
+          `task.fail taskId=${frame.taskId} code=${terminal.code} elapsedMs=${elapsedMs}`,
+        );
+      }
     } catch (err) {
+      const elapsedMs = Date.now() - startedAt;
+      const code = 'backend_error';
       this.send({
         type: 'task.fail',
         taskId: frame.taskId,
         error: {
-          code: 'backend_error',
+          code,
           message: err instanceof Error ? err.message : String(err),
         },
       });
+      this.logger.info(
+        `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
+      );
     } finally {
       this.inflight.delete(frame.taskId);
     }
   }
+}
+
+// Summarize an A2A message's parts as a comma-separated list of unique MIME
+// types for logging. Avoids leaking content (text bodies, file bytes) by
+// reporting only the structural shape of the message.
+export function summarizeParts(parts: readonly Part[]): string {
+  if (parts.length === 0) return '(none)';
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const part of parts) {
+    const mime = mimeForPart(part);
+    if (!seen.has(mime)) {
+      seen.add(mime);
+      ordered.push(mime);
+    }
+  }
+  return ordered.join(',');
+}
+
+function mimeForPart(part: Part): string {
+  if (part.kind === 'text') return 'text/plain';
+  if (part.kind === 'file') return part.file.mimeType ?? 'application/octet-stream';
+  return 'application/json';
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -9,7 +9,7 @@ import {
   type UpFrame,
 } from '@vicoop-bridge/protocol';
 import type { Backend, Emit } from './backend.js';
-import { createLogger, type LogLevel, type Logger } from './logger.js';
+import { createLogger, type LogLevel, type Logger, safeToken } from './logger.js';
 
 export interface ClientOptions {
   serverUrl: string;
@@ -192,15 +192,15 @@ export class Client {
       switch (frame.type) {
         case 'task.assign':
           this.logger.info(
-            `task.assign taskId=${frame.taskId} contextId=${frame.contextId} parts=${summarizeParts(frame.message.parts)}`,
+            `task.assign taskId=${safeToken(frame.taskId)} contextId=${safeToken(frame.contextId)} parts=${safeToken(summarizeParts(frame.message.parts))}`,
           );
           this.logger.debug(
-            `task.assign detail taskId=${frame.taskId} messageId=${frame.message.messageId} role=${frame.message.role} partsCount=${frame.message.parts.length}`,
+            `task.assign detail taskId=${safeToken(frame.taskId)} messageId=${safeToken(frame.message.messageId)} role=${frame.message.role} partsCount=${frame.message.parts.length}`,
           );
           this.runTask(frame);
           break;
         case 'task.cancel':
-          this.logger.info(`task.cancel taskId=${frame.taskId}`);
+          this.logger.info(`task.cancel taskId=${safeToken(frame.taskId)}`);
           this.inflight.get(frame.taskId)?.abort();
           break;
         case 'ping':
@@ -210,7 +210,10 @@ export class Client {
     });
 
     ws.on('close', (code, reason) => {
-      this.logger.info(`disconnected: ${code} ${reason.toString()}`);
+      // `reason` is a remote-controlled byte buffer from the WebSocket
+      // close frame; sanitize before logging so a server can't inject a
+      // fake `[client] …` line via newlines.
+      this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       this.ws = null;
       if (!this.stopped) {
         const delay = this.opts.reconnectDelayMs ?? 3000;
@@ -297,7 +300,12 @@ export async function processTask(
     deps.send(f);
   };
 
-  deps.logger.info(`backend.start taskId=${frame.taskId} backend=${deps.backend.name}`);
+  // Sanitize wire-derived tokens so a hostile server (or a bug in a
+  // backend that derives strings from user content) can't break out of a
+  // single log line via embedded \n / control chars.
+  const taskTok = safeToken(frame.taskId);
+  const backendTok = safeToken(deps.backend.name);
+  deps.logger.info(`backend.start taskId=${taskTok} backend=${backendTok}`);
   try {
     await deps.backend.handle(frame, emit, signal);
     const elapsedMs = Date.now() - startedAt;
@@ -307,19 +315,19 @@ export async function processTask(
       // bridge server will likely time the task out; surface it at warn so
       // operators see the broken contract instead of a silent gap.
       deps.logger.warn(
-        `backend.end taskId=${frame.taskId} elapsedMs=${elapsedMs} (no terminal frame)`,
+        `backend.end taskId=${taskTok} elapsedMs=${elapsedMs} (no terminal frame)`,
       );
     } else if (terminal.kind === 'complete') {
       deps.logger.info(
-        `task.complete taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+        `task.complete taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
       );
     } else if (terminal.kind === 'canceled') {
       deps.logger.info(
-        `task.canceled taskId=${frame.taskId} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
       );
     } else {
       deps.logger.info(
-        `task.fail taskId=${frame.taskId} code=${terminal.code} elapsedMs=${elapsedMs}`,
+        `task.fail taskId=${taskTok} code=${safeToken(terminal.code)} elapsedMs=${elapsedMs}`,
       );
     }
   } catch (err) {
@@ -337,10 +345,10 @@ export async function processTask(
       // default-visible warn line; debug carries the full text for
       // operators who opt in.
       deps.logger.warn(
-        `backend threw after terminal taskId=${frame.taskId} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} errorClass=${errorClass}`,
+        `backend threw after terminal taskId=${taskTok} elapsedMs=${elapsedMs} terminal=${state.terminal.kind} errorClass=${safeToken(errorClass)}`,
       );
       deps.logger.debug(
-        `backend threw after terminal taskId=${frame.taskId} message=${message}`,
+        `backend threw after terminal taskId=${taskTok} message=${safeToken(message)}`,
       );
     } else if (signal.aborted) {
       // The throw is plausibly the backend reacting to the AbortSignal it
@@ -354,9 +362,7 @@ export async function processTask(
         taskId: frame.taskId,
         status: { state: 'canceled', timestamp: new Date().toISOString() },
       });
-      deps.logger.info(
-        `task.canceled taskId=${frame.taskId} elapsedMs=${elapsedMs}`,
-      );
+      deps.logger.info(`task.canceled taskId=${taskTok} elapsedMs=${elapsedMs}`);
     } else {
       const code = 'backend_error';
       deps.send({
@@ -365,7 +371,7 @@ export async function processTask(
         error: { code, message },
       });
       deps.logger.info(
-        `task.fail taskId=${frame.taskId} code=${code} elapsedMs=${elapsedMs}`,
+        `task.fail taskId=${taskTok} code=${code} elapsedMs=${elapsedMs}`,
       );
     }
   }
@@ -373,13 +379,16 @@ export async function processTask(
 
 // Summarize an A2A message's parts as a comma-separated list of unique MIME
 // types for logging. Avoids leaking content (text bodies, file bytes) by
-// reporting only the structural shape of the message.
+// reporting only the structural shape of the message. The MIME from a
+// `file` part is user/peer-supplied, so each entry is run through
+// `safeToken` to neutralize embedded newlines / control chars before the
+// summary is interpolated into a log line.
 export function summarizeParts(parts: readonly Part[]): string {
   if (parts.length === 0) return '(none)';
   const seen = new Set<string>();
   const ordered: string[] = [];
   for (const part of parts) {
-    const mime = mimeForPart(part);
+    const mime = safeToken(mimeForPart(part));
     if (!seen.has(mime)) {
       seen.add(mime);
       ordered.push(mime);

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,6 @@
 export { Client } from './client.js';
 export type { Backend, TaskAssign, Emit } from './backend.js';
+export type { LogLevel, Logger } from './logger.js';
 export { echoBackend } from './backends/echo.js';
 export { createOpenclawBackend } from './backends/openclaw.js';
 export type { OpenclawBackendOptions } from './backends/openclaw.js';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,6 +1,6 @@
 export { Client } from './client.js';
 export type { Backend, TaskAssign, Emit } from './backend.js';
-export type { LogLevel, Logger } from './logger.js';
+export type { ConsoleSink, LogLevel, Logger } from './logger.js';
 export { echoBackend } from './backends/echo.js';
 export { createOpenclawBackend } from './backends/openclaw.js';
 export type { OpenclawBackendOptions } from './backends/openclaw.js';

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -181,3 +181,24 @@ test('createLogger: trims an explicit level string', () => {
   assert.equal(logger.level, 'debug');
   assert.deepEqual(c.warn, []);
 });
+
+test('resolveLogLevel: non-string explicit value warns and falls through (does not crash)', () => {
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, undefined, () => {
+    // JS caller bypasses the TS type and passes a number/object/etc.
+    assert.equal(resolveLogLevel(123 as unknown as 'debug', c.sink), 'info');
+    assert.equal(resolveLogLevel({} as unknown as 'debug', c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 2);
+  for (const line of c.warn) {
+    assert.match(line, /ignoring non-string logLevel of type/);
+  }
+});
+
+test('resolveLogLevel: null explicit value is treated as not provided', () => {
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'debug', () => {
+    assert.equal(resolveLogLevel(null as unknown as 'debug', c.sink), 'debug');
+  });
+  assert.deepEqual(c.warn, []);
+});

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  _resetLogLevelWarningsForTests,
   type ConsoleSink,
   createLogger,
   isLogLevel,
@@ -103,6 +104,7 @@ test('resolveLogLevel: trims whitespace from env values', () => {
 });
 
 test('resolveLogLevel: invalid env value falls back to info and warns once', () => {
+  _resetLogLevelWarningsForTests();
   const c = makeSink();
   withEnv(LOG_LEVEL_ENV, 'verbose', () => {
     assert.equal(resolveLogLevel(undefined, c.sink), 'info');
@@ -112,6 +114,7 @@ test('resolveLogLevel: invalid env value falls back to info and warns once', () 
 });
 
 test('resolveLogLevel: invalid explicit value warns then falls through to env', () => {
+  _resetLogLevelWarningsForTests();
   const c = makeSink();
   withEnv(LOG_LEVEL_ENV, 'debug', () => {
     assert.equal(resolveLogLevel('TRACE' as 'debug', c.sink), 'debug');
@@ -121,12 +124,50 @@ test('resolveLogLevel: invalid explicit value warns then falls through to env', 
 });
 
 test('resolveLogLevel: invalid explicit value with no env falls back to info', () => {
+  _resetLogLevelWarningsForTests();
   const c = makeSink();
   withEnv(LOG_LEVEL_ENV, undefined, () => {
     assert.equal(resolveLogLevel('verbose' as 'debug', c.sink), 'info');
   });
   assert.equal(c.warn.length, 1);
   assert.match(c.warn[0], /ignoring invalid logLevel=verbose/);
+});
+
+test('resolveLogLevel: warns at most once per distinct invalid value across calls', () => {
+  _resetLogLevelWarningsForTests();
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'fatal', () => {
+    resolveLogLevel(undefined, c.sink);
+    resolveLogLevel(undefined, c.sink);
+    resolveLogLevel(undefined, c.sink);
+  });
+  assert.equal(c.warn.length, 1, 'same invalid value warns only once');
+  // A different invalid value still warns (distinct dedup key).
+  withEnv(LOG_LEVEL_ENV, 'panic', () => {
+    resolveLogLevel(undefined, c.sink);
+  });
+  assert.equal(c.warn.length, 2, 'a distinct invalid value warns separately');
+});
+
+test('resolveLogLevel: warn passes PREFIX as a separate sink argument', () => {
+  _resetLogLevelWarningsForTests();
+  const calls: unknown[][] = [];
+  const sink: ConsoleSink = {
+    log: () => {},
+    warn: (...args) => {
+      calls.push(args);
+    },
+    error: () => {},
+  };
+  withEnv(LOG_LEVEL_ENV, 'bogus', () => {
+    resolveLogLevel(undefined, sink);
+  });
+  assert.equal(calls.length, 1);
+  // First arg is the prefix, second is the structured message — same shape
+  // the logger's own .warn() uses, so structured-logging sinks can treat
+  // them consistently.
+  assert.equal(calls[0][0], '[client]');
+  assert.match(String(calls[0][1]), /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=bogus/);
 });
 
 test('createLogger at info: error/warn/info pass, debug filtered', () => {
@@ -183,6 +224,7 @@ test('createLogger: trims an explicit level string', () => {
 });
 
 test('resolveLogLevel: non-string explicit value warns and falls through (does not crash)', () => {
+  _resetLogLevelWarningsForTests();
   const c = makeSink();
   withEnv(LOG_LEVEL_ENV, undefined, () => {
     // JS caller bypasses the TS type and passes a number/object/etc.

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -1,0 +1,154 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createLogger, isLogLevel, LOG_LEVEL_ENV, resolveLogLevel } from './logger.js';
+
+interface CapturedConsole {
+  log: string[];
+  warn: string[];
+  error: string[];
+  restore: () => void;
+}
+
+function captureConsole(): CapturedConsole {
+  const captured: CapturedConsole = {
+    log: [],
+    warn: [],
+    error: [],
+    restore: () => {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+    },
+  };
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  const join = (args: unknown[]): string => args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ');
+  console.log = (...args: unknown[]) => {
+    captured.log.push(join(args));
+  };
+  console.warn = (...args: unknown[]) => {
+    captured.warn.push(join(args));
+  };
+  console.error = (...args: unknown[]) => {
+    captured.error.push(join(args));
+  };
+  return captured;
+}
+
+function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  }
+}
+
+test('isLogLevel accepts the documented levels and rejects anything else', () => {
+  for (const level of ['silent', 'error', 'warn', 'info', 'debug']) {
+    assert.equal(isLogLevel(level), true, level);
+  }
+  for (const bad of ['', 'verbose', 'trace', 'INFO', 'log', 'fatal']) {
+    assert.equal(isLogLevel(bad), false, bad);
+  }
+});
+
+test('resolveLogLevel: explicit value wins over env and default', () => {
+  withEnv(LOG_LEVEL_ENV, 'debug', () => {
+    assert.equal(resolveLogLevel('warn'), 'warn');
+  });
+});
+
+test('resolveLogLevel: env var is honored when no explicit value', () => {
+  withEnv(LOG_LEVEL_ENV, 'debug', () => {
+    assert.equal(resolveLogLevel(), 'debug');
+  });
+  withEnv(LOG_LEVEL_ENV, 'SILENT', () => {
+    assert.equal(resolveLogLevel(), 'silent');
+  });
+});
+
+test('resolveLogLevel: defaults to info when env is unset', () => {
+  withEnv(LOG_LEVEL_ENV, undefined, () => {
+    assert.equal(resolveLogLevel(), 'info');
+  });
+});
+
+test('resolveLogLevel: invalid env value falls back to info and warns once', () => {
+  const captured = captureConsole();
+  try {
+    withEnv(LOG_LEVEL_ENV, 'verbose', () => {
+      assert.equal(resolveLogLevel(), 'info');
+    });
+    assert.equal(captured.warn.length, 1);
+    assert.match(captured.warn[0], /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=verbose/);
+  } finally {
+    captured.restore();
+  }
+});
+
+test('createLogger at info: error/warn/info pass, debug filtered', () => {
+  const captured = captureConsole();
+  try {
+    const logger = createLogger('info');
+    logger.error('boom');
+    logger.warn('careful');
+    logger.info('hello');
+    logger.debug('quiet');
+    assert.deepEqual(captured.error, ['[client] boom']);
+    assert.deepEqual(captured.warn, ['[client] careful']);
+    assert.deepEqual(captured.log, ['[client] hello']);
+  } finally {
+    captured.restore();
+  }
+});
+
+test('createLogger at debug: every level passes through', () => {
+  const captured = captureConsole();
+  try {
+    const logger = createLogger('debug');
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+    assert.deepEqual(captured.error, ['[client] e']);
+    assert.deepEqual(captured.warn, ['[client] w']);
+    assert.deepEqual(captured.log, ['[client] i', '[client] d']);
+  } finally {
+    captured.restore();
+  }
+});
+
+test('createLogger at warn: info and debug filtered', () => {
+  const captured = captureConsole();
+  try {
+    const logger = createLogger('warn');
+    logger.info('i');
+    logger.debug('d');
+    logger.warn('w');
+    assert.deepEqual(captured.log, []);
+    assert.deepEqual(captured.warn, ['[client] w']);
+  } finally {
+    captured.restore();
+  }
+});
+
+test('createLogger at silent: every level filtered', () => {
+  const captured = captureConsole();
+  try {
+    const logger = createLogger('silent');
+    logger.error('e');
+    logger.warn('w');
+    logger.info('i');
+    logger.debug('d');
+    assert.deepEqual(captured.error, []);
+    assert.deepEqual(captured.warn, []);
+    assert.deepEqual(captured.log, []);
+  } finally {
+    captured.restore();
+  }
+});

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -7,6 +7,7 @@ import {
   isLogLevel,
   LOG_LEVEL_ENV,
   resolveLogLevel,
+  safeToken,
 } from './logger.js';
 
 interface Captured {
@@ -239,6 +240,34 @@ test('createLogger at silent: every level filtered', () => {
   assert.deepEqual(c.error, []);
   assert.deepEqual(c.warn, []);
   assert.deepEqual(c.log, []);
+});
+
+test('safeToken: leaves plain ASCII tokens unchanged', () => {
+  assert.equal(safeToken('abc-123_def'), 'abc-123_def');
+  assert.equal(safeToken('text/plain'), 'text/plain');
+  assert.equal(safeToken(''), '');
+});
+
+test('safeToken: escapes newlines / control chars so a token cannot inject log lines', () => {
+  const escaped = safeToken('evil\n[client] FAKE');
+  assert.equal(escaped.includes('\n'), false);
+  assert.match(escaped, /^evil\\n\[client\] FAKE$/);
+  // No surrounding quotes (those are reserved for safeForLog-style messages).
+  assert.equal(escaped.startsWith('"'), false);
+  assert.equal(escaped.endsWith('"'), false);
+});
+
+test('safeToken: escapes embedded quotes and backslashes', () => {
+  assert.equal(safeToken('a"b'), 'a\\"b');
+  assert.equal(safeToken('a\\b'), 'a\\\\b');
+  assert.equal(safeToken('\t\r'), '\\t\\r');
+});
+
+test('safeToken: truncates very long tokens', () => {
+  const long = 'a'.repeat(500);
+  const out = safeToken(long, 50);
+  assert.ok(out.length <= 50, `expected <=50, got ${out.length}`);
+  assert.match(out, /…$/);
 });
 
 test('createLogger: trims an explicit level string', () => {

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -270,6 +270,28 @@ test('safeToken: truncates very long tokens', () => {
   assert.match(out, /…$/);
 });
 
+test('safeToken: escapes Unicode line/paragraph separators (U+2028/U+2029)', () => {
+  // JSON.stringify leaves these raw, but several log collectors render
+  // them as line breaks — they must be escaped to keep tokens single-line.
+  const ls = ' ';
+  const ps = ' ';
+  const out = safeToken(`pre${ls}mid${ps}post`);
+  assert.equal(out.includes(ls), false, 'raw U+2028 must not survive');
+  assert.equal(out.includes(ps), false, 'raw U+2029 must not survive');
+  assert.match(out, /pre\\u2028mid\\u2029post/);
+});
+
+test('safeForLog: escapes Unicode line/paragraph separators (U+2028/U+2029)', () => {
+  _resetLogLevelWarningsForTests();
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'evil [client] FAKE INJECTED LINE', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 1);
+  assert.equal(c.warn[0].includes(' '), false, 'raw U+2028 must not survive');
+  assert.match(c.warn[0], /evil\\u2028\[client\] FAKE INJECTED LINE/);
+});
+
 test('createLogger: trims an explicit level string', () => {
   const c = makeSink();
   const logger = createLogger(' DEBUG ', c.sink);

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -1,41 +1,45 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { createLogger, isLogLevel, LOG_LEVEL_ENV, resolveLogLevel } from './logger.js';
+import {
+  type ConsoleSink,
+  createLogger,
+  isLogLevel,
+  LOG_LEVEL_ENV,
+  resolveLogLevel,
+} from './logger.js';
 
-interface CapturedConsole {
+interface Captured {
   log: string[];
   warn: string[];
   error: string[];
-  restore: () => void;
+  sink: ConsoleSink;
 }
 
-function captureConsole(): CapturedConsole {
-  const captured: CapturedConsole = {
-    log: [],
-    warn: [],
-    error: [],
-    restore: () => {
-      console.log = originalLog;
-      console.warn = originalWarn;
-      console.error = originalError;
+// Capturing sink. Tests inject this instead of monkey-patching the global
+// console so a parallel test file in the same process (or a future change
+// to test-runner isolation) cannot interleave global mutations.
+function makeSink(): Captured {
+  const log: string[] = [];
+  const warn: string[] = [];
+  const error: string[] = [];
+  const join = (args: unknown[]): string =>
+    args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ');
+  return {
+    log,
+    warn,
+    error,
+    sink: {
+      log: (...a: unknown[]) => log.push(join(a)),
+      warn: (...a: unknown[]) => warn.push(join(a)),
+      error: (...a: unknown[]) => error.push(join(a)),
     },
   };
-  const originalLog = console.log;
-  const originalWarn = console.warn;
-  const originalError = console.error;
-  const join = (args: unknown[]): string => args.map((a) => (typeof a === 'string' ? a : String(a))).join(' ');
-  console.log = (...args: unknown[]) => {
-    captured.log.push(join(args));
-  };
-  console.warn = (...args: unknown[]) => {
-    captured.warn.push(join(args));
-  };
-  console.error = (...args: unknown[]) => {
-    captured.error.push(join(args));
-  };
-  return captured;
 }
 
+// `process.env` is process-global; this helper restores the previous value
+// in a `finally` so each test leaves the environment as it found it. The
+// node:test runner isolates test files in separate processes by default,
+// so a single test's env mutation cannot leak to another file.
 function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
   const prev = process.env[key];
   if (value === undefined) delete process.env[key];
@@ -59,96 +63,121 @@ test('isLogLevel accepts the documented levels and rejects anything else', () =>
 
 test('resolveLogLevel: explicit value wins over env and default', () => {
   withEnv(LOG_LEVEL_ENV, 'debug', () => {
-    assert.equal(resolveLogLevel('warn'), 'warn');
+    const c = makeSink();
+    assert.equal(resolveLogLevel('warn', c.sink), 'warn');
+    assert.deepEqual(c.warn, []);
   });
 });
 
 test('resolveLogLevel: env var is honored when no explicit value', () => {
+  const c = makeSink();
   withEnv(LOG_LEVEL_ENV, 'debug', () => {
-    assert.equal(resolveLogLevel(), 'debug');
+    assert.equal(resolveLogLevel(undefined, c.sink), 'debug');
   });
   withEnv(LOG_LEVEL_ENV, 'SILENT', () => {
-    assert.equal(resolveLogLevel(), 'silent');
+    assert.equal(resolveLogLevel(undefined, c.sink), 'silent');
   });
+  assert.deepEqual(c.warn, []);
 });
 
-test('resolveLogLevel: defaults to info when env is unset', () => {
+test('resolveLogLevel: defaults to info when env is unset or empty', () => {
+  const c = makeSink();
   withEnv(LOG_LEVEL_ENV, undefined, () => {
-    assert.equal(resolveLogLevel(), 'info');
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
   });
+  withEnv(LOG_LEVEL_ENV, '   ', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
+  });
+  assert.deepEqual(c.warn, []);
+});
+
+test('resolveLogLevel: trims whitespace from env values', () => {
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, ' debug ', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'debug');
+  });
+  withEnv(LOG_LEVEL_ENV, '\tWarn\n', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'warn');
+  });
+  assert.deepEqual(c.warn, []);
 });
 
 test('resolveLogLevel: invalid env value falls back to info and warns once', () => {
-  const captured = captureConsole();
-  try {
-    withEnv(LOG_LEVEL_ENV, 'verbose', () => {
-      assert.equal(resolveLogLevel(), 'info');
-    });
-    assert.equal(captured.warn.length, 1);
-    assert.match(captured.warn[0], /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=verbose/);
-  } finally {
-    captured.restore();
-  }
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'verbose', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=verbose/);
+});
+
+test('resolveLogLevel: invalid explicit value warns then falls through to env', () => {
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'debug', () => {
+    assert.equal(resolveLogLevel('TRACE' as 'debug', c.sink), 'debug');
+  });
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], /ignoring invalid logLevel=TRACE/);
+});
+
+test('resolveLogLevel: invalid explicit value with no env falls back to info', () => {
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, undefined, () => {
+    assert.equal(resolveLogLevel('verbose' as 'debug', c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], /ignoring invalid logLevel=verbose/);
 });
 
 test('createLogger at info: error/warn/info pass, debug filtered', () => {
-  const captured = captureConsole();
-  try {
-    const logger = createLogger('info');
-    logger.error('boom');
-    logger.warn('careful');
-    logger.info('hello');
-    logger.debug('quiet');
-    assert.deepEqual(captured.error, ['[client] boom']);
-    assert.deepEqual(captured.warn, ['[client] careful']);
-    assert.deepEqual(captured.log, ['[client] hello']);
-  } finally {
-    captured.restore();
-  }
+  const c = makeSink();
+  const logger = createLogger('info', c.sink);
+  logger.error('boom');
+  logger.warn('careful');
+  logger.info('hello');
+  logger.debug('quiet');
+  assert.deepEqual(c.error, ['[client] boom']);
+  assert.deepEqual(c.warn, ['[client] careful']);
+  assert.deepEqual(c.log, ['[client] hello']);
 });
 
 test('createLogger at debug: every level passes through', () => {
-  const captured = captureConsole();
-  try {
-    const logger = createLogger('debug');
-    logger.error('e');
-    logger.warn('w');
-    logger.info('i');
-    logger.debug('d');
-    assert.deepEqual(captured.error, ['[client] e']);
-    assert.deepEqual(captured.warn, ['[client] w']);
-    assert.deepEqual(captured.log, ['[client] i', '[client] d']);
-  } finally {
-    captured.restore();
-  }
+  const c = makeSink();
+  const logger = createLogger('debug', c.sink);
+  logger.error('e');
+  logger.warn('w');
+  logger.info('i');
+  logger.debug('d');
+  assert.deepEqual(c.error, ['[client] e']);
+  assert.deepEqual(c.warn, ['[client] w']);
+  assert.deepEqual(c.log, ['[client] i', '[client] d']);
 });
 
 test('createLogger at warn: info and debug filtered', () => {
-  const captured = captureConsole();
-  try {
-    const logger = createLogger('warn');
-    logger.info('i');
-    logger.debug('d');
-    logger.warn('w');
-    assert.deepEqual(captured.log, []);
-    assert.deepEqual(captured.warn, ['[client] w']);
-  } finally {
-    captured.restore();
-  }
+  const c = makeSink();
+  const logger = createLogger('warn', c.sink);
+  logger.info('i');
+  logger.debug('d');
+  logger.warn('w');
+  assert.deepEqual(c.log, []);
+  assert.deepEqual(c.warn, ['[client] w']);
 });
 
 test('createLogger at silent: every level filtered', () => {
-  const captured = captureConsole();
-  try {
-    const logger = createLogger('silent');
-    logger.error('e');
-    logger.warn('w');
-    logger.info('i');
-    logger.debug('d');
-    assert.deepEqual(captured.error, []);
-    assert.deepEqual(captured.warn, []);
-    assert.deepEqual(captured.log, []);
-  } finally {
-    captured.restore();
-  }
+  const c = makeSink();
+  const logger = createLogger('silent', c.sink);
+  logger.error('e');
+  logger.warn('w');
+  logger.info('i');
+  logger.debug('d');
+  assert.deepEqual(c.error, []);
+  assert.deepEqual(c.warn, []);
+  assert.deepEqual(c.log, []);
+});
+
+test('createLogger: trims an explicit level string', () => {
+  const c = makeSink();
+  const logger = createLogger(' DEBUG ', c.sink);
+  assert.equal(logger.level, 'debug');
+  assert.deepEqual(c.warn, []);
 });

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -273,8 +273,8 @@ test('safeToken: truncates very long tokens', () => {
 test('safeToken: escapes Unicode line/paragraph separators (U+2028/U+2029)', () => {
   // JSON.stringify leaves these raw, but several log collectors render
   // them as line breaks — they must be escaped to keep tokens single-line.
-  const ls = ' ';
-  const ps = ' ';
+  const ls = '\u2028';
+  const ps = '\u2029';
   const out = safeToken(`pre${ls}mid${ps}post`);
   assert.equal(out.includes(ls), false, 'raw U+2028 must not survive');
   assert.equal(out.includes(ps), false, 'raw U+2029 must not survive');
@@ -284,11 +284,11 @@ test('safeToken: escapes Unicode line/paragraph separators (U+2028/U+2029)', () 
 test('safeForLog: escapes Unicode line/paragraph separators (U+2028/U+2029)', () => {
   _resetLogLevelWarningsForTests();
   const c = makeSink();
-  withEnv(LOG_LEVEL_ENV, 'evil [client] FAKE INJECTED LINE', () => {
+  withEnv(LOG_LEVEL_ENV, `evil\u2028[client] FAKE INJECTED LINE`, () => {
     assert.equal(resolveLogLevel(undefined, c.sink), 'info');
   });
   assert.equal(c.warn.length, 1);
-  assert.equal(c.warn[0].includes(' '), false, 'raw U+2028 must not survive');
+  assert.equal(c.warn[0].includes('\u2028'), false, 'raw U+2028 must not survive');
   assert.match(c.warn[0], /evil\\u2028\[client\] FAKE INJECTED LINE/);
 });
 

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -110,7 +110,7 @@ test('resolveLogLevel: invalid env value falls back to info and warns once', () 
     assert.equal(resolveLogLevel(undefined, c.sink), 'info');
   });
   assert.equal(c.warn.length, 1);
-  assert.match(c.warn[0], /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=verbose/);
+  assert.match(c.warn[0], /ignoring invalid VICOOP_CLIENT_LOG_LEVEL="verbose"/);
 });
 
 test('resolveLogLevel: invalid explicit value warns then falls through to env', () => {
@@ -120,7 +120,7 @@ test('resolveLogLevel: invalid explicit value warns then falls through to env', 
     assert.equal(resolveLogLevel('TRACE' as 'debug', c.sink), 'debug');
   });
   assert.equal(c.warn.length, 1);
-  assert.match(c.warn[0], /ignoring invalid logLevel=TRACE/);
+  assert.match(c.warn[0], /ignoring invalid logLevel="TRACE"/);
 });
 
 test('resolveLogLevel: invalid explicit value with no env falls back to info', () => {
@@ -130,7 +130,32 @@ test('resolveLogLevel: invalid explicit value with no env falls back to info', (
     assert.equal(resolveLogLevel('verbose' as 'debug', c.sink), 'info');
   });
   assert.equal(c.warn.length, 1);
-  assert.match(c.warn[0], /ignoring invalid logLevel=verbose/);
+  assert.match(c.warn[0], /ignoring invalid logLevel="verbose"/);
+});
+
+test('resolveLogLevel: sanitizes newlines/control chars in invalid value (no log injection)', () => {
+  _resetLogLevelWarningsForTests();
+  const c = makeSink();
+  withEnv(LOG_LEVEL_ENV, 'evil\n[client] FAKE INJECTED LINE', () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 1);
+  // Single line — newline must be escaped, not literal.
+  assert.equal(c.warn[0].includes('\n'), false, 'warn message must not contain raw newlines');
+  assert.match(c.warn[0], /\\n\[client\] FAKE INJECTED LINE/);
+});
+
+test('resolveLogLevel: truncates very long invalid values', () => {
+  _resetLogLevelWarningsForTests();
+  const c = makeSink();
+  const long = 'x'.repeat(500);
+  withEnv(LOG_LEVEL_ENV, long, () => {
+    assert.equal(resolveLogLevel(undefined, c.sink), 'info');
+  });
+  assert.equal(c.warn.length, 1);
+  // Bounded length: prefix line + escaped+truncated value should be short.
+  assert.ok(c.warn[0].length < 250, `warn line should be bounded, got ${c.warn[0].length} chars`);
+  assert.match(c.warn[0], /…/);
 });
 
 test('resolveLogLevel: warns at most once per distinct invalid value across calls', () => {
@@ -167,7 +192,7 @@ test('resolveLogLevel: warn passes PREFIX as a separate sink argument', () => {
   // the logger's own .warn() uses, so structured-logging sinks can treat
   // them consistently.
   assert.equal(calls[0][0], '[client]');
-  assert.match(String(calls[0][1]), /ignoring invalid VICOOP_CLIENT_LOG_LEVEL=bogus/);
+  assert.match(String(calls[0][1]), /ignoring invalid VICOOP_CLIENT_LOG_LEVEL="bogus"/);
 });
 
 test('createLogger at info: error/warn/info pass, debug filtered', () => {

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -34,14 +34,32 @@ export function isLogLevel(value: string): value is LogLevel {
   return Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
 }
 
+// Process-wide dedup of "ignoring invalid" warnings. Without this,
+// `createLogger` (called per Client instance) would re-emit the same
+// warning every time it ran, contradicting the PR's "warn once" promise
+// in long-running processes that build multiple loggers.
+const warnedKeys = new Set<string>();
+
+// Test-only: clear the dedup state so warn-asserting tests don't suffer
+// from prior tests' suppression. Underscored to signal non-public.
+export function _resetLogLevelWarningsForTests(): void {
+  warnedKeys.clear();
+}
+
+function warnOnce(sink: ConsoleSink, key: string, message: string): void {
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  sink.warn(PREFIX, message);
+}
+
 // Normalize a level string from any source (explicit option, env var) by
 // trimming and lowercasing, then validating against the known set. An
-// invalid non-empty value is reported via `sink.warn` once and returns
-// `undefined` so the caller can fall through to the next priority. We
-// validate explicit values too — even though TS `LogLevel` constrains them
-// for typed callers, a plain-JS consumer can still pass anything, and an
-// unrecognized string would otherwise produce `LEVEL_RANK[v] === undefined`
-// and silently disable every level.
+// invalid non-empty value is reported via `warnOnce` (per distinct
+// source+value) and returns `undefined` so the caller can fall through to
+// the next priority. We validate explicit values too — even though TS
+// `LogLevel` constrains them for typed callers, a plain-JS consumer can
+// still pass anything, and an unrecognized string would otherwise produce
+// `LEVEL_RANK[v] === undefined` and silently disable every level.
 //
 // `raw` is typed `unknown` rather than `string | undefined` so a JS caller
 // passing a number/object/null doesn't crash the client at startup with a
@@ -54,8 +72,10 @@ function tryParseLevel(
 ): LogLevel | undefined {
   if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== 'string') {
-    sink.warn(
-      `${PREFIX} ignoring non-string ${source} of type ${typeof raw} (expected silent|error|warn|info|debug)`,
+    warnOnce(
+      sink,
+      `${source}:type:${typeof raw}`,
+      `ignoring non-string ${source} of type ${typeof raw} (expected silent|error|warn|info|debug)`,
     );
     return undefined;
   }
@@ -63,8 +83,10 @@ function tryParseLevel(
   if (!trimmed) return undefined;
   const v = trimmed.toLowerCase();
   if (isLogLevel(v)) return v;
-  sink.warn(
-    `${PREFIX} ignoring invalid ${source}=${raw} (expected silent|error|warn|info|debug)`,
+  warnOnce(
+    sink,
+    `${source}:value:${trimmed}`,
+    `ignoring invalid ${source}=${raw} (expected silent|error|warn|info|debug)`,
   );
   return undefined;
 }

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -52,12 +52,21 @@ function warnOnce(sink: ConsoleSink, key: string, message: string): void {
   sink.warn(PREFIX, message);
 }
 
+// JSON.stringify covers \n / \r / control chars and the standard JSON
+// escapes, but the spec leaves U+2028 (Line Separator) and U+2029
+// (Paragraph Separator) raw — and several log collectors / terminals
+// render them as line breaks. Replace them with their `\uXXXX` escape
+// sequences so the single-line invariant survives those sinks too.
+function escapeLineSeparators(s: string): string {
+  return s.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029');
+}
+
 // Quote+escape+truncate. Use for "what value was rejected"-style messages
 // where the surrounding quotes help operators see the exact string the
 // client received. Newlines and control chars are escaped; long inputs
 // are truncated with an ellipsis.
 function safeForLog(value: string, maxLen = 120): string {
-  const escaped = JSON.stringify(value);
+  const escaped = escapeLineSeparators(JSON.stringify(value));
   if (escaped.length <= maxLen) return escaped;
   // Trim to maxLen and tack on an ellipsis. The result intentionally
   // doesn't preserve the closing quote — readers see the truncation.
@@ -74,7 +83,9 @@ export function safeToken(value: string, maxLen = 200): string {
   // JSON.stringify produces a fully escaped, double-quoted string; strip
   // the surrounding quotes to keep tokens lightweight while inheriting
   // every escape rule (\n, \r, \t, \", \\, \uXXXX for control chars).
-  const escaped = JSON.stringify(value).slice(1, -1);
+  // The line-separator post-process closes the U+2028/U+2029 gap left by
+  // JSON.stringify.
+  const escaped = escapeLineSeparators(JSON.stringify(value).slice(1, -1));
   return escaped.length <= maxLen ? escaped : `${escaped.slice(0, maxLen - 1)}…`;
 }
 

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -19,42 +19,76 @@ export interface Logger {
   debug(...args: unknown[]): void;
 }
 
+// Subset of `Console` the logger writes to. Letting callers (and tests)
+// inject this sink avoids monkey-patching the global console — important
+// because Node's test runner can execute test files concurrently in
+// separate processes, but a future refactor that drops process isolation
+// would re-introduce cross-file flakiness on a global-patch approach.
+export interface ConsoleSink {
+  error(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  log(...args: unknown[]): void;
+}
+
 export function isLogLevel(value: string): value is LogLevel {
   return Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
 }
 
-export function resolveLogLevel(explicit?: LogLevel): LogLevel {
-  if (explicit) return explicit;
-  const raw = process.env[LOG_LEVEL_ENV];
-  if (!raw) return 'info';
-  const v = raw.toLowerCase();
+// Normalize a level string from any source (explicit option, env var) by
+// trimming and lowercasing, then validating against the known set. An
+// invalid non-empty value is reported via `sink.warn` once and returns
+// `undefined` so the caller can fall through to the next priority. We
+// validate explicit values too — even though TS `LogLevel` constrains them
+// for typed callers, a plain-JS consumer can still pass anything, and an
+// unrecognized string would otherwise produce `LEVEL_RANK[v] === undefined`
+// and silently disable every level.
+function tryParseLevel(
+  raw: string | undefined,
+  source: string,
+  sink: ConsoleSink,
+): LogLevel | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const v = trimmed.toLowerCase();
   if (isLogLevel(v)) return v;
-  // The env var came from the operator; surface the misconfiguration once at
-  // logger creation rather than silently falling back, so an unexpected level
-  // string ("verbose", "trace") doesn't quietly degrade observability.
-  console.warn(
-    `${PREFIX} ignoring invalid ${LOG_LEVEL_ENV}=${raw} (expected silent|error|warn|info|debug)`,
+  sink.warn(
+    `${PREFIX} ignoring invalid ${source}=${raw} (expected silent|error|warn|info|debug)`,
   );
-  return 'info';
+  return undefined;
 }
 
-export function createLogger(level?: LogLevel): Logger {
-  const resolved = resolveLogLevel(level);
+export function resolveLogLevel(
+  explicit?: LogLevel | string,
+  sink: ConsoleSink = console,
+): LogLevel {
+  return (
+    tryParseLevel(explicit, 'logLevel', sink) ??
+    tryParseLevel(process.env[LOG_LEVEL_ENV], LOG_LEVEL_ENV, sink) ??
+    'info'
+  );
+}
+
+export function createLogger(
+  level?: LogLevel | string,
+  sink: ConsoleSink = console,
+): Logger {
+  const resolved = resolveLogLevel(level, sink);
   const threshold = LEVEL_RANK[resolved];
   const enabled = (l: LogLevel): boolean => threshold >= LEVEL_RANK[l];
   return {
     level: resolved,
     error: (...args) => {
-      if (enabled('error')) console.error(PREFIX, ...args);
+      if (enabled('error')) sink.error(PREFIX, ...args);
     },
     warn: (...args) => {
-      if (enabled('warn')) console.warn(PREFIX, ...args);
+      if (enabled('warn')) sink.warn(PREFIX, ...args);
     },
     info: (...args) => {
-      if (enabled('info')) console.log(PREFIX, ...args);
+      if (enabled('info')) sink.log(PREFIX, ...args);
     },
     debug: (...args) => {
-      if (enabled('debug')) console.log(PREFIX, ...args);
+      if (enabled('debug')) sink.log(PREFIX, ...args);
     },
   };
 }

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -52,6 +52,18 @@ function warnOnce(sink: ConsoleSink, key: string, message: string): void {
   sink.warn(PREFIX, message);
 }
 
+// Render an arbitrary string as a safe, single-line log token. Uses
+// JSON.stringify so newlines and control chars are escaped (preventing
+// log-injection / multi-line entries) and truncates to keep one bad env
+// value from flooding the log.
+function safeForLog(value: string, maxLen = 120): string {
+  const escaped = JSON.stringify(value);
+  if (escaped.length <= maxLen) return escaped;
+  // Trim to maxLen and tack on an ellipsis. The result intentionally
+  // doesn't preserve the closing quote — readers see the truncation.
+  return `${escaped.slice(0, maxLen - 1)}…`;
+}
+
 // Normalize a level string from any source (explicit option, env var) by
 // trimming and lowercasing, then validating against the known set. An
 // invalid non-empty value is reported via `warnOnce` (per distinct
@@ -86,7 +98,7 @@ function tryParseLevel(
   warnOnce(
     sink,
     `${source}:value:${trimmed}`,
-    `ignoring invalid ${source}=${raw} (expected silent|error|warn|info|debug)`,
+    `ignoring invalid ${source}=${safeForLog(raw)} (expected silent|error|warn|info|debug)`,
   );
   return undefined;
 }

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -42,12 +42,23 @@ export function isLogLevel(value: string): value is LogLevel {
 // for typed callers, a plain-JS consumer can still pass anything, and an
 // unrecognized string would otherwise produce `LEVEL_RANK[v] === undefined`
 // and silently disable every level.
+//
+// `raw` is typed `unknown` rather than `string | undefined` so a JS caller
+// passing a number/object/null doesn't crash the client at startup with a
+// "raw.trim is not a function" TypeError; we warn and fall through to the
+// next priority instead.
 function tryParseLevel(
-  raw: string | undefined,
+  raw: unknown,
   source: string,
   sink: ConsoleSink,
 ): LogLevel | undefined {
-  if (raw === undefined) return undefined;
+  if (raw === undefined || raw === null) return undefined;
+  if (typeof raw !== 'string') {
+    sink.warn(
+      `${PREFIX} ignoring non-string ${source} of type ${typeof raw} (expected silent|error|warn|info|debug)`,
+    );
+    return undefined;
+  }
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
   const v = trimmed.toLowerCase();

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -1,0 +1,60 @@
+export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug';
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+const PREFIX = '[client]';
+export const LOG_LEVEL_ENV = 'VICOOP_CLIENT_LOG_LEVEL';
+
+export interface Logger {
+  readonly level: LogLevel;
+  error(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  debug(...args: unknown[]): void;
+}
+
+export function isLogLevel(value: string): value is LogLevel {
+  return Object.prototype.hasOwnProperty.call(LEVEL_RANK, value);
+}
+
+export function resolveLogLevel(explicit?: LogLevel): LogLevel {
+  if (explicit) return explicit;
+  const raw = process.env[LOG_LEVEL_ENV];
+  if (!raw) return 'info';
+  const v = raw.toLowerCase();
+  if (isLogLevel(v)) return v;
+  // The env var came from the operator; surface the misconfiguration once at
+  // logger creation rather than silently falling back, so an unexpected level
+  // string ("verbose", "trace") doesn't quietly degrade observability.
+  console.warn(
+    `${PREFIX} ignoring invalid ${LOG_LEVEL_ENV}=${raw} (expected silent|error|warn|info|debug)`,
+  );
+  return 'info';
+}
+
+export function createLogger(level?: LogLevel): Logger {
+  const resolved = resolveLogLevel(level);
+  const threshold = LEVEL_RANK[resolved];
+  const enabled = (l: LogLevel): boolean => threshold >= LEVEL_RANK[l];
+  return {
+    level: resolved,
+    error: (...args) => {
+      if (enabled('error')) console.error(PREFIX, ...args);
+    },
+    warn: (...args) => {
+      if (enabled('warn')) console.warn(PREFIX, ...args);
+    },
+    info: (...args) => {
+      if (enabled('info')) console.log(PREFIX, ...args);
+    },
+    debug: (...args) => {
+      if (enabled('debug')) console.log(PREFIX, ...args);
+    },
+  };
+}

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -52,16 +52,30 @@ function warnOnce(sink: ConsoleSink, key: string, message: string): void {
   sink.warn(PREFIX, message);
 }
 
-// Render an arbitrary string as a safe, single-line log token. Uses
-// JSON.stringify so newlines and control chars are escaped (preventing
-// log-injection / multi-line entries) and truncates to keep one bad env
-// value from flooding the log.
+// Quote+escape+truncate. Use for "what value was rejected"-style messages
+// where the surrounding quotes help operators see the exact string the
+// client received. Newlines and control chars are escaped; long inputs
+// are truncated with an ellipsis.
 function safeForLog(value: string, maxLen = 120): string {
   const escaped = JSON.stringify(value);
   if (escaped.length <= maxLen) return escaped;
   // Trim to maxLen and tack on an ellipsis. The result intentionally
   // doesn't preserve the closing quote — readers see the truncation.
   return `${escaped.slice(0, maxLen - 1)}…`;
+}
+
+// Escape+truncate without surrounding quotes. Use for lifecycle log
+// tokens (taskId=, contextId=, parts=, errorClass=, …) where wire-derived
+// values must not be able to break out of the log line. A plain ASCII
+// taskId like `abc-123` is left unchanged; a hostile value like
+// `evil\n[client] FAKE` is escaped to `evil\\n[client] FAKE`, preserving
+// the single-line invariant.
+export function safeToken(value: string, maxLen = 200): string {
+  // JSON.stringify produces a fully escaped, double-quoted string; strip
+  // the surrounding quotes to keep tokens lightweight while inheriting
+  // every escape rule (\n, \r, \t, \", \\, \uXXXX for control chars).
+  const escaped = JSON.stringify(value).slice(1, -1);
+  return escaped.length <= maxLen ? escaped : `${escaped.slice(0, maxLen - 1)}…`;
 }
 
 // Normalize a level string from any source (explicit option, env var) by


### PR DESCRIPTION
## Summary

Closes #98.

- Adds task lifecycle logs to the standalone bridge client so operators can answer "did the task reach this client, and what happened to it?" from `vicoop-client.log` alone.
- Introduces a small leveled logger (`silent | error | warn | info | debug`) configurable via `VICOOP_CLIENT_LOG_LEVEL` env var or `ClientOptions.logLevel`. Default is `info`; lifecycle events surface there. `debug` adds `messageId`, `role`, and `partsCount`.
- Wraps the backend `emit` pipeline so the client can observe terminal frames the backend sends — without inspecting payloads. Logs report only structural facts (`taskId`, `contextId`, unique part MIME types, `elapsedMs`, artifact count, fail code) — never message content, file bytes, or error messages at the default level.
- Surfaces a `warn` when a backend resolves without emitting `task.complete` or `task.fail`, and a `warn` when a backend throws after emitting a terminal frame.
- All wire-derived tokens (`taskId`, `contextId`, MIME types, ws close `reason`, error class names, env-var values) pass through `safeToken` / `safeForLog` so newlines and control chars in untrusted strings cannot inject extra log lines.

### Lifecycle event names

| Event | Level | When |
|---|---|---|
| `task.assign` | info | bridge sent us a `task.assign` frame |
| `backend.start` | info | client invoked `backend.handle` |
| `task.complete` | info | backend emitted a successful `task.complete` |
| `task.canceled` | info | terminal cancellation — backend emitted `task.complete` with `status.state="canceled"`, OR threw after the AbortSignal fired (client synthesizes the canceled frame in that case) |
| `task.fail` | info | backend emitted `task.fail`, OR backend threw without ever emitting a terminal (synthesized as `code=backend_error`) |
| `task.cancel` | info | bridge sent us a `task.cancel` frame (receipt) — distinct from `task.canceled` (terminal outcome) |
| `backend.end ... (no terminal frame)` | warn | backend resolved without emitting any terminal — protocol violation |
| `backend threw after terminal` | warn | backend emitted a terminal then threw — also protocol violation; raw error message stays at debug |

### Sample output (default `info`)

```text
[client] connected, sending hello
[client] task.assign taskId=abc123 contextId=ctx7 parts=text/plain,image/png
[client] backend.start taskId=abc123 backend=claude
[client] task.complete taskId=abc123 elapsedMs=12345 artifacts=2
[client] task.cancel taskId=abc123          # bridge told us to cancel
[client] task.canceled taskId=abc123 elapsedMs=1200 artifacts=0   # backend settled in canceled state
[client] task.fail taskId=abc123 code=backend_error elapsedMs=1234
```

### Configuration

- `VICOOP_CLIENT_LOG_LEVEL=debug` in launchd `EnvironmentVariables` to opt into verbose logs without code changes.
- Invalid values warn at most once per distinct value (process-wide dedup) and fall back to `info`. Whitespace is trimmed; non-string values from JS callers warn instead of crashing the client.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 184 passing, 39 new tests for `logger.ts`, `summarizeParts`, and `processTask` lifecycle paths
- [x] `pnpm -r typecheck` across all workspace packages
- [ ] Manual smoke: install on macOS launchd with `claude` backend, trigger a chat, verify `vicoop-client.log` shows the lifecycle events
- [ ] Verify `VICOOP_CLIENT_LOG_LEVEL=debug` adds `messageId`/`role`/`partsCount` debug lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)