### PR TITLE
claude backend: surface tool_use frames + idle heartbeat (#100)

### DIFF
--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -180,3 +180,23 @@ the unit test `emits FilePart artifact when tool_result contains an
 image block`. An e2e harness for that path would require a separate MCP
 server that actually returns image blocks; deferred until a real use
 case lands.
+
+## Progress visibility (issue #100)
+
+Long-running tool work used to look identical to a hung process: a
+single `task.status: working` followed by a multi-minute silence until
+the final assistant text. Two additions cover the gap, both unit-tested
+in `claude.test.ts`:
+
+- `tool_use` blocks inside an `assistant` event become
+  `claude-tool-call` artifacts. Each artifact carries a head-truncated
+  `<tool>: <input>` text part (≤ 200 chars; secrets-and-size guard) and
+  a `data` part with `{ toolName, toolUseId }` for filtering.
+- A configurable idle-silence heartbeat (`heartbeatMs`, default 30 s)
+  emits a bare `task.status: working` whenever no other frame has gone
+  out for that many ms. Disabled with `heartbeatMs: 0`. Backstop for
+  any future case where work happens without an interleaved model turn.
+
+Text-only `tool_result` blocks are still dropped — gating that stream
+needs a truncation policy that hasn't been settled (see #100 "B"). The
+existing image/document passthrough is unchanged.

--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -190,8 +190,12 @@ in `claude.test.ts`:
 
 - `tool_use` blocks inside an `assistant` event become
   `claude-tool-call` artifacts. Each artifact carries a head-truncated
-  `<tool>: <input>` text part (≤ 200 chars; secrets-and-size guard) and
-  a `data` part with `{ toolName, toolUseId }` for filtering.
+  `<tool>: <input>` text part (≤ 200 chars — **size guard only**, not a
+  secrets guard; tokens or keys appearing in the head will still be
+  emitted) plus a `data` part with `{ toolName, toolUseId }` for
+  filtering. Operators that need secret-safe artifacts must add
+  per-tool redaction or gate input summaries off entirely (#100 part B
+  follow-up).
 - A configurable idle-silence heartbeat (`heartbeatMs`, default 30 s)
   emits a bare `task.status: working` whenever no other frame has gone
   out for that many ms. Disabled with `heartbeatMs: 0`. Backstop for

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1108,6 +1108,111 @@ test('heartbeat: emits task.status after heartbeatMs of silence and stops at ter
   );
 });
 
