### PR TITLE
[codex] Gate Claude tool traces behind traceability opt-in

### DIFF
--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -181,26 +181,32 @@ image block`. An e2e harness for that path would require a separate MCP
 server that actually returns image blocks; deferred until a real use
 case lands.
 
-## Progress visibility (issue #100)
+## Progress visibility and traces (issues #100, #111)
 
 Long-running tool work used to look identical to a hung process: a
 single `task.status: working` followed by a multi-minute silence until
-the final assistant text. Two additions cover the gap, both unit-tested
-in `claude.test.ts`:
+the final assistant text. The bridge now separates caller-visible
+progress from execution trace details:
 
-- `tool_use` blocks inside an `assistant` event become
-  `claude-tool-call` artifacts. Each artifact carries a head-truncated
-  `<tool>: <input>` text part (≤ 200 chars — **size guard only**, not a
-  secrets guard; tokens or keys appearing in the head will still be
-  emitted) plus a `data` part with `{ toolName, toolUseId }` for
-  filtering. Operators that need secret-safe artifacts must add
-  per-tool redaction or gate input summaries off entirely (#100 part B
-  follow-up).
 - A configurable idle-silence heartbeat (`heartbeatMs`, default 30 s)
   emits a bare `task.status: working` whenever no other frame has gone
   out for that many ms. Disabled with `heartbeatMs: 0`. Backstop for
   any future case where work happens without an interleaved model turn.
+- When the caller opts into the Traceability Extension with
+  `X-A2A-Extensions:
+  https://github.com/a2aproject/a2a-samples/extensions/traceability/v1`,
+  `tool_use` blocks inside an `assistant` event become
+  `claude-tool-call` artifacts. Each artifact carries a head-truncated
+  `<tool>: <input>` text part (<= 200 chars — **size guard only**, not a
+  secrets guard; tokens or keys appearing in the head will still be
+  emitted) plus a `data` part with `{ toolName, toolUseId }` for
+  filtering. The artifact also carries the Traceability Extension URI in
+  `artifact.extensions`.
+- Tool-result image/PDF media from Claude's synthetic `user` events is
+  also treated as trace output and is only emitted when the same
+  extension is requested.
 
 Text-only `tool_result` blocks are still dropped — gating that stream
 needs a truncation policy that hasn't been settled (see #100 "B"). The
-existing image/document passthrough is unchanged.
+explicit `send_file` MCP artifact path is unchanged and remains visible
+without Traceability Extension opt-in.

--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -193,8 +193,7 @@ progress from execution trace details:
   out for that many ms. Disabled with `heartbeatMs: 0`. Backstop for
   any future case where work happens without an interleaved model turn.
 - When the caller opts into the Traceability Extension with
-  `X-A2A-Extensions:
-  https://github.com/a2aproject/a2a-samples/extensions/traceability/v1`,
+  `X-A2A-Extensions: https://github.com/a2aproject/a2a-samples/extensions/traceability/v1`,
   `tool_use` blocks inside an `assistant` event become
   `claude-tool-call` artifacts. Each artifact carries a head-truncated
   `<tool>: <input>` text part (<= 200 chars — **size guard only**, not a

--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -3,7 +3,16 @@
   "description": "Anthropic Claude Code CLI agent. Spawns the local `claude` binary per task and streams each assistant message back as an A2A artifact. Accepts text, image, and PDF inputs; can return text plus image/PDF outputs from tool results.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": true },
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Claude Code tool calls and tool-result media.",
+        "required": false
+      }
+    ]
+  },
   "defaultInputModes": [
     "text/plain",
     "image/png",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -833,6 +833,7 @@ test('coalesces split stdout chunks (partial line across data events)', async ()
 
 test('skips tool_result media whose decoded bytes match an inbound FilePart (input echo dedup)', async () => {
   const sharedBytes = 'iVBORw0KAA==';
+  const distinctBytes = 'ZGlzdGluY3Q=';
   const fake = scriptedSpawn({
     lines: [
       // Same base64 the caller sent on stdin — the model "Read" the input.
@@ -849,6 +850,10 @@ test('skips tool_result media whose decoded bytes match an inbound FilePart (inp
                   type: 'image',
                   source: { type: 'base64', media_type: 'image/png', data: sharedBytes },
                 },
+                {
+                  type: 'image',
+                  source: { type: 'base64', media_type: 'image/png', data: distinctBytes },
+                },
               ],
             },
           ],
@@ -864,6 +869,7 @@ test('skips tool_result media whose decoded bytes match an inbound FilePart (inp
     type: 'task.assign',
     taskId: 't',
     contextId: 'c',
+    requestedExtensions: [TRACEABILITY_EXTENSION_URI],
     message: {
       role: 'user',
       messageId: 'm',
@@ -881,9 +887,16 @@ test('skips tool_result media whose decoded bytes match an inbound FilePart (inp
   );
   assert.equal(
     fileArtifacts.length,
-    0,
-    'tool_result whose bytes echo the inbound FilePart must not re-emit',
+    1,
+    'Traceability-enabled tool_result media should emit only non-echo files',
   );
+  const part = fileArtifacts[0].artifact.parts[0];
+  assert.equal(part.kind, 'file');
+  if (part.kind === 'file') {
+    assert.equal(part.file.bytes, distinctBytes);
+  }
+  assert.deepEqual(fileArtifacts[0].artifact.extensions, [TRACEABILITY_EXTENSION_URI]);
+  assert.equal(fileArtifacts[0].artifact.metadata?.traceType, 'tool-result');
 });
 
 test('emits FilePart artifact when tool_result contains an image block', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -10,7 +10,11 @@ import {
   type ClaudeChildHandle,
   type ClaudeSpawnOptions,
 } from './claude.js';
-import type { TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
+import {
+  TRACEABILITY_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
 
 const NEVER: AbortSignal = new AbortController().signal;
 
@@ -149,6 +153,13 @@ function assign(text: string): TaskAssignFrame {
       messageId: 'm1',
       parts: [{ kind: 'text', text }],
     },
+  };
+}
+
+function assignWithTraceability(text: string): TaskAssignFrame {
+  return {
+    ...assign(text),
+    requestedExtensions: [TRACEABILITY_EXTENSION_URI],
   };
 }
 
@@ -902,13 +913,15 @@ test('emits FilePart artifact when tool_result contains an image block', async (
   });
   const backend = createClaudeBackend({ spawn: fake.spawn });
   const { emit, frames } = collect();
-  await backend.handle(assign('x'), emit, NEVER);
+  await backend.handle(assignWithTraceability('x'), emit, NEVER);
 
   const fileArtifact = frames.find(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
       f.type === 'task.artifact' && f.artifact.parts[0]?.kind === 'file',
   );
   assert.ok(fileArtifact, 'expected a FilePart artifact for tool_result image');
+  assert.deepEqual(fileArtifact.artifact.extensions, [TRACEABILITY_EXTENSION_URI]);
+  assert.equal(fileArtifact.artifact.metadata?.traceType, 'tool-result');
   const part = fileArtifact.artifact.parts[0];
   assert.equal(part.kind, 'file');
   if (part.kind === 'file') {
@@ -917,7 +930,7 @@ test('emits FilePart artifact when tool_result contains an image block', async (
   }
 });
 
-test('emits a claude-tool-call artifact per tool_use block in an assistant event', async () => {
+test('suppresses Claude tool trace artifacts unless Traceability Extension is requested', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -967,6 +980,62 @@ test('emits a claude-tool-call artifact per tool_use block in an assistant event
   const artifacts = frames.filter(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
   );
+  assert.deepEqual(
+    artifacts.map((a) => a.artifact.name),
+    ['claude-message', 'claude-message'],
+  );
+});
+
+test('emits a trace claude-tool-call artifact per tool_use block when requested', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Let me check the directory.' },
+            {
+              type: 'tool_use',
+              id: 'tu_1',
+              name: 'Bash',
+              input: { command: 'ls -la /tmp' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              tool_use_id: 'tu_1',
+              type: 'tool_result',
+              content: [{ type: 'text', text: 'total 0' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'No files.' }],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'No files.' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assignWithTraceability('list /tmp'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
   const names = artifacts.map((a) => a.artifact.name);
   assert.deepEqual(
     names,
@@ -976,6 +1045,8 @@ test('emits a claude-tool-call artifact per tool_use block in an assistant event
 
   const callArtifact = artifacts[1];
   assert.equal(callArtifact.lastChunk, true);
+  assert.deepEqual(callArtifact.artifact.extensions, [TRACEABILITY_EXTENSION_URI]);
+  assert.equal(callArtifact.artifact.metadata?.traceType, 'tool-call');
   assert.equal(callArtifact.artifact.parts.length, 2);
   const textPart = callArtifact.artifact.parts[0];
   assert.equal(textPart.kind, 'text');
@@ -1021,7 +1092,7 @@ test('truncates a long tool_use input summary to a bounded length', async () => 
   });
   const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
   const { emit, frames } = collect();
-  await backend.handle(assign('x'), emit, NEVER);
+  await backend.handle(assignWithTraceability('x'), emit, NEVER);
 
   const callArtifact = frames.find(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -759,12 +759,14 @@ export function createClaudeBackend(
           // model said" before "what tools it then called", matching the
           // visible CLI ordering inside that turn.
           emitAssistantArtifact(extractAssistantText(evt.message.content));
+          if (!emitTraceArtifacts) return;
           for (const tu of extractAssistantToolUses(evt.message.content)) {
             emitToolCallArtifact(tu);
           }
           return;
         }
         if (evt.type === 'user') {
+          if (!emitTraceArtifacts) return;
           // tool_result events come in as a synthetic user message in the
           // stream-json transcript; pull out any image/document blocks and
           // emit them as A2A FileParts. Text-only tool results are skipped.

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import type { Part } from '@vicoop-bridge/protocol';
+import { TRACEABILITY_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
 import {
   startSendFileMcpServer,
@@ -78,11 +78,16 @@ interface SessionEntry {
 //
 //   spawn (initial)            → task.status (state: working)
 //   assistant: text block(s)   → task.artifact (name: claude-message)
-//   assistant: tool_use block  → task.artifact (name: claude-tool-call)
-//   user: tool_result image/PDF→ task.artifact (name: claude-tool-result, file)
+//   assistant: tool_use block  → trace task.artifact when requested
+//   user: tool_result image/PDF→ trace task.artifact when requested
 //   user: tool_result text     → dropped (size/secrets policy; see #100)
 //   result                     → task.complete (state: completed)
 //   <heartbeatMs of silence>   → task.status (state: working, no body)
+//
+// Traceability Extension opt-in is per A2A request. Without it,
+// `claude-tool-call` and `claude-tool-result` are suppressed so regular
+// clients see only assistant-facing messages and explicit `send_file`
+// artifacts.
 //
 // The `claude-tool-call` summary line is bounded as a whole: the
 // `<tool>: <input>` text part is hard-capped at TOOL_CALL_SUMMARY_MAX_CHARS
@@ -294,6 +299,16 @@ function clipTo(line: string, max: number): string {
   // signalling truncation. Callers know the cap; they can recover the
   // tool name (and full input from a server-side log) if needed.
   return `${line.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function traceabilityRequested(task: {
+  requestedExtensions?: readonly string[];
+  message?: { extensions?: readonly string[] };
+}): boolean {
+  return (
+    task.requestedExtensions?.includes(TRACEABILITY_EXTENSION_URI) === true ||
+    task.message?.extensions?.includes(TRACEABILITY_EXTENSION_URI) === true
+  );
 }
 
 // Pull `tool_use` blocks out of an `assistant`-role message's content
@@ -653,6 +668,7 @@ export function createClaudeBackend(
       let stderrTail = '';
       let aborted = false;
       let settled = false;
+      const emitTraceArtifacts = traceabilityRequested(task);
 
       // Register this task with the send_file MCP server (if running) so
       // tool calls landing during this run resolve to this task's emit().
@@ -694,6 +710,7 @@ export function createClaudeBackend(
       };
 
       const emitToolResultMedia = (parts: Part[]): void => {
+        if (!emitTraceArtifacts) return;
         if (parts.length === 0) return;
         emit({
           type: 'task.artifact',
@@ -702,6 +719,8 @@ export function createClaudeBackend(
             artifactId: randomUUID(),
             name: 'claude-tool-result',
             parts,
+            extensions: [TRACEABILITY_EXTENSION_URI],
+            metadata: { traceType: 'tool-result' },
           },
           lastChunk: true,
         });
@@ -709,6 +728,7 @@ export function createClaudeBackend(
       };
 
       const emitToolCallArtifact = (block: ToolUseBlock): void => {
+        if (!emitTraceArtifacts) return;
         emit({
           type: 'task.artifact',
           taskId: task.taskId,
@@ -722,6 +742,8 @@ export function createClaudeBackend(
                 data: { toolName: block.toolName, toolUseId: block.toolUseId },
               },
             ],
+            extensions: [TRACEABILITY_EXTENSION_URI],
+            metadata: { traceType: 'tool-call' },
           },
           lastChunk: true,
         });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 
 export const PROTOCOL_VERSION = '0.1';
+export const TRACEABILITY_EXTENSION_URI =
+  'https://github.com/a2aproject/a2a-samples/extensions/traceability/v1';
 
 export const TextPart = z.object({
   kind: z.literal('text'),
@@ -29,6 +31,8 @@ export const Message = z.object({
   role: z.enum(['user', 'agent']),
   parts: z.array(Part),
   messageId: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  extensions: z.array(z.string()).optional(),
 });
 export type Message = z.infer<typeof Message>;
 
@@ -53,6 +57,8 @@ export const Artifact = z.object({
   artifactId: z.string(),
   name: z.string().optional(),
   parts: z.array(Part),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  extensions: z.array(z.string()).optional(),
 });
 export type Artifact = z.infer<typeof Artifact>;
 
@@ -62,6 +68,14 @@ export const AgentSkill = z.object({
   description: z.string().optional(),
   tags: z.array(z.string()).optional(),
 });
+
+export const AgentExtension = z.object({
+  uri: z.string(),
+  description: z.string().optional(),
+  required: z.boolean().optional(),
+  params: z.record(z.string(), z.unknown()).optional(),
+});
+export type AgentExtension = z.infer<typeof AgentExtension>;
 
 export const SecurityScheme = z.object({
   type: z.string(),
@@ -82,6 +96,7 @@ export const AgentCard = z.object({
     .object({
       streaming: z.boolean().optional(),
       pushNotifications: z.boolean().optional(),
+      extensions: z.array(AgentExtension).optional(),
     })
     .optional(),
   defaultInputModes: z.array(z.string()).optional(),
@@ -155,6 +170,7 @@ export const TaskAssignFrame = z.object({
   taskId: z.string(),
   contextId: z.string(),
   message: Message,
+  requestedExtensions: z.array(z.string()).optional(),
 });
 
 export const TaskCancelFrame = z.object({

--- a/packages/server/src/a2a-extensions.test.ts
+++ b/packages/server/src/a2a-extensions.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseA2AExtensionsHeader } from './a2a-extensions.js';
+
+test('parseA2AExtensionsHeader trims, drops empties, and dedupes in order', () => {
+  assert.deepEqual(
+    parseA2AExtensionsHeader(' https://example.test/a , ,https://example.test/b,https://example.test/a '),
+    ['https://example.test/a', 'https://example.test/b'],
+  );
+});
+
+test('parseA2AExtensionsHeader returns empty list when absent', () => {
+  assert.deepEqual(parseA2AExtensionsHeader(undefined), []);
+});

--- a/packages/server/src/a2a-extensions.ts
+++ b/packages/server/src/a2a-extensions.ts
@@ -1,0 +1,15 @@
+export const A2A_EXTENSIONS_HEADER = 'X-A2A-Extensions';
+export const A2A_EXTENSIONS_LEGACY_HEADER = 'A2A-Extensions';
+
+export function parseA2AExtensionsHeader(value: string | undefined): string[] {
+  if (!value) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const part of value.split(',')) {
+    const uri = part.trim();
+    if (!uri || seen.has(uri)) continue;
+    seen.add(uri);
+    out.push(uri);
+  }
+  return out;
+}

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { InMemoryTaskStore, type AgentCardV03 } from '@a2x/sdk';
+import { TRACEABILITY_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
+import { buildAgentA2XAgent } from './agent-card.js';
+import { Registry, type ClientConnection } from './registry.js';
+
+function fakeConn(card: AgentCard): ClientConnection {
+  return {
+    agentId: 'claude',
+    clientId: 'client-1',
+    ownerPrincipal: 'eth:0x0000000000000000000000000000000000000001',
+    agentCard: card,
+    allowedCallers: [],
+    ws: {} as ClientConnection['ws'],
+    connectedAt: Date.now(),
+  };
+}
+
+test('buildAgentA2XAgent preserves advertised optional extensions', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn({
+      name: 'claude',
+      description: 'Claude Code',
+      version: '0.0.1',
+      protocolVersion: '0.3.0',
+      capabilities: {
+        streaming: true,
+        extensions: [{ uri: TRACEABILITY_EXTENSION_URI, required: false }],
+      },
+      skills: [],
+    }),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  assert.deepEqual(card.capabilities.extensions, [
+    { uri: TRACEABILITY_EXTENSION_URI, required: false },
+  ]);
+});

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -57,6 +57,10 @@ export function buildAgentA2XAgent(
       pushNotifications: wire.capabilities?.pushNotifications ?? false,
     });
 
+  for (const extension of wire.capabilities?.extensions ?? []) {
+    a2xAgent.addExtension(extension);
+  }
+
   for (const skill of wire.skills ?? []) {
     a2xAgent.addSkill({
       id: skill.id,
@@ -99,4 +103,3 @@ export function buildAgentA2XAgent(
 
   return a2xAgent;
 }
-

--- a/packages/server/src/cards/claude.json
+++ b/packages/server/src/cards/claude.json
@@ -3,7 +3,16 @@
   "description": "Anthropic Claude Code CLI agent. Spawns the local `claude` binary per task and streams each assistant message back as an A2A artifact. Accepts text, image, and PDF inputs; can return text plus image/PDF outputs from tool results.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": true },
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Claude Code tool calls and tool-result media.",
+        "required": false
+      }
+    ]
+  },
   "defaultInputModes": [
     "text/plain",
     "image/png",

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -101,7 +101,10 @@ export class WSForwardingExecutor extends AgentExecutor {
         // the parts through as-is.
         parts: message.parts as never,
         messageId: message.messageId,
+        ...(message.metadata !== undefined ? { metadata: message.metadata } : {}),
+        ...(message.extensions !== undefined ? { extensions: message.extensions } : {}),
       },
+      ...(message.extensions !== undefined ? { requestedExtensions: message.extensions } : {}),
     });
 
     if (!sent) {

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -54,7 +54,12 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     '*',
     cors({
       origin: (origin) => origin ?? '',
-      allowHeaders: ['Authorization', 'Content-Type'],
+      allowHeaders: [
+        'Authorization',
+        'Content-Type',
+        A2A_EXTENSIONS_HEADER,
+        A2A_EXTENSIONS_LEGACY_HEADER,
+      ],
       allowMethods: ['GET', 'POST', 'OPTIONS'],
       credentials: true,
       maxAge: 600,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -42,6 +42,10 @@ export interface ServerHttpOptions {
   deviceFlowStateSecret?: string;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 export function createHttpApp(opts: ServerHttpOptions): Hono {
   const app = new Hono();
 
@@ -270,9 +274,10 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     const rawBody = await c.req.text();
     const parsed = JSON.parse(rawBody);
 
-    if (parsed.params?.message) {
-      parsed.params.message.metadata = {
-        ...parsed.params.message.metadata,
+    const message = parsed.params?.message;
+    if (isRecord(message)) {
+      message.metadata = {
+        ...(isRecord(message.metadata) ? message.metadata : {}),
         _principalId: principalId,
         _bearerToken: bearerToken,
         ...(callerEmail !== undefined ? { _email: callerEmail } : {}),
@@ -348,11 +353,12 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_HEADER)),
       ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_LEGACY_HEADER)),
     ];
-    if (requestedExtensions.length > 0 && parsed.params?.message) {
-      const existing = Array.isArray(parsed.params.message.extensions)
-        ? parsed.params.message.extensions.filter((v: unknown): v is string => typeof v === 'string')
+    const message = parsed.params?.message;
+    if (requestedExtensions.length > 0 && isRecord(message)) {
+      const existing = Array.isArray(message.extensions)
+        ? message.extensions.filter((v: unknown): v is string => typeof v === 'string')
         : [];
-      parsed.params.message.extensions = [...new Set([...existing, ...requestedExtensions])];
+      message.extensions = [...new Set([...existing, ...requestedExtensions])];
     }
     const handler = getHandlerForConn(conn);
     const result = await handler.handle(parsed);

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -43,7 +43,7 @@ export interface ServerHttpOptions {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export function createHttpApp(opts: ServerHttpOptions): Hono {

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -17,6 +17,11 @@ import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from '.
 import { mountDeviceFlow } from './auth/device-flow.js';
 import { mountDeviceUi } from './auth/device-ui.js';
 import { mountSiweExchange } from './auth/siwe-exchange.js';
+import {
+  A2A_EXTENSIONS_HEADER,
+  A2A_EXTENSIONS_LEGACY_HEADER,
+  parseA2AExtensionsHeader,
+} from './a2a-extensions.js';
 import type { GoogleConfig } from './auth/google-oauth.js';
 import type { Sql } from './db.js';
 import { Landing } from './landing.js';
@@ -334,6 +339,16 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
     const rawBody = await c.req.text();
     const parsed = JSON.parse(rawBody);
+    const requestedExtensions = [
+      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_HEADER)),
+      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_LEGACY_HEADER)),
+    ];
+    if (requestedExtensions.length > 0 && parsed.params?.message) {
+      const existing = Array.isArray(parsed.params.message.extensions)
+        ? parsed.params.message.extensions.filter((v: unknown): v is string => typeof v === 'string')
+        : [];
+      parsed.params.message.extensions = [...new Set([...existing, ...requestedExtensions])];
+    }
     const handler = getHandlerForConn(conn);
     const result = await handler.handle(parsed);
     return handleHandlerResult(result, c);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -191,6 +191,8 @@ function wireMessageToA2X(
     // either (text-part guard hits on `'text' in part`; file/data fall
     // through to fallback that spreads). Cast keeps type-checker happy.
     parts: m.parts as unknown as Message['parts'],
+    ...(m.metadata !== undefined ? { metadata: m.metadata } : {}),
+    ...(m.extensions !== undefined ? { extensions: m.extensions } : {}),
     taskId,
     contextId,
   };
@@ -280,6 +282,8 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           artifact: {
             artifactId: frame.artifact.artifactId,
             ...(frame.artifact.name !== undefined ? { name: frame.artifact.name } : {}),
+            ...(frame.artifact.metadata !== undefined ? { metadata: frame.artifact.metadata } : {}),
+            ...(frame.artifact.extensions !== undefined ? { extensions: frame.artifact.extensions } : {}),
             // Wire-shape parts; see wireMessageToA2X for the shape note.
             parts: frame.artifact.parts as unknown as Part[] as never,
           },


### PR DESCRIPTION
## Summary

- advertises the A2A Traceability Extension on Claude agent cards
- forwards `X-A2A-Extensions` / legacy `A2A-Extensions` request opt-ins through the bridge WS protocol
- suppresses Claude `tool_use` / tool-result media artifacts by default and emits them only as trace artifacts when traceability is requested
- preserves artifact/message metadata and extensions through the server mapper

Fixes #111

## Validation

- `pnpm --filter @vicoop-bridge/protocol typecheck`
- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/server typecheck`
- `pnpm --filter @vicoop-bridge/client test -- src/backends/claude.test.ts`
- `pnpm --filter @vicoop-bridge/server test`
- `pnpm -r build`
