### PR TITLE
[codex] Accept uri-only FileParts

### DIFF
--- a/docs/claude-e2e.md
+++ b/docs/claude-e2e.md
@@ -16,7 +16,7 @@ discovery, model behavior on tool use). This guide fills that gap.
 - `claude` on `PATH` and authenticated. Verify with `claude --version`.
 - Repo built: `pnpm install && pnpm --filter @vicoop-bridge/client build`.
 - Network egress to the Anthropic API. Each harness consumes real
-  inference credits; total cost across the four scripts is small (single
+  inference credits; total cost across the five scripts is small (single
   digits of cents at current rates) but non-zero.
 
 The harnesses live under `packages/client/scripts/` and each one is a
@@ -59,7 +59,22 @@ node packages/client/scripts/e2e-claude-input-image.mjs
 
 Expected (≈ 11 s): final assistant text `red`.
 
-### 3. PDF input — `e2e-claude-input-pdf.mjs`
+### 3. URI image input — `e2e-claude-input-image-uri.mjs`
+
+A public 1×1 solid-red PNG URL is sent as a uri-only `FilePart` with no
+inline `bytes`, and the harness asserts the model's reply mentions
+`red`. Confirms bridge clients fetch inbound file URIs before building
+the Claude vision content block.
+
+```bash
+node packages/client/scripts/e2e-claude-input-image-uri.mjs
+# Override the fixture URI:
+E2E_IMAGE_URI=https://example.com/red.png node packages/client/scripts/e2e-claude-input-image-uri.mjs
+```
+
+Expected (≈ 6 s): final assistant text `red`.
+
+### 4. PDF input — `e2e-claude-input-pdf.mjs`
 
 Generates a 1-page PDF on the fly with a known word (default `KUMQUAT`)
 drawn in Helvetica, sends it as a `FilePart` with `mimeType:
@@ -74,7 +89,7 @@ E2E_PDF_WORD=PINEAPPLE node packages/client/scripts/e2e-claude-input-pdf.mjs
 
 Expected (≈ 7 s): final assistant text equals the secret word.
 
-### 4. send_file MCP — `e2e-claude-send-file.mjs`
+### 5. send_file MCP — `e2e-claude-send-file.mjs`
 
 Most complex path. The harness:
 
@@ -172,6 +187,7 @@ present in argv) or is blocked on the first model call. Re-run with
 |---|---|---|
 | Text → text | text-smoke | stream-json stdin envelope, `--session-id`, `result` event parsing |
 | Image FilePart → model | input-image | image content block reaches vision |
+| URI image FilePart → model | input-image-uri | client-side file URI fetch, image content block reaches vision |
 | PDF FilePart → model | input-pdf | document content block reaches doc parser |
 | Model → file artifact | send-file | `--mcp-config` injection, R1 routing, MCP `send_file` tool, bounded read, `task.artifact` round-trip |
 

--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -33,7 +33,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`.",
+      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / 10 s policy).",
       "tags": ["chat", "assistant", "claude"]
     }
   ]

--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -33,7 +33,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / 10 s policy).",
+      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / default 10 s policy).",
       "tags": ["chat", "assistant", "claude"]
     }
   ]

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -39,7 +39,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / 10 s policy). When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / default 10 s policy). When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
       "tags": ["chat", "assistant"]
     }
   ]

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -39,7 +39,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Include image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as either `file.bytes` or `file.uri` (https only; bridge fetches under a 5 MiB / 10 s policy). When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
       "tags": ["chat", "assistant"]
     }
   ]

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vicoop-bridge/client",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/client/scripts/e2e-claude-input-image-uri.mjs
+++ b/packages/client/scripts/e2e-claude-input-image-uri.mjs
@@ -1,0 +1,90 @@
+// E2E for uri-only image FilePart input on the claude backend. Verifies
+// that a PNG referenced by FilePart.file.uri is fetched by the client
+// backend and reaches the model's vision path.
+//
+// Prereqs: `claude` on PATH and authenticated; dist built; network
+// access to the configured image URI.
+
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+const IMAGE_URI =
+  process.env.E2E_IMAGE_URI ?? 'https://placehold.co/1x1/ff0000/ff0000.png';
+
+const PROMPT =
+  process.env.E2E_PROMPT ??
+  'What single color is the attached image? Reply with one word only.';
+
+const backend = createClaudeBackend({
+  extraArgs: ['--max-turns', '1'],
+});
+
+const t0 = Date.now();
+const task = {
+  type: 'task.assign',
+  taskId: `e2e-claude-uri-img-${t0}`,
+  contextId: `e2e-claude-uri-img-ctx-${t0}`,
+  message: {
+    role: 'user',
+    messageId: `m-${t0}`,
+    parts: [
+      { kind: 'text', text: PROMPT },
+      {
+        kind: 'file',
+        file: { name: 'red.png', mimeType: 'image/png', uri: IMAGE_URI },
+      },
+    ],
+  },
+};
+
+const frames = [];
+console.log(`[e2e] task=${task.taskId}`);
+console.log(`[e2e] uri=${IMAGE_URI}`);
+console.log(`[e2e] prompt: ${PROMPT}`);
+
+await backend.handle(
+  task,
+  (f) => {
+    const delta = Date.now() - t0;
+    frames.push({ t: delta, ...f });
+    let summary = '';
+    if (f.type === 'task.artifact') {
+      const k = f.artifact.parts.map((p) => p.kind).join(',');
+      summary = `name=${f.artifact.name} parts=[${k}]`;
+    } else if (f.type === 'task.complete') {
+      summary = `state=${f.status.state}`;
+    } else if (f.type === 'task.fail') {
+      summary = `code=${f.error.code} msg=${f.error.message}`;
+    } else if (f.type === 'task.status') {
+      summary = `state=${f.status.state}`;
+    }
+    console.log(`[frame +${delta}ms] ${f.type} ${summary}`);
+  },
+  new AbortController().signal,
+);
+
+const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+const artifacts = frames.filter((f) => f.type === 'task.artifact');
+const text = artifacts
+  .flatMap((a) => a.artifact.parts.filter((p) => p.kind === 'text').map((p) => p.text))
+  .join('')
+  .toLowerCase();
+
+let failed = false;
+const assert = (cond, msg) => {
+  if (!cond) {
+    console.error(`[e2e] FAIL: ${msg}`);
+    failed = true;
+  } else {
+    console.log(`[e2e] PASS: ${msg}`);
+  }
+};
+
+assert(
+  terminal?.type === 'task.complete' && terminal.status.state === 'completed',
+  `terminal is task.complete with state=completed (got ${terminal?.type})`,
+);
+assert(text.includes('red'), `model response mentions "red" (got "${text.trim()}")`);
+
+console.log(`[e2e] assistant text: ${text.trim()}`);
+
+process.exit(failed ? 1 : 0);

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -401,6 +401,33 @@ test('rejects FilePart with uri-only when URI fetching is disabled', async () =>
   assert.match(fail.error.message, /URI fetching is disabled/);
 });
 
