### PR TITLE
[codex] Prepare client v0.7.1 release

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump `@vicoop-bridge/client` from `0.7.0` to `0.7.1` for the next client release.

## Why

`client-v0.7.0` is already published. The merged client fixes after that tag need a new release tag, so the package version should match `client-v0.7.1` before tagging.

## Validation

- `pnpm --filter @vicoop-bridge/client test` passed: 199 tests
- `pnpm --filter @vicoop-bridge/client typecheck` passed
- `pnpm --filter @vicoop-bridge/protocol --filter @vicoop-bridge/client build` passed
- `scripts/package-client-release.sh client-v0.7.1` created `dist-release/vicoop-bridge-client-0.7.1.tgz` and `.sha256`
- `shasum -a 256 -c dist-release/vicoop-bridge-client-0.7.1.tgz.sha256` passed
- `dist-release/work/vicoop-bridge-client-0.7.1/bin/vicoop-client -v` printed `0.7.1`
- `dist-release/work/vicoop-bridge-client-0.7.1/bin/vicoop-client login --help` returned `exit=0`