### PR TITLE
[codex] Fix login help exit code

### DIFF
--- a/packages/client/src/login.test.ts
+++ b/packages/client/src/login.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runLogin } from './login.js';
+
+test('login --help prints usage and exits successfully', async () => {
+  const originalWrite = process.stderr.write;
+  let stderr = '';
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const code = await runLogin(['--help']);
+    assert.equal(code, 0);
+    assert.match(stderr, /usage: vicoop-client login/);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+});

--- a/packages/client/src/login.test.ts
+++ b/packages/client/src/login.test.ts
@@ -2,19 +2,19 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { runLogin } from './login.js';
 
-test('login --help prints usage and exits successfully', async () => {
-  const originalWrite = process.stderr.write;
+test('login help flags print usage and exit successfully', async (t) => {
   let stderr = '';
-  process.stderr.write = ((chunk: string | Uint8Array) => {
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
     stderr += String(chunk);
     return true;
-  }) as typeof process.stderr.write;
+  });
 
-  try {
-    const code = await runLogin(['--help']);
-    assert.equal(code, 0);
-    assert.match(stderr, /usage: vicoop-client login/);
-  } finally {
-    process.stderr.write = originalWrite;
-  }
+  const longCode = await runLogin(['--help']);
+  assert.equal(longCode, 0);
+  assert.match(stderr, /usage: vicoop-client login/);
+
+  stderr = '';
+  const shortCode = await runLogin(['-h']);
+  assert.equal(shortCode, 0);
+  assert.match(stderr, /usage: vicoop-client login/);
 });

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -211,6 +211,11 @@ function writeEnvFile(path: string, success: TokenSuccessResponse, bridgeUrl: st
 }
 
 export async function runLogin(args: string[]): Promise<number> {
+  if (args.includes('-h') || args.includes('--help')) {
+    usage();
+    return 0;
+  }
+
   const parsed = parseArgs(args);
   if (!parsed) return 1;
 

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -78,10 +78,6 @@ function parseArgs(args: string[]): LoginArgs | null {
   };
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
-    if (a === '-h' || a === '--help') {
-      usage();
-      return null;
-    }
     if (a === '--json') {
       out.json = true;
       continue;


### PR DESCRIPTION
## Summary

- Make `vicoop-client login --help` and `login -h` exit successfully after printing usage.
- Add a regression test for the login help path.

## Why

`docs/install-client.md` uses `login --help` as a bundle verification command. It printed the expected usage text, but returned exit code 1 because the login argument parser represented both help and parse errors as `null`.

## Impact

Automated smoke checks can now treat `vicoop-client login --help` as a normal successful help command.

## Validation

- `pnpm --filter @vicoop-bridge/client test` passed: 196 tests
- `pnpm --filter @vicoop-bridge/client typecheck` passed
- `pnpm --filter @vicoop-bridge/client build` passed
- `dist-release/work/vicoop-bridge-client-0.7.0/bin/vicoop-client login --help` returned `exit=0`
- `shasum -a 256 -c dist-release/vicoop-bridge-client-0.7.0.tgz.sha256` passed