### PR TITLE
[codex] Resolve agent cards server-side

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -21,8 +21,8 @@ External A2A Client
         │
 ┌───────┴─────────────────────┐
 │  vicoop-bridge Client       │   사설망
-│  - backend: openclaw | claude-cli | codex | webhook
-│  - AgentCard 제공            │
+│  - backend: echo | openclaw | claude
+│  - backendKind + optional AgentCard override
 │  - task lifecycle 번역       │
 └─────────────────────────────┘
         │
@@ -30,7 +30,9 @@ External A2A Client
   실제 에이전트 프로세스 / API
 ```
 
-- **Server**는 에이전트 종류를 모른다. 순수 A2A 프록시 + 라우터.
+- **Server**는 dispatch 로직을 에이전트 종류에 결합하지 않는다. 다만
+  built-in backend의 AgentCard metadata는 `backendKind`로 canonical card를
+  선택해 서버 배포만으로 갱신할 수 있다.
 - **Client**가 에이전트별 변환을 담당. Claude Code/Codex 같은 CLI 에이전트는 태스크당 subprocess spawn, `--resume` / `--session-id` 로 세션 유지.
 - 연결 방향은 항상 Client → Server (아웃바운드).
 
@@ -51,7 +53,7 @@ vicoop-bridge/
 ## 4. Server ↔ Client Protocol (WS JSON frames)
 
 **Client → Server**
-- `hello`         — `{ agentCard, version, token }`
+- `hello`         — `{ backendKind?, agentCard?, version, token }`
 - `task.status`   — `{ taskId, status }`
 - `task.artifact` — `{ taskId, artifact }`
 - `task.complete` — `{ taskId, result }`
@@ -77,8 +79,8 @@ vicoop-client \
   --backend claude
   # internally: `claude -p --session-id <ctx> --resume ...`
 
-# Codex
-vicoop-client --backend codex
+# Future/custom Codex adapter (not shipped in the current client bundle)
+vicoop-client --backend codex --card ./cards/codex.json
 
 # Generic webhook
 vicoop-client \
@@ -87,9 +89,9 @@ vicoop-client \
   --card ./cards/custom.json
 ```
 
-Built-in backends send a `backendKind` and can use the bridge server's
-canonical AgentCard. `--card` is only needed for operator overrides or custom
-backends.
+Shipped built-in backends (`echo`, `openclaw`, `claude`) send a `backendKind`
+and can use the bridge server's canonical AgentCard. `--card` is only needed
+for operator overrides, older server compatibility, or custom/future backends.
 
 각 backend는 공통 인터페이스를 구현:
 ```ts

--- a/docs/design.md
+++ b/docs/design.md
@@ -70,17 +70,15 @@ vicoop-bridge/
 vicoop-client \
   --server wss://bridge.vicoop.xyz \
   --token $TOKEN \
-  --backend openclaw \
-  --card ./cards/openclaw.json
+  --backend openclaw
 
 # Claude Code
 vicoop-client \
-  --backend claude-cli \
-  --card ./cards/claude-code.json
+  --backend claude
   # internally: `claude -p --session-id <ctx> --resume ...`
 
 # Codex
-vicoop-client --backend codex --card ./cards/codex.json
+vicoop-client --backend codex
 
 # Generic webhook
 vicoop-client \
@@ -88,6 +86,10 @@ vicoop-client \
   --backend-url http://localhost:8080/agent \
   --card ./cards/custom.json
 ```
+
+Built-in backends send a `backendKind` and can use the bridge server's
+canonical AgentCard. `--card` is only needed for operator overrides or custom
+backends.
 
 각 backend는 공통 인터페이스를 구현:
 ```ts

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -132,7 +132,7 @@ include the `login` command used in Step 4:
 ```
 
 If `login --help` prints usage, you're on a current bundle. If it instead
-fails with the daemon usage (`--server`, `--token`, `--agentId`, `--card`)
+fails with the daemon usage (`--server`, `--token`, `--agentId`, `--backend`)
 or doesn't recognize `login`, you're still on an older pre-device-flow
 release and should reinstall into a fresh directory or rerun Step 1 with
 `FORCE=1`.
@@ -239,19 +239,34 @@ This means a Google-only operator can stand up a bridge client without
 ever holding a wallet or seed phrase. Owner is recorded as
 `google:sub:<sub>` (stable id, not the email).
 
-## Step 5 — Prepare the agent card
+## Step 5 — Choose a backend and optional agent card
 
-The bundle ships backend-specific starter cards under `$INSTALL_DIR/cards/`
-(`openclaw.json`, `claude.json`, `echo.json`). Agent cards are published at
-`GET <bridge>/agents/<agent_id>/.well-known/agent-card.json` and describe
-what callers can expect. At minimum you usually want to:
+Pick the local backend this client should drive:
+
+- `openclaw` — OpenClaw gateway at `OPENCLAW_GATEWAY_URL`
+- `claude` — local Claude Code CLI
+- `echo` — smoke-test backend
+
+For these built-in backends, you normally do **not** pass an agent card file.
+The client sends `BACKEND` as `backendKind`, and the bridge server publishes
+the canonical card for that backend at
+`GET <bridge>/agents/<agent_id>/.well-known/agent-card.json`. That keeps
+metadata/capability fixes on the faster server deploy path instead of
+requiring every operator to upgrade their client bundle.
+
+The bundle still ships backend-specific starter cards under
+`$INSTALL_DIR/cards/` (`openclaw.json`, `claude.json`, `echo.json`) for
+operator overrides and compatibility with older bridge servers. Set
+`AGENT_CARD` only when you intentionally want to override the server card,
+for example to:
 
 - Rename `name` to something meaningful (it defaults to `openclaw`).
 - Tighten `description` to what this specific instance actually does.
 - Adjust `skills[]` if you've customized the backend.
 
 Schema reference: `packages/protocol/src/index.ts` (`AgentCard` Zod schema,
-validated by the client at startup — invalid cards exit with a Zod error).
+validated by the client at startup when `AGENT_CARD` is set — invalid cards
+exit with a Zod error).
 
 For custom backends, write a fresh card:
 
@@ -280,7 +295,6 @@ file written by Step 4 can be loaded directly:
 ```sh
 . "$INSTALL_DIR/vicoop-client.env"
 
-AGENT_CARD="$INSTALL_DIR/cards/openclaw.json" \
 BACKEND=openclaw \
   "$INSTALL_DIR/bin/vicoop-client"
 ```
@@ -306,16 +320,14 @@ second WS. Override if yours isn't on the default:
 
 ### Claude-specific env
 
-If you're running the Claude backend, point the client at the bundled
-Claude card and optionally set `CLAUDE_CWD` so Claude works against a
-different repository than the directory where `vicoop-client` itself was
-started:
+If you're running the Claude backend, set `BACKEND=claude` and optionally set
+`CLAUDE_CWD` so Claude works against a different repository than the directory
+where `vicoop-client` itself was started:
 
 ```sh
 SERVER_URL="$SERVER_URL" \
 SERVER_TOKEN="$CLIENT_TOKEN" \
 AGENT_ID="$AGENT_ID" \
-AGENT_CARD="$INSTALL_DIR/cards/claude.json" \
 BACKEND=claude \
 CLAUDE_CWD="$HOME/vicoop-bridge" \
   "$INSTALL_DIR/bin/vicoop-client"
@@ -327,7 +339,6 @@ already-populated `SERVER_URL`, `SERVER_TOKEN`, and `AGENT_ID` assignments:
 ```sh
 . "$INSTALL_DIR/vicoop-client.env"
 
-AGENT_CARD="$INSTALL_DIR/cards/claude.json" \
 BACKEND=claude \
 CLAUDE_CWD="$HOME/vicoop-bridge" \
   "$INSTALL_DIR/bin/vicoop-client"
@@ -347,7 +358,6 @@ On systemd hosts where `install.sh` wrote a unit, update the generated env
 file with the same values used for the foreground run:
 
 ```sh
-AGENT_CARD="$INSTALL_DIR/cards/openclaw.json"
 BACKEND=openclaw
 ```
 
@@ -408,7 +418,8 @@ The upgrade command:
 3. Extracts into `$INSTALL_DIR.new/` (sibling of the current install).
 4. Copies operator files that don't ship with the bundle — notably any
    `cards/*.json` you added or files placed directly under `$INSTALL_DIR`.
-   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`) are always
+   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`) are kept for
+   optional overrides and older server compatibility; they are always
    replaced with the new release's versions.
 5. Runs `node $INSTALL_DIR.new/dist/cli.js --version` as a healthcheck. If it
    exits non-zero or reports the wrong version, `$INSTALL_DIR.new` is deleted
@@ -515,8 +526,9 @@ device flow and can use the admin agent the same way; admin **scope**
   `["openclaw-a", "openclaw-b", ...]`) and run one `vicoop-client` per id.
   No token rotation needed.
 - **Different backends**: in the published bundle today, pass
-  `--backend openclaw`, `--backend claude`, or `--backend echo` with a
-  matching card. Codex and other future backends are still described in
+  `--backend openclaw`, `--backend claude`, or `--backend echo`. Set
+  `--card`/`AGENT_CARD` only when you need to override the server's
+  canonical card. Codex and other future backends are still described in
   `docs/design.md` §5 but are not shipped yet.
 - **Audit/revoke access**: the admin agent exposes `list_caller_tokens`,
   `list_callers`, and `revoke_caller_token` tools; see the tool list in

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -81,28 +81,13 @@ VALUES (
 ) ON CONFLICT (token_hash) DO NOTHING;
 SQL
 
-# 2. Write an agent card.
-cat > /tmp/echo-card.json <<'JSON'
-{
-  "name": "echo",
-  "description": "Echo backend for dispatch testing",
-  "version": "0.0.1",
-  "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": false },
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["text/plain"],
-  "skills": [{ "id": "echo", "name": "echo", "description": "Echo back", "tags": ["echo"] }]
-}
-JSON
-
-# 3. Run the client. NOTE: --server is the base URL WITHOUT /connect — the
+# 2. Run the client. NOTE: --server is the base URL WITHOUT /connect — the
 # client appends /connect itself (client.ts:39). Pass ws:// not http://.
 cd packages/client
 ../../node_modules/.bin/tsx src/cli.ts \
   --server ws://localhost:8787 \
   --token dev-client-token-raw-12345 \
   --agentId echo-agent \
-  --card /tmp/echo-card.json \
   --backend echo
 # logs: [client] connected, sending hello
 ```

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -153,24 +153,10 @@ attempts are silently replaced with the caller's own principal
 ## Step 3 — Run the echo client against WSS
 
 ```bash
-cat > /tmp/echo-card.json <<'JSON'
-{
-  "name": "echo",
-  "description": "Echo backend for e2e testing",
-  "version": "0.0.1",
-  "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": false },
-  "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["text/plain"],
-  "skills": [{ "id": "echo", "name": "echo", "description": "Echo back", "tags": ["echo"] }]
-}
-JSON
-
 (cd packages/client && ../../node_modules/.bin/tsx src/cli.ts \
   --server "$BRIDGE_WS_URL" \
   --token "$CLIENT_TOKEN" \
   --agentId "$AGENT_ID" \
-  --card /tmp/echo-card.json \
   --backend echo) &
 CLIENT_PID=$!
 # logs: [client] connected, sending hello

--- a/install.sh
+++ b/install.sh
@@ -17,9 +17,7 @@
 #   3. Downloads the .tgz + .sha256 and verifies integrity.
 #   4. Extracts the bundle into INSTALL_DIR.
 #   5. On systemd hosts, drops an optional vicoop-client.service unit + env
-#      template (does NOT enable/start — verify a foreground run first). The
-#      shipped bundle already contains cards/openclaw.json, so the env
-#      template points AGENT_CARD at that file by default.
+#      template (does NOT enable/start — verify a foreground run first).
 #   6. Prints next-step instructions for login and a foreground first run.
 
 set -eu
@@ -335,14 +333,13 @@ SERVER_TOKEN=
 # One of the agent IDs allowed for this client token.
 AGENT_ID=
 
-# Absolute path to the agent card JSON (template ships at
-# \$INSTALL_DIR/cards/openclaw.json). Double-quoted so systemd's
-# EnvironmentFile parser accepts the literal value if the path is ever
-# edited to contain spaces.
-AGENT_CARD="$INSTALL_DIR/cards/openclaw.json"
-
-# One of: echo, openclaw (more backends pending, see docs/design.md §5).
+# One of: echo, openclaw, claude.
 BACKEND=openclaw
+
+# Optional operator override for the published AgentCard metadata. Leave unset
+# for the bridge server's canonical card for BACKEND. Double-quote paths with
+# spaces if you enable this in systemd EnvironmentFile syntax.
+#AGENT_CARD="$INSTALL_DIR/cards/openclaw.json"
 
 # --- OpenClaw-only (uncomment if overriding defaults) ---
 #OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789
@@ -361,7 +358,7 @@ ENVF
   # failure mode we could leave behind.
   chmod 600 "$env_file" 2>/dev/null || log "warning: could not chmod 600 $env_file"
 
-  # Warn if a kept env file's AGENT_CARD still points at a different
+  # Warn if a kept env file's optional AGENT_CARD still points at a different
   # install root than the one we just extracted into. We don't rewrite —
   # the operator may have intentionally pointed at a different card — but
   # an invisible stale pointer after \`INSTALL_DIR=\` reinstalls is worse
@@ -397,14 +394,14 @@ Next steps (the agent that owns this client should perform these):
        "$INSTALL_DIR/bin/vicoop-client" -v
        "$INSTALL_DIR/bin/vicoop-client" login --help
 
-     Then follow docs/install-client.md steps 3-5 to pick AGENT_ID, run
-     login, and choose an agent card.
+     Then follow docs/install-client.md steps 3-6 to pick AGENT_ID, run
+     login, choose a backend, and start the client.
 EOF
 
 if [ -n "$SERVICE_INSTALLED" ]; then
   cat <<EOF
   2. First run the client in the foreground with SERVER_URL / SERVER_TOKEN /
-     AGENT_ID / AGENT_CARD / BACKEND. See docs/install-client.md step 6.
+     AGENT_ID / BACKEND. See docs/install-client.md step 6.
 
   3. Optional: after the foreground run works, fill in $SERVICE_ENV_FILE,
      then reload systemd and enable + start the service:
@@ -438,7 +435,6 @@ else
        SERVER_URL=wss://your-server-host \\
        SERVER_TOKEN=... \\
        AGENT_ID=... \\
-       AGENT_CARD="$INSTALL_DIR/cards/openclaw.json" \\
        BACKEND=openclaw \\
          "$INSTALL_DIR/bin/vicoop-client"
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -14,7 +14,7 @@ interface Args {
   server: string;
   token: string;
   agentId: string;
-  card: string;
+  card?: string;
   backend: string;
 }
 
@@ -33,13 +33,19 @@ function parseClientArgs(argv: string[]): Args {
     server: env('SERVER_URL', out.server)!,
     token: env('SERVER_TOKEN', out.token)!,
     agentId: env('AGENT_ID', out.agentId)!,
-    card: env('AGENT_CARD', out.card)!,
+    card: env('AGENT_CARD', out.card),
     backend: env('BACKEND', out.backend) ?? 'echo',
   };
-  const missing = Object.entries(resolved).filter(([, v]) => !v).map(([k]) => k);
+  const required = {
+    server: resolved.server,
+    token: resolved.token,
+    agentId: resolved.agentId,
+    backend: resolved.backend,
+  };
+  const missing = Object.entries(required).filter(([, v]) => !v).map(([k]) => k);
   if (missing.length) {
     console.error(`missing required args: ${missing.join(', ')}`);
-    console.error('usage: vicoop-client --server <ws://...> --token <t> --agentId <id> --card <path> [--backend echo]');
+    console.error('usage: vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude> [--card <path>]');
     process.exit(1);
   }
   return resolved;