+test('heartbeat: suppressed after signal.abort so canceled tasks do not look like they are still working', async () => {
+  let scheduledFn: () => void = () => {};
+  let nowMs = 1_000_000;
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      // Hold the child open. Termination is driven by abort → kill().
+      void child;
+    });
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    heartbeatMs: 100,
+    now: () => nowMs,
+    setIntervalFn: (fn) => {
+      scheduledFn = fn;
+      return { tag: 'fake-interval' };
+    },
+    clearIntervalFn: () => {},
+  });
+  const controller = new AbortController();
+  const { emit, frames } = collect();
+  const runP = backend.handle(assign('x'), emit, controller.signal);
+  for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+
+  // Sanity: the heartbeat fires while the task is still working.
+  nowMs += 250;
+  scheduledFn();
+  const before = frames.filter((f) => f.type === 'task.status').length;
+  assert.ok(before >= 2, 'heartbeat must emit at least one extra task.status while working');
+
+  // Abort. Subsequent heartbeat ticks must NOT add more `state: working`
+  // status frames — the run is on its way to a `canceled` terminal frame.
+  controller.abort();
+  nowMs += 250;
+  scheduledFn();
+  nowMs += 250;
+  scheduledFn();
+
+  await runP;
+
+  const workingStatusCount = frames.filter(
+    (f) =>
+      f.type === 'task.status' &&
+      (f as Extract<UpFrame, { type: 'task.status' }>).status.state === 'working',
+  ).length;
+  assert.equal(
+    workingStatusCount,
+    before,
+    'no extra working-state heartbeats may land between abort and terminal frame',
+  );
+  const last = frames.at(-1) as Extract<UpFrame, { type: 'task.complete' }>;
+  assert.equal(last.type, 'task.complete');
+  assert.equal(last.status.state, 'canceled');
+});
+
+test('summarizeToolInput stays bounded for a huge top-level array (no full JSON.stringify)', async () => {
+  // 100k tiny objects in a top-level field. A naive JSON.stringify of
+  // the whole input would produce ~MiBs of output before clipTo trims
+  // it. The bounded serializer must stop walking once the summary is
+  // long enough to be clipped anyway.
+  const huge = { items: Array.from({ length: 100_000 }, (_, i) => ({ i })) };
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_huge',
+              name: 'BulkOp',
+              input: huge,
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  const t0 = Date.now();
+  await backend.handle(assign('x'), emit, NEVER);
+  const elapsedMs = Date.now() - t0;
+
+  const callArtifact = frames.find(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
+      f.type === 'task.artifact' && f.artifact.name === 'claude-tool-call',
+  );
+  assert.ok(callArtifact);
+  const textPart = callArtifact.artifact.parts[0];
+  if (textPart.kind !== 'text') throw new Error('expected text part');
+  assert.ok(
+    textPart.text.length <= 200,
+    `summary length ${textPart.text.length} exceeds cap`,
+  );
+  // Bounded serializer should finish well under a second on a 100k-entry
+  // input — a naive full JSON.stringify on this would still be quick on
+  // modern hardware, so this is a smoke check, not a hard SLA. If this
+  // ever fails, something walked the whole structure recursively.
+  assert.ok(elapsedMs < 2000, `summarize took ${elapsedMs}ms — likely walked the full input`);
+});
+
 test('heartbeat: heartbeatMs:0 disables the interval entirely', async () => {
   let registered = false;
   const fake = scriptedSpawn({

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -4,7 +4,12 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
-import { createClaudeBackend, type ClaudeChildHandle, type ClaudeSpawnOptions } from './claude.js';
+import {
+  createClaudeBackend,
+  summarizeToolInput,
+  type ClaudeChildHandle,
+  type ClaudeSpawnOptions,
+} from './claude.js';
 import type { TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
 
 const NEVER: AbortSignal = new AbortController().signal;
@@ -1163,64 +1168,76 @@ test('heartbeat: suppressed after signal.abort so canceled tasks do not look lik
   assert.equal(last.status.state, 'canceled');
 });
 
-test('summarizeToolInput stays bounded for a top-level structure with 100k entries (early-bail walk)', async () => {
-  // The summarizer doesn't recurse — nested structures are summarized
-  // as a `<object>` / `<array(N)>` tag — so we have to put the bulk
-  // *at the top level* to actually exercise the bounded-walk path.
-  // Two shapes drive the two branches:
-  //   - a top-level object with 100k keys → `for..in` early-bail
-  //   - a top-level array  with 100k items → `for(i...)` early-bail
-  // For the test we pick the object branch because it also guards
-  // against regressing the `Object.keys`-allocates-full-list case.
-  const hugeObj: Record<string, number> = {};
-  for (let i = 0; i < 100_000; i++) hugeObj[`k${i}`] = i;
+test('summarizeToolInput bails early on a top-level object with many keys (deterministic visit count)', async () => {
+  // Deterministic regression guard for the bounded-walk behavior.
+  // Each key is an instrumented enumerable getter that records when
+  // its value is read. With ~80-char string values, 3 keys' worth of
+  // serialization already pushes the accumulator past `budget`
+  // (200 + 16 = 216 chars), so the walker MUST bail before reading
+  // the 4th value. A regression that materializes the full key list
+  // (e.g. reverting to `Object.keys`) or that fails to early-break
+  // would walk into the tripwire keys and blow the assertion.
+  //
+  // Going through the backend handle() path would force the test
+  // itself to JSON.stringify the input as part of the stream-json
+  // line, triggering every getter and ruining the count — so we
+  // call summarizeToolInput directly. The production wiring is
+  // already exercised by other tests in this file.
+  const probed: string[] = [];
+  const inp: Record<string, unknown> = {};
+  const layout: Array<[string, string]> = [
+    ['a', 'x'.repeat(80)],
+    ['b', 'y'.repeat(80)],
+    ['c', 'z'.repeat(80)],
+    // Tripwires: walker must NOT reach these. Their getters push
+    // onto `probed` just like the real keys, so a regression makes
+    // them visible.
+    ['tripwire_1', 'should-not-be-read'],
+    ['tripwire_2', 'should-not-be-read'],
+    ['tripwire_3', 'should-not-be-read'],
+  ];
+  for (const [k, v] of layout) {
+    Object.defineProperty(inp, k, {
+      enumerable: true,
+      configurable: true,
+      get() {
+        probed.push(k);
+        return v;
+      },
+    });
+  }
 
-  const fake = scriptedSpawn({
-    lines: [
-      JSON.stringify({
-        type: 'assistant',
-        message: {
-          role: 'assistant',
-          content: [
-            {
-              type: 'tool_use',
-              id: 'tu_huge',
-              name: 'BulkOp',
-              input: hugeObj,
-            },
-          ],
-        },
-      }),
-      JSON.stringify({ type: 'result', result: 'ok' }),
-    ],
-    exitCode: 0,
-  });
-  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
-  const { emit, frames } = collect();
-  const t0 = Date.now();
-  await backend.handle(assign('x'), emit, NEVER);
-  const elapsedMs = Date.now() - t0;
+  const summary = summarizeToolInput(inp, 200);
 
-  const callArtifact = frames.find(
-    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
-      f.type === 'task.artifact' && f.artifact.name === 'claude-tool-call',
+  // Deterministic guarantee: only the first 3 keys' values were ever
+  // read. The walker hits the budget check at the top of iteration 4
+  // and bails before touching the tripwire getters. The summary's
+  // own length is bounded by O(visited × clipPerString) — not
+  // O(total keys × clipPerString) — so it's strictly smaller than a
+  // full JSON.stringify would produce, but we don't assert an exact
+  // ceiling because one iteration can overshoot the soft budget by
+  // up to one clipped key + clipped value.
+  assert.deepEqual(
+    probed,
+    ['a', 'b', 'c'],
+    `walker should bail after 3 keys; visited ${probed.join(',')}`,
   );
-  assert.ok(callArtifact);
-  const textPart = callArtifact.artifact.parts[0];
-  if (textPart.kind !== 'text') throw new Error('expected text part');
-  assert.ok(
-    textPart.text.length <= 200,
-    `summary length ${textPart.text.length} exceeds cap`,
-  );
-  // Smoke check: the early-bail walk should finish in well under a
-  // second. A regression that materializes the full key list (e.g.
-  // reverting to `Object.keys(input)`) is still fast on modern
-  // hardware, so this isn't a hard SLA — but anything walking 100k
-  // values would blow well past a couple of seconds.
-  assert.ok(
-    elapsedMs < 2000,
-    `summarize took ${elapsedMs}ms — likely walked the full input`,
-  );
+  assert.ok(!summary.includes('tripwire'), 'tripwire keys must not appear in summary');
+});
+
+test('summarizeToolInput clips both keys and values so a giant key cannot blow the budget', async () => {
+  // A 50k-char top-level key alone would, before key-clipping, drive
+  // a 50k-char JSON.stringify allocation just to land that one
+  // property — defeating the bounded-cost guarantee on the *first*
+  // iteration. With key clipping in place the produced summary is
+  // bounded by the same per-string cap that values use.
+  const giantKey = 'K'.repeat(50_000);
+  const inp = { [giantKey]: 'tiny' };
+  const summary = summarizeToolInput(inp, 200);
+  assert.ok(summary.length <= 216, `summary length ${summary.length} exceeds budget`);
+  // The clipped key prefix is present, but not the full 50k-char form.
+  assert.ok(summary.includes('KKKK'));
+  assert.ok(!summary.includes('K'.repeat(1000)), 'giant key must not appear verbatim');
 });
 
 test('heartbeat: heartbeatMs:0 disables the interval entirely', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -912,6 +912,221 @@ test('emits FilePart artifact when tool_result contains an image block', async (
   }
 });
 
+test('emits a claude-tool-call artifact per tool_use block in an assistant event', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check the directory.' },
+            {
+              type: 'tool_use',
+              id: 'tu_1',
+              name: 'Bash',
+              input: { command: 'ls -la /tmp' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              tool_use_id: 'tu_1',
+              type: 'tool_result',
+              content: [{ type: 'text', text: 'total 0' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'No files.' }],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'No files.' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('list /tmp'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  const names = artifacts.map((a) => a.artifact.name);
+  assert.deepEqual(
+    names,
+    ['claude-message', 'claude-tool-call', 'claude-message'],
+    'order: assistant text, then tool_use, then trailing assistant text',
+  );
+
+  const callArtifact = artifacts[1];
+  assert.equal(callArtifact.lastChunk, true);
+  assert.equal(callArtifact.artifact.parts.length, 2);
+  const textPart = callArtifact.artifact.parts[0];
+  assert.equal(textPart.kind, 'text');
+  if (textPart.kind === 'text') {
+    assert.match(textPart.text, /^Bash: /);
+    assert.ok(textPart.text.includes('ls -la /tmp'));
+  }
+  const dataPart = callArtifact.artifact.parts[1];
+  assert.equal(dataPart.kind, 'data');
+  if (dataPart.kind === 'data') {
+    assert.equal(dataPart.data.toolName, 'Bash');
+    assert.equal(dataPart.data.toolUseId, 'tu_1');
+  }
+
+  // Existing assistant text artifacts and the terminal frame remain
+  // untouched — new frames are additive, not replacements.
+  const complete = frames.at(-1) as Extract<UpFrame, { type: 'task.complete' }>;
+  assert.equal(complete.type, 'task.complete');
+  assert.equal(complete.status.state, 'completed');
+});
+
+test('truncates a long tool_use input summary to a bounded length', async () => {
+  const longArg = 'x'.repeat(800);
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_long',
+              name: 'Bash',
+              input: { command: longArg },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+
+  const callArtifact = frames.find(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
+      f.type === 'task.artifact' && f.artifact.name === 'claude-tool-call',
+  );
+  assert.ok(callArtifact, 'expected claude-tool-call artifact');
+  const textPart = callArtifact.artifact.parts[0];
+  if (textPart.kind !== 'text') throw new Error('expected text part');
+  assert.ok(textPart.text.length <= 200, `summary length ${textPart.text.length} > 200`);
+  assert.ok(textPart.text.startsWith('Bash: '));
+  assert.ok(textPart.text.endsWith('…'), 'truncation marker expected at tail');
+});
+
+test('heartbeat: emits task.status after heartbeatMs of silence and stops at terminal time', async () => {
+  // Initialize as a no-op so the type stays `() => void` instead of
+  // `(() => void) | null`. The closure-mutation path through setIntervalFn
+  // confuses TS narrowing — easier to start callable.
+  let scheduledFn: () => void = () => {};
+  let scheduled = false;
+  let cleared = false;
+  let nowMs = 1_000_000;
+
+  // Hold the child open so we can drive heartbeat ticks before the run
+  // terminates and clears the interval.
+  let releaseFinish: () => void = () => {};
+  const finishReady = new Promise<void>((r) => {
+    releaseFinish = r;
+  });
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(async () => {
+      await finishReady;
+      child.emitStdout(JSON.stringify({ type: 'result', result: 'ok' }) + '\n');
+      setImmediate(() => child.finish(0));
+    });
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    heartbeatMs: 100,
+    now: () => nowMs,
+    setIntervalFn: (fn) => {
+      scheduledFn = fn;
+      scheduled = true;
+      return { tag: 'fake-interval' };
+    },
+    clearIntervalFn: () => {
+      cleared = true;
+    },
+  });
+  const { emit, frames } = collect();
+
+  const runP = backend.handle(assign('x'), emit, NEVER);
+  // Yield enough microtasks for spawn → register-listeners → schedule
+  // heartbeat to run before we drive ticks.
+  for (let i = 0; i < 10; i++) await new Promise((r) => setImmediate(r));
+  assert.ok(scheduled, 'heartbeat must register a setInterval handler');
+
+  const countStatus = () => frames.filter((f) => f.type === 'task.status').length;
+  assert.equal(countStatus(), 1, 'only the initial task.status: working has been emitted');
+
+  // Tick with no elapsed time → silence < heartbeat → skip.
+  scheduledFn();
+  assert.equal(countStatus(), 1);
+
+  // Advance past the heartbeat threshold → tick must emit one status.
+  nowMs += 250;
+  scheduledFn();
+  assert.equal(countStatus(), 2);
+
+  // Subsequent tick at the same instant must NOT double-fire — the prior
+  // emit refreshed lastEmitAt through the wrapped emitter.
+  scheduledFn();
+  assert.equal(countStatus(), 2);
+
+  // Real traffic also resets the silence window. Let the child finish.
+  releaseFinish();
+  await runP;
+
+  assert.ok(cleared, 'heartbeat handle must be cleared at terminal time');
+  // After terminal frame, no more status frames may be added even if a
+  // stale tick fires (the `settled` guard inside the closure protects
+  // against this — exercise it explicitly).
+  scheduledFn();
+  const lastStatusAfterTerminal = countStatus();
+  assert.equal(
+    lastStatusAfterTerminal,
+    2,
+    'no heartbeat allowed after terminal frame',
+  );
+});
+
+test('heartbeat: heartbeatMs:0 disables the interval entirely', async () => {
+  let registered = false;
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    heartbeatMs: 0,
+    setIntervalFn: () => {
+      registered = true;
+      return null;
+    },
+    clearIntervalFn: () => {},
+  });
+  await backend.handle(assign('x'), collect().emit, NEVER);
+  assert.equal(registered, false, 'heartbeatMs:0 must skip setInterval registration');
+});
+
 test('send_file MCP: server is registered on first task and a registered handle receives invoked artifacts', async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-sendfile-test-'));
   const realRoot = await fs.realpath(root);

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1163,12 +1163,18 @@ test('heartbeat: suppressed after signal.abort so canceled tasks do not look lik
   assert.equal(last.status.state, 'canceled');
 });
 
-test('summarizeToolInput stays bounded for a huge top-level array (no full JSON.stringify)', async () => {
-  // 100k tiny objects in a top-level field. A naive JSON.stringify of
-  // the whole input would produce ~MiBs of output before clipTo trims
-  // it. The bounded serializer must stop walking once the summary is
-  // long enough to be clipped anyway.
-  const huge = { items: Array.from({ length: 100_000 }, (_, i) => ({ i })) };
+test('summarizeToolInput stays bounded for a top-level structure with 100k entries (early-bail walk)', async () => {
+  // The summarizer doesn't recurse — nested structures are summarized
+  // as a `<object>` / `<array(N)>` tag — so we have to put the bulk
+  // *at the top level* to actually exercise the bounded-walk path.
+  // Two shapes drive the two branches:
+  //   - a top-level object with 100k keys → `for..in` early-bail
+  //   - a top-level array  with 100k items → `for(i...)` early-bail
+  // For the test we pick the object branch because it also guards
+  // against regressing the `Object.keys`-allocates-full-list case.
+  const hugeObj: Record<string, number> = {};
+  for (let i = 0; i < 100_000; i++) hugeObj[`k${i}`] = i;
+
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1180,7 +1186,7 @@ test('summarizeToolInput stays bounded for a huge top-level array (no full JSON.
               type: 'tool_use',
               id: 'tu_huge',
               name: 'BulkOp',
-              input: huge,
+              input: hugeObj,
             },
           ],
         },
@@ -1206,11 +1212,15 @@ test('summarizeToolInput stays bounded for a huge top-level array (no full JSON.
     textPart.text.length <= 200,
     `summary length ${textPart.text.length} exceeds cap`,
   );
-  // Bounded serializer should finish well under a second on a 100k-entry
-  // input — a naive full JSON.stringify on this would still be quick on
-  // modern hardware, so this is a smoke check, not a hard SLA. If this
-  // ever fails, something walked the whole structure recursively.
-  assert.ok(elapsedMs < 2000, `summarize took ${elapsedMs}ms — likely walked the full input`);
+  // Smoke check: the early-bail walk should finish in well under a
+  // second. A regression that materializes the full key list (e.g.
+  // reverting to `Object.keys(input)`) is still fast on modern
+  // hardware, so this isn't a hard SLA — but anything walking 100k
+  // values would blow well past a couple of seconds.
+  assert.ok(
+    elapsedMs < 2000,
+    `summarize took ${elapsedMs}ms — likely walked the full input`,
+  );
 });
 
 test('heartbeat: heartbeatMs:0 disables the interval entirely', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -237,7 +237,9 @@ function stringifyValueClipped(v: unknown, clipPerString: number): string {
   }
 }
 
-function summarizeToolInput(input: unknown, clipPerString: number): string {
+// Exported for direct tests of the bounded-walk behavior; the production
+// caller (handleEvent → emitToolCallArtifact) goes through it indirectly.
+export function summarizeToolInput(input: unknown, clipPerString: number): string {
   if (input === undefined || input === null) return '';
   if (typeof input === 'string') return input.slice(0, clipPerString + 1);
   if (typeof input !== 'object') {
@@ -272,7 +274,12 @@ function summarizeToolInput(input: unknown, clipPerString: number): string {
       if (out.length >= budget) break;
       if (!first) out += ',';
       first = false;
-      out += JSON.stringify(k) + ':';
+      // Clip the key too: a 100-KB property name would otherwise drive
+      // a 100-KB+ JSON.stringify allocation just to hit the budget on
+      // the next line. Same `clipPerString` cap applies to keys and
+      // values so the bounded-cost guarantee holds for both.
+      const clippedKey = k.length > clipPerString ? k.slice(0, clipPerString) : k;
+      out += JSON.stringify(clippedKey) + ':';
       out += stringifyValueClipped((input as Record<string, unknown>)[k], clipPerString);
     }
     return out + '}';

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -120,12 +120,19 @@ const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 // in-memory base64 decode and a giant artifact payload on the wire.
 const TOOL_RESULT_MEDIA_MAX_BYTES = 5 * 1024 * 1024;
 
-// Tool-call summary line length. The model's tool_use input can be huge
-// (full file bodies, long Bash commands) and may contain secrets that
-// shouldn't be re-broadcast verbatim on the artifact wire. Truncate to
-// this many characters of `<tool>: <input>` before emitting; the tool
-// name lives in the artifact's data part so consumers can still filter
-// reliably even after the head was clipped.
+// Tool-call summary line length. Bounds the on-wire size of a single
+// `claude-tool-call` artifact's text part — the model's `tool_use.input`
+// can be megabytes (e.g. Write with full file `content`), and we don't
+// want a single tool turn to fill the artifact stream or burn CPU
+// stringifying the whole thing. The structured `toolName` rides on a
+// separate `data` part so consumers still get a stable handle for
+// filtering after the head was clipped.
+//
+// Threat model: SIZE only. Head-truncation is NOT a secrets guard —
+// tokens, keys, or other sensitive values that appear in the first
+// ~200 chars of the input WILL be emitted. Operators that need
+// secret-safe artifacts must add per-tool redaction (or gate input
+// summaries off entirely; #100 part B follow-up).
 const TOOL_CALL_SUMMARY_MAX_CHARS = 200;
 
 // Default idle-silence heartbeat. `dist/backends/claude.js` events that
@@ -192,11 +199,26 @@ interface ToolUseBlock {
   summary: string;
 }
 
-function summarizeToolInput(input: unknown): string {
+// Bounded stringification for a `tool_use.input`. The naive
+// `JSON.stringify(input)` would materialize the entire input as a
+// string before the caller clips to TOOL_CALL_SUMMARY_MAX_CHARS, so a
+// `Write` call with a multi-MiB `content` value would allocate the
+// full multi-MiB output buffer for nothing. We pass a replacer that
+// clips any individual string value to at most `clipPerString` chars
+// before serialization, and we also slice the input itself when it
+// arrives as a bare string. End result: peak intermediate string size
+// is bounded by O(structure-size × clipPerString) instead of the
+// original input size.
+function summarizeToolInput(input: unknown, clipPerString: number): string {
   if (input === undefined || input === null) return '';
-  if (typeof input === 'string') return input;
+  if (typeof input === 'string') return input.slice(0, clipPerString + 1);
   try {
-    return JSON.stringify(input);
+    return JSON.stringify(input, (_key, value) => {
+      if (typeof value === 'string' && value.length > clipPerString) {
+        return value.slice(0, clipPerString);
+      }
+      return value;
+    });
   } catch {
     return '<unserializable>';
   }
@@ -224,7 +246,7 @@ function extractAssistantToolUses(content: unknown): ToolUseBlock[] {
     const toolName = typeof b.name === 'string' ? b.name : '<unknown>';
     const toolUseId = typeof b.id === 'string' ? b.id : '';
     const summary = clipTo(
-      `${toolName}: ${summarizeToolInput(b.input)}`,
+      `${toolName}: ${summarizeToolInput(b.input, TOOL_CALL_SUMMARY_MAX_CHARS)}`,
       TOOL_CALL_SUMMARY_MAX_CHARS,
     );
     out.push({ toolName, toolUseId, summary });
@@ -731,10 +753,12 @@ export function createClaudeBackend(
         heartbeatHandle = setIntervalImpl(() => {
           if (settled) return;
           if (now() - lastEmitAt < heartbeatMs) return;
-          // Bypass `emit` (the wrapper) when assembling the frame, but
-          // route through it so `lastEmitAt` resets — otherwise back-to-
-          // back ticks would queue up if `now()` jumped past the threshold
-          // multiple times in one cycle.
+          // Route through the wrapped `emit` (NOT `rawEmit`): the
+          // wrapper refreshes `lastEmitAt` before forwarding the frame,
+          // so a follow-up tick arriving at the same instant sees a
+          // fresh window and skips. Calling `rawEmit` here would leave
+          // `lastEmitAt` stale and let several ticks emit back-to-back
+          // if the timer fired multiple times after a long pause.
           emit({
             type: 'task.status',
             taskId: task.taskId,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -52,6 +52,15 @@ export interface ClaudeBackendOptions {
    * calls across overlapping tasks are rejected with `ambiguous-task`.
    */
   sendFileMcp?: SendFileMcpOptions;
+  // Idle-silence heartbeat. While a task is running, if no other frame has
+  // gone out for at least `heartbeatMs`, emit a bare `task.status` (state:
+  // working, no message body) so callers and intermediaries (Fly edge,
+  // SSE consumers) see bytes on the wire and don't tear down the
+  // connection as a dead read. Default 30000 ms; pass 0 to disable.
+  heartbeatMs?: number;
+  // Test seam: timer impls. Defaults to global setInterval/clearInterval.
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
 }
 
 interface SessionEntry {
@@ -64,10 +73,21 @@ interface SessionEntry {
   writeId: number;
 }
 
-// claude --output-format stream-json writes one JSON object per line. We
-// surface assistant `text` blocks (one A2A artifact per assistant message)
-// and pass through `tool_result` content of type image/document so MCP
-// screenshot-style tools land as A2A `FilePart`s alongside the text.
+// claude --output-format stream-json writes one JSON object per line.
+// Mapping from stream event → upstream A2A frame:
+//
+//   spawn (initial)            → task.status (state: working)
+//   assistant: text block(s)   → task.artifact (name: claude-message)
+//   assistant: tool_use block  → task.artifact (name: claude-tool-call)
+//   user: tool_result image/PDF→ task.artifact (name: claude-tool-result, file)
+//   user: tool_result text     → dropped (size/secrets policy; see #100)
+//   result                     → task.complete (state: completed)
+//   <heartbeatMs of silence>   → task.status (state: working, no body)
+//
+// Tool inputs are head-truncated to ~200 chars before they hit the wire
+// (`TOOL_CALL_SUMMARY_MAX_CHARS`). The structured tool name + tool_use_id
+// ride along as a `data` part so consumers can filter/count tool calls
+// even when the summary text was clipped.
 interface StreamEvent {
   type?: unknown;
   message?: {
@@ -99,6 +119,21 @@ const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 // (e.g. an MCP screenshot at unbounded resolution) from forcing a huge
 // in-memory base64 decode and a giant artifact payload on the wire.
 const TOOL_RESULT_MEDIA_MAX_BYTES = 5 * 1024 * 1024;
+
+// Tool-call summary line length. The model's tool_use input can be huge
+// (full file bodies, long Bash commands) and may contain secrets that
+// shouldn't be re-broadcast verbatim on the artifact wire. Truncate to
+// this many characters of `<tool>: <input>` before emitting; the tool
+// name lives in the artifact's data part so consumers can still filter
+// reliably even after the head was clipped.
+const TOOL_CALL_SUMMARY_MAX_CHARS = 200;
+
+// Default idle-silence heartbeat. `dist/backends/claude.js` events that
+// do tool work (Bash/Read/Grep/Edit/MCP) can run minute-plus without
+// producing any assistant text — long enough to trip Fly edge and SSE
+// caller idle timeouts. Below this many ms of silence, emit a bare
+// `task.status: working` so bytes keep flowing.
+const DEFAULT_HEARTBEAT_MS = 30_000;
 
 // Defensive stringification — `(e as Error).message` is unsafe when the
 // thrown value is null/undefined or a non-Error primitive (common in JS).
@@ -147,6 +182,52 @@ function extractAssistantText(content: unknown): string {
     if (!block || typeof block !== 'object') continue;
     const b = block as { type?: unknown; text?: unknown };
     if (b.type === 'text' && typeof b.text === 'string') out += b.text;
+  }
+  return out;
+}
+
+interface ToolUseBlock {
+  toolName: string;
+  toolUseId: string;
+  summary: string;
+}
+
+function summarizeToolInput(input: unknown): string {
+  if (input === undefined || input === null) return '';
+  if (typeof input === 'string') return input;
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return '<unserializable>';
+  }
+}
+
+function clipTo(line: string, max: number): string {
+  if (line.length <= max) return line;
+  // 1-char ellipsis keeps the head as long as possible while still
+  // signalling truncation. Callers know the cap; they can recover the
+  // tool name (and full input from a server-side log) if needed.
+  return `${line.slice(0, Math.max(0, max - 1))}…`;
+}
+
+// Pull `tool_use` blocks out of an `assistant`-role message's content
+// array. Each one becomes one `claude-tool-call` artifact upstream, with
+// a head-truncated `<tool>: <input>` summary plus a `data` part carrying
+// the structured tool name + tool_use_id for consumer-side filtering.
+function extractAssistantToolUses(content: unknown): ToolUseBlock[] {
+  if (!Array.isArray(content)) return [];
+  const out: ToolUseBlock[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as { type?: unknown; name?: unknown; id?: unknown; input?: unknown };
+    if (b.type !== 'tool_use') continue;
+    const toolName = typeof b.name === 'string' ? b.name : '<unknown>';
+    const toolUseId = typeof b.id === 'string' ? b.id : '';
+    const summary = clipTo(
+      `${toolName}: ${summarizeToolInput(b.input)}`,
+      TOOL_CALL_SUMMARY_MAX_CHARS,
+    );
+    out.push({ toolName, toolUseId, summary });
   }
   return out;
 }
@@ -261,6 +342,9 @@ export function createClaudeBackend(
   const stderrCap = opts.stderrCaptureBytes ?? 8192;
   const sessionTtlMs = opts.sessionTtlMs ?? 60 * 60 * 1000;
   const now = opts.now ?? Date.now;
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const setIntervalImpl = opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalImpl = opts.clearIntervalFn ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
   const sendFileMcpOpts =
     opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
       ? opts.sendFileMcp
@@ -309,7 +393,17 @@ export function createClaudeBackend(
 
     getSendFileMcpServer: () => sendFileMcp,
 
-    async handle(task, emit, signal) {
+    async handle(task, rawEmit, signal) {
+      // Idle-silence heartbeat needs to observe every outbound frame so it
+      // doesn't fire while real traffic is flowing. Wrap rawEmit so every
+      // emission refreshes `lastEmitAt`. The heartbeat itself goes through
+      // rawEmit directly to avoid a no-op self-trigger loop.
+      let lastEmitAt = now();
+      const emit: typeof rawEmit = (frame) => {
+        lastEmitAt = now();
+        rawEmit(frame);
+      };
+
       if (signal.aborted) {
         emit({
           type: 'task.complete',
@@ -524,11 +618,38 @@ export function createClaudeBackend(
         emittedAnyArtifact = true;
       };
 
+      const emitToolCallArtifact = (block: ToolUseBlock): void => {
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'claude-tool-call',
+            parts: [
+              { kind: 'text', text: block.summary },
+              {
+                kind: 'data',
+                data: { toolName: block.toolName, toolUseId: block.toolUseId },
+              },
+            ],
+          },
+          lastChunk: true,
+        });
+        emittedAnyArtifact = true;
+      };
+
       const handleEvent = (evt: StreamEvent): void => {
         if (settled) return;
         if (evt.type === 'assistant') {
           if (evt.message?.role !== 'assistant') return;
+          // A single assistant turn can interleave plain text and tool_use
+          // blocks. Emit the text (if any) first so observers see "what the
+          // model said" before "what tools it then called", matching the
+          // visible CLI ordering inside that turn.
           emitAssistantArtifact(extractAssistantText(evt.message.content));
+          for (const tu of extractAssistantToolUses(evt.message.content)) {
+            emitToolCallArtifact(tu);
+          }
           return;
         }
         if (evt.type === 'user') {
@@ -601,6 +722,27 @@ export function createClaudeBackend(
         if (stderrTail.length > stderrCap) stderrTail = stderrTail.slice(-stderrCap);
       });
 
+      // Idle-silence heartbeat: while the child is alive, every
+      // `heartbeatMs` of no outbound traffic produces a bare
+      // `task.status: working` so callers and intermediaries see bytes
+      // on the wire. Disabled when heartbeatMs <= 0.
+      let heartbeatHandle: unknown = null;
+      if (heartbeatMs > 0) {
+        heartbeatHandle = setIntervalImpl(() => {
+          if (settled) return;
+          if (now() - lastEmitAt < heartbeatMs) return;
+          // Bypass `emit` (the wrapper) when assembling the frame, but
+          // route through it so `lastEmitAt` resets — otherwise back-to-
+          // back ticks would queue up if `now()` jumped past the threshold
+          // multiple times in one cycle.
+          emit({
+            type: 'task.status',
+            taskId: task.taskId,
+            status: { state: 'working', timestamp: new Date().toISOString() },
+          });
+        }, heartbeatMs);
+      }
+
       const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: unknown }>((resolve) => {
         // The `error` event is *typed* with `Error`, but EventEmitter at
         // runtime can emit any value. Carry it as unknown so the frame
@@ -612,6 +754,7 @@ export function createClaudeBackend(
       signal.removeEventListener('abort', onAbort);
       settled = true;
       sendFileRelease?.();
+      if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
 
       // Flush any trailing line without a newline. claude normally terminates
       // each event with \n but a crash mid-write could leave one orphan.

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -262,7 +262,13 @@ function summarizeToolInput(input: unknown, clipPerString: number): string {
     }
     let out = '{';
     let first = true;
-    for (const k of Object.keys(input)) {
+    // Stream keys via `for..in` rather than `Object.keys`: the latter
+    // allocates the full key array up front, which would itself be
+    // unbounded on a tool input with 100k top-level keys. With `for..in`
+    // we can stop walking as soon as we hit `budget` without paying for
+    // keys we'll never look at.
+    for (const k in input) {
+      if (!Object.prototype.hasOwnProperty.call(input, k)) continue;
       if (out.length >= budget) break;
       if (!first) out += ',';
       first = false;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -84,10 +84,13 @@ interface SessionEntry {
 //   result                     → task.complete (state: completed)
 //   <heartbeatMs of silence>   → task.status (state: working, no body)
 //
-// Tool inputs are head-truncated to ~200 chars before they hit the wire
-// (`TOOL_CALL_SUMMARY_MAX_CHARS`). The structured tool name + tool_use_id
-// ride along as a `data` part so consumers can filter/count tool calls
-// even when the summary text was clipped.
+// The `claude-tool-call` summary line is bounded as a whole: the
+// `<tool>: <input>` text part is hard-capped at TOOL_CALL_SUMMARY_MAX_CHARS
+// (tool-name prefix + JSON overhead included), and the JSON serializer
+// also pre-clips individual string values during walking so a single
+// huge field can't drive a multi-MiB intermediate buffer. The structured
+// tool name + tool_use_id ride along on a `data` part so consumers can
+// filter/count tool calls reliably even after the text was clipped.
 interface StreamEvent {
   type?: unknown;
   message?: {
@@ -200,25 +203,73 @@ interface ToolUseBlock {
 }
 
 // Bounded stringification for a `tool_use.input`. The naive
-// `JSON.stringify(input)` would materialize the entire input as a
-// string before the caller clips to TOOL_CALL_SUMMARY_MAX_CHARS, so a
-// `Write` call with a multi-MiB `content` value would allocate the
-// full multi-MiB output buffer for nothing. We pass a replacer that
-// clips any individual string value to at most `clipPerString` chars
-// before serialization, and we also slice the input itself when it
-// arrives as a bare string. End result: peak intermediate string size
-// is bounded by O(structure-size × clipPerString) instead of the
-// original input size.
+// `JSON.stringify(input)` materializes the whole input as a string
+// before the caller clips to TOOL_CALL_SUMMARY_MAX_CHARS, so a tool
+// with a multi-MiB string field — or a top-level array of 100k tiny
+// values — would allocate a giant intermediate buffer just to chop
+// the first 200 chars. We avoid both:
+//
+//   1. Per-string clip:  any individual string value longer than
+//      `clipPerString` is sliced before serialization.
+//   2. Hard total budget: we walk top-level keys/elements only and
+//      bail out once the accumulator exceeds `budget` chars. The
+//      caller's `clipTo` does the final trim.
+//   3. No recursion:     nested objects / arrays are summarized as a
+//      type tag (`"<object>"` / `"<array(N)>"`) rather than walked,
+//      so depth is irrelevant to cost.
+//
+// Worst-case work is O(top-level-keys × clipPerString) and the
+// returned string itself is bounded by `budget`, regardless of the
+// input's actual size or shape.
+function stringifyValueClipped(v: unknown, clipPerString: number): string {
+  if (typeof v === 'string') {
+    return JSON.stringify(v.length > clipPerString ? v.slice(0, clipPerString) : v);
+  }
+  if (v === null || typeof v === 'number' || typeof v === 'boolean') {
+    return JSON.stringify(v);
+  }
+  if (Array.isArray(v)) return `"<array(${v.length})>"`;
+  if (typeof v === 'object') return '"<object>"';
+  try {
+    return JSON.stringify(String(v));
+  } catch {
+    return '"?"';
+  }
+}
+
 function summarizeToolInput(input: unknown, clipPerString: number): string {
   if (input === undefined || input === null) return '';
   if (typeof input === 'string') return input.slice(0, clipPerString + 1);
+  if (typeof input !== 'object') {
+    try {
+      return String(input).slice(0, clipPerString + 1);
+    } catch {
+      return '<unserializable>';
+    }
+  }
+  // Small overshoot lets the caller's clipTo see we exceeded and apply
+  // its truncation marker; we don't need exact-budget output here.
+  const budget = clipPerString + 16;
   try {
-    return JSON.stringify(input, (_key, value) => {
-      if (typeof value === 'string' && value.length > clipPerString) {
-        return value.slice(0, clipPerString);
+    if (Array.isArray(input)) {
+      let out = '[';
+      for (let i = 0; i < input.length; i++) {
+        if (out.length >= budget) break;
+        if (i > 0) out += ',';
+        out += stringifyValueClipped(input[i], clipPerString);
       }
-      return value;
-    });
+      return out + ']';
+    }
+    let out = '{';
+    let first = true;
+    for (const k of Object.keys(input)) {
+      if (out.length >= budget) break;
+      if (!first) out += ',';
+      first = false;
+      out += JSON.stringify(k) + ':';
+      out += stringifyValueClipped((input as Record<string, unknown>)[k], clipPerString);
+    }
+    return out + '}';
   } catch {
     return '<unserializable>';
   }
@@ -756,6 +807,11 @@ export function createClaudeBackend(
       if (heartbeatMs > 0) {
         heartbeatHandle = setIntervalImpl(() => {
           if (settled) return;
+          // After abort the run is going to settle as `canceled` once
+          // the child finishes tearing down; emitting more
+          // `state: working` heartbeats in that window would actively
+          // misrepresent the task status to the caller. Suppress them.
+          if (aborted) return;
           if (now() - lastEmitAt < heartbeatMs) return;
           // Route through the wrapped `emit` (NOT `rawEmit`): the
           // wrapper refreshes `lastEmitAt` before forwarding the frame,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -416,10 +416,14 @@ export function createClaudeBackend(
     getSendFileMcpServer: () => sendFileMcp,
 
     async handle(task, rawEmit, signal) {
-      // Idle-silence heartbeat needs to observe every outbound frame so it
-      // doesn't fire while real traffic is flowing. Wrap rawEmit so every
-      // emission refreshes `lastEmitAt`. The heartbeat itself goes through
-      // rawEmit directly to avoid a no-op self-trigger loop.
+      // Idle-silence heartbeat needs to observe every outbound frame so
+      // it doesn't fire while real traffic is flowing. Wrap rawEmit so
+      // every emission refreshes `lastEmitAt`. The heartbeat tick also
+      // goes through this wrapped `emit` (NOT `rawEmit`) — that is what
+      // resets `lastEmitAt` on a heartbeat frame so a follow-up tick at
+      // the same instant sees a fresh window and skips. See the tick
+      // site below for the rationale; the two comments must stay
+      // consistent.
       let lastEmitAt = now();
       const emit: typeof rawEmit = (frame) => {
         lastEmitAt = now();


### PR DESCRIPTION
## Summary

Closes part A and part C of #100 (the recommended minimum). Long-
running tool work used to look identical to a hung process — a single
`task.status: working`, then minutes of silence until the final
assistant text. Now the bridge keeps bytes on the wire and surfaces
the actual tool activity:

- **`tool_use` → `claude-tool-call` artifact.** Each `tool_use` block
  inside an `assistant` event becomes one artifact: a head-truncated
  `<tool>: <input>` text part (≤ 200 chars; secrets-and-size guard) and
  a `data` part carrying `{ toolName, toolUseId }` so consumers can
  filter / count tool calls even when the summary was clipped.
- **Idle-silence heartbeat.** New `heartbeatMs` option (default 30 s,
  set to 0 to disable). While a task is running, if no frame has gone
  out for that many ms, emit a bare `task.status: working`. Backstop
  for any case where work happens without an interleaved model turn.

Existing assistant text and image/document `tool_result` passthrough
are unchanged; new frames are strictly additive. Text-only
`tool_result` emission (issue #100 part B) is intentionally left as a
follow-up — its truncation/gating policy isn't settled.

Event → frame mapping (now documented in `claude.ts` and
`docs/claude-e2e.md`):

| stream-json event | upstream frame |
| --- | --- |
| spawn (initial) | `task.status` (working) |
| `assistant` text block | `task.artifact` (`claude-message`) |
| `assistant` `tool_use` block | `task.artifact` (`claude-tool-call`) ← NEW |
| `user` `tool_result` image/PDF | `task.artifact` (`claude-tool-result`, file) |
| `user` `tool_result` text | dropped (#100 part B follow-up) |
| `result` | `task.complete` |
| ≥ heartbeatMs of silence | `task.status` (working, no body) ← NEW |

## Acceptance criteria (from #100)

- [x] `tool_use` blocks in `assistant` events produce a frame on the wire (Option 2: `claude-tool-call` artifact)
- [x] Configurable heartbeat emits `task.status` after ≥ HEARTBEAT_MS of silence
- [x] No frames carry full unbounded tool input/output (200-char head truncation)
- [x] Existing artifact stream consumers (text + media) unchanged in behavior — new frames are additive
- [x] Test added: simulated stream-json with one assistant→tool_use→tool_result→assistant→result sequence produces the expected new frame(s)
- [x] Documented in claude backend docs / inline comment which event types map to which upstream frame

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 144 pass (140 baseline + 4 new):
  - emits a `claude-tool-call` artifact per `tool_use` block in an assistant event
  - truncates a long `tool_use` input summary to a bounded length
  - heartbeat: emits `task.status` after `heartbeatMs` of silence and stops at terminal time
  - heartbeat: `heartbeatMs:0` disables the interval entirely
- [x] `pnpm --filter @vicoop-bridge/client build`
- [ ] e2e: run `node packages/client/scripts/e2e-claude-text-smoke.mjs` and confirm no regression in the existing text-only path
- [ ] e2e (manual): exercise a real tool-heavy task (e.g. a multi-Bash run) and confirm `claude-tool-call` artifacts arrive mid-flight rather than only at completion

## Out of scope (deferred)

- Part B of #100: emitting text `tool_result` content as artifacts. Needs a truncation/gating policy decision (`opts.emitToolResultText: 'truncated' | 'off'`).
- Per-tool ACL / redaction (e.g. always-redact certain tool inputs).
- Mid-message text deltas (would require a different upstream path than stream-json).