### PR TITLE
protocol: resolve types from source so fresh-checkout typecheck works

### DIFF
--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -4,16 +4,17 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
## Summary
- Fixes #106. `packages/protocol/package.json` resolved types via the gitignored `./dist/index.d.ts`, so on a fresh checkout (or any edit to `protocol/src/*` without a follow-up build) consumer typechecks read stale/missing `.d.ts` and failed with errors pointing at the consumer rather than the protocol source.
- Switch the `types` field and the `types` condition under `exports` to `./src/index.ts`. Runtime resolution (`import`, `default`) still points at `./dist/index.js`, so production startup, `pnpm deploy --prod`, and the release tarball (`node dist/cli.js`) are unchanged.
- Add `src` to `files` so any downstream consumer of a deployed bundle still resolves types cleanly.

This is Option 1 from the issue, in the safest form: types-only source resolution, runtime untouched.

## Why this works
- TypeScript with `moduleResolution: "Bundler"` (set in `tsconfig.base.json`) honors the `types` condition in `exports`. Pointing it at the source `.ts` means consumer `tsc --noEmit` reads the actual source of truth instead of a possibly-stale `.d.ts`.
- The `import`/`default` conditions still resolve to `./dist/index.js`, so `node dist/cli.js` (release tarball runtime) keeps working without changes to `release-client.yml` or `package-client-release.sh`.
- `server-ci.yml`'s `Build protocol` step is now redundant for the typecheck stage, but it remains harmless and still populates `dist/` for any downstream runtime use, so this PR leaves CI alone.

## Test plan
- [x] Repro: `rm -rf packages/protocol/dist && pnpm install && pnpm --filter @vicoop-bridge/client typecheck` — was failing on `main`, now passes.
- [x] `rm -rf packages/{protocol,client,server,admin-ui}/dist && pnpm -r typecheck` — all four projects pass without any prior build.
- [x] `pnpm -r build` still succeeds end-to-end.
- [x] `pnpm -r test` — 129 server tests pass, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)