@@ -62,14 +68,16 @@ function pickBackend(name: string): Backend {
 
 function runClient(argv: string[]): void {
   const args = parseClientArgs(argv);
-  const cardJson = JSON.parse(readFileSync(args.card, 'utf8'));
-  const agentCard = AgentCard.parse(cardJson);
+  const agentCard = args.card
+    ? AgentCard.parse(JSON.parse(readFileSync(args.card, 'utf8')))
+    : undefined;
 
   const client = new Client({
     serverUrl: args.server,
     token: args.token,
     agentId: args.agentId,
     agentCard,
+    backendKind: args.backend,
     backend: pickBackend(args.backend),
   });
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -15,7 +15,8 @@ export interface ClientOptions {
   serverUrl: string;
   token: string;
   agentId: string;
-  agentCard: AgentCard;
+  agentCard?: AgentCard;
+  backendKind: string;
   backend: Backend;
   maxConcurrency?: number;
   reconnectDelayMs?: number;
@@ -45,7 +46,7 @@ export class Client {
   // backend's actual upstream capability. Cached across reconnects so we
   // don't re-probe on every bridge WS reconnect — the underlying upstream
   // doesn't change mid-process.
-  private effectiveCardPromise: Promise<AgentCard> | null = null;
+  private effectiveCardPromise: Promise<AgentCard | undefined> | null = null;
   private readonly logger: Logger;
 
   constructor(private readonly opts: ClientOptions) {
@@ -71,9 +72,13 @@ export class Client {
     this.ws?.close();
   }
 
-  private resolveEffectiveCard(): Promise<AgentCard> {
+  private resolveEffectiveCard(): Promise<AgentCard | undefined> {
     if (this.effectiveCardPromise) return this.effectiveCardPromise;
     const base = this.opts.agentCard;
+    if (!base) {
+      this.effectiveCardPromise = Promise.resolve(undefined);
+      return this.effectiveCardPromise;
+    }
     const probe = this.opts.backend.resolveCapabilities;
     if (!probe) {
       this.effectiveCardPromise = Promise.resolve(base);
@@ -160,14 +165,15 @@ export class Client {
       // handler coming. Also drop the frame silently if this socket moved
       // out of OPEN before the probe settled — the next `connect()` cycle
       // will issue its own hello.
-      const sendHello = (agentCard: AgentCard): void => {
+      const sendHello = (agentCard: AgentCard | undefined): void => {
         if (ws.readyState !== WebSocket.OPEN) return;
         this.logger.info('connected, sending hello');
         ws.send(
           encodeFrame({
             type: 'hello',
             agentId: this.opts.agentId,
-            agentCard,
+            ...(agentCard ? { agentCard } : {}),
+            backendKind: this.opts.backendKind,
             version: PROTOCOL_VERSION,
             token: this.opts.token,
           }),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -92,10 +92,14 @@ export const AgentCard = z.object({
 });
 export type AgentCard = z.infer<typeof AgentCard>;
 
+export const BackendKind = z.string().min(1);
+export type BackendKind = z.infer<typeof BackendKind>;
+
 export const HelloFrame = z.object({
   type: z.literal('hello'),
   agentId: z.string(),
-  agentCard: AgentCard,
+  agentCard: AgentCard.optional(),
+  backendKind: BackendKind.optional(),
   version: z.literal(PROTOCOL_VERSION),
   token: z.string(),
 });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "vicoop-server": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && rm -rf dist/cards && cp -R src/cards dist/cards",
+    "build": "tsc -p tsconfig.json && node -e \"const fs=require('fs'); fs.rmSync('dist/cards',{recursive:true,force:true}); fs.cpSync('src/cards','dist/cards',{recursive:true});\"",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
     "start": "tsx src/cli.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -8,7 +8,7 @@
     "vicoop-server": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && rm -rf dist/cards && cp -R src/cards dist/cards",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
     "start": "tsx src/cli.ts",

--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { HelloFrame } from '@vicoop-bridge/protocol';
+import { resolveHelloAgentCard } from './card-resolver.js';
+
+function frame(overrides: Partial<HelloFrame>): Pick<HelloFrame, 'agentCard' | 'backendKind'> {
+  return overrides;
+}
+
+test('resolves canonical server card from backendKind when inline card is absent', () => {
+  const result = resolveHelloAgentCard(frame({ backendKind: 'claude' }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.source, 'canonical');
+  assert.equal(result.ok && result.agentCard.name, 'claude');
+  assert.deepEqual(
+    result.ok && result.agentCard.defaultInputModes,
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/pdf'],
+  );
+});
+
+test('inline card overrides backendKind', () => {
+  const inline = {
+    name: 'operator-custom',
+    description: 'custom card',
+    version: '9.9.9',
+    protocolVersion: '0.3.0',
+    capabilities: { streaming: false },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+  };
+
+  const result = resolveHelloAgentCard(frame({ backendKind: 'claude', agentCard: inline }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.source, 'inline');
+  assert.equal(result.ok && result.agentCard.name, 'operator-custom');
+  assert.equal(result.ok && result.agentCard.capabilities?.streaming, false);
+});
+
+test('rejects hello without inline card or backendKind', () => {
+  const result = resolveHelloAgentCard(frame({}));
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: 4012,
+    reason: 'missing agent card or backend kind',
+  });
+});
+
+test('rejects unknown backendKind when no inline card is provided', () => {
+  const result = resolveHelloAgentCard(frame({ backendKind: 'custom' }));
+
+  assert.deepEqual(result, {
+    ok: false,
+    code: 4013,
+    reason: 'unknown backend kind: custom',
+  });
+});

--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -55,6 +55,7 @@ test('rejects unknown backendKind when no inline card is provided', () => {
   assert.deepEqual(result, {
     ok: false,
     code: 4013,
-    reason: 'unknown backend kind: custom',
+    reason: 'unknown backend kind',
+    backendKind: 'custom',
   });
 });

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -1,0 +1,43 @@
+import {
+  AgentCard,
+  type AgentCard as AgentCardType,
+  type HelloFrame,
+} from '@vicoop-bridge/protocol';
+import claudeCard from './cards/claude.json';
+import echoCard from './cards/echo.json';
+import openclawCard from './cards/openclaw.json';
+
+const canonicalCards = new Map<string, AgentCardType>(
+  Object.entries({
+    claude: AgentCard.parse(claudeCard),
+    echo: AgentCard.parse(echoCard),
+    openclaw: AgentCard.parse(openclawCard),
+  }),
+);
+
+export type ResolvedAgentCard =
+  | { ok: true; agentCard: AgentCardType; source: 'inline' | 'canonical' }
+  | { ok: false; code: number; reason: string };
+
+export function resolveHelloAgentCard(
+  frame: Pick<HelloFrame, 'agentCard' | 'backendKind'>,
+): ResolvedAgentCard {
+  if (frame.agentCard) {
+    return { ok: true, agentCard: frame.agentCard, source: 'inline' };
+  }
+
+  if (!frame.backendKind) {
+    return { ok: false, code: 4012, reason: 'missing agent card or backend kind' };
+  }
+
+  const canonical = canonicalCards.get(frame.backendKind);
+  if (!canonical) {
+    return { ok: false, code: 4013, reason: `unknown backend kind: ${frame.backendKind}` };
+  }
+
+  return {
+    ok: true,
+    agentCard: AgentCard.parse(canonical),
+    source: 'canonical',
+  };
+}

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -1,17 +1,20 @@
+import { readFileSync } from 'node:fs';
 import {
   AgentCard,
   type AgentCard as AgentCardType,
   type HelloFrame,
 } from '@vicoop-bridge/protocol';
-import claudeCard from './cards/claude.json' with { type: 'json' };
-import echoCard from './cards/echo.json' with { type: 'json' };
-import openclawCard from './cards/openclaw.json' with { type: 'json' };
+
+function readCanonicalCard(kind: string): AgentCardType {
+  const url = new URL(`./cards/${kind}.json`, import.meta.url);
+  return AgentCard.parse(JSON.parse(readFileSync(url, 'utf8')));
+}
 
 const canonicalCards = new Map<string, AgentCardType>(
   Object.entries({
-    claude: AgentCard.parse(claudeCard),
-    echo: AgentCard.parse(echoCard),
-    openclaw: AgentCard.parse(openclawCard),
+    claude: readCanonicalCard('claude'),
+    echo: readCanonicalCard('echo'),
+    openclaw: readCanonicalCard('openclaw'),
   }),
 );
 

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -3,9 +3,9 @@ import {
   type AgentCard as AgentCardType,
   type HelloFrame,
 } from '@vicoop-bridge/protocol';
-import claudeCard from './cards/claude.json';
-import echoCard from './cards/echo.json';
-import openclawCard from './cards/openclaw.json';
+import claudeCard from './cards/claude.json' with { type: 'json' };
+import echoCard from './cards/echo.json' with { type: 'json' };
+import openclawCard from './cards/openclaw.json' with { type: 'json' };
 
 const canonicalCards = new Map<string, AgentCardType>(
   Object.entries({
@@ -17,7 +17,7 @@ const canonicalCards = new Map<string, AgentCardType>(
 
 export type ResolvedAgentCard =
   | { ok: true; agentCard: AgentCardType; source: 'inline' | 'canonical' }
-  | { ok: false; code: number; reason: string };
+  | { ok: false; code: number; reason: string; backendKind?: string };
 
 export function resolveHelloAgentCard(
   frame: Pick<HelloFrame, 'agentCard' | 'backendKind'>,
@@ -32,12 +32,17 @@ export function resolveHelloAgentCard(
 
   const canonical = canonicalCards.get(frame.backendKind);
   if (!canonical) {
-    return { ok: false, code: 4013, reason: `unknown backend kind: ${frame.backendKind}` };
+    return {
+      ok: false,
+      code: 4013,
+      reason: 'unknown backend kind',
+      backendKind: frame.backendKind,
+    };
   }
 
   return {
     ok: true,
-    agentCard: AgentCard.parse(canonical),
+    agentCard: canonical,
     source: 'canonical',
   };
 }

--- a/packages/server/src/cards/claude.json
+++ b/packages/server/src/cards/claude.json
@@ -1,0 +1,31 @@
+{
+  "name": "claude",
+  "description": "Anthropic Claude Code CLI agent. Spawns the local `claude` binary per task and streams each assistant message back as an A2A artifact. Accepts text, image, and PDF inputs; can return text plus image/PDF outputs from tool results.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": { "streaming": true },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
+  "defaultOutputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`.",
+      "tags": ["chat", "assistant", "claude"]
+    }
+  ]
+}

--- a/packages/server/src/cards/echo.json
+++ b/packages/server/src/cards/echo.json
@@ -1,0 +1,17 @@
+{
+  "name": "echo-agent",
+  "description": "Echoes the first text part back as an artifact and final message.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": { "streaming": false },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [
+    {
+      "id": "echo",
+      "name": "echo",
+      "description": "Returns the input back to the sender.",
+      "tags": ["debug", "smoke-test"]
+    }
+  ]
+}

--- a/packages/server/src/cards/openclaw.json
+++ b/packages/server/src/cards/openclaw.json
@@ -1,0 +1,46 @@
+{
+  "name": "openclaw",
+  "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; when the operator enables outbound file delivery, can also return file artifacts spanning images, PDFs, structured data (JSON/XML/CSV/HTML/Markdown), archives, audio, video, and other binary types.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": { "streaming": true },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/pdf"
+  ],
+  "defaultOutputModes": [
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/html",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/svg+xml",
+    "image/bmp",
+    "application/pdf",
+    "application/json",
+    "application/xml",
+    "application/zip",
+    "application/octet-stream",
+    "audio/mpeg",
+    "audio/wav",
+    "audio/ogg",
+    "video/mp4",
+    "video/quicktime",
+    "video/webm"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
+      "tags": ["chat", "assistant"]
+    }
+  ]
+}

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -128,6 +128,19 @@ async function authenticateAndRegister(
   const clientId = client.id;
   const ownerPrincipal = client.owner_principal;
 
+  const resolvedCard = resolveHelloAgentCard(frame);
+  if (!resolvedCard.ok) {
+    logEvent('client_rejected', {
+      reason: resolvedCard.reason,
+      agentId: frame.agentId,
+      clientId,
+      ...(resolvedCard.backendKind
+        ? { backendKind: truncate(resolvedCard.backendKind, 128) }
+        : {}),
+    });
+    return { ok: false, code: resolvedCard.code, reason: resolvedCard.reason };
+  }
+
   const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerPrincipal, clientId);
   if (!policyResult.ok) {
     logEvent('client_rejected', {
@@ -136,17 +149,6 @@ async function authenticateAndRegister(
       clientId,
     });
     return { ok: false, code: 4010, reason: policyResult.reason };
-  }
-
-  const resolvedCard = resolveHelloAgentCard(frame);
-  if (!resolvedCard.ok) {
-    logEvent('client_rejected', {
-      reason: resolvedCard.reason,
-      agentId: frame.agentId,
-      clientId,
-      backendKind: frame.backendKind,
-    });
-    return { ok: false, code: resolvedCard.code, reason: resolvedCard.reason };
   }
 
   const result = opts.registry.registerAgent({

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -14,6 +14,7 @@ import type { Sql } from './db.js';
 import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
 import { isReservedAgentId } from './reserved-agent-ids.js';
+import { resolveHelloAgentCard } from './card-resolver.js';
 
 interface ClientRow {
   id: string;
@@ -90,7 +91,7 @@ export function attachWsServer(server: Server, opts: ServerWsOptions): void {
 }
 
 type AuthResult =
-  | { ok: true; clientId: string }
+  | { ok: true; clientId: string; cardName: string; cardSource: 'inline' | 'canonical' }
   | { ok: false; code: number; reason: string };
 
 async function authenticateAndRegister(
@@ -137,11 +138,22 @@ async function authenticateAndRegister(
     return { ok: false, code: 4010, reason: policyResult.reason };
   }
 
+  const resolvedCard = resolveHelloAgentCard(frame);
+  if (!resolvedCard.ok) {
+    logEvent('client_rejected', {
+      reason: resolvedCard.reason,
+      agentId: frame.agentId,
+      clientId,
+      backendKind: frame.backendKind,
+    });
+    return { ok: false, code: resolvedCard.code, reason: resolvedCard.reason };
+  }
+
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
     ownerPrincipal,
-    agentCard: frame.agentCard,
+    agentCard: resolvedCard.agentCard,
     allowedCallers: policyResult.allowedCallers,
     ws,
     connectedAt: Date.now(),
@@ -155,7 +167,12 @@ async function authenticateAndRegister(
     return { ok: false, code: 4006, reason: result.reason };
   }
 
-  return { ok: true, clientId };
+  return {
+    ok: true,
+    clientId,
+    cardName: resolvedCard.agentCard.name,
+    cardSource: resolvedCard.source,
+  };
 }
 
 function wireMessageToA2X(
@@ -230,7 +247,8 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         logEvent('client_connected', {
           agentId,
           clientId: result.clientId,
-          name: frame.agentCard.name,
+          name: result.cardName,
+          cardSource: result.cardSource,
         });
       }).catch((err) => {
         console.error('[server] auth error:', err);


### PR DESCRIPTION
## Summary

Implements the Shape A path from #97 so bridge clients can identify their backend kind and let the bridge server resolve the canonical AgentCard when no operator override is provided.

- Extend the bridge hello frame with optional `backendKind` and make inline `agentCard` optional for migration compatibility.
- Send `backendKind` from the client and make `--card` optional; when provided, the inline card is still sent as an operator override.
- Add server-side canonical cards for `echo`, `claude`, and `openclaw`, plus a resolver that prefers inline cards and falls back to the canonical card by backend kind.
- Reject cardless hellos with a missing or unknown backend kind before registering the agent.
- Update install/testing docs and the installer systemd env template so `AGENT_CARD` is documented as optional rather than the default path.
- Address Copilot review feedback around server-card loading, portable build output, bounded close reasons/log fields, early card validation, and design doc consistency.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @vicoop-bridge/protocol build`
- `pnpm -r typecheck`
- `pnpm --filter @vicoop-bridge/server test -- card-resolver`
- `pnpm --filter @vicoop-bridge/client test`
- `pnpm --filter @vicoop-bridge/server build`
- `node -e "import('./packages/server/dist/card-resolver.js').then(m => console.log(m.resolveHelloAgentCard({ backendKind: 'echo' }).ok))"`
- `pnpm --filter @vicoop-bridge/client build`
- `sh -n install.sh`
- `git diff --check`

Closes #97