### PR TITLE
[codex] Fix client WebSocket reconnect

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,8 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { Part, TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { WebSocketServer, type WebSocket } from 'ws';
+import {
+  parseUpFrame,
+  type Part,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
 import type { Backend, Emit } from './backend.js';
-import { processTask, summarizeParts } from './client.js';
+import { Client, processTask, summarizeParts } from './client.js';
 import { type ConsoleSink, createLogger } from './logger.js';
 
 interface CapturedSink {
@@ -51,6 +59,38 @@ function makeAssign(taskId: string): TaskAssignFrame {
 
 function backendOf(name: string, handle: Backend['handle']): Backend {
   return { name, handle };
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address() as AddressInfo;
+  return `ws://127.0.0.1:${addr.port}`;
+}
+
+async function closeServer(server: Server, wss: WebSocketServer): Promise<void> {
+  for (const client of wss.clients) client.terminate();
+  await new Promise<void>((resolve, reject) => {
+    wss.close((wssErr) => {
+      server.close((serverErr) => {
+        const err = wssErr ?? serverErr;
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.fail(message);
 }
 
 test('summarizeParts: empty', () => {
@@ -116,6 +156,52 @@ test('summarizeParts: does not include user-supplied content', () => {
   ];
   const summary = summarizeParts(parts);
   assert.equal(summary.includes(secret), false);
+});
+
+test('Client reconnects after WebSocket close and sends hello again', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  const hellos: UpFrame[] = [];
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', (raw) => {
+      hellos.push(parseUpFrame(typeof raw === 'string' ? raw : raw.toString('utf8')));
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks in this test */
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+  });
+
+  try {
+    client.start();
+    await waitFor(() => hellos.length === 1, 'expected initial hello');
+    connections[0]!.close(1012, 'service restart');
+    await waitFor(() => hellos.length === 2, 'expected hello after reconnect');
+    for (const frame of hellos) {
+      assert.equal(frame.type, 'hello');
+      if (frame.type === 'hello') {
+        assert.equal(frame.agentId, 'agent-1');
+        assert.equal(frame.token, 'client-token');
+      }
+    }
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
 });
 
 // processTask lifecycle tests — exercise the runTask body directly with

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -19,7 +19,17 @@ export interface ClientOptions {
   backendKind: string;
   backend: Backend;
   maxConcurrency?: number;
+  // Initial reconnect delay after an unintentional disconnect. Retries use
+  // exponential backoff from this value up to `reconnectMaxDelayMs`.
   reconnectDelayMs?: number;
+  reconnectMaxDelayMs?: number;
+  reconnectJitterRatio?: number;
+  reconnectStableMs?: number;
+  // WebSocket protocol ping interval. The client terminates the socket when
+  // a previous ping has not received a pong by the next tick, which turns
+  // half-open network failures into a normal reconnect path. Set to 0 to
+  // disable.
+  heartbeatIntervalMs?: number;
   // Upper bound on how long we'll wait for `backend.resolveCapabilities()`
   // before sending the bridge-server hello with the card's declared
   // capabilities. Defaults to 3000 ms — comfortably under the bridge
@@ -36,10 +46,20 @@ export interface ClientOptions {
 }
 
 const DEFAULT_PROBE_DEADLINE_MS = 3000;
+const DEFAULT_RECONNECT_DELAY_MS = 3000;
+const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
+const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;
+const DEFAULT_RECONNECT_STABLE_MS = 60_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 
 export class Client {
   private ws: WebSocket | null = null;
   private stopped = false;
+  private reconnectAttempt = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectResetTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatAwaitingPong = false;
   private inflight = new Map<string, AbortController>();
   // Resolved once per process via backend.resolveCapabilities(); the bridge
   // hello frame is held until this settles so the advertised card matches the
@@ -66,6 +86,9 @@ export class Client {
 
   stop(): void {
     this.stopped = true;
+    this.clearReconnectTimer();
+    this.clearReconnectResetTimer();
+    this.clearHeartbeat();
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
     for (const controller of this.inflight.values()) controller.abort();
@@ -152,6 +175,8 @@ export class Client {
     this.ws = ws;
 
     ws.on('open', () => {
+      this.scheduleReconnectAttemptReset(ws);
+      this.startHeartbeat(ws);
       // The probe runs in parallel with the bridge TCP/WS handshake; by the
       // time `open` fires it's usually already settled. Awaiting here means
       // the bridge-server sees a card whose capabilities match what the
@@ -232,15 +257,21 @@ export class Client {
       }
     });
 
+    ws.on('pong', () => {
+      if (this.ws === ws) this.heartbeatAwaitingPong = false;
+    });
+
     ws.on('close', (code, reason) => {
+      const current = this.ws === ws;
+      if (current) this.clearReconnectResetTimer();
+      if (current) this.clearHeartbeat();
       // `reason` is a remote-controlled byte buffer from the WebSocket
       // close frame; sanitize before logging so a server can't inject a
       // fake `[client] …` line via newlines.
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
-      this.ws = null;
-      if (!this.stopped) {
-        const delay = this.opts.reconnectDelayMs ?? 3000;
-        setTimeout(() => this.connect(), delay);
+      if (current) {
+        this.ws = null;
+        this.scheduleReconnect();
       }
     });
 
@@ -250,6 +281,94 @@ export class Client {
       // applied to the close `reason` and lifecycle logs.
       this.logger.error(`ws error: ${safeToken(err.message)}`);
     });
+  }
+
+  private startHeartbeat(ws: WebSocket): void {
+    this.clearHeartbeat();
+    const intervalMs = this.opts.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+    if (intervalMs <= 0) return;
+    this.heartbeatAwaitingPong = false;
+    this.heartbeatTimer = setInterval(() => {
+      if (this.stopped || this.ws !== ws) return;
+      if (ws.readyState !== WebSocket.OPEN) return;
+      if (this.heartbeatAwaitingPong) {
+        this.logger.warn('connection heartbeat timed out; reconnecting');
+        ws.terminate();
+        return;
+      }
+      this.heartbeatAwaitingPong = true;
+      try {
+        ws.ping();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`connection heartbeat failed (${safeToken(message)}); reconnecting`);
+        ws.terminate();
+      }
+    }, intervalMs);
+    this.heartbeatTimer.unref?.();
+  }
+
+  private clearHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+    this.heartbeatAwaitingPong = false;
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private clearReconnectResetTimer(): void {
+    if (this.reconnectResetTimer) {
+      clearTimeout(this.reconnectResetTimer);
+      this.reconnectResetTimer = null;
+    }
+  }
+
+  private scheduleReconnectAttemptReset(ws: WebSocket): void {
+    this.clearReconnectResetTimer();
+    const stableMs = this.opts.reconnectStableMs ?? DEFAULT_RECONNECT_STABLE_MS;
+    if (stableMs <= 0) {
+      this.reconnectAttempt = 0;
+      return;
+    }
+    this.reconnectResetTimer = setTimeout(() => {
+      this.reconnectResetTimer = null;
+      if (!this.stopped && this.ws === ws && ws.readyState === WebSocket.OPEN) {
+        this.reconnectAttempt = 0;
+      }
+    }, stableMs);
+    this.reconnectResetTimer.unref?.();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    const attempt = this.reconnectAttempt++;
+    const delay = this.nextReconnectDelay(attempt);
+    this.logger.info(`reconnecting in ${delay}ms attempt=${attempt + 1}`);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.logger.info(`reconnect attempt=${attempt + 1}`);
+      this.connect();
+    }, delay);
+    this.reconnectTimer.unref?.();
+  }
+
+  private nextReconnectDelay(attempt: number): number {
+    const base = Math.max(0, this.opts.reconnectDelayMs ?? DEFAULT_RECONNECT_DELAY_MS);
+    const max = Math.max(base, this.opts.reconnectMaxDelayMs ?? DEFAULT_RECONNECT_MAX_DELAY_MS);
+    const capped = Math.min(max, base * 2 ** attempt);
+    const ratio = Math.max(0, this.opts.reconnectJitterRatio ?? DEFAULT_RECONNECT_JITTER_RATIO);
+    if (capped === 0 || ratio === 0) return Math.round(capped);
+    const jitter = capped * ratio;
+    const min = Math.max(0, capped - jitter);
+    const maxWithJitter = Math.min(max, capped + jitter);
+    return Math.round(min + Math.random() * (maxWithJitter - min));
   }
 
   private send(frame: UpFrame): void {


### PR DESCRIPTION
## Summary

Fixes #104.

- Adds bounded exponential reconnect backoff with jitter for the long-running client WebSocket.
- Adds a WebSocket protocol ping/pong heartbeat so half-open or stale connections are terminated and enter the reconnect path.
- Keeps reconnects sending `hello` again so the bridge re-registers the agent after a transient disconnect.
- Adds a client integration-style test that closes the WebSocket and verifies a second `hello` after reconnect.

## Root Cause

The client only retried after the WebSocket emitted `close`, using a fixed delay. Laptop sleep or network interruption can leave the local process alive while the bridge has dropped the registration, and half-open connections may not surface promptly as a close event.

## Validation

- `pnpm --filter @vicoop-bridge/client test`
- `pnpm --filter @vicoop-bridge/client typecheck`