+test('rejects FilePart missing both bytes and uri as invalid', async () => {
+  let spawned = 0;
+  const backend = createClaudeBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+  });
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png' } }],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  assert.equal(spawned, 0);
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'invalid_file_part');
+});
+
 test('stdin envelope: URI FilePart is fetched and mapped like inline image bytes', async () => {
   const png = Buffer.from('png-bytes');
   const fake = scriptedSpawn({

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -437,7 +437,7 @@ test('stdin envelope: URI FilePart is fetched and mapped like inline image bytes
   const backend = createClaudeBackend({
     spawn: fake.spawn,
     fetchUriPolicy: {
-      fetchImpl: async () =>
+      fetchImplForTest: async () =>
         new Response(png, {
           headers: {
             'content-type': 'image/png',
@@ -477,7 +477,7 @@ test('rejects URI FilePart when host resolves to a private address', async () =>
       throw new Error('should not spawn');
     },
     fetchUriPolicy: {
-      fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+      fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
       resolveHost: async () => ['10.0.0.1'],
     },
   });

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -375,8 +375,9 @@ test('rejects FilePart whose decoded bytes exceed INPUT_FILE_MAX_BYTES (5 MiB)',
   assert.equal(fail.error.code, 'file_too_large');
 });
 
-test('rejects FilePart with uri-only (no inline bytes)', async () => {
+test('rejects FilePart with uri-only when URI fetching is disabled', async () => {
   const backend = createClaudeBackend({
+    fetchUriPolicy: { enabled: false },
     spawn: () => {
       throw new Error('should not spawn');
     },
@@ -397,6 +398,78 @@ test('rejects FilePart with uri-only (no inline bytes)', async () => {
   const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
   assert.ok(fail);
   assert.equal(fail.error.code, 'unsupported_file_uri');
+});
+
+test('stdin envelope: URI FilePart is fetched and mapped like inline image bytes', async () => {
+  const png = Buffer.from('png-bytes');
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    fetchUriPolicy: {
+      fetchImpl: async () =>
+        new Response(png, {
+          headers: {
+            'content-type': 'image/png',
+            'content-length': String(png.length),
+          },
+        }),
+      resolveHost: async () => ['93.184.216.34'],
+    },
+  });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', uri: 'https://example.com/x.png' } }],
+    },
+  };
+  await backend.handle(task, collect().emit, NEVER);
+
+  const child = fake.lastChild()!;
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    message: { content: Array<{ type: string; source?: { media_type: string; data: string } }> };
+  };
+  assert.equal(env.message.content.length, 1);
+  assert.equal(env.message.content[0].type, 'image');
+  assert.equal(env.message.content[0].source!.media_type, 'image/png');
+  assert.equal(env.message.content[0].source!.data, png.toString('base64'));
+});
+
+test('rejects URI FilePart when host resolves to a private address', async () => {
+  let spawned = 0;
+  const backend = createClaudeBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+    fetchUriPolicy: {
+      fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+      resolveHost: async () => ['10.0.0.1'],
+    },
+  });
+  const { emit, frames } = collect();
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', uri: 'https://example.com/x.png' } }],
+    },
+  };
+  await backend.handle(task, emit, NEVER);
+
+  assert.equal(spawned, 0);
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'fetch_blocked_host');
 });
 
 test('already-aborted signal short-circuits before spawn', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -398,6 +398,7 @@ test('rejects FilePart with uri-only when URI fetching is disabled', async () =>
   const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
   assert.ok(fail);
   assert.equal(fail.error.code, 'unsupported_file_uri');
+  assert.match(fail.error.message, /URI fetching is disabled/);
 });
 
 test('stdin envelope: URI FilePart is fetched and mapped like inline image bytes', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -387,7 +387,7 @@ async function mapPartsToContentBlocks(
     if (p.kind === 'file') {
       let bytes = p.file.bytes;
       let mime = p.file.mimeType ?? '';
-      if (!bytes && p.file.uri && fetchUriPolicy?.enabled !== false) {
+      if (!bytes && p.file.uri !== undefined && fetchUriPolicy?.enabled !== false) {
         try {
           const fetched = await fetchUriToBytes(p.file.uri, p.file.mimeType, fetchUriPolicy, signal);
           bytes = fetched.bytes;
@@ -403,11 +403,18 @@ async function mapPartsToContentBlocks(
           };
         }
       }
-      if (!bytes && p.file.uri && fetchUriPolicy?.enabled === false) {
+      if (!bytes && p.file.uri !== undefined && fetchUriPolicy?.enabled === false) {
         return {
           ok: false,
           code: 'unsupported_file_uri',
           message: 'claude backend URI fetching is disabled; provide inline FilePart bytes',
+        };
+      }
+      if (!bytes && p.file.uri === undefined) {
+        return {
+          ok: false,
+          code: 'invalid_file_part',
+          message: 'claude backend FilePart must carry either bytes or uri',
         };
       }
       if (!bytes) {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -7,6 +7,13 @@ import {
   type SendFileMcpOptions,
   type SendFileMcpServer,
 } from './send-file-mcp.js';
+import {
+  FetchUriError,
+  fetchUriToBytes,
+  INPUT_FILE_MAX_BYTES,
+  INPUT_IMAGE_MIME,
+  type FetchUriPolicy,
+} from './fetch-uri-file.js';
 
 // Slim subset of ChildProcess that the backend actually uses. Tests inject a
 // fake that satisfies this without wiring up a real OS process.
@@ -61,6 +68,9 @@ export interface ClaudeBackendOptions {
   // Test seam: timer impls. Defaults to global setInterval/clearInterval.
   setIntervalFn?: (fn: () => void, ms: number) => unknown;
   clearIntervalFn?: (handle: unknown) => void;
+  // Fetch uri-only inbound FileParts under the shared HTTPS/SSRF/size/MIME
+  // policy. Enabled by default; set enabled:false to require inline bytes.
+  fetchUriPolicy?: FetchUriPolicy;
 }
 
 interface SessionEntry {
@@ -112,15 +122,6 @@ type InputContentBlock =
       type: 'image' | 'document';
       source: { type: 'base64'; media_type: string; data: string };
     };
-
-const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
-
-// Hard cap on a single inbound FilePart's decoded size. base64 in the
-// stream-json envelope expands ~4/3, and the model context plus per-call
-// API limits make multi-megabyte attachments expensive even when accepted.
-// Reject above this with a stable code rather than silently embedding a
-// huge payload.
-const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
 
 // Hard cap on a single tool_result media block's decoded size before
 // it becomes an outbound A2A FilePart. Prevents a misbehaving tool
@@ -362,11 +363,15 @@ function extractToolResultMediaParts(content: unknown): Part[] {
   return out;
 }
 
-function mapPartsToContentBlocks(
+async function mapPartsToContentBlocks(
   parts: readonly Part[],
+  fetchUriPolicy: FetchUriPolicy | undefined,
+  signal: AbortSignal,
 ):
-  | { ok: true; blocks: InputContentBlock[]; inboundHashes: Set<string> }
-  | { ok: false; code: string; message: string } {
+  Promise<
+    | { ok: true; blocks: InputContentBlock[]; inboundHashes: Set<string> }
+    | { ok: false; code: string; message: string }
+  > {
   const blocks: InputContentBlock[] = [];
   // SHA-256 (hex) of every accepted FilePart's decoded bytes. Used by the
   // tool_result passthrough to skip echoes — if the model Reads a caller-
@@ -380,16 +385,32 @@ function mapPartsToContentBlocks(
       continue;
     }
     if (p.kind === 'file') {
-      // uri-only FilePart is not supported — fetching is the responsibility
-      // of a different backend or the caller. Reject with a stable code.
-      if (!p.file.bytes) {
+      let bytes = p.file.bytes;
+      let mime = p.file.mimeType ?? '';
+      if (!bytes && p.file.uri && fetchUriPolicy?.enabled !== false) {
+        try {
+          const fetched = await fetchUriToBytes(p.file.uri, p.file.mimeType, fetchUriPolicy, signal);
+          bytes = fetched.bytes;
+          mime = fetched.mimeType;
+        } catch (err) {
+          if (err instanceof FetchUriError) {
+            return { ok: false, code: err.code, message: err.message };
+          }
+          return {
+            ok: false,
+            code: 'fetch_failed',
+            message: errorMessage(err),
+          };
+        }
+      }
+      if (!bytes) {
         return {
           ok: false,
           code: 'unsupported_file_uri',
-          message: 'claude backend requires inline FilePart bytes; uri-only is not supported',
+          message: 'claude backend requires inline FilePart bytes or fetchable file.uri',
         };
       }
-      const decodedSize = decodedBase64Size(p.file.bytes);
+      const decodedSize = decodedBase64Size(bytes);
       if (decodedSize > INPUT_FILE_MAX_BYTES) {
         return {
           ok: false,
@@ -397,16 +418,15 @@ function mapPartsToContentBlocks(
           message: `FilePart exceeds INPUT_FILE_MAX_BYTES (${decodedSize} > ${INPUT_FILE_MAX_BYTES})`,
         };
       }
-      const mime = p.file.mimeType ?? '';
       if (INPUT_IMAGE_MIME.has(mime)) {
         blocks.push({
           type: 'image',
-          source: { type: 'base64', media_type: mime, data: p.file.bytes },
+          source: { type: 'base64', media_type: mime, data: bytes },
         });
       } else if (mime === 'application/pdf') {
         blocks.push({
           type: 'document',
-          source: { type: 'base64', media_type: mime, data: p.file.bytes },
+          source: { type: 'base64', media_type: mime, data: bytes },
         });
       } else {
         return {
@@ -415,7 +435,7 @@ function mapPartsToContentBlocks(
           message: `claude backend accepts image/{png,jpeg,webp,gif} or application/pdf (got ${mime || 'unknown'})`,
         };
       }
-      inboundHashes.add(sha256OfBase64(p.file.bytes));
+      inboundHashes.add(sha256OfBase64(bytes));
       continue;
     }
     return {
@@ -518,7 +538,7 @@ export function createClaudeBackend(
         return;
       }
 
-      const mapped = mapPartsToContentBlocks(task.message.parts);
+      const mapped = await mapPartsToContentBlocks(task.message.parts, opts.fetchUriPolicy, signal);
       if (!mapped.ok) {
         emit({
           type: 'task.fail',

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -403,6 +403,13 @@ async function mapPartsToContentBlocks(
           };
         }
       }
+      if (!bytes && p.file.uri && fetchUriPolicy?.enabled === false) {
+        return {
+          ok: false,
+          code: 'unsupported_file_uri',
+          message: 'claude backend URI fetching is disabled; provide inline FilePart bytes',
+        };
+      }
       if (!bytes) {
         return {
           ok: false,

--- a/packages/client/src/backends/fetch-uri-file.test.ts
+++ b/packages/client/src/backends/fetch-uri-file.test.ts
@@ -11,7 +11,7 @@ test('fetchUriToBytes: fetches supported https content as base64', async () => {
     'https://example.com/x.png',
     'image/png',
     {
-      fetchImpl: async () =>
+      fetchImplForTest: async () =>
         new Response(body, {
           headers: { 'content-type': 'image/png', 'content-length': String(body.length) },
         }),
@@ -30,7 +30,7 @@ test('fetchUriToBytes: blocks non-https schemes before fetch', async () => {
       'file:///etc/passwd',
       'image/png',
       {
-        fetchImpl: async () => {
+        fetchImplForTest: async () => {
           fetched = true;
           return new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } });
         },
@@ -49,7 +49,7 @@ test('fetchUriToBytes: blocks hosts resolving to private addresses', async () =>
       'https://example.com/x.png',
       'image/png',
       {
-        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+        fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
         resolveHost: async () => ['169.254.169.254'],
       },
       NEVER,
@@ -64,7 +64,7 @@ test('fetchUriToBytes: blocks direct IPv6 loopback hosts', async () => {
       'https://[::1]/x.png',
       'image/png',
       {
-        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+        fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
       },
       NEVER,
     ),
@@ -79,7 +79,7 @@ test('fetchUriToBytes: timeout bounds hostname resolution', async () => {
       'image/png',
       {
         timeoutMs: 5,
-        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+        fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
         resolveHost: async () => new Promise<string[]>(() => undefined),
       },
       NEVER,
@@ -94,7 +94,7 @@ test('fetchUriToBytes: revalidates redirect targets', async () => {
       'https://example.com/start',
       'image/png',
       {
-        fetchImpl: async () =>
+        fetchImplForTest: async () =>
           new Response(null, {
             status: 302,
             headers: { location: 'https://private.example/x.png' },
@@ -113,7 +113,7 @@ test('fetchUriToBytes: rejects Content-Length over the inbound cap', async () =>
       'https://example.com/x.png',
       'image/png',
       {
-        fetchImpl: async () =>
+        fetchImplForTest: async () =>
           new Response(Buffer.from('unused'), {
             headers: { 'content-type': 'image/png', 'content-length': String(6 * 1024 * 1024) },
           }),
@@ -131,7 +131,7 @@ test('fetchUriToBytes: rejects responses that exceed the inbound cap while strea
       'https://example.com/x.png',
       'image/png',
       {
-        fetchImpl: async () =>
+        fetchImplForTest: async () =>
           new Response(Buffer.alloc(INPUT_FILE_MAX_BYTES + 1), {
             headers: { 'content-type': 'image/png' },
           }),
@@ -149,7 +149,7 @@ test('fetchUriToBytes: rejects empty response bodies', async () => {
       'https://example.com/x.png',
       'image/png',
       {
-        fetchImpl: async () =>
+        fetchImplForTest: async () =>
           new Response(null, {
             headers: { 'content-type': 'image/png' },
           }),
@@ -167,7 +167,7 @@ test('fetchUriToBytes: rejects unsupported observed MIME', async () => {
       'https://example.com/archive.zip',
       'application/zip',
       {
-        fetchImpl: async () =>
+        fetchImplForTest: async () =>
           new Response(Buffer.from('zip'), {
             headers: { 'content-type': 'application/zip', 'content-length': '3' },
           }),

--- a/packages/client/src/backends/fetch-uri-file.test.ts
+++ b/packages/client/src/backends/fetch-uri-file.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchUriToBytes } from './fetch-uri-file.js';
+import { INPUT_FILE_MAX_BYTES, fetchUriToBytes } from './fetch-uri-file.js';
 
 const NEVER: AbortSignal = new AbortController().signal;
 const PUBLIC_IP = ['93.184.216.34'];
@@ -106,6 +106,42 @@ test('fetchUriToBytes: rejects Content-Length over the inbound cap', async () =>
       NEVER,
     ),
     { name: 'FetchUriError', code: 'fetch_too_large' },
+  );
+});
+
+test('fetchUriToBytes: rejects responses that exceed the inbound cap while streaming', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/x.png',
+      'image/png',
+      {
+        fetchImpl: async () =>
+          new Response(Buffer.alloc(INPUT_FILE_MAX_BYTES + 1), {
+            headers: { 'content-type': 'image/png' },
+          }),
+        resolveHost: async () => PUBLIC_IP,
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_too_large' },
+  );
+});
+
+test('fetchUriToBytes: rejects empty response bodies', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/x.png',
+      'image/png',
+      {
+        fetchImpl: async () =>
+          new Response(null, {
+            headers: { 'content-type': 'image/png' },
+          }),
+        resolveHost: async () => PUBLIC_IP,
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_failed' },
   );
 });
 

--- a/packages/client/src/backends/fetch-uri-file.test.ts
+++ b/packages/client/src/backends/fetch-uri-file.test.ts
@@ -72,6 +72,22 @@ test('fetchUriToBytes: blocks direct IPv6 loopback hosts', async () => {
   );
 });
 
+test('fetchUriToBytes: timeout bounds hostname resolution', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/x.png',
+      'image/png',
+      {
+        timeoutMs: 5,
+        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+        resolveHost: async () => new Promise<string[]>(() => undefined),
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_failed' },
+  );
+});
+
 test('fetchUriToBytes: revalidates redirect targets', async () => {
   await assert.rejects(
     fetchUriToBytes(

--- a/packages/client/src/backends/fetch-uri-file.test.ts
+++ b/packages/client/src/backends/fetch-uri-file.test.ts
@@ -1,0 +1,128 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchUriToBytes } from './fetch-uri-file.js';
+
+const NEVER: AbortSignal = new AbortController().signal;
+const PUBLIC_IP = ['93.184.216.34'];
+
+test('fetchUriToBytes: fetches supported https content as base64', async () => {
+  const body = Buffer.from('png-bytes');
+  const result = await fetchUriToBytes(
+    'https://example.com/x.png',
+    'image/png',
+    {
+      fetchImpl: async () =>
+        new Response(body, {
+          headers: { 'content-type': 'image/png', 'content-length': String(body.length) },
+        }),
+      resolveHost: async () => PUBLIC_IP,
+    },
+    NEVER,
+  );
+  assert.equal(result.mimeType, 'image/png');
+  assert.equal(result.bytes, body.toString('base64'));
+});
+
+test('fetchUriToBytes: blocks non-https schemes before fetch', async () => {
+  let fetched = false;
+  await assert.rejects(
+    fetchUriToBytes(
+      'file:///etc/passwd',
+      'image/png',
+      {
+        fetchImpl: async () => {
+          fetched = true;
+          return new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } });
+        },
+        resolveHost: async () => PUBLIC_IP,
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_blocked_host' },
+  );
+  assert.equal(fetched, false);
+});
+
+test('fetchUriToBytes: blocks hosts resolving to private addresses', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/x.png',
+      'image/png',
+      {
+        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+        resolveHost: async () => ['169.254.169.254'],
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_blocked_host' },
+  );
+});
+
+test('fetchUriToBytes: blocks direct IPv6 loopback hosts', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://[::1]/x.png',
+      'image/png',
+      {
+        fetchImpl: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_blocked_host' },
+  );
+});
+
+test('fetchUriToBytes: revalidates redirect targets', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/start',
+      'image/png',
+      {
+        fetchImpl: async () =>
+          new Response(null, {
+            status: 302,
+            headers: { location: 'https://private.example/x.png' },
+          }),
+        resolveHost: async (host) => (host === 'private.example' ? ['10.0.0.1'] : PUBLIC_IP),
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_blocked_host' },
+  );
+});
+
+test('fetchUriToBytes: rejects Content-Length over the inbound cap', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/x.png',
+      'image/png',
+      {
+        fetchImpl: async () =>
+          new Response(Buffer.from('unused'), {
+            headers: { 'content-type': 'image/png', 'content-length': String(6 * 1024 * 1024) },
+          }),
+        resolveHost: async () => PUBLIC_IP,
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_too_large' },
+  );
+});
+
+test('fetchUriToBytes: rejects unsupported observed MIME', async () => {
+  await assert.rejects(
+    fetchUriToBytes(
+      'https://example.com/archive.zip',
+      'application/zip',
+      {
+        fetchImpl: async () =>
+          new Response(Buffer.from('zip'), {
+            headers: { 'content-type': 'application/zip', 'content-length': '3' },
+          }),
+        resolveHost: async () => PUBLIC_IP,
+      },
+      NEVER,
+    ),
+    { name: 'FetchUriError', code: 'fetch_mime_mismatch' },
+  );
+});

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -132,7 +132,44 @@ async function defaultResolveHost(hostname: string): Promise<string[]> {
   return records.map((r) => r.address);
 }
 
-async function validateUrlForFetch(url: URL, resolveHost: (hostname: string) => Promise<string[]>): Promise<void> {
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted');
+  }
+}
+
+async function waitForResolution(
+  hostname: string,
+  resolveHost: (hostname: string) => Promise<string[]>,
+  signal: AbortSignal,
+): Promise<string[]> {
+  throwIfAborted(signal);
+  return new Promise<string[]>((resolve, reject) => {
+    const abort = () => reject(new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted'));
+    signal.addEventListener('abort', abort, { once: true });
+    resolveHost(hostname).then(
+      (addresses) => {
+        signal.removeEventListener('abort', abort);
+        if (signal.aborted) {
+          reject(new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted'));
+          return;
+        }
+        resolve(addresses);
+      },
+      (err: unknown) => {
+        signal.removeEventListener('abort', abort);
+        reject(err);
+      },
+    );
+  });
+}
+
+async function validateUrlForFetch(
+  url: URL,
+  resolveHost: (hostname: string) => Promise<string[]>,
+  signal: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal);
   if (url.protocol !== 'https:') {
     throw new FetchUriError('fetch_blocked_host', `file.uri must use https (got ${url.protocol || 'unknown'})`);
   }
@@ -141,8 +178,9 @@ async function validateUrlForFetch(url: URL, resolveHost: (hostname: string) => 
   }
   let addresses: string[];
   try {
-    addresses = await resolveHost(url.hostname);
+    addresses = await waitForResolution(url.hostname, resolveHost, signal);
   } catch (err) {
+    if (err instanceof FetchUriError) throw err;
     throw new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`, { cause: err });
   }
   if (addresses.length === 0) {
@@ -153,6 +191,7 @@ async function validateUrlForFetch(url: URL, resolveHost: (hostname: string) => 
       throw new FetchUriError('fetch_blocked_host', `file.uri host resolves to a blocked address (${address})`);
     }
   }
+  throwIfAborted(signal);
 }
 
 function makeTimeoutSignal(parent: AbortSignal, timeoutMs: number): { signal: AbortSignal; cleanup: () => void } {
@@ -224,7 +263,7 @@ export async function fetchUriToBytes(
   const timeout = makeTimeoutSignal(signal, timeoutMs);
   try {
     for (let redirects = 0; redirects <= maxRedirects; redirects++) {
-      await validateUrlForFetch(current, resolveHost);
+      await validateUrlForFetch(current, resolveHost, timeout.signal);
       let res: Response;
       try {
         res = await fetchImpl(current, { redirect: 'manual', signal: timeout.signal });

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -1,0 +1,273 @@
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+export const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
+
+export const INPUT_FILE_MAX_BYTES = 5 * 1024 * 1024;
+
+export type FetchUriErrorCode =
+  | 'fetch_blocked_host'
+  | 'fetch_failed'
+  | 'fetch_too_large'
+  | 'fetch_mime_mismatch';
+
+export class FetchUriError extends Error {
+  readonly code: FetchUriErrorCode;
+  constructor(code: FetchUriErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.code = code;
+    this.name = 'FetchUriError';
+  }
+}
+
+export interface FetchUriPolicy {
+  enabled?: boolean;
+  timeoutMs?: number;
+  maxRedirects?: number;
+  fetchImpl?: typeof fetch;
+  resolveHost?: (hostname: string) => Promise<string[]>;
+}
+
+export interface FetchedUriFile {
+  bytes: string;
+  mimeType: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_REDIRECTS = 3;
+
+export function isSupportedInputFileMime(mime: string): boolean {
+  return INPUT_IMAGE_MIME.has(mime) || mime === 'application/pdf';
+}
+
+function normalizeMime(raw: string | null): string {
+  return (raw ?? '').split(';', 1)[0].trim().toLowerCase();
+}
+
+function parseIpv4(ip: string): number[] | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  const out: number[] = [];
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    out.push(n);
+  }
+  return out;
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const p = parseIpv4(ip);
+  if (!p) return true;
+  const [a, b] = p;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a >= 224
+  );
+}
+
+function expandIpv6(ip: string): number[] | null {
+  const zone = ip.indexOf('%');
+  const clean = (zone >= 0 ? ip.slice(0, zone) : ip).toLowerCase();
+  const mapped = clean.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) {
+    const v4 = parseIpv4(mapped[1]);
+    if (!v4) return null;
+    return [0, 0, 0, 0, 0, 0xffff, (v4[0] << 8) | v4[1], (v4[2] << 8) | v4[3]];
+  }
+  const pieces = clean.split('::');
+  if (pieces.length > 2) return null;
+  const left = pieces[0] ? pieces[0].split(':') : [];
+  const right = pieces.length === 2 && pieces[1] ? pieces[1].split(':') : [];
+  if (pieces.length === 1 && left.length !== 8) return null;
+  const missing = 8 - left.length - right.length;
+  if (missing < 0) return null;
+  const nums = [...left, ...Array.from({ length: missing }, () => '0'), ...right].map((part) => {
+    if (!/^[0-9a-f]{1,4}$/.test(part)) return -1;
+    return Number.parseInt(part, 16);
+  });
+  return nums.length === 8 && nums.every((n) => n >= 0 && n <= 0xffff) ? nums : null;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const p = expandIpv6(ip);
+  if (!p) return true;
+  const isUnspecified = p.every((n) => n === 0);
+  const isLoopback = p.slice(0, 7).every((n) => n === 0) && p[7] === 1;
+  const firstByte = p[0] >> 8;
+  const secondByte = p[0] & 0xff;
+  const isUniqueLocal = (firstByte & 0xfe) === 0xfc;
+  const isLinkLocal = firstByte === 0xfe && (secondByte & 0xc0) === 0x80;
+  const isMulticast = firstByte === 0xff;
+  const isMappedIpv4 = p.slice(0, 5).every((n) => n === 0) && p[5] === 0xffff;
+  if (isMappedIpv4) {
+    const a = p[6] >> 8;
+    const b = p[6] & 0xff;
+    const c = p[7] >> 8;
+    const d = p[7] & 0xff;
+    return isBlockedIpv4(`${a}.${b}.${c}.${d}`);
+  }
+  return isUnspecified || isLoopback || isUniqueLocal || isLinkLocal || isMulticast;
+}
+
+function isBlockedIp(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) return isBlockedIpv4(ip);
+  if (family === 6) return isBlockedIpv6(ip);
+  return true;
+}
+
+async function defaultResolveHost(hostname: string): Promise<string[]> {
+  const host = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+  const directFamily = net.isIP(host);
+  if (directFamily !== 0) return [host];
+  const records = await dns.lookup(host, { all: true, verbatim: true });
+  return records.map((r) => r.address);
+}
+
+async function validateUrlForFetch(url: URL, resolveHost: (hostname: string) => Promise<string[]>): Promise<void> {
+  if (url.protocol !== 'https:') {
+    throw new FetchUriError('fetch_blocked_host', `file.uri must use https (got ${url.protocol || 'unknown'})`);
+  }
+  if (url.username || url.password) {
+    throw new FetchUriError('fetch_blocked_host', 'file.uri must not include userinfo');
+  }
+  let addresses: string[];
+  try {
+    addresses = await resolveHost(url.hostname);
+  } catch (err) {
+    throw new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`, { cause: err });
+  }
+  if (addresses.length === 0) {
+    throw new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`);
+  }
+  for (const address of addresses) {
+    if (isBlockedIp(address)) {
+      throw new FetchUriError('fetch_blocked_host', `file.uri host resolves to a blocked address (${address})`);
+    }
+  }
+}
+
+function makeTimeoutSignal(parent: AbortSignal, timeoutMs: number): { signal: AbortSignal; cleanup: () => void } {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const abort = () => controller.abort(parent.reason);
+  if (parent.aborted) {
+    abort();
+  } else {
+    parent.addEventListener('abort', abort, { once: true });
+    timeout = setTimeout(() => controller.abort(new Error(`fetch timed out after ${timeoutMs}ms`)), timeoutMs);
+    timeout.unref?.();
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      parent.removeEventListener('abort', abort);
+      if (timeout) clearTimeout(timeout);
+    },
+  };
+}
+
+async function responseBytesToBase64(res: Response): Promise<string> {
+  const buf = Buffer.from(await res.arrayBuffer());
+  return buf.toString('base64');
+}
+
+async function responseStreamToBase64(res: Response, maxBytes: number): Promise<string> {
+  const body = res.body;
+  if (!body) return '';
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      throw new FetchUriError('fetch_too_large', `file.uri response exceeded INPUT_FILE_MAX_BYTES (${total} > ${maxBytes})`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString('base64');
+}
+
+export async function fetchUriToBytes(
+  uri: string,
+  declaredMimeType: string | undefined,
+  policy: FetchUriPolicy | undefined,
+  signal: AbortSignal,
+): Promise<FetchedUriFile> {
+  const timeoutMs = policy?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRedirects = policy?.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  const fetchImpl = policy?.fetchImpl ?? fetch;
+  const resolveHost = policy?.resolveHost ?? defaultResolveHost;
+  let current: URL;
+  try {
+    current = new URL(uri);
+  } catch (err) {
+    throw new FetchUriError('fetch_blocked_host', 'file.uri must be an absolute https URL', { cause: err });
+  }
+
+  const timeout = makeTimeoutSignal(signal, timeoutMs);
+  try {
+    for (let redirects = 0; redirects <= maxRedirects; redirects++) {
+      await validateUrlForFetch(current, resolveHost);
+      let res: Response;
+      try {
+        res = await fetchImpl(current, { redirect: 'manual', signal: timeout.signal });
+      } catch (err) {
+        throw new FetchUriError('fetch_failed', `failed to fetch file.uri (${current.hostname})`, { cause: err });
+      }
+
+      if (res.status >= 300 && res.status < 400) {
+        const location = res.headers.get('location');
+        if (!location) {
+          throw new FetchUriError('fetch_failed', `file.uri redirect missing Location header (${res.status})`);
+        }
+        if (redirects === maxRedirects) {
+          throw new FetchUriError('fetch_failed', `file.uri exceeded max redirects (${maxRedirects})`);
+        }
+        current = new URL(location, current);
+        continue;
+      }
+
+      if (!res.ok) {
+        throw new FetchUriError('fetch_failed', `file.uri fetch returned HTTP ${res.status}`);
+      }
+
+      const contentLength = res.headers.get('content-length');
+      if (contentLength !== null) {
+        const n = Number(contentLength);
+        if (Number.isFinite(n) && n > INPUT_FILE_MAX_BYTES) {
+          throw new FetchUriError('fetch_too_large', `file.uri Content-Length exceeds INPUT_FILE_MAX_BYTES (${n} > ${INPUT_FILE_MAX_BYTES})`);
+        }
+      }
+
+      const observedMime = normalizeMime(res.headers.get('content-type'));
+      const declared = normalizeMime(declaredMimeType ?? null);
+      if (!observedMime || !isSupportedInputFileMime(observedMime)) {
+        throw new FetchUriError('fetch_mime_mismatch', `file.uri Content-Type is not supported (${observedMime || 'unknown'})`);
+      }
+      if (declared && declared !== observedMime) {
+        throw new FetchUriError('fetch_mime_mismatch', `file.uri declared mimeType ${declared} does not match Content-Type ${observedMime}`);
+      }
+
+      const bytes = res.body
+        ? await responseStreamToBase64(res, INPUT_FILE_MAX_BYTES)
+        : await responseBytesToBase64(res);
+      return { bytes, mimeType: observedMime };
+    }
+  } finally {
+    timeout.cleanup();
+  }
+  throw new FetchUriError('fetch_failed', 'file.uri fetch failed');
+}

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -26,7 +26,9 @@ export interface FetchUriPolicy {
   enabled?: boolean;
   timeoutMs?: number;
   maxRedirects?: number;
-  fetchImpl?: typeof fetch;
+  // Test seam only. Production uses the pinned-IP HTTPS path so DNS cannot
+  // be resolved again after the SSRF policy check.
+  fetchImplForTest?: typeof fetch;
   resolveHost?: (hostname: string) => Promise<string[]>;
 }
 
@@ -238,11 +240,7 @@ function headersFromIncoming(headers: Record<string, string | string[] | undefin
   return out;
 }
 
-function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal): Promise<Response> {
-  const address = addresses[0];
-  if (!address) {
-    return Promise.reject(new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`));
-  }
+function fetchPinnedToAddress(url: URL, address: string, signal: AbortSignal): Promise<Response> {
   const family = net.isIP(address);
   return new Promise<Response>((resolve, reject) => {
     let activeResponse: Readable | null = null;
@@ -284,6 +282,19 @@ function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal
   });
 }
 
+async function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal): Promise<Response> {
+  let lastErr: unknown = null;
+  for (const address of addresses) {
+    throwIfAborted(signal);
+    try {
+      return await fetchPinnedToAddress(url, address, signal);
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr ?? new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`);
+}
+
 async function responseStreamToBase64(res: Response, maxBytes: number): Promise<string> {
   const body = res.body;
   if (!body) {
@@ -317,7 +328,7 @@ export async function fetchUriToBytes(
 ): Promise<FetchedUriFile> {
   const timeoutMs = policy?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxRedirects = policy?.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
-  const fetchImpl = policy?.fetchImpl;
+  const fetchImplForTest = policy?.fetchImplForTest;
   const resolveHost = policy?.resolveHost ?? defaultResolveHost;
   let current: URL;
   try {
@@ -332,8 +343,8 @@ export async function fetchUriToBytes(
       const addresses = await validateUrlForFetch(current, resolveHost, timeout.signal);
       let res: Response;
       try {
-        res = fetchImpl
-          ? await fetchImpl(current, { redirect: 'manual', signal: timeout.signal })
+        res = fetchImplForTest
+          ? await fetchImplForTest(current, { redirect: 'manual', signal: timeout.signal })
           : await fetchPinned(current, addresses, timeout.signal);
       } catch (err) {
         throw new FetchUriError('fetch_failed', `failed to fetch file.uri (${current.hostname})`, { cause: err });

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -175,14 +175,15 @@ function makeTimeoutSignal(parent: AbortSignal, timeoutMs: number): { signal: Ab
   };
 }
 
-async function responseBytesToBase64(res: Response): Promise<string> {
-  const buf = Buffer.from(await res.arrayBuffer());
-  return buf.toString('base64');
+async function cancelResponseBody(res: Response): Promise<void> {
+  await res.body?.cancel().catch(() => undefined);
 }
 
 async function responseStreamToBase64(res: Response, maxBytes: number): Promise<string> {
   const body = res.body;
-  if (!body) return '';
+  if (!body) {
+    throw new FetchUriError('fetch_failed', 'file.uri response had no body');
+  }
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
@@ -196,6 +197,9 @@ async function responseStreamToBase64(res: Response, maxBytes: number): Promise<
       throw new FetchUriError('fetch_too_large', `file.uri response exceeded INPUT_FILE_MAX_BYTES (${total} > ${maxBytes})`);
     }
     chunks.push(value);
+  }
+  if (total === 0) {
+    throw new FetchUriError('fetch_failed', 'file.uri response body was empty');
   }
   return Buffer.concat(chunks.map((c) => Buffer.from(c))).toString('base64');
 }
@@ -231,16 +235,20 @@ export async function fetchUriToBytes(
       if (res.status >= 300 && res.status < 400) {
         const location = res.headers.get('location');
         if (!location) {
+          await cancelResponseBody(res);
           throw new FetchUriError('fetch_failed', `file.uri redirect missing Location header (${res.status})`);
         }
         if (redirects === maxRedirects) {
+          await cancelResponseBody(res);
           throw new FetchUriError('fetch_failed', `file.uri exceeded max redirects (${maxRedirects})`);
         }
+        await cancelResponseBody(res);
         current = new URL(location, current);
         continue;
       }
 
       if (!res.ok) {
+        await cancelResponseBody(res);
         throw new FetchUriError('fetch_failed', `file.uri fetch returned HTTP ${res.status}`);
       }
 
@@ -248,6 +256,7 @@ export async function fetchUriToBytes(
       if (contentLength !== null) {
         const n = Number(contentLength);
         if (Number.isFinite(n) && n > INPUT_FILE_MAX_BYTES) {
+          await cancelResponseBody(res);
           throw new FetchUriError('fetch_too_large', `file.uri Content-Length exceeds INPUT_FILE_MAX_BYTES (${n} > ${INPUT_FILE_MAX_BYTES})`);
         }
       }
@@ -255,15 +264,15 @@ export async function fetchUriToBytes(
       const observedMime = normalizeMime(res.headers.get('content-type'));
       const declared = normalizeMime(declaredMimeType ?? null);
       if (!observedMime || !isSupportedInputFileMime(observedMime)) {
+        await cancelResponseBody(res);
         throw new FetchUriError('fetch_mime_mismatch', `file.uri Content-Type is not supported (${observedMime || 'unknown'})`);
       }
       if (declared && declared !== observedMime) {
+        await cancelResponseBody(res);
         throw new FetchUriError('fetch_mime_mismatch', `file.uri declared mimeType ${declared} does not match Content-Type ${observedMime}`);
       }
 
-      const bytes = res.body
-        ? await responseStreamToBase64(res, INPUT_FILE_MAX_BYTES)
-        : await responseBytesToBase64(res);
+      const bytes = await responseStreamToBase64(res, INPUT_FILE_MAX_BYTES);
       return { bytes, mimeType: observedMime };
     }
   } finally {

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -257,7 +257,11 @@ function fetchPinnedToAddress(url: URL, address: string, signal: AbortSignal): P
       path: `${url.pathname}${url.search}`,
       method: 'GET',
       servername: stripIpv6Brackets(url.hostname),
-      lookup: (_hostname, _options, cb) => {
+      lookup: (_hostname, options, cb) => {
+        if (typeof options === 'object' && options?.all) {
+          cb(null, [{ address, family }]);
+          return;
+        }
         cb(null, address, family);
       },
     });

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -245,6 +245,13 @@ function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal
   }
   const family = net.isIP(address);
   return new Promise<Response>((resolve, reject) => {
+    let activeResponse: Readable | null = null;
+    const cleanupAbort = () => signal.removeEventListener('abort', abort);
+    const abort = () => {
+      const err = new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted');
+      activeResponse?.destroy(err);
+      req.destroy(err);
+    };
     const req = https.request({
       protocol: 'https:',
       hostname: stripIpv6Brackets(url.hostname),
@@ -256,12 +263,12 @@ function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal
         cb(null, address, family);
       },
     });
-    const abort = () => {
-      req.destroy(new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted'));
-    };
     signal.addEventListener('abort', abort, { once: true });
     req.on('response', (res) => {
-      signal.removeEventListener('abort', abort);
+      activeResponse = res;
+      res.once('close', cleanupAbort);
+      res.once('end', cleanupAbort);
+      res.once('error', cleanupAbort);
       const body = Readable.toWeb(res) as ReadableStream<Uint8Array>;
       resolve(new Response(body, {
         status: res.statusCode ?? 0,
@@ -270,7 +277,7 @@ function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal
       }));
     });
     req.on('error', (err) => {
-      signal.removeEventListener('abort', abort);
+      cleanupAbort();
       reject(err);
     });
     req.end();

--- a/packages/client/src/backends/fetch-uri-file.ts
+++ b/packages/client/src/backends/fetch-uri-file.ts
@@ -1,5 +1,7 @@
 import dns from 'node:dns/promises';
+import https from 'node:https';
 import net from 'node:net';
+import { Readable } from 'node:stream';
 
 export const INPUT_IMAGE_MIME = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif']);
 
@@ -164,11 +166,15 @@ async function waitForResolution(
   });
 }
 
+function stripIpv6Brackets(hostname: string): string {
+  return hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+}
+
 async function validateUrlForFetch(
   url: URL,
   resolveHost: (hostname: string) => Promise<string[]>,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<string[]> {
   throwIfAborted(signal);
   if (url.protocol !== 'https:') {
     throw new FetchUriError('fetch_blocked_host', `file.uri must use https (got ${url.protocol || 'unknown'})`);
@@ -192,6 +198,7 @@ async function validateUrlForFetch(
     }
   }
   throwIfAborted(signal);
+  return addresses;
 }
 
 function makeTimeoutSignal(parent: AbortSignal, timeoutMs: number): { signal: AbortSignal; cleanup: () => void } {
@@ -216,6 +223,58 @@ function makeTimeoutSignal(parent: AbortSignal, timeoutMs: number): { signal: Ab
 
 async function cancelResponseBody(res: Response): Promise<void> {
   await res.body?.cancel().catch(() => undefined);
+}
+
+function headersFromIncoming(headers: Record<string, string | string[] | undefined>): Headers {
+  const out = new Headers();
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const v of value) out.append(key, v);
+    } else {
+      out.set(key, value);
+    }
+  }
+  return out;
+}
+
+function fetchPinned(url: URL, addresses: readonly string[], signal: AbortSignal): Promise<Response> {
+  const address = addresses[0];
+  if (!address) {
+    return Promise.reject(new FetchUriError('fetch_failed', `failed to resolve ${url.hostname}`));
+  }
+  const family = net.isIP(address);
+  return new Promise<Response>((resolve, reject) => {
+    const req = https.request({
+      protocol: 'https:',
+      hostname: stripIpv6Brackets(url.hostname),
+      port: url.port ? Number(url.port) : 443,
+      path: `${url.pathname}${url.search}`,
+      method: 'GET',
+      servername: stripIpv6Brackets(url.hostname),
+      lookup: (_hostname, _options, cb) => {
+        cb(null, address, family);
+      },
+    });
+    const abort = () => {
+      req.destroy(new FetchUriError('fetch_failed', 'file.uri fetch timed out or was aborted'));
+    };
+    signal.addEventListener('abort', abort, { once: true });
+    req.on('response', (res) => {
+      signal.removeEventListener('abort', abort);
+      const body = Readable.toWeb(res) as ReadableStream<Uint8Array>;
+      resolve(new Response(body, {
+        status: res.statusCode ?? 0,
+        statusText: res.statusMessage,
+        headers: headersFromIncoming(res.headers),
+      }));
+    });
+    req.on('error', (err) => {
+      signal.removeEventListener('abort', abort);
+      reject(err);
+    });
+    req.end();
+  });
 }
 
 async function responseStreamToBase64(res: Response, maxBytes: number): Promise<string> {
@@ -251,7 +310,7 @@ export async function fetchUriToBytes(
 ): Promise<FetchedUriFile> {
   const timeoutMs = policy?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxRedirects = policy?.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
-  const fetchImpl = policy?.fetchImpl ?? fetch;
+  const fetchImpl = policy?.fetchImpl;
   const resolveHost = policy?.resolveHost ?? defaultResolveHost;
   let current: URL;
   try {
@@ -263,10 +322,12 @@ export async function fetchUriToBytes(
   const timeout = makeTimeoutSignal(signal, timeoutMs);
   try {
     for (let redirects = 0; redirects <= maxRedirects; redirects++) {
-      await validateUrlForFetch(current, resolveHost, timeout.signal);
+      const addresses = await validateUrlForFetch(current, resolveHost, timeout.signal);
       let res: Response;
       try {
-        res = await fetchImpl(current, { redirect: 'manual', signal: timeout.signal });
+        res = fetchImpl
+          ? await fetchImpl(current, { redirect: 'manual', signal: timeout.signal })
+          : await fetchPinned(current, addresses, timeout.signal);
       } catch (err) {
         throw new FetchUriError('fetch_failed', `failed to fetch file.uri (${current.hostname})`, { cause: err });
       }

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -868,8 +868,8 @@ test('gateway close mid-run fails in-flight task deterministically', async () =>
   }
 });
 
-test('mapPartsToChatInput: text-only parts are joined with newline and carry no attachments', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: text-only parts are joined with newline and carry no attachments', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'text', text: 'first line' },
     { kind: 'text', text: 'second line' },
   ]);
@@ -879,8 +879,8 @@ test('mapPartsToChatInput: text-only parts are joined with newline and carry no 
   assert.deepEqual(result.input.attachments, []);
 });
 
-test('mapPartsToChatInput: file part with image bytes maps to an OpenClaw image attachment', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: file part with image bytes maps to an OpenClaw image attachment', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'text', text: 'describe this' },
     {
       kind: 'file',
@@ -895,8 +895,8 @@ test('mapPartsToChatInput: file part with image bytes maps to an OpenClaw image 
   ]);
 });
 
-test('mapPartsToChatInput: image file without a name omits fileName cleanly', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: image file without a name omits fileName cleanly', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'file', file: { mimeType: 'image/jpeg', bytes: 'BBBB' } },
   ]);
   assert.equal(result.ok, true);
@@ -905,18 +905,45 @@ test('mapPartsToChatInput: image file without a name omits fileName cleanly', ()
   assert.equal(result.input.attachments[0].fileName, undefined);
 });
 
-test('mapPartsToChatInput: file.uri is rejected explicitly instead of silently dropped', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: file.uri is rejected when URI fetching is disabled', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'file', file: { uri: 'https://example.com/doc.pdf', mimeType: 'application/pdf' } },
-  ]);
+  ], { enabled: false });
   assert.equal(result.ok, false);
   if (result.ok) return;
   assert.equal(result.error.code, 'unsupported_file_uri');
   assert.match(result.error.message, /part\[0\]/);
 });
 
-test('mapPartsToChatInput: non-image file maps to a generic file attachment (OpenClaw >= v2026.4.27 offloads to media://inbound/<id>)', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: file.uri is fetched and mapped to an attachment', async () => {
+  const body = Buffer.from('pdf-bytes');
+  const result = await mapPartsToChatInput(
+    [{ kind: 'file', file: { name: 'doc.pdf', mimeType: 'application/pdf', uri: 'https://example.com/doc.pdf' } }],
+    {
+      fetchImpl: async () =>
+        new Response(body, {
+          headers: {
+            'content-type': 'application/pdf',
+            'content-length': String(body.length),
+          },
+        }),
+      resolveHost: async () => ['93.184.216.34'],
+    },
+  );
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.input.attachments, [
+    {
+      type: 'file',
+      mimeType: 'application/pdf',
+      fileName: 'doc.pdf',
+      content: body.toString('base64'),
+    },
+  ]);
+});
+
+test('mapPartsToChatInput: non-image file maps to a generic file attachment (OpenClaw >= v2026.4.27 offloads to media://inbound/<id>)', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'text', text: 'summarize' },
     { kind: 'file', file: { name: 'report.pdf', mimeType: 'application/pdf', bytes: 'CCCC' } },
   ]);
@@ -928,8 +955,8 @@ test('mapPartsToChatInput: non-image file maps to a generic file attachment (Ope
   ]);
 });
 
-test('mapPartsToChatInput: missing both bytes and uri is rejected', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: missing both bytes and uri is rejected', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'file', file: { mimeType: 'image/png' } },
   ]);
   assert.equal(result.ok, false);
@@ -937,8 +964,8 @@ test('mapPartsToChatInput: missing both bytes and uri is rejected', () => {
   assert.equal(result.error.code, 'invalid_file_part');
 });
 
-test('mapPartsToChatInput: missing mimeType is rejected (gateway needs it for sniff/route)', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: missing mimeType is rejected (gateway needs it for sniff/route)', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'file', file: { name: 'blob.bin', bytes: 'DDDD' } },
   ]);
   assert.equal(result.ok, false);
@@ -947,8 +974,8 @@ test('mapPartsToChatInput: missing mimeType is rejected (gateway needs it for sn
   assert.match(result.error.message, /mimeType/);
 });
 
-test('mapPartsToChatInput: data part is rejected since OpenClaw has no structured input surface', () => {
-  const result = mapPartsToChatInput([
+test('mapPartsToChatInput: data part is rejected since OpenClaw has no structured input surface', async () => {
+  const result = await mapPartsToChatInput([
     { kind: 'text', text: 'context follows' },
     { kind: 'data', data: { foo: 'bar', n: 42 } },
   ]);
@@ -1128,7 +1155,7 @@ test('handle(): file.uri fails fast with unsupported_file_uri', async () => {
     },
   });
   try {
-    const backend = createOpenclawBackend({ url: fake.url });
+    const backend = createOpenclawBackend({ url: fake.url, fetchUriPolicy: { enabled: false } });
     const frames: UpFrame[] = [];
     const task: TaskAssignFrame = {
       type: 'task.assign',

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -920,7 +920,7 @@ test('mapPartsToChatInput: file.uri is fetched and mapped to an attachment', asy
   const result = await mapPartsToChatInput(
     [{ kind: 'file', file: { name: 'doc.pdf', mimeType: 'application/pdf', uri: 'https://example.com/doc.pdf' } }],
     {
-      fetchImpl: async () =>
+      fetchImplForTest: async () =>
         new Response(body, {
           headers: {
             'content-type': 'application/pdf',

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1171,6 +1171,7 @@ test('handle(): file.uri fails fast with unsupported_file_uri', async () => {
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail);
     assert.equal(fail!.error.code, 'unsupported_file_uri');
+    assert.match(fail!.error.message, /URI fetching is disabled/);
     await new Promise((r) => setTimeout(r, 30));
     assert.equal(chatSendSeen, false);
   } finally {

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -17,6 +17,11 @@ import {
   type SendFileMcpServer,
   type SendFileMcpOptions,
 } from './send-file-mcp.js';
+import {
+  FetchUriError,
+  fetchUriToBytes,
+  type FetchUriPolicy,
+} from './fetch-uri-file.js';
 import { clientVersion } from '../version.js';
 
 const execFileP = promisify(execFile);
@@ -353,8 +358,10 @@ class GatewayClient {
 // reject non-image mimes server-side; we do not pre-filter here because the
 // rejection should be surfaced as a gateway error, not silently swallowed.
 //
-// Out of scope: `file.uri` (requires fetching with caller auth) and
-// `kind: 'data'` (no structured-input surface on OpenClaw).
+// `file.uri` inputs are fetched by the bridge under the shared inbound file
+// safety policy, then forwarded as the same base64 attachment shape as
+// caller-inline `file.bytes`. `kind: 'data'` remains out of scope because
+// OpenClaw has no structured-input surface for it.
 interface OpenclawChatInput {
   message: string;
   attachments: Array<{
@@ -376,9 +383,11 @@ function isImageMime(mime: string | undefined): boolean {
 
 // Exported for unit testing; shape matches what `handle()` feeds into
 // `chat.send` (minus `sessionKey` / `idempotencyKey` / `thinking`).
-export function mapPartsToChatInput(
+export async function mapPartsToChatInput(
   parts: Part[],
-): { ok: true; input: OpenclawChatInput } | { ok: false; error: PartMappingError } {
+  fetchUriPolicy?: FetchUriPolicy,
+  signal: AbortSignal = new AbortController().signal,
+): Promise<{ ok: true; input: OpenclawChatInput } | { ok: false; error: PartMappingError }> {
   const textBits: string[] = [];
   const attachments: OpenclawChatInput['attachments'] = [];
   for (const [idx, p] of parts.entries()) {
@@ -388,22 +397,31 @@ export function mapPartsToChatInput(
     }
     if (p.kind === 'file') {
       const f = p.file;
-      // uri requires fetching and may need caller auth — out of scope for
-      // this backend. Reject explicitly so callers know to inline bytes.
-      if (f.uri !== undefined) {
-        return {
-          ok: false,
-          error: {
-            code: 'unsupported_file_uri',
-            message: `part[${idx}]: file.uri is not supported by the openclaw backend; inline the file as base64 bytes instead`,
-          },
-        };
+      let bytes = f.bytes;
+      let mimeType = f.mimeType;
+      if (bytes === undefined && f.uri !== undefined && fetchUriPolicy?.enabled !== false) {
+        try {
+          const fetched = await fetchUriToBytes(f.uri, f.mimeType, fetchUriPolicy, signal);
+          bytes = fetched.bytes;
+          mimeType = fetched.mimeType;
+        } catch (err) {
+          if (err instanceof FetchUriError) {
+            return {
+              ok: false,
+              error: { code: err.code, message: `part[${idx}]: ${err.message}` },
+            };
+          }
+          return {
+            ok: false,
+            error: { code: 'fetch_failed', message: `part[${idx}]: ${errorMessage(err)}` },
+          };
+        }
       }
-      if (f.bytes === undefined) {
+      if (bytes === undefined) {
         return {
           ok: false,
           error: {
-            code: 'invalid_file_part',
+            code: f.uri !== undefined ? 'unsupported_file_uri' : 'invalid_file_part',
             message: `part[${idx}]: file part must carry either bytes or uri`,
           },
         };
@@ -411,7 +429,7 @@ export function mapPartsToChatInput(
       // mimeType is required so the gateway can sniff/route correctly.
       // Without it, OpenClaw's mime-resolution falls back to label-derived
       // guessing which is unreliable for arbitrary callers.
-      if (typeof f.mimeType !== 'string' || f.mimeType.length === 0) {
+      if (typeof mimeType !== 'string' || mimeType.length === 0) {
         return {
           ok: false,
           error: {
@@ -421,10 +439,10 @@ export function mapPartsToChatInput(
         };
       }
       attachments.push({
-        type: isImageMime(f.mimeType) ? 'image' : 'file',
-        mimeType: f.mimeType,
+        type: isImageMime(mimeType) ? 'image' : 'file',
+        mimeType,
         ...(f.name !== undefined ? { fileName: f.name } : {}),
-        content: f.bytes,
+        content: bytes,
       });
       continue;
     }
@@ -547,6 +565,11 @@ export interface OpenclawBackendOptions {
   /** Test seam: timer impls. Defaults to global setInterval/clearInterval. */
   setIntervalFn?: (fn: () => void, ms: number) => unknown;
   clearIntervalFn?: (handle: unknown) => void;
+  /**
+   * Fetch uri-only inbound FileParts under the shared HTTPS/SSRF/size/MIME
+   * policy. Enabled by default; set enabled:false to require inline bytes.
+   */
+  fetchUriPolicy?: FetchUriPolicy;
 }
 
 const DEFAULT_ATTACH_OUTPUTS_MAX_BYTES = 20 * 1024 * 1024;
@@ -1203,7 +1226,7 @@ export function createOpenclawBackend(
       // Validate and normalize A2A parts BEFORE touching the gateway so
       // malformed input fails fast without opening a WS or consuming a
       // session slot.
-      const mapped = mapPartsToChatInput(task.message.parts);
+      const mapped = await mapPartsToChatInput(task.message.parts, opts.fetchUriPolicy, signal);
       if (!mapped.ok) {
         emit({
           type: 'task.fail',

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -353,10 +353,13 @@ class GatewayClient {
 // `{ type, mimeType, fileName, content }` where `content` is base64 and
 // `type` is a label-only field (the real routing decision is mime-based).
 //
-// OpenClaw >= v2026.4.27 accepts non-image attachments and offloads them to
-// `media://inbound/<id>` for the agent to read via Read/Bash. Older gateways
-// reject non-image mimes server-side; we do not pre-filter here because the
-// rejection should be surfaced as a gateway error, not silently swallowed.
+// OpenClaw >= v2026.4.27 accepts non-image inline attachments and offloads
+// them to `media://inbound/<id>` for the agent to read via Read/Bash. Older
+// gateways reject non-image inline mimes server-side; we do not pre-filter
+// caller-provided `file.bytes` because the rejection should be surfaced as a
+// gateway error, not silently swallowed. URI-fetched inputs are different:
+// they pass through the shared inbound fetch policy and are MIME-gated before
+// reaching the gateway.
 //
 // `file.uri` inputs are fetched by the bridge under the shared inbound file
 // safety policy, then forwarded as the same base64 attachment shape as

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -417,6 +417,15 @@ export async function mapPartsToChatInput(
           };
         }
       }
+      if (bytes === undefined && f.uri !== undefined && fetchUriPolicy?.enabled === false) {
+        return {
+          ok: false,
+          error: {
+            code: 'unsupported_file_uri',
+            message: `part[${idx}]: URI fetching is disabled; provide inline file.bytes`,
+          },
+        };
+      }
       if (bytes === undefined) {
         return {
           ok: false,


### PR DESCRIPTION
## Summary

- Add a shared inbound `file.uri` fetch helper for HTTPS-only FileParts with host/IP validation, redirect revalidation, timeout, size, and MIME checks.
- Wire URI fetching into Claude and OpenClaw while preserving existing inline `file.bytes` behavior and `fetchUriPolicy.enabled: false` opt-out.
- Update Claude/OpenClaw agent cards to advertise `file.bytes` or `file.uri` image/PDF inputs.

Fixes #113

## Validation

- `pnpm --filter @vicoop-bridge/protocol build`
- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/client test`