### PR TITLE
openclaw backend: idle-silence heartbeat (port of #100 part C)

### DIFF
--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -2515,4 +2515,230 @@ test('sendFileMcp: not configured -> getSendFileMcpServer() stays null even afte
   }
 });
 
+test('heartbeat: emits task.status after heartbeatMs of silence and stops at terminal time', async () => {
+  // Initialize as a no-op so the type stays `() => void` instead of
+  // `(() => void) | null`. The closure-mutation path through setIntervalFn
+  // confuses TS narrowing — easier to start callable.
+  let scheduledFn: () => void = () => {};
+  let scheduled = false;
+  let cleared = false;
+  let nowMs = 1_000_000;
+
+  // Hold the chat.send ack so the task stays mid-flight while we drive
+  // heartbeat ticks before the run terminates and clears the interval.
+  let releaseFinish: () => void = () => {};
+  const finishReady = new Promise<void>((r) => {
+    releaseFinish = r;
+  });
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      void (async () => {
+        await finishReady;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-hb', status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: 'run-hb',
+            sessionKey: 'agent:main:ctx-t1',
+            seq: 1,
+            state: 'final',
+            message: { text: 'done' },
+          });
+        });
+      })();
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({
+      url: fake.url,
+      heartbeatMs: 100,
+      now: () => nowMs,
+      setIntervalFn: (fn) => {
+        scheduledFn = fn;
+        scheduled = true;
+        return { tag: 'fake-interval' };
+      },
+      clearIntervalFn: () => {
+        cleared = true;
+      },
+    });
+    const frames: UpFrame[] = [];
+    const runP = backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f), NEVER);
+
+    // Wait for ensureConnected + sessions.messages.subscribe + chat.send
+    // to land before driving ticks. 50ms is enough on loopback.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.ok(scheduled, 'heartbeat must register a setInterval handler');
+
+    const countStatus = () => frames.filter((f) => f.type === 'task.status').length;
+    assert.equal(countStatus(), 1, 'only the initial task.status: working has been emitted');
+
+    // Tick with no elapsed time → silence < heartbeat → skip.
+    scheduledFn();
+    assert.equal(countStatus(), 1);
+
+    // Advance past the heartbeat threshold → tick must emit one status.
+    nowMs += 250;
+    scheduledFn();
+    assert.equal(countStatus(), 2);
+
+    // Subsequent tick at the same instant must NOT double-fire — the prior
+    // emit refreshed lastEmitAt through the wrapped emitter.
+    scheduledFn();
+    assert.equal(countStatus(), 2);
+
+    // Real traffic also resets the silence window. Let the gateway send
+    // its ack + final event.
+    releaseFinish();
+    await runP;
+
+    assert.ok(cleared, 'heartbeat handle must be cleared at terminal time');
+    // After the terminal frame, no more status frames may be added even if
+    // a stale tick fires (the `terminalSettled` guard inside the closure
+    // protects against this — exercise it explicitly).
+    scheduledFn();
+    const lastStatusAfterTerminal = countStatus();
+    assert.equal(
+      lastStatusAfterTerminal,
+      2,
+      'no heartbeat allowed after terminal frame',
+    );
+  } finally {
+    await fake.close();
+  }
+});
+
+test('heartbeat: heartbeatMs:0 disables the interval entirely', async () => {
+  let registered = false;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      sock.send(
+        JSON.stringify({
+          type: 'res',
+          id: req.id,
+          ok: true,
+          payload: { runId: 'run-hb0', status: 'started' },
+        }),
+      );
+      setImmediate(() => {
+        fake.emitChat(sock, {
+          runId: 'run-hb0',
+          sessionKey: 'agent:main:ctx-t1',
+          seq: 1,
+          state: 'final',
+          message: { text: 'ok' },
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({
+      url: fake.url,
+      heartbeatMs: 0,
+      setIntervalFn: () => {
+        registered = true;
+        return null;
+      },
+      clearIntervalFn: () => {},
+    });
+    await backend.handle(makeTask('t1', 'hi'), () => {}, NEVER);
+    assert.equal(registered, false, 'heartbeatMs:0 must skip setInterval registration');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('heartbeat: suppressed after signal.abort so canceled tasks do not look like they are still working', async () => {
+  let scheduledFn: () => void = () => {};
+  let nowMs = 1_000_000;
+  let activeRunId: string | null = null;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        activeRunId = `run-${(req.params as { idempotencyKey: string }).idempotencyKey}`;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: activeRunId, status: 'started' },
+          }),
+        );
+        // Stay silent — the test drives the run to abort.
+      }
+      if (req.method === 'chat.abort') {
+        sock.send(JSON.stringify({ type: 'res', id: req.id, ok: true, payload: {} }));
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: activeRunId,
+            sessionKey: 'agent:main:ctx-t1',
+            seq: 2,
+            state: 'aborted',
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({
+      url: fake.url,
+      heartbeatMs: 100,
+      now: () => nowMs,
+      setIntervalFn: (fn) => {
+        scheduledFn = fn;
+        return { tag: 'fake-interval' };
+      },
+      clearIntervalFn: () => {},
+    });
+    const controller = new AbortController();
+    const frames: UpFrame[] = [];
+    const runP = backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f), controller.signal);
+    // Let the chat.send round-trip land.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Sanity: the heartbeat fires while the task is still working.
+    nowMs += 250;
+    scheduledFn();
+    const before = frames.filter((f) => f.type === 'task.status').length;
+    assert.ok(
+      before >= 2,
+      'heartbeat must emit at least one extra task.status while working',
+    );
+
+    // Abort. Subsequent heartbeat ticks must NOT add more `state: working`
+    // status frames — the run is on its way to a `canceled` terminal frame.
+    controller.abort();
+    nowMs += 250;
+    scheduledFn();
+    nowMs += 250;
+    scheduledFn();
+
+    await runP;
+
+    const workingStatusCount = frames.filter(
+      (f) =>
+        f.type === 'task.status' &&
+        (f as Extract<UpFrame, { type: 'task.status' }>).status.state === 'working',
+    ).length;
+    assert.equal(
+      workingStatusCount,
+      before,
+      'no extra working-state heartbeats may land between abort and terminal frame',
+    );
+    const last = frames.at(-1) as Extract<UpFrame, { type: 'task.complete' }>;
+    assert.equal(last.type, 'task.complete');
+    assert.equal(last.status.state, 'canceled');
+  } finally {
+    await fake.close();
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -534,12 +534,32 @@ export interface OpenclawBackendOptions {
    * rejected with `ambiguous-task`.
    */
   sendFileMcp?: SendFileMcpOptions;
+  /**
+   * Idle-silence heartbeat. While a task is running, if no other frame has
+   * gone out for at least `heartbeatMs`, emit a bare `task.status` (state:
+   * working, no message body) so callers and intermediaries (Fly edge,
+   * SSE consumers) see bytes on the wire and don't tear down the
+   * connection as a dead read. Default 30000 ms; pass 0 to disable.
+   */
+  heartbeatMs?: number;
+  /** Test seam: deterministic clock for heartbeat. Defaults to Date.now. */
+  now?: () => number;
+  /** Test seam: timer impls. Defaults to global setInterval/clearInterval. */
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
 }
 
 const DEFAULT_ATTACH_OUTPUTS_MAX_BYTES = 20 * 1024 * 1024;
 
 const DEFAULT_TASK_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 10 * 1000;
+// Default idle-silence heartbeat. OpenClaw `chat` runs can spend minutes
+// in heavy tool use without producing any `session.message` event — long
+// enough to trip Fly edge / SSE / A2A caller idle timeouts. Below this
+// many ms of silence, emit a bare `task.status: working` so bytes keep
+// flowing. Mirrors the claude backend's heartbeat (issue #100 part C,
+// ported in #102).
+const DEFAULT_HEARTBEAT_MS = 30_000;
 const DEFAULT_DISCOVERY_PROCESS_NAME = 'openclaw';
 const DEFAULT_DISCOVERY_HANDSHAKE_TIMEOUT_MS = 3_000;
 const DISCOVERY_LSOF_TIMEOUT_MS = 2_000;
@@ -764,6 +784,12 @@ export function createOpenclawBackend(
     DEFAULT_HANDSHAKE_TIMEOUT_MS,
     'handshakeTimeoutMs',
   );
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const now = opts.now ?? Date.now;
+  const setIntervalImpl =
+    opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalImpl =
+    opts.clearIntervalFn ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
   const attachOutputs =
     opts.attachOutputs && opts.attachOutputs.allowedRoots.length > 0
       ? (() => {
@@ -1149,7 +1175,20 @@ export function createOpenclawBackend(
       }
     },
 
-    async handle(task, emit, signal) {
+    async handle(task, rawEmit, signal) {
+      // Idle-silence heartbeat needs to observe every outbound frame so it
+      // doesn't fire while real traffic is flowing. Wrap rawEmit so every
+      // emission refreshes `lastEmitAt`. The heartbeat tick also goes
+      // through this wrapped `emit` (NOT `rawEmit`) so a heartbeat frame
+      // resets the silence window — a follow-up tick at the same instant
+      // sees a fresh window and skips. See the tick site below.
+      let lastEmitAt = now();
+      let terminalSettled = false;
+      const emit: typeof rawEmit = (frame) => {
+        lastEmitAt = now();
+        rawEmit(frame);
+      };
+
       // Fast path: the task was canceled before we even started. Emit a
       // terminal canceled frame and do not touch the gateway.
       if (signal.aborted) {
@@ -1193,6 +1232,31 @@ export function createOpenclawBackend(
         taskId: task.taskId,
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
+
+      // Idle-silence heartbeat: while the task is in flight, every
+      // `heartbeatMs` of no outbound traffic produces a bare
+      // `task.status: working` so callers and intermediaries see bytes on
+      // the wire. Disabled when heartbeatMs <= 0. Cleared in finally{}.
+      let heartbeatHandle: unknown = null;
+      if (heartbeatMs > 0) {
+        heartbeatHandle = setIntervalImpl(() => {
+          if (terminalSettled) return;
+          // After abort the run is heading toward a `canceled` terminal
+          // frame; emitting more `state: working` heartbeats in that
+          // window would actively misrepresent the task status. Suppress.
+          if (signal.aborted) return;
+          if (now() - lastEmitAt < heartbeatMs) return;
+          // Route through the wrapped `emit` (NOT `rawEmit`): the wrapper
+          // refreshes `lastEmitAt` before forwarding the frame, so a
+          // follow-up tick arriving at the same instant sees a fresh
+          // window and skips.
+          emit({
+            type: 'task.status',
+            taskId: task.taskId,
+            status: { state: 'working', timestamp: new Date().toISOString() },
+          });
+        }, heartbeatMs);
+      }
 
       // Subscribe to per-message transcript events for this sessionKey so we
       // can forward each assistant message as a separate A2A artifact while
@@ -1551,6 +1615,12 @@ export function createOpenclawBackend(
         // explicit gate close above (synchronous throw, early return), the
         // session.message handler could otherwise still fire for this task.
         sessionMessageSettled = true;
+        // Close the heartbeat gate before clearing the interval so a tick
+        // already pending in the event queue sees `terminalSettled` and
+        // bails instead of squeezing a `state: working` frame in past the
+        // terminal emit.
+        terminalSettled = true;
+        if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
         if (ownedSession && sessionMessageOwners.get(sessionKey)?.taskId === task.taskId) {
           sessionMessageOwners.delete(sessionKey);
         }


### PR DESCRIPTION
## Summary

Closes #102. Ports the idle-silence heartbeat from the `claude` backend (#100 part C / #101) to `openclaw`.

While a task is in flight, if no frame has gone out for ≥ `heartbeatMs` (default 30 s, `0` disables), emit a bare `task.status: working` so callers and Fly edge / SSE intermediaries see bytes on the wire and don't tear the connection down as a dead read. The tool_use half (#100 part A) is intentionally **not** ported — see issue #102 "Out of scope".

## Implementation

Mirrors `claude.ts` exactly:

- `OpenClawBackendOptions` gains `heartbeatMs?: number`, plus `now` / `setIntervalFn` / `clearIntervalFn` test seams.
- Inside `handle()`, the incoming `emit` is wrapped so every emission refreshes `lastEmitAt`. The heartbeat tick routes through the wrapper (not the raw emitter) so a heartbeat frame resets the silence window — a follow-up tick at the same instant sees a fresh window and skips.
- `terminalSettled` flag flips before `clearIntervalImpl` runs, so a tick already pending in the event queue bails instead of squeezing a `state: working` past the terminal frame.
- After `signal.abort` the tick is suppressed — a canceled run is heading toward a `canceled` terminal frame, and emitting more `state: working` heartbeats would actively misrepresent the task status.

## Test plan

- [x] Unit tests added in `openclaw.test.ts` matching `claude.test.ts` shape:
  - `heartbeat: emits task.status after heartbeatMs of silence and stops at terminal time`
  - `heartbeat: heartbeatMs:0 disables the interval entirely`
  - `heartbeat: suppressed after signal.abort so canceled tasks do not look like they are still working`
- [x] All 62 backend tests pass locally (`pnpm exec tsx --test src/backends/openclaw.test.ts`)
- [ ] Soak against a real OpenClaw gateway with a long-running tool task and confirm `task.status: working` frames flow during quiet stretches

## Acceptance criteria (from #102)

- [x] `openclaw.ts` accepts `heartbeatMs` (default 30 000, 0 disables) and `setIntervalFn` / `clearIntervalFn` test seams
- [x] After heartbeatMs of silence during an in-flight task, a bare `task.status: working` frame is emitted
- [x] Heartbeat is cleared at every terminal exit (no late `task.status` after `task.complete` / `task.fail`)
- [x] Existing `session.message` / `chat`-final flow unchanged in behavior — heartbeat is additive
- [x] Unit test added matching the claude.test.ts structure