### PR TITLE
feat: scriptable caller management via /admin-api + vicoop-client subcommands

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -376,11 +376,34 @@ one live `vicoop-client` process connected for the agent id.
 ### Restrict who can call your agent
 
 By default the policy has empty `allowed_callers`, which the dispatcher
-treats as "public". To lock it down, use the admin agent's `add_caller`
-tool. The admin agent at `POST /` accepts any **owner-session token**
+treats as "public". To lock it down, either use the `vicoop-client`
+subcommands (deterministic, scriptable) or send a natural-language
+request to the admin agent. Both require an **owner-session token**
 (`vbc_owner_*`) — wallet (SIWE) or Google (device flow with
 `intent=owner_session`). Admin scope (`is_admin()`) is wallet-only and
 gates only the cross-owner tools.
+
+#### Option A: `vicoop-client` subcommands (recommended for scripts)
+
+```sh
+# One-time login — saves the bearer to ~/.vicoop/owner-session.json (chmod 600).
+vicoop-client login --owner-session --bridge "$BRIDGE_URL"
+
+# Now any of these work without re-authenticating:
+vicoop-client list-agents
+vicoop-client list-callers "$AGENT_ID"
+vicoop-client add-caller "$AGENT_ID" "eth:0x<40-hex>"
+vicoop-client remove-caller "$AGENT_ID" "google:email:caller@example.com"
+
+# Pass --json for machine-readable output, or --bridge / --token to override
+# the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
+# work too (handy for CI).
+```
+
+These talk to the bridge's `/admin-api/*` routes — same logic the admin
+agent's tools run, but without an LLM round-trip per call.
+
+#### Option B: natural-language admin agent
 
 ```sh
 # $OWNER_TOKEN: vbc_owner_* token from /auth/siwe/exchange or
@@ -394,7 +417,7 @@ curl -sX POST "$BRIDGE_URL/" \
   | jq -r '.result.status.message.parts[0].text'
 ```
 
-The change hot-reloads via `registry.updateAllowedCallers` — no client
+Either path hot-reloads via `registry.updateAllowedCallers` — no client
 restart needed.
 
 ## Updating the client

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -93,9 +93,15 @@ cd packages/client
 ```
 
 The WS registration auto-creates an `agent_policies` row with
-`allowed_callers = '{}'` (public). To make the agent require auth, populate
-`allowed_callers` then restart the client (registry reads the list only at
-registration time).
+`allowed_callers = '{}'` (public). Two ways to populate it:
+
+- **`vicoop-client add-caller`** (Paths B/C below) — hot-reloads via
+  `registry.updateAllowedCallers`, no restart needed. Requires an
+  owner-session bearer (issued via SIWE exchange or Google device flow).
+- **Raw SQL `UPDATE agent_policies SET allowed_callers = …`** (Path A
+  below) — bypasses the registry, so the connected client must be killed
+  and rerun to pick up the new list. Useful when you want to skip the
+  auth flow entirely for the smoke test.
 
 ## Path A — opaque token via direct DB insert
 
@@ -167,15 +173,23 @@ curl -sX POST http://localhost:8787/oauth/token \
 # while pending: {"error":"authorization_pending"}
 # after approval: {"access_token":"vbc_caller_...","token_type":"Bearer","expires_in":...}
 
-# 4. Find the principal that was bound to your token
+# 4. Find the Google sub that was bound to your token
 psql vicoop_bridge_dev -c \
   "SELECT principal_id, email, expires_at FROM callers ORDER BY created_at DESC LIMIT 1;"
+# principal_id will be 'google:<sub>' — keep the sub for step 5b.
 
-# 5. Grant that principal access to the agent + restart echo client
-psql vicoop_bridge_dev -c \
-  "UPDATE agent_policies SET allowed_callers = ARRAY['google:sub:<YOUR_SUB>'] WHERE agent_id='echo-agent';"
-pkill -f 'tsx.*cli.ts.*echo-agent'
-# ...rerun client...
+# 5a. Get an owner-session bearer (separate device-flow run with
+#     intent=owner_session). Saves the token to ~/.vicoop/owner-session.json
+#     so 5b picks it up automatically. Re-using the same Google account is
+#     fine; the audiences are independent.
+#     (`CLI` is just shorthand for the local-source invocation — see the
+#     callout below if you're working from a published bundle.)
+CLI="pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts"
+$CLI login --owner-session --bridge http://localhost:8787
+
+# 5b. Add the caller principal — hot-reloads via registry.updateAllowedCallers,
+#     no client restart needed.
+$CLI add-caller echo-agent "google:sub:<YOUR_SUB>"
 
 # 6. Call the agent with the issued Bearer
 TOKEN="vbc_caller_..."   # from step 3
@@ -184,6 +198,11 @@ curl -s -X POST http://localhost:8787/agents/echo-agent \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"m","role":"user","kind":"message","parts":[{"kind":"text","text":"hi"}]}}}'
 ```
+
+> Working from a published client bundle instead of source? Swap `$CLI`
+> for `"$INSTALL_DIR/bin/vicoop-client"` (the path
+> [`docs/install-client.md`](./install-client.md) sets up). The
+> subcommands are identical.
 
 Other entry formats:
 - `google:email:<your_email>` — matches on verified email
@@ -237,10 +256,13 @@ JS
 cp /tmp/gen-siwe.mjs packages/admin-ui/
 (cd packages/admin-ui && node gen-siwe.mjs) > /tmp/siwe.json
 
-# Exchange SIWE → opaque caller token.
+# Exchange SIWE → opaque caller token. The exchange endpoint defaults to
+# audience='owner_session' (vbc_owner_*) when intent is omitted, so for the
+# /agents/:id call below we ask explicitly for intent=caller.
 TOKEN=$(curl -sX POST http://localhost:8787/auth/siwe/exchange \
   -H "Content-Type: application/json" \
-  --data @/tmp/siwe.json | jq -r .access_token)
+  --data "$(jq -c '. + {intent: "caller"}' /tmp/siwe.json)" \
+  | jq -r .access_token)
 echo "$TOKEN"   # vbc_caller_...
 
 # Confirm the callers row landed with provider='siwe'.
@@ -249,11 +271,25 @@ psql vicoop_bridge_dev -c \
 # principal_id should be eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266 (Anvil #0, lowercased)
 # provider should be 'siwe'
 
-# Grant the wallet, restart client, call the agent with the opaque token.
-psql vicoop_bridge_dev -c \
-  "UPDATE agent_policies SET allowed_callers = ARRAY['eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'] WHERE agent_id='echo-agent';"
-# ...restart client...
+# Grant the wallet via the CLI (no client restart needed). Two-step:
+#   (a) sign a fresh SIWE for an owner-session bearer
+#   (b) add the eth:* principal to the agent's allowed_callers
+# The step-3 exchange asked for intent=caller; here we use the exchange
+# endpoint's owner_session default (intent omitted) for the policy bearer.
+# Re-run /tmp/gen-siwe.mjs to mint a fresh nonce — single-use per exchange.
+(cd packages/admin-ui && node gen-siwe.mjs) > /tmp/siwe-owner.json
+OWNER_TOKEN=$(curl -sX POST 'http://localhost:8787/auth/siwe/exchange' \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/siwe-owner.json \
+  | jq -r .access_token)
+echo "$OWNER_TOKEN"   # vbc_owner_...
 
+CLI="pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts"
+VICOOP_BRIDGE=http://localhost:8787 VICOOP_OWNER_TOKEN="$OWNER_TOKEN" \
+  $CLI add-caller echo-agent \
+  'eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+
+# Call the agent with the caller-audience opaque token from step 3.
 curl -s -X POST http://localhost:8787/agents/echo-agent \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
@@ -284,9 +320,12 @@ DATABASE_URL="postgres://$USER@localhost:5432/vicoop_bridge_dev" \
 
 ## Gotchas
 
-- **`allowed_callers` edits via SQL don't hot-reload** — `registry.ts` caches
-  the list in memory at WS registration. After updating the DB, kill and
-  re-run the echo client so it re-registers and the registry re-reads the row.
+- **`allowed_callers` edits via raw SQL don't hot-reload** — `registry.ts`
+  caches the list in memory at WS registration. After a `psql` `UPDATE`
+  (Path A), kill and re-run the echo client so it re-registers and the
+  registry re-reads the row. The `vicoop-client add-caller` /
+  `remove-caller` subcommands and the admin agent's `add_caller` tool
+  call `registry.updateAllowedCallers` and don't need a restart.
 - **Client `--server` URL must not include `/connect`** — client.ts appends it.
   `--server ws://localhost:8787/connect` results in `/connect/connect` and
   immediate disconnects.

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -182,20 +182,33 @@ curl -s -X POST "$BRIDGE_URL/agents/$AGENT_ID" \
 
 ## Step 5 — Restrict with `add_caller`
 
-`POST /` is the admin agent — a Claude-backed A2A endpoint with tools like
-`add_caller`, `remove_caller`, `list_active_agents`, `list_callers`,
-`list_caller_tokens`, `revoke_caller_token`. It accepts any verified
-caller token (`eth:*` or `google:*`); tool execution runs under RLS with
-your principal as the authenticated subject, so mutations on agents you
-own are authorized. The admin scope (`is_admin()`) is wallet-only and
-gates only the cross-owner tools (`list_caller_tokens`,
-`revoke_caller_token`).
+There are two ways to mutate `allowed_callers`:
+
+* **Deterministic HTTP** at `/admin-api/*` — recommended for tests and
+  scripts. The `vicoop-client` CLI wraps it (see below).
+* **Natural-language admin agent** at `POST /` — same logic, exposed as
+  Claude-backed tools (`add_caller`, `remove_caller`, `list_callers`,
+  `list_active_agents`, `list_caller_tokens`, `revoke_caller_token`).
+  Useful for interactive operator chat.
+
+Both paths require an **owner-session bearer** (`vbc_owner_*`). Tool
+execution runs under RLS with your principal as the authenticated
+subject, so mutations on agents you own are authorized. Admin scope
+(`is_admin()`) is wallet-only and gates only the cross-owner tools
+(`list_caller_tokens`, `revoke_caller_token`).
 
 ```bash
 WALLET_PRINCIPAL=eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266   # lowercase
 
+# Deterministic CLI path:
+vicoop-client login --owner-session --bridge "$BRIDGE_URL"   # one-time
+vicoop-client add-caller "$AGENT_ID" "$WALLET_PRINCIPAL"
+
+# Or the natural-language admin agent (uses $OWNER_TOKEN, a vbc_owner_*
+# bearer obtained via /auth/siwe/exchange or device flow with
+# intent=owner_session):
 curl -s -X POST "$BRIDGE_URL/" \
-  -H "Authorization: Bearer $CALLER_TOKEN" -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $OWNER_TOKEN" -H 'Content-Type: application/json' \
   -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"message/send\",\"params\":{\"message\":{\"messageId\":\"ac\",\"role\":\"user\",\"kind\":\"message\",\"parts\":[{\"kind\":\"text\",\"text\":\"Use the add_caller tool to add principal '${WALLET_PRINCIPAL}' to agent '${AGENT_ID}'.\"}]}}}" \
   | jq -r '.result.status.message.parts[0].text'
 ```

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   runAddCaller,
   runListAgents,
@@ -58,11 +61,15 @@ function installFetch(t: { after: (fn: () => void) => void }, response: {
   return { calls };
 }
 
-function withEnv(t: { after: (fn: () => void) => void }, env: Record<string, string>): void {
+function withEnv(
+  t: { after: (fn: () => void) => void },
+  env: Record<string, string | undefined>,
+): void {
   const prev: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(env)) {
     prev[k] = process.env[k];
-    process.env[k] = v;
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
   }
   t.after(() => {
     for (const [k, v] of Object.entries(prev)) {
@@ -194,34 +201,32 @@ test('list-callers GETs the agent endpoint', async (t) => {
 });
 
 test('subcommand exits 1 with hint when no token is available', async (t) => {
-  // Wipe both env and the default file lookup. We can't easily redirect the
-  // file path without exposing a hook, so just unset the env and rely on the
-  // user not having a stale ~/.vicoop/owner-session.json — gate on the message
-  // structure rather than the exact failure mode.
-  withEnv(t, {});
-  delete process.env.VICOOP_OWNER_TOKEN;
-  delete process.env.VICOOP_BRIDGE;
+  // Hermetic missing-auth: redirect HOME (and USERPROFILE on Windows) to an
+  // empty temp dir so os.homedir() resolves into a location without an
+  // owner-session.json — independent of whether the developer running these
+  // tests has one in their real home. With env unset and the file lookup
+  // pointing at an empty dir, resolveOwnerSession returns null deterministically.
+  const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-no-token-'));
+  t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
+  withEnv(t, {
+    HOME: tmpHome,
+    USERPROFILE: tmpHome,
+    VICOOP_OWNER_TOKEN: undefined,
+    VICOOP_BRIDGE: undefined,
+  });
   const stderr = captureStderr(t);
 
-  // Fetch should not be called when auth is missing; install a guard.
+  // Fetch must not be called when auth is missing; throw if it is so the
+  // assertion fails loudly rather than silently masking a regression.
   const original = globalThis.fetch;
-  let fetchCalled = false;
   globalThis.fetch = (async () => {
-    fetchCalled = true;
-    return new Response('', { status: 200 });
+    throw new Error('fetch should not be called when no owner-session is available');
   }) as typeof fetch;
   t.after(() => {
     globalThis.fetch = original;
   });
 
   const code = await runListAgents([]);
-  // If the developer running tests has a real owner-session file, the call
-  // would actually go out — skip the assertion in that case rather than
-  // failing on environment leakage.
-  if (fetchCalled) {
-    t.skip('developer has a stored owner-session.json — env-only assertion would be unsafe');
-    return;
-  }
   assert.equal(code, 1);
   assert.match(stderr.read(), /vicoop-client login --owner-session/);
 });

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -231,6 +231,23 @@ test('subcommand exits 1 with hint when no token is available', async (t) => {
   assert.match(stderr.read(), /vicoop-client login --owner-session/);
 });
 
+test('subcommand surfaces network errors as a clean exit-1 instead of crashing', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stderr = captureStderr(t);
+
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new TypeError('fetch failed');
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+
+  const code = await runListAgents([]);
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /network error.*fetch failed/);
+});
+
 test('subcommand surfaces server error on non-2xx response', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   const stderr = captureStderr(t);

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  runAddCaller,
+  runListAgents,
+  runListCallers,
+  runRemoveCaller,
+} from './admin-cli.js';
+
+interface Captured {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+function installFetch(t: { after: (fn: () => void) => void }, response: {
+  status?: number;
+  body?: unknown;
+}): { calls: Captured[] } {
+  const calls: Captured[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const headers: Record<string, string> = {};
+    const rawHeaders = init?.headers;
+    // Lowercase all header keys so assertions don't depend on the casing
+    // each call site happens to use.
+    if (rawHeaders) {
+      if (rawHeaders instanceof Headers) {
+        rawHeaders.forEach((v, k) => {
+          headers[k.toLowerCase()] = v;
+        });
+      } else if (Array.isArray(rawHeaders)) {
+        for (const [k, v] of rawHeaders) headers[k.toLowerCase()] = v;
+      } else {
+        for (const [k, v] of Object.entries(rawHeaders)) {
+          headers[k.toLowerCase()] = v as string;
+        }
+      }
+    }
+    calls.push({
+      url,
+      method: init?.method ?? 'GET',
+      headers,
+      body: typeof init?.body === 'string' ? init.body : null,
+    });
+    const status = response.status ?? 200;
+    const body = response.body ?? {};
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  return { calls };
+}
+
+function withEnv(t: { after: (fn: () => void) => void }, env: Record<string, string>): void {
+  const prev: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    prev[k] = process.env[k];
+    process.env[k] = v;
+  }
+  t.after(() => {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+}
+
+function captureStdout(t: { after: (fn: () => void) => void }): { read: () => string } {
+  let captured = '';
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+    return true;
+  }) as typeof process.stdout.write;
+  t.after(() => {
+    process.stdout.write = original;
+  });
+  return { read: () => captured };
+}
+
+function captureStderr(t: { after: (fn: () => void) => void }): { read: () => string } {
+  let captured = '';
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+    return true;
+  }) as typeof process.stderr.write;
+  t.after(() => {
+    process.stderr.write = original;
+  });
+  return { read: () => captured };
+}
+
+const TOKEN = 'vbc_owner_testtokenxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+const BRIDGE = 'https://bridge.test';
+
+test('list-agents calls GET /admin-api/agents and renders human output', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: {
+      agents: [
+        {
+          agent_id: 'foo',
+          client_id: 'cid',
+          agent_name: 'Foo',
+          allowed_callers: [],
+          connected_at: '2026-05-07T00:00:00.000Z',
+        },
+      ],
+    },
+  });
+
+  const code = await runListAgents([]);
+  assert.equal(code, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents`);
+  assert.equal(calls[0].headers.authorization, `Bearer ${TOKEN}`);
+  assert.match(stdout.read(), /agent_id:\s+foo/);
+});
+
+test('list-agents --json prints raw JSON', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, { body: { agents: [] } });
+
+  const code = await runListAgents(['--json']);
+  assert.equal(code, 0);
+  const parsed = JSON.parse(stdout.read()) as { agents: unknown[] };
+  assert.deepEqual(parsed, { agents: [] });
+});
+
+test('add-caller posts the principal in the body', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const principal = 'eth:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const { calls } = installFetch(t, {
+    body: {
+      agent_id: 'foo',
+      principal,
+      allowed_callers: [principal],
+    },
+  });
+
+  const code = await runAddCaller(['foo', principal]);
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'POST');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/callers`);
+  assert.equal(calls[0].headers['content-type'], 'application/json');
+  assert.deepEqual(JSON.parse(calls[0].body!), { principal });
+});
+
+test('remove-caller URL-encodes the principal in the query string', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const principal = 'google:email:owner@example.com';
+  const { calls } = installFetch(t, {
+    body: { agent_id: 'foo', principal, allowed_callers: [] },
+  });
+
+  const code = await runRemoveCaller(['foo', principal]);
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'DELETE');
+  assert.equal(
+    calls[0].url,
+    `${BRIDGE}/admin-api/agents/foo/callers?principal=${encodeURIComponent(principal)}`,
+  );
+});
+
+test('list-callers GETs the agent endpoint', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: {
+      agent_id: 'foo',
+      owner_principal: 'eth:0xabc',
+      allowed_callers: [],
+      is_public: true,
+    },
+  });
+
+  const code = await runListCallers(['foo']);
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/callers`);
+});
+
+test('subcommand exits 1 with hint when no token is available', async (t) => {
+  // Wipe both env and the default file lookup. We can't easily redirect the
+  // file path without exposing a hook, so just unset the env and rely on the
+  // user not having a stale ~/.vicoop/owner-session.json — gate on the message
+  // structure rather than the exact failure mode.
+  withEnv(t, {});
+  delete process.env.VICOOP_OWNER_TOKEN;
+  delete process.env.VICOOP_BRIDGE;
+  const stderr = captureStderr(t);
+
+  // Fetch should not be called when auth is missing; install a guard.
+  const original = globalThis.fetch;
+  let fetchCalled = false;
+  globalThis.fetch = (async () => {
+    fetchCalled = true;
+    return new Response('', { status: 200 });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+
+  const code = await runListAgents([]);
+  // If the developer running tests has a real owner-session file, the call
+  // would actually go out — skip the assertion in that case rather than
+  // failing on environment leakage.
+  if (fetchCalled) {
+    t.skip('developer has a stored owner-session.json — env-only assertion would be unsafe');
+    return;
+  }
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /vicoop-client login --owner-session/);
+});
+
+test('subcommand surfaces server error on non-2xx response', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stderr = captureStderr(t);
+  installFetch(t, { status: 403, body: { error: 'Not authorized to modify this agent policy.' } });
+
+  const code = await runAddCaller(['foo', 'eth:0xabc']);
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /403.*Not authorized/);
+});

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -1,0 +1,298 @@
+// Caller-management subcommands for vicoop-client. Thin wrappers over the
+// bridge's deterministic /admin-api/* routes — no LLM round-trip — so they
+// can be safely used in scripts and CI.
+//
+// Auth: each subcommand resolves an owner-session bearer via env
+// (VICOOP_OWNER_TOKEN + VICOOP_BRIDGE) or the file written by
+// `vicoop-client login --owner-session`. If neither is present (or the
+// stored token is expired) the user gets a clear "run login" hint and the
+// process exits with code 1.
+
+import { resolveOwnerSession } from './owner-session.js';
+
+type Subcommand = 'add-caller' | 'remove-caller' | 'list-callers' | 'list-agents';
+
+interface ParsedArgs {
+  positional: string[];
+  bridge?: string;
+  token?: string;
+  json: boolean;
+  help: boolean;
+}
+
+function parseArgs(args: string[]): ParsedArgs | { error: string } {
+  const out: ParsedArgs = { positional: [], json: false, help: false };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    if (a === '-h' || a === '--help') {
+      out.help = true;
+      continue;
+    }
+    if (a === '--bridge' || a === '--token') {
+      const v = args[i + 1];
+      if (v === undefined) return { error: `${a} requires a value` };
+      if (a === '--bridge') out.bridge = v;
+      else out.token = v;
+      i++;
+      continue;
+    }
+    if (a.startsWith('--')) {
+      return { error: `unknown flag: ${a}` };
+    }
+    out.positional.push(a);
+  }
+  return out;
+}
+
+function usage(sub: Subcommand): string {
+  switch (sub) {
+    case 'add-caller':
+      return 'usage: vicoop-client add-caller <agent_id> <principal> [--bridge URL] [--token TOKEN] [--json]';
+    case 'remove-caller':
+      return 'usage: vicoop-client remove-caller <agent_id> <principal> [--bridge URL] [--token TOKEN] [--json]';
+    case 'list-callers':
+      return 'usage: vicoop-client list-callers <agent_id> [--bridge URL] [--token TOKEN] [--json]';
+    case 'list-agents':
+      return 'usage: vicoop-client list-agents [--bridge URL] [--token TOKEN] [--json]';
+  }
+}
+
+interface Session {
+  bridge: string;
+  token: string;
+}
+
+function resolveSession(parsed: ParsedArgs): Session | { error: string } {
+  // Explicit --bridge / --token wins over env wins over file.
+  if (parsed.bridge && parsed.token) {
+    return { bridge: parsed.bridge.replace(/\/$/, ''), token: parsed.token };
+  }
+  const stored = resolveOwnerSession();
+  // Allow --bridge or --token to override one half.
+  const bridge = parsed.bridge ?? stored?.bridge;
+  const token = parsed.token ?? stored?.token;
+  if (!bridge || !token) {
+    return {
+      error:
+        'No owner-session bearer found. Run `vicoop-client login --owner-session --bridge <URL>` first, ' +
+        'or pass --bridge and --token explicitly (or set VICOOP_BRIDGE / VICOOP_OWNER_TOKEN).',
+    };
+  }
+  return { bridge: bridge.replace(/\/$/, ''), token };
+}
+
+interface RequestArgs {
+  session: Session;
+  method: 'GET' | 'POST' | 'DELETE';
+  path: string;
+  body?: unknown;
+}
+
+interface ApiResult {
+  status: number;
+  body: unknown;
+}
+
+async function callApi({ session, method, path, body }: RequestArgs): Promise<ApiResult> {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${session.token}`,
+  };
+  if (body !== undefined) headers['content-type'] = 'application/json';
+  const res = await fetch(`${session.bridge}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: unknown = text;
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // leave as raw text
+    }
+  }
+  return { status: res.status, body: parsed };
+}
+
+function emitError(result: ApiResult): void {
+  if (result.body && typeof result.body === 'object' && 'error' in result.body) {
+    process.stderr.write(`error (${result.status}): ${(result.body as { error: string }).error}\n`);
+  } else {
+    process.stderr.write(`error (${result.status}): ${JSON.stringify(result.body)}\n`);
+  }
+}
+
+function emit(result: ApiResult, json: boolean, humanRender: (body: unknown) => string): number {
+  if (result.status >= 400) {
+    emitError(result);
+    return 1;
+  }
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result.body, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${humanRender(result.body)}\n`);
+  }
+  return 0;
+}
+
+function renderCallerMutation(body: unknown): string {
+  if (!body || typeof body !== 'object') return String(body);
+  const b = body as { agent_id?: string; allowed_callers?: string[]; message?: string };
+  const callers = (b.allowed_callers ?? []).join(', ') || '(none — agent is public)';
+  const note = b.message ? ` (${b.message})` : '';
+  return `agent: ${b.agent_id}\nallowed_callers: ${callers}${note}`;
+}
+
+function renderCallerList(body: unknown): string {
+  if (!body || typeof body !== 'object') return String(body);
+  const b = body as {
+    agent_id?: string;
+    owner_principal?: string;
+    allowed_callers?: string[];
+    is_public?: boolean;
+  };
+  const callers = (b.allowed_callers ?? []).join('\n  ') || '(none — agent is public)';
+  return [
+    `agent:           ${b.agent_id}`,
+    `owner_principal: ${b.owner_principal}`,
+    `is_public:       ${b.is_public}`,
+    'allowed_callers:',
+    `  ${callers}`,
+  ].join('\n');
+}
+
+function renderAgentList(body: unknown): string {
+  if (!body || typeof body !== 'object' || !('agents' in body)) return String(body);
+  const agents = (body as { agents: Array<Record<string, unknown>> }).agents;
+  if (agents.length === 0) return '(no connected agents)';
+  return agents
+    .map((a) => {
+      const callers = (a.allowed_callers as string[] | undefined)?.join(', ') ?? '';
+      return [
+        `agent_id:    ${a.agent_id}`,
+        `agent_name:  ${a.agent_name}`,
+        `client_id:   ${a.client_id}`,
+        `connected:   ${a.connected_at}`,
+        `is_public:   ${(a.allowed_callers as string[] | undefined)?.length === 0}`,
+        `callers:     ${callers}`,
+      ].join('\n');
+    })
+    .join('\n---\n');
+}
+
+export async function runAddCaller(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('add-caller')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('add-caller')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 2) {
+    process.stderr.write(`${usage('add-caller')}\n`);
+    return 1;
+  }
+  const [agentId, principal] = parsed.positional;
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'POST',
+    path: `/admin-api/agents/${encodeURIComponent(agentId)}/callers`,
+    body: { principal },
+  });
+  return emit(result, parsed.json, renderCallerMutation);
+}
+
+export async function runRemoveCaller(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('remove-caller')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('remove-caller')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 2) {
+    process.stderr.write(`${usage('remove-caller')}\n`);
+    return 1;
+  }
+  const [agentId, principal] = parsed.positional;
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'DELETE',
+    path: `/admin-api/agents/${encodeURIComponent(agentId)}/callers?principal=${encodeURIComponent(principal)}`,
+  });
+  return emit(result, parsed.json, renderCallerMutation);
+}
+
+export async function runListCallers(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('list-callers')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('list-callers')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 1) {
+    process.stderr.write(`${usage('list-callers')}\n`);
+    return 1;
+  }
+  const [agentId] = parsed.positional;
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: `/admin-api/agents/${encodeURIComponent(agentId)}/callers`,
+  });
+  return emit(result, parsed.json, renderCallerList);
+}
+
+export async function runListAgents(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('list-agents')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('list-agents')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 0) {
+    process.stderr.write(`${usage('list-agents')}\n`);
+    return 1;
+  }
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: '/admin-api/agents',
+  });
+  return emit(result, parsed.json, renderAgentList);
+}

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -102,11 +102,23 @@ async function callApi({ session, method, path, body }: RequestArgs): Promise<Ap
     Authorization: `Bearer ${session.token}`,
   };
   if (body !== undefined) headers['content-type'] = 'application/json';
-  const res = await fetch(`${session.bridge}${path}`, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${session.bridge}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    // Surface DNS / ECONNREFUSED / TLS / aborted-connection failures through
+    // the same emitError path the rest of the subcommands use, so the user
+    // gets a clean "error (0): …" line + exit code 1 instead of an unhandled
+    // rejection stack trace. Status 0 is a sentinel for "no HTTP response".
+    return {
+      status: 0,
+      body: { error: `network error: ${(err as Error).message}` },
+    };
+  }
   const text = await res.text();
   let parsed: unknown = text;
   if (text) {
@@ -128,7 +140,9 @@ function emitError(result: ApiResult): void {
 }
 
 function emit(result: ApiResult, json: boolean, humanRender: (body: unknown) => string): number {
-  if (result.status >= 400) {
+  // status 0 is the network-error sentinel from callApi; treat it as failure
+  // alongside the regular HTTP error range.
+  if (result.status === 0 || result.status >= 400) {
     emitError(result);
     return 1;
   }

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -9,6 +9,12 @@ import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
 import { runLogin } from './login.js';
+import {
+  runAddCaller,
+  runListAgents,
+  runListCallers,
+  runRemoveCaller,
+} from './admin-cli.js';
 
 interface Args {
   server: string;
@@ -138,6 +144,22 @@ async function main(): Promise<void> {
 
   if (argv[0] === 'login') {
     process.exit(await runLogin(argv.slice(1)));
+  }
+
+  if (argv[0] === 'add-caller') {
+    process.exit(await runAddCaller(argv.slice(1)));
+  }
+
+  if (argv[0] === 'remove-caller') {
+    process.exit(await runRemoveCaller(argv.slice(1)));
+  }
+
+  if (argv[0] === 'list-callers') {
+    process.exit(await runListCallers(argv.slice(1)));
+  }
+
+  if (argv[0] === 'list-agents') {
+    process.exit(await runListAgents(argv.slice(1)));
   }
 
   // Default path: long-running daemon. Do not exit — client.start() keeps the

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -1,9 +1,14 @@
-// `vicoop-client login` — device-flow client registration (issue #79).
+// `vicoop-client login` — device-flow login (issue #79). Two intents:
 //
-// Drives the bridge's RFC-8628 device authorization endpoint with
-// intent=client_register, prints the verification URL + user_code for the
-// operator to open in a browser, polls /oauth/token until approved, and
-// hands back a CLIENT_TOKEN. No SIWE / wallet involved.
+//   * default: `intent=client_register` — registers a new client and returns
+//     a CLIENT_TOKEN bound to the resulting client. Required flags:
+//     --bridge, --client-name, --agent-ids.
+//
+//   * `--owner-session`: `intent=owner_session` — issues an owner-session
+//     bearer (`vbc_owner_*`) used by the admin-management subcommands
+//     (add-caller etc) to authenticate against /admin-api/*. The bearer is
+//     persisted to ~/.vicoop/owner-session.json (chmod 600) by default.
+//     Only --bridge is required.
 //
 // Output goes to stderr for human guidance; the final result is written to
 // stdout as either an env-style block or a JSON document. That keeps shell
@@ -11,11 +16,15 @@
 // straightforward.
 
 import { writeFileSync, chmodSync } from 'node:fs';
+import { saveOwnerSession, defaultStorePath } from './owner-session.js';
+
+type Intent = 'client_register' | 'owner_session';
 
 interface LoginArgs {
+  intent: Intent;
   bridge: string;
-  clientName: string;
-  allowedAgentIds: string[];
+  clientName: string;          // unused for owner_session
+  allowedAgentIds: string[];   // unused for owner_session
   envFile: string | null;
   json: boolean;
   pollOnce: boolean; // for tests / CI smoke
@@ -30,7 +39,7 @@ interface DeviceCodeResponse {
   interval: number;
 }
 
-interface TokenSuccessResponse {
+interface ClientRegisterSuccess {
   intent: 'client_register';
   client_id: string;
   client_token: string;
@@ -38,6 +47,20 @@ interface TokenSuccessResponse {
   owner_email: string | null;
   client_name: string;
   allowed_agent_ids: string[];
+}
+
+interface OwnerSessionSuccess {
+  access_token: string;
+  token_type: 'Bearer';
+  expires_in: number;
+  principal_id: string;
+  email: string | null;
+}
+
+type TokenSuccessResponse = ClientRegisterSuccess | OwnerSessionSuccess;
+
+function isClientRegister(body: TokenSuccessResponse): body is ClientRegisterSuccess {
+  return (body as ClientRegisterSuccess).intent === 'client_register';
 }
 
 interface OAuthError {
@@ -50,20 +73,27 @@ function usage(): void {
     [
       'usage: vicoop-client login --bridge <https://...> --client-name <name>',
       '                          --agent-ids <id1,id2> [--write-env-file <path>] [--json]',
+      '       vicoop-client login --owner-session --bridge <https://...> [--json]',
       '',
-      'Drives Google OAuth device flow against the bridge to register a new client.',
-      'Prints the resulting CLIENT_TOKEN once — save it immediately, it is unrecoverable.',
+      'Default: drives Google OAuth device flow to register a new client and prints',
+      '         the resulting CLIENT_TOKEN once. Required: --bridge, --client-name, --agent-ids.',
+      '',
+      '--owner-session: drives the same flow but issues an owner-session bearer used',
+      '         by add-caller / list-callers / list-agents / remove-caller. The token',
+      '         is saved to ~/.vicoop/owner-session.json (chmod 600) by default.',
       '',
       'Flags:',
       '  --bridge          Bridge HTTP URL (e.g. https://vicoop-bridge-server.fly.dev)',
-      '  --client-name     Human-readable client name shown in admin tooling',
-      '  --agent-ids       CSV of agent ids this client is allowed to register as',
+      '  --owner-session   Issue an owner-session bearer instead of registering a client.',
+      '  --client-name     Human-readable client name (client_register only).',
+      '  --agent-ids       CSV of agent ids this client is allowed to register as.',
       '  --write-env-file PATH',
-      '                    Write SERVER_URL / SERVER_TOKEN / AGENT_ID env block to PATH',
-      '                    (chmod 600). When omitted, the env block is printed to stdout.',
+      '                    Write env block to PATH (chmod 600).',
+      '                      client_register: SERVER_URL / SERVER_TOKEN / AGENT_ID',
+      '                      owner-session:   VICOOP_BRIDGE / VICOOP_OWNER_TOKEN',
       '  --env-file PATH   Deprecated alias for --write-env-file. Avoid on Node 24+',
       '                    unless your wrapper invokes node with "--" before the script.',
-      '  --json            Print the token endpoint response as JSON to stdout instead.',
+      '  --json            Print the token endpoint response as JSON to stdout.',
       '',
     ].join('\n'),
   );
@@ -71,6 +101,7 @@ function usage(): void {
 
 function parseArgs(args: string[]): LoginArgs | null {
   const out: Partial<LoginArgs> & { allowedAgentIds: string[] } = {
+    intent: 'client_register',
     allowedAgentIds: [],
     envFile: null,
     json: false,
@@ -80,6 +111,10 @@ function parseArgs(args: string[]): LoginArgs | null {
     const a = args[i];
     if (a === '--json') {
       out.json = true;
+      continue;
+    }
+    if (a === '--owner-session') {
+      out.intent = 'owner_session';
       continue;
     }
     if (a === '--poll-once') {
@@ -112,19 +147,25 @@ function parseArgs(args: string[]): LoginArgs | null {
     }
     i++;
   }
-  if (!out.bridge || !out.clientName || out.allowedAgentIds.length === 0) {
+  if (!out.bridge) {
     usage();
     return null;
+  }
+  if (out.intent === 'client_register') {
+    if (!out.clientName || out.allowedAgentIds.length === 0) {
+      usage();
+      return null;
+    }
   }
   return out as LoginArgs;
 }
 
 async function fetchDeviceCode(args: LoginArgs): Promise<DeviceCodeResponse> {
-  const body = new URLSearchParams({
-    intent: 'client_register',
-    client_name: args.clientName,
-    allowed_agent_ids: args.allowedAgentIds.join(','),
-  });
+  const body = new URLSearchParams({ intent: args.intent });
+  if (args.intent === 'client_register') {
+    body.set('client_name', args.clientName);
+    body.set('allowed_agent_ids', args.allowedAgentIds.join(','));
+  }
   const res = await fetch(`${args.bridge.replace(/\/$/, '')}/oauth/device/code`, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -188,14 +229,20 @@ function sleep(ms: number): Promise<void> {
 }
 
 function writeEnvFile(path: string, success: TokenSuccessResponse, bridgeUrl: string): void {
-  const wsUrl = bridgeUrl.replace(/^http(s?):\/\//, (_m, s) => (s === 's' ? 'wss://' : 'ws://'));
-  const lines = [
-    `# vicoop-client env (generated by 'vicoop-client login')`,
-    `SERVER_URL=${wsUrl}`,
-    `SERVER_TOKEN=${success.client_token}`,
-    `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
-    '',
-  ].join('\n');
+  const lines = isClientRegister(success)
+    ? [
+        `# vicoop-client env (generated by 'vicoop-client login')`,
+        `SERVER_URL=${bridgeUrl.replace(/^http(s?):\/\//, (_m, s) => (s === 's' ? 'wss://' : 'ws://'))}`,
+        `SERVER_TOKEN=${success.client_token}`,
+        `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
+        '',
+      ].join('\n')
+    : [
+        `# vicoop-client env (generated by 'vicoop-client login --owner-session')`,
+        `VICOOP_BRIDGE=${bridgeUrl.replace(/\/$/, '')}`,
+        `VICOOP_OWNER_TOKEN=${success.access_token}`,
+        '',
+      ].join('\n');
   writeFileSync(path, lines);
   // chmod 600 so a peer process on the same host can't read the token. Best
   // effort — fails silently on filesystems that don't support POSIX modes.
@@ -247,35 +294,71 @@ export async function runLogin(args: string[]): Promise<number> {
     if (result.kind === 'success') {
       const success = result.body;
       process.stderr.write('\nApproved.\n\n');
-      process.stderr.write(
-        `  client_id        ${success.client_id}\n` +
-          `  owner_principal  ${success.owner_principal}\n` +
-          `  owner_email      ${success.owner_email ?? '(none)'}\n` +
-          `  client_name      ${success.client_name}\n` +
-          `  allowed_agents   ${success.allowed_agent_ids.join(', ')}\n\n`,
-      );
-      process.stderr.write(
-        '⚠ The CLIENT_TOKEN below is shown only once and cannot be retrieved later.\n' +
-          '  Save it now (export to env, write to a vault, etc.).\n\n',
-      );
 
-      if (parsed.envFile) {
-        writeEnvFile(parsed.envFile, success, parsed.bridge);
-        process.stderr.write(`Wrote env block to ${parsed.envFile} (mode 600).\n`);
-      } else if (parsed.json) {
-        process.stdout.write(`${JSON.stringify(success, null, 2)}\n`);
+      if (isClientRegister(success)) {
+        process.stderr.write(
+          `  client_id        ${success.client_id}\n` +
+            `  owner_principal  ${success.owner_principal}\n` +
+            `  owner_email      ${success.owner_email ?? '(none)'}\n` +
+            `  client_name      ${success.client_name}\n` +
+            `  allowed_agents   ${success.allowed_agent_ids.join(', ')}\n\n`,
+        );
+        process.stderr.write(
+          'The CLIENT_TOKEN below is shown only once and cannot be retrieved later.\n' +
+            '  Save it now (export to env, write to a vault, etc.).\n\n',
+        );
+
+        if (parsed.envFile) {
+          writeEnvFile(parsed.envFile, success, parsed.bridge);
+          process.stderr.write(`Wrote env block to ${parsed.envFile} (mode 600).\n`);
+        } else if (parsed.json) {
+          process.stdout.write(`${JSON.stringify(success, null, 2)}\n`);
+        } else {
+          const wsUrl = parsed.bridge.replace(/^http(s?):\/\//, (_m, s) =>
+            s === 's' ? 'wss://' : 'ws://',
+          );
+          process.stdout.write(
+            [
+              `SERVER_URL=${wsUrl}`,
+              `SERVER_TOKEN=${success.client_token}`,
+              `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
+              '',
+            ].join('\n'),
+          );
+        }
       } else {
-        const wsUrl = parsed.bridge.replace(/^http(s?):\/\//, (_m, s) =>
-          s === 's' ? 'wss://' : 'ws://',
+        process.stderr.write(
+          `  principal_id     ${success.principal_id}\n` +
+            `  email            ${success.email ?? '(none)'}\n` +
+            `  expires_in       ${success.expires_in}s\n\n`,
         );
-        process.stdout.write(
-          [
-            `SERVER_URL=${wsUrl}`,
-            `SERVER_TOKEN=${success.client_token}`,
-            `AGENT_ID=${success.allowed_agent_ids[0] ?? ''}`,
-            '',
-          ].join('\n'),
-        );
+
+        const expiresAt = new Date(Date.now() + success.expires_in * 1000).toISOString();
+
+        if (parsed.envFile) {
+          writeEnvFile(parsed.envFile, success, parsed.bridge);
+          process.stderr.write(`Wrote env block to ${parsed.envFile} (mode 600).\n`);
+        } else if (parsed.json) {
+          process.stdout.write(`${JSON.stringify(success, null, 2)}\n`);
+        } else {
+          // Default for owner-session: persist to ~/.vicoop/owner-session.json so
+          // subsequent admin-management subcommands pick it up automatically. This
+          // mirrors how `gh auth login` plants ~/.config/gh/hosts.yml — no env
+          // wiring required for the common single-host case.
+          const path = defaultStorePath();
+          saveOwnerSession({
+            bridge: parsed.bridge.replace(/\/$/, ''),
+            token: success.access_token,
+            principal_id: success.principal_id,
+            email: success.email,
+            expires_at: expiresAt,
+            saved_at: new Date().toISOString(),
+          }, path);
+          process.stderr.write(
+            `Saved owner-session bearer to ${path} (mode 600).\n` +
+              `Use VICOOP_OWNER_TOKEN / VICOOP_BRIDGE to override per-invocation.\n`,
+          );
+        }
       }
       return 0;
     }

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -15,7 +15,8 @@
 // composition (`$(vicoop-client login --json | jq -r .client_token)`)
 // straightforward.
 
-import { writeFileSync, chmodSync } from 'node:fs';
+import { closeSync, openSync, renameSync, writeFileSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { saveOwnerSession, defaultStorePath } from './owner-session.js';
 
 type Intent = 'client_register' | 'owner_session';
@@ -243,14 +244,19 @@ function writeEnvFile(path: string, success: TokenSuccessResponse, bridgeUrl: st
         `VICOOP_OWNER_TOKEN=${success.access_token}`,
         '',
       ].join('\n');
-  writeFileSync(path, lines);
-  // chmod 600 so a peer process on the same host can't read the token. Best
-  // effort — fails silently on filesystems that don't support POSIX modes.
+  // Same atomic write+rename pattern saveOwnerSession uses: openSync's mode
+  // arg is only honoured on creation, so write-then-chmod against an existing
+  // path would leave looser perms in place, and even on first creation under
+  // a permissive umask the file is briefly world-readable. Writing fresh to
+  // a 0o600 temp sibling and renaming sidesteps both.
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  const fd = openSync(tmp, 'wx', 0o600);
   try {
-    chmodSync(path, 0o600);
-  } catch {
-    // ignore
+    writeFileSync(fd, lines);
+  } finally {
+    closeSync(fd);
   }
+  renameSync(tmp, path);
 }
 
 export async function runLogin(args: string[]): Promise<number> {

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -21,15 +21,28 @@ import { saveOwnerSession, defaultStorePath } from './owner-session.js';
 
 type Intent = 'client_register' | 'owner_session';
 
-interface LoginArgs {
-  intent: Intent;
+// Modelled as a discriminated union on `intent` so TypeScript blocks
+// accidental access to `clientName` / `allowedAgentIds` on the
+// owner-session path (where they don't apply) and parseArgs is forced to
+// validate them before constructing a ClientRegisterArgs.
+interface BaseLoginArgs {
   bridge: string;
-  clientName: string;          // unused for owner_session
-  allowedAgentIds: string[];   // unused for owner_session
   envFile: string | null;
   json: boolean;
   pollOnce: boolean; // for tests / CI smoke
 }
+
+interface ClientRegisterArgs extends BaseLoginArgs {
+  intent: 'client_register';
+  clientName: string;
+  allowedAgentIds: string[];
+}
+
+interface OwnerSessionArgs extends BaseLoginArgs {
+  intent: 'owner_session';
+}
+
+type LoginArgs = ClientRegisterArgs | OwnerSessionArgs;
 
 interface DeviceCodeResponse {
   device_code: string;
@@ -101,26 +114,27 @@ function usage(): void {
 }
 
 function parseArgs(args: string[]): LoginArgs | null {
-  const out: Partial<LoginArgs> & { allowedAgentIds: string[] } = {
-    intent: 'client_register',
-    allowedAgentIds: [],
-    envFile: null,
-    json: false,
-    pollOnce: false,
-  };
+  let intent: Intent = 'client_register';
+  let bridge: string | undefined;
+  let clientName: string | undefined;
+  let allowedAgentIds: string[] = [];
+  let envFile: string | null = null;
+  let json = false;
+  let pollOnce = false;
+
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === '--json') {
-      out.json = true;
+      json = true;
       continue;
     }
     if (a === '--owner-session') {
-      out.intent = 'owner_session';
+      intent = 'owner_session';
       continue;
     }
     if (a === '--poll-once') {
       // Internal: bail after a single poll, regardless of state. Used by tests.
-      out.pollOnce = true;
+      pollOnce = true;
       continue;
     }
     const v = args[i + 1];
@@ -130,17 +144,17 @@ function parseArgs(args: string[]): LoginArgs | null {
     }
     switch (a) {
       case '--bridge':
-        out.bridge = v;
+        bridge = v;
         break;
       case '--client-name':
-        out.clientName = v;
+        clientName = v;
         break;
       case '--agent-ids':
-        out.allowedAgentIds = v.split(',').map((s) => s.trim()).filter(Boolean);
+        allowedAgentIds = v.split(',').map((s) => s.trim()).filter(Boolean);
         break;
       case '--write-env-file':
       case '--env-file':
-        out.envFile = v;
+        envFile = v;
         break;
       default:
         process.stderr.write(`unknown flag: ${a}\n`);
@@ -148,17 +162,19 @@ function parseArgs(args: string[]): LoginArgs | null {
     }
     i++;
   }
-  if (!out.bridge) {
+  if (!bridge) {
     usage();
     return null;
   }
-  if (out.intent === 'client_register') {
-    if (!out.clientName || out.allowedAgentIds.length === 0) {
+  const base = { bridge, envFile, json, pollOnce };
+  if (intent === 'client_register') {
+    if (!clientName || allowedAgentIds.length === 0) {
       usage();
       return null;
     }
+    return { intent, ...base, clientName, allowedAgentIds };
   }
-  return out as LoginArgs;
+  return { intent, ...base };
 }
 
 async function fetchDeviceCode(args: LoginArgs): Promise<DeviceCodeResponse> {

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -10,10 +10,18 @@
 //     persisted to ~/.vicoop/owner-session.json (chmod 600) by default.
 //     Only --bridge is required.
 //
-// Output goes to stderr for human guidance; the final result is written to
-// stdout as either an env-style block or a JSON document. That keeps shell
-// composition (`$(vicoop-client login --json | jq -r .client_token)`)
-// straightforward.
+// Output: stderr is always used for human guidance. The destination of the
+// "final result" depends on intent + flags:
+//   * client_register, default          → stdout, env-style block
+//   * client_register, --json            → stdout, JSON document
+//   * client_register, --write-env-file  → file at the given path, env-style
+//   * owner_session, default             → ~/.vicoop/owner-session.json (chmod 600)
+//   * owner_session, --json              → stdout, JSON document
+//   * owner_session, --write-env-file    → file at the given path, env-style
+// Stdout-as-default for client_register keeps shell composition working
+// (`$(vicoop-client login --json | jq -r .client_token)`); owner-session's
+// default-to-file matches the way `gh auth login` plants ~/.config/gh/hosts.yml,
+// so subsequent admin subcommands pick up the bearer with no env wiring.
 
 import { closeSync, openSync, renameSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
@@ -87,7 +95,8 @@ function usage(): void {
     [
       'usage: vicoop-client login --bridge <https://...> --client-name <name>',
       '                          --agent-ids <id1,id2> [--write-env-file <path>] [--json]',
-      '       vicoop-client login --owner-session --bridge <https://...> [--json]',
+      '       vicoop-client login --owner-session --bridge <https://...>',
+      '                          [--write-env-file <path>] [--json]',
       '',
       'Default: drives Google OAuth device flow to register a new client and prints',
       '         the resulting CLIENT_TOKEN once. Required: --bridge, --client-name, --agent-ids.',

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -23,9 +23,11 @@
 // default-to-file matches the way `gh auth login` plants ~/.config/gh/hosts.yml,
 // so subsequent admin subcommands pick up the bearer with no env wiring.
 
-import { closeSync, openSync, renameSync, writeFileSync } from 'node:fs';
-import { randomBytes } from 'node:crypto';
-import { saveOwnerSession, defaultStorePath } from './owner-session.js';
+import {
+  atomicWriteFile,
+  defaultStorePath,
+  saveOwnerSession,
+} from './owner-session.js';
 
 type Intent = 'client_register' | 'owner_session';
 
@@ -269,19 +271,11 @@ function writeEnvFile(path: string, success: TokenSuccessResponse, bridgeUrl: st
         `VICOOP_OWNER_TOKEN=${success.access_token}`,
         '',
       ].join('\n');
-  // Same atomic write+rename pattern saveOwnerSession uses: openSync's mode
-  // arg is only honoured on creation, so write-then-chmod against an existing
-  // path would leave looser perms in place, and even on first creation under
-  // a permissive umask the file is briefly world-readable. Writing fresh to
-  // a 0o600 temp sibling and renaming sidesteps both.
-  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
-  const fd = openSync(tmp, 'wx', 0o600);
-  try {
-    writeFileSync(fd, lines);
-  } finally {
-    closeSync(fd);
-  }
-  renameSync(tmp, path);
+  // Shared atomic write helper: creates a 0o600 temp sibling and renames it
+  // into place, handling Windows' non-overwriting rename so re-running
+  // `login --write-env-file` updates an existing file reliably. Same
+  // semantics saveOwnerSession uses.
+  atomicWriteFile(path, lines, 0o600);
 }
 
 export async function runLogin(args: string[]): Promise<number> {

--- a/packages/client/src/owner-session.test.ts
+++ b/packages/client/src/owner-session.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
+  atomicWriteFile,
   loadOwnerSession,
   resolveOwnerSession,
   saveOwnerSession,
@@ -87,6 +88,22 @@ test('loadOwnerSession returns null when fields have wrong types', () => {
       saved_at: new Date().toISOString(),
     }));
     assert.equal(loadOwnerSession(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('atomicWriteFile cleans up its temp file on rename failure', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-atomic-fail-'));
+  try {
+    // Force renameSync to fail by making the destination an existing
+    // directory — POSIX rename(2) returns EISDIR / ENOTEMPTY in that case.
+    const dest = join(dir, 'collide');
+    mkdirSync(dest);
+    assert.throws(() => atomicWriteFile(dest, 'irrelevant'));
+    // No *.tmp file should remain in the parent dir.
+    const stragglers = readdirSync(dir).filter((n) => n.endsWith('.tmp'));
+    assert.deepEqual(stragglers, []);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/client/src/owner-session.test.ts
+++ b/packages/client/src/owner-session.test.ts
@@ -56,6 +56,40 @@ test('loadOwnerSession returns null on malformed JSON', () => {
   }
 });
 
+test('loadOwnerSession returns null when fields have wrong types', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-types-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    // Tampered: `bridge` is a number, not a string. The truthiness check
+    // would have let this through and resolveOwnerSession would have
+    // crashed in `.replace()`.
+    writeFileSync(path, JSON.stringify({
+      bridge: 123,
+      token: 'vbc_owner_xxx',
+      expires_at: new Date(Date.now() + 1000).toISOString(),
+      saved_at: new Date().toISOString(),
+    }));
+    assert.equal(loadOwnerSession(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('saveOwnerSession can overwrite an existing file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-overwrite-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    saveOwnerSession(makeSession({ token: 'vbc_owner_first' }), path);
+    // Re-saving must succeed cross-platform — Windows' non-overwriting
+    // rename was leaving the new token stranded in the temp file.
+    saveOwnerSession(makeSession({ token: 'vbc_owner_second' }), path);
+    const loaded = loadOwnerSession(path);
+    assert.equal(loaded?.token, 'vbc_owner_second');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('resolveOwnerSession prefers env over file when both present', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-env-'));
   try {

--- a/packages/client/src/owner-session.test.ts
+++ b/packages/client/src/owner-session.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  loadOwnerSession,
+  resolveOwnerSession,
+  saveOwnerSession,
+  type OwnerSession,
+} from './owner-session.js';
+
+function makeSession(overrides: Partial<OwnerSession> = {}): OwnerSession {
+  return {
+    bridge: 'https://bridge.test',
+    token: 'vbc_owner_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    principal_id: 'eth:0x1111111111111111111111111111111111111111',
+    email: null,
+    expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    saved_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+test('saveOwnerSession + loadOwnerSession round-trip preserves fields', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    const session = makeSession();
+    saveOwnerSession(session, path);
+    const loaded = loadOwnerSession(path);
+    assert.deepEqual(loaded, session);
+    // chmod 600 best-effort; if the platform supports POSIX modes, verify.
+    const mode = statSync(path).mode & 0o777;
+    if (process.platform !== 'win32') {
+      assert.equal(mode, 0o600, `expected 0o600, got 0o${mode.toString(8)}`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadOwnerSession returns null when file is missing', () => {
+  const path = join(tmpdir(), `vicoop-owner-missing-${Date.now()}.json`);
+  assert.equal(loadOwnerSession(path), null);
+});
+
+test('loadOwnerSession returns null on malformed JSON', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-bad-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    writeFileSync(path, '{not json');
+    assert.equal(loadOwnerSession(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOwnerSession prefers env over file when both present', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-env-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    saveOwnerSession(
+      makeSession({ bridge: 'https://from-file.test', token: 'vbc_owner_filetokenxxxxxxxxxxxxxxxxxxx' }),
+      path,
+    );
+
+    const prevToken = process.env.VICOOP_OWNER_TOKEN;
+    const prevBridge = process.env.VICOOP_BRIDGE;
+    process.env.VICOOP_OWNER_TOKEN = 'vbc_owner_envtokenxxxxxxxxxxxxxxxxxxxx';
+    process.env.VICOOP_BRIDGE = 'https://from-env.test';
+    t.after(() => {
+      if (prevToken === undefined) delete process.env.VICOOP_OWNER_TOKEN;
+      else process.env.VICOOP_OWNER_TOKEN = prevToken;
+      if (prevBridge === undefined) delete process.env.VICOOP_BRIDGE;
+      else process.env.VICOOP_BRIDGE = prevBridge;
+    });
+
+    const resolved = resolveOwnerSession(path);
+    assert.deepEqual(resolved, {
+      bridge: 'https://from-env.test',
+      token: 'vbc_owner_envtokenxxxxxxxxxxxxxxxxxxxx',
+      source: 'env',
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOwnerSession falls back to file when env unset', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-file-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    saveOwnerSession(makeSession({ bridge: 'https://file.test', token: 'vbc_owner_fromfile' }), path);
+
+    const prevToken = process.env.VICOOP_OWNER_TOKEN;
+    const prevBridge = process.env.VICOOP_BRIDGE;
+    delete process.env.VICOOP_OWNER_TOKEN;
+    delete process.env.VICOOP_BRIDGE;
+    t.after(() => {
+      if (prevToken !== undefined) process.env.VICOOP_OWNER_TOKEN = prevToken;
+      if (prevBridge !== undefined) process.env.VICOOP_BRIDGE = prevBridge;
+    });
+
+    const resolved = resolveOwnerSession(path);
+    assert.deepEqual(resolved, {
+      bridge: 'https://file.test',
+      token: 'vbc_owner_fromfile',
+      source: 'file',
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveOwnerSession ignores file when stored token is expired', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-exp-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    saveOwnerSession(
+      makeSession({ expires_at: new Date(Date.now() - 1000).toISOString() }),
+      path,
+    );
+
+    const prevToken = process.env.VICOOP_OWNER_TOKEN;
+    const prevBridge = process.env.VICOOP_BRIDGE;
+    delete process.env.VICOOP_OWNER_TOKEN;
+    delete process.env.VICOOP_BRIDGE;
+    t.after(() => {
+      if (prevToken !== undefined) process.env.VICOOP_OWNER_TOKEN = prevToken;
+      if (prevBridge !== undefined) process.env.VICOOP_BRIDGE = prevBridge;
+    });
+
+    assert.equal(resolveOwnerSession(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/client/src/owner-session.test.ts
+++ b/packages/client/src/owner-session.test.ts
@@ -56,6 +56,23 @@ test('loadOwnerSession returns null on malformed JSON', () => {
   }
 });
 
+test('loadOwnerSession returns null when required field saved_at is missing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-missing-'));
+  try {
+    const path = join(dir, 'owner-session.json');
+    // OwnerSession requires saved_at; an older or hand-edited file without
+    // it shouldn't slip through and violate the declared return type.
+    writeFileSync(path, JSON.stringify({
+      bridge: 'https://bridge.test',
+      token: 'vbc_owner_xxx',
+      expires_at: new Date(Date.now() + 1000).toISOString(),
+    }));
+    assert.equal(loadOwnerSession(path), null);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('loadOwnerSession returns null when fields have wrong types', () => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-owner-types-'));
   try {

--- a/packages/client/src/owner-session.ts
+++ b/packages/client/src/owner-session.ts
@@ -18,11 +18,40 @@ import {
   openSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+
+// Atomic write that's safe on Windows. POSIX rename is overwrite-by-default,
+// but Node's renameSync on win32 throws EEXIST/EPERM when the destination
+// already exists, which would leave a re-saved token stranded in the temp
+// file. We unlink the destination first on win32 (ignoring ENOENT for the
+// first-save case). Exported so other client modules — currently login.ts's
+// writeEnvFile — can share the same write semantics.
+export function atomicWriteFile(path: string, contents: string, mode = 0o600): void {
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  const fd = openSync(tmp, 'wx', mode);
+  try {
+    writeFileSync(fd, contents);
+  } finally {
+    closeSync(fd);
+  }
+  if (process.platform === 'win32') {
+    try {
+      unlinkSync(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        // Cleanup so we don't leave a stray temp file on the way out.
+        try { unlinkSync(tmp); } catch { /* ignore */ }
+        throw err;
+      }
+    }
+  }
+  renameSync(tmp, path);
+}
 
 export interface OwnerSession {
   bridge: string;
@@ -44,34 +73,42 @@ export function saveOwnerSession(session: OwnerSession, path: string = defaultSt
   const dir = dirname(path);
   // mkdirSync's `mode` only applies to directories actually created here;
   // pre-existing dirs keep their permissions. The bearer's defence-in-depth
-  // is the file mode we set below.
+  // is the file mode atomicWriteFile sets below.
   mkdirSync(dir, { recursive: true, mode: 0o700 });
 
-  // Write to a temp sibling at mode 0o600, then rename. Rationale:
-  //   * openSync's mode arg is only honoured on creation, so if `path` already
-  //     exists with looser perms (e.g. a legacy save), opening it with 'w'
-  //     would leave the old mode in place.
-  //   * write-then-chmod creates a window where the file is world-readable
-  //     under a permissive umask — exactly what the review flagged.
+  // Write to a temp sibling at mode 0o600, then rename atomically. Rationale:
+  //   * openSync's mode arg is only honoured on creation, so opening an
+  //     existing path with 'w' would keep the old (possibly looser) mode.
+  //   * write-then-chmod leaves a window where the file is world-readable
+  //     under a permissive umask.
   // Writing fresh + atomic rename avoids both: the resulting file is always
   // mode 0o600 with no partial-write state visible on the canonical path.
-  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
-  const fd = openSync(tmp, 'wx', 0o600);
-  try {
-    writeFileSync(fd, JSON.stringify(session, null, 2));
-  } finally {
-    closeSync(fd);
-  }
-  renameSync(tmp, path);
+  // atomicWriteFile also handles Windows' non-overwriting rename so a
+  // second `login --owner-session` invocation replaces the file cleanly.
+  atomicWriteFile(path, JSON.stringify(session, null, 2), 0o600);
+}
+
+// Strict shape check: a tampered or hand-edited file with non-string fields
+// would otherwise crash later in resolveOwnerSession's `.replace()` call.
+// Optional fields (principal_id, email) are checked only when present;
+// `email` may be null per the persisted shape.
+function isOwnerSession(value: unknown): value is OwnerSession {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.bridge !== 'string' || !v.bridge) return false;
+  if (typeof v.token !== 'string' || !v.token) return false;
+  if (typeof v.expires_at !== 'string' || !v.expires_at) return false;
+  if ('saved_at' in v && typeof v.saved_at !== 'string') return false;
+  if ('principal_id' in v && v.principal_id !== undefined && typeof v.principal_id !== 'string') return false;
+  if ('email' in v && v.email !== null && v.email !== undefined && typeof v.email !== 'string') return false;
+  return true;
 }
 
 export function loadOwnerSession(path: string = defaultStorePath()): OwnerSession | null {
   if (!existsSync(path)) return null;
   try {
-    const raw = readFileSync(path, 'utf-8');
-    const parsed = JSON.parse(raw) as OwnerSession;
-    if (!parsed.bridge || !parsed.token || !parsed.expires_at) return null;
-    return parsed;
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    return isOwnerSession(parsed) ? parsed : null;
   } catch {
     return null;
   }

--- a/packages/client/src/owner-session.ts
+++ b/packages/client/src/owner-session.ts
@@ -11,7 +11,16 @@
 // and we want feature-parity. Tokens are short-ish (default 90 days) and the
 // CLI re-prompts via login when expired.
 
-import { readFileSync, writeFileSync, chmodSync, mkdirSync, existsSync } from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -33,15 +42,27 @@ export function defaultStorePath(): string {
 
 export function saveOwnerSession(session: OwnerSession, path: string = defaultStorePath()): void {
   const dir = dirname(path);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(session, null, 2));
-  // chmod 600 so peer processes on a shared host can't read the bearer.
-  // Best-effort — silently ignore on filesystems without POSIX modes.
+  // mkdirSync's `mode` only applies to directories actually created here;
+  // pre-existing dirs keep their permissions. The bearer's defence-in-depth
+  // is the file mode we set below.
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  // Write to a temp sibling at mode 0o600, then rename. Rationale:
+  //   * openSync's mode arg is only honoured on creation, so if `path` already
+  //     exists with looser perms (e.g. a legacy save), opening it with 'w'
+  //     would leave the old mode in place.
+  //   * write-then-chmod creates a window where the file is world-readable
+  //     under a permissive umask — exactly what the review flagged.
+  // Writing fresh + atomic rename avoids both: the resulting file is always
+  // mode 0o600 with no partial-write state visible on the canonical path.
+  const tmp = `${path}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`;
+  const fd = openSync(tmp, 'wx', 0o600);
   try {
-    chmodSync(path, 0o600);
-  } catch {
-    // ignore
+    writeFileSync(fd, JSON.stringify(session, null, 2));
+  } finally {
+    closeSync(fd);
   }
+  renameSync(tmp, path);
 }
 
 export function loadOwnerSession(path: string = defaultStorePath()): OwnerSession | null {

--- a/packages/client/src/owner-session.ts
+++ b/packages/client/src/owner-session.ts
@@ -90,15 +90,18 @@ export function saveOwnerSession(session: OwnerSession, path: string = defaultSt
 
 // Strict shape check: a tampered or hand-edited file with non-string fields
 // would otherwise crash later in resolveOwnerSession's `.replace()` call.
-// Optional fields (principal_id, email) are checked only when present;
-// `email` may be null per the persisted shape.
+// Required fields (bridge / token / expires_at / saved_at per OwnerSession)
+// are enforced as non-empty strings so the guard matches the interface and
+// loadOwnerSession's return type is honest. Truly optional fields
+// (principal_id, email) are checked only when present; `email` may be null
+// per the persisted shape.
 function isOwnerSession(value: unknown): value is OwnerSession {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;
   if (typeof v.bridge !== 'string' || !v.bridge) return false;
   if (typeof v.token !== 'string' || !v.token) return false;
   if (typeof v.expires_at !== 'string' || !v.expires_at) return false;
-  if ('saved_at' in v && typeof v.saved_at !== 'string') return false;
+  if (typeof v.saved_at !== 'string' || !v.saved_at) return false;
   if ('principal_id' in v && v.principal_id !== undefined && typeof v.principal_id !== 'string') return false;
   if ('email' in v && v.email !== null && v.email !== undefined && typeof v.email !== 'string') return false;
   return true;

--- a/packages/client/src/owner-session.ts
+++ b/packages/client/src/owner-session.ts
@@ -39,18 +39,29 @@ export function atomicWriteFile(path: string, contents: string, mode = 0o600): v
   } finally {
     closeSync(fd);
   }
+
+  // From here on, every error path must clean up `tmp` so repeated
+  // login / write-env-file attempts don't accumulate stray *.tmp files
+  // on permission errors, locked files, etc.
+  const cleanupAndThrow = (err: unknown): never => {
+    try { unlinkSync(tmp); } catch { /* ignore */ }
+    throw err;
+  };
+
   if (process.platform === 'win32') {
     try {
       unlinkSync(path);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        // Cleanup so we don't leave a stray temp file on the way out.
-        try { unlinkSync(tmp); } catch { /* ignore */ }
-        throw err;
+        cleanupAndThrow(err);
       }
     }
   }
-  renameSync(tmp, path);
+  try {
+    renameSync(tmp, path);
+  } catch (err) {
+    cleanupAndThrow(err);
+  }
 }
 
 export interface OwnerSession {

--- a/packages/client/src/owner-session.ts
+++ b/packages/client/src/owner-session.ts
@@ -1,0 +1,79 @@
+// Persists and loads the operator's owner-session bearer token, used by the
+// admin-management subcommands (add-caller / remove-caller / list-callers /
+// list-agents) to authenticate against the bridge's /admin-api/* routes.
+//
+// Resolution order when the CLI needs a token:
+//   1. VICOOP_OWNER_TOKEN env (paired with VICOOP_BRIDGE for the URL)
+//   2. ~/.vicoop/owner-session.json written by `vicoop-client login --owner-session`
+//
+// Storage is a single JSON file (chmod 600) rather than a credential keychain
+// because the rest of the client already keeps its bearer in plain env files
+// and we want feature-parity. Tokens are short-ish (default 90 days) and the
+// CLI re-prompts via login when expired.
+
+import { readFileSync, writeFileSync, chmodSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface OwnerSession {
+  bridge: string;
+  token: string;
+  principal_id?: string;
+  email?: string | null;
+  expires_at: string;        // ISO 8601
+  saved_at: string;          // ISO 8601
+}
+
+export function defaultStorePath(): string {
+  // ~/.vicoop/ keeps the file colocated with future client state; an XDG
+  // state-dir layout would be more correct on Linux but cross-platform
+  // parity (macOS/Linux/WSL) is more useful here than strict XDG.
+  return join(homedir(), '.vicoop', 'owner-session.json');
+}
+
+export function saveOwnerSession(session: OwnerSession, path: string = defaultStorePath()): void {
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, JSON.stringify(session, null, 2));
+  // chmod 600 so peer processes on a shared host can't read the bearer.
+  // Best-effort — silently ignore on filesystems without POSIX modes.
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // ignore
+  }
+}
+
+export function loadOwnerSession(path: string = defaultStorePath()): OwnerSession | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    const parsed = JSON.parse(raw) as OwnerSession;
+    if (!parsed.bridge || !parsed.token || !parsed.expires_at) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResolvedSession {
+  bridge: string;
+  token: string;
+  source: 'env' | 'file';
+}
+
+// Returns the token + bridge URL the CLI should use, with env taking
+// precedence over the persisted file (matches the pattern parseClientArgs
+// uses for SERVER_TOKEN etc).
+export function resolveOwnerSession(path?: string): ResolvedSession | null {
+  const envToken = process.env.VICOOP_OWNER_TOKEN;
+  const envBridge = process.env.VICOOP_BRIDGE;
+  if (envToken && envBridge) {
+    return { bridge: envBridge.replace(/\/$/, ''), token: envToken, source: 'env' };
+  }
+  const file = loadOwnerSession(path);
+  if (file && new Date(file.expires_at).getTime() > Date.now()) {
+    return { bridge: file.bridge.replace(/\/$/, ''), token: file.token, source: 'file' };
+  }
+  return null;
+}

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -1,0 +1,296 @@
+// Integration tests for the deterministic /admin-api/* HTTP routes.
+// Mounts the real createHttpApp against a real Postgres so RLS, the shared
+// admin-api functions, and the route plumbing are all exercised together.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+import type { WebSocket } from 'ws';
+import type { AgentCard } from '@vicoop-bridge/protocol';
+import { createHttpApp } from './http.js';
+import { Registry, type ClientConnection } from './registry.js';
+import { issueSessionToken } from './auth/caller-token.js';
+
+const hasDb = !!process.env.DATABASE_URL;
+
+function fakeAgentCard(name: string): AgentCard {
+  return {
+    name,
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+  };
+}
+
+function fakeConnection(opts: {
+  agentId: string;
+  clientId: string;
+  ownerPrincipal: string;
+  allowedCallers?: string[];
+}): ClientConnection {
+  return {
+    agentId: opts.agentId,
+    clientId: opts.clientId,
+    ownerPrincipal: opts.ownerPrincipal,
+    agentCard: fakeAgentCard(opts.agentId),
+    allowedCallers: opts.allowedCallers ?? [],
+    // No real WebSocket — none of the routes under test touch it.
+    ws: { close() {} } as unknown as WebSocket,
+    connectedAt: Date.now(),
+  };
+}
+
+interface SetupResult {
+  ownerPrincipal: string;
+  ownerToken: string;
+  clientId: string;
+  agentId: string;
+}
+
+async function setupOwner(
+  sql: postgres.Sql,
+  ownerPrincipal: string,
+): Promise<SetupResult> {
+  const agentId = `admin-api-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const clients = await sql<{ id: string }[]>`
+    INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
+    VALUES (
+      ${ownerPrincipal},
+      'admin-api-test',
+      ${`fake-hash-${agentId}`},
+      ARRAY[${agentId}]
+    )
+    RETURNING id
+  `;
+  const clientId = clients[0]!.id;
+  await sql`
+    INSERT INTO agent_policies (agent_id, owner_principal, client_id)
+    VALUES (${agentId}, ${ownerPrincipal}, ${clientId})
+  `;
+  const issued = await issueSessionToken(sql, {
+    principalId: ownerPrincipal,
+    provider: 'siwe',
+    audience: 'owner_session',
+  });
+  return { ownerPrincipal, ownerToken: issued.rawToken, clientId, agentId };
+}
+
+async function teardown(sql: postgres.Sql, principalId: string, clientId: string): Promise<void> {
+  // agent_policies cascades on clients.id, callers wiped by principal_id.
+  await sql`DELETE FROM clients WHERE id = ${clientId}`;
+  await sql`DELETE FROM callers WHERE principal_id = ${principalId}`;
+}
+
+function authHeaders(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+test(
+  'GET /admin-api/agents requires owner-session bearer',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      const noAuth = await app.request('/admin-api/agents');
+      assert.equal(noAuth.status, 401);
+      const noAuthBody = (await noAuth.json()) as { error: string };
+      assert.match(noAuthBody.error, /Authentication required/);
+
+      // Caller-audience tokens are not accepted here.
+      const callerIssued = await issueSessionToken(sql, {
+        principalId: 'eth:0x1111111111111111111111111111111111111111',
+        provider: 'siwe',
+        audience: 'caller',
+      });
+      try {
+        const wrongAud = await app.request('/admin-api/agents', {
+          headers: authHeaders(callerIssued.rawToken),
+        });
+        assert.equal(wrongAud.status, 401);
+      } finally {
+        await sql`DELETE FROM callers WHERE id = ${callerIssued.callerId}`;
+      }
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'GET /admin-api/agents returns the operator’s own agents only',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const ownerA = `eth:0x${'a'.repeat(40)}`;
+    const ownerB = `eth:0x${'b'.repeat(40)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, ownerA);
+      setupB = await setupOwner(sql, ownerB);
+
+      const registry = new Registry();
+      registry.registerAgent(fakeConnection({
+        agentId: setupA.agentId,
+        clientId: setupA.clientId,
+        ownerPrincipal: ownerA,
+      }));
+      registry.registerAgent(fakeConnection({
+        agentId: setupB.agentId,
+        clientId: setupB.clientId,
+        ownerPrincipal: ownerB,
+      }));
+
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request('/admin-api/agents', {
+        headers: authHeaders(setupA.ownerToken),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { agents: { agent_id: string; client_id: string }[] };
+      const agentIds = body.agents.map((a) => a.agent_id);
+      assert.ok(agentIds.includes(setupA.agentId), 'should see own agent');
+      assert.ok(!agentIds.includes(setupB.agentId), 'should not see other owner’s agent');
+    } finally {
+      if (setupA) await teardown(sql, ownerA, setupA.clientId);
+      if (setupB) await teardown(sql, ownerB, setupB.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /admin-api/agents/:id/callers adds a principal and hot-reloads registry',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'c'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      registry.registerAgent(fakeConnection({
+        agentId: setup.agentId,
+        clientId: setup.clientId,
+        ownerPrincipal: owner,
+      }));
+
+      const callerSeen: { agentId: string; callers: string[] }[] = [];
+      registry.onCallerChange((agentId, callers) => {
+        callerSeen.push({ agentId, callers: [...callers] });
+      });
+
+      const app = createHttpApp({ db: sql, registry });
+      const target = `eth:0x${'d'.repeat(40)}`;
+      const res = await app.request(`/admin-api/agents/${setup.agentId}/callers`, {
+        method: 'POST',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify({ principal: target }),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { allowed_callers: string[]; principal: string };
+      assert.deepEqual(body.allowed_callers, [target]);
+      assert.equal(body.principal, target);
+
+      // Idempotency: adding the same principal again returns 200 with a message
+      // and a non-duplicated list.
+      const repeat = await app.request(`/admin-api/agents/${setup.agentId}/callers`, {
+        method: 'POST',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify({ principal: target }),
+      });
+      assert.equal(repeat.status, 200);
+      const repeatBody = (await repeat.json()) as { allowed_callers: string[]; message?: string };
+      assert.deepEqual(repeatBody.allowed_callers, [target]);
+      assert.match(repeatBody.message ?? '', /already/i);
+
+      // Hot-reload notification fired (at least the first add).
+      assert.ok(
+        callerSeen.some((e) => e.agentId === setup!.agentId && e.callers.includes(target)),
+        'registry caller-change listener should have been notified',
+      );
+
+      // GET reflects the new state.
+      const list = await app.request(`/admin-api/agents/${setup.agentId}/callers`, {
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.equal(list.status, 200);
+      const listBody = (await list.json()) as { allowed_callers: string[]; is_public: boolean };
+      assert.deepEqual(listBody.allowed_callers, [target]);
+      assert.equal(listBody.is_public, false);
+
+      // DELETE removes it.
+      const del = await app.request(
+        `/admin-api/agents/${setup.agentId}/callers?principal=${encodeURIComponent(target)}`,
+        { method: 'DELETE', headers: authHeaders(setup.ownerToken) },
+      );
+      assert.equal(del.status, 200);
+      const delBody = (await del.json()) as { allowed_callers: string[] };
+      assert.deepEqual(delBody.allowed_callers, []);
+
+      // Removing again is idempotent.
+      const delAgain = await app.request(
+        `/admin-api/agents/${setup.agentId}/callers?principal=${encodeURIComponent(target)}`,
+        { method: 'DELETE', headers: authHeaders(setup.ownerToken) },
+      );
+      assert.equal(delAgain.status, 200);
+      const delAgainBody = (await delAgain.json()) as { message?: string };
+      assert.match(delAgainBody.message ?? '', /not in/i);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'POST /admin-api/agents/:id/callers rejects invalid principals with 400',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'e'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(`/admin-api/agents/${setup.agentId}/callers`, {
+        method: 'POST',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify({ principal: 'not-a-valid-principal' }),
+      });
+      assert.equal(res.status, 400);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'GET /admin-api/agents/:id/callers returns 404 for another owner’s agent (RLS)',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const ownerA = `eth:0x${'1'.repeat(40)}`;
+    const ownerB = `eth:0x${'2'.repeat(40)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, ownerA);
+      setupB = await setupOwner(sql, ownerB);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      // ownerA tries to inspect ownerB's agent — RLS hides it as non-existent.
+      const res = await app.request(`/admin-api/agents/${setupB.agentId}/callers`, {
+        headers: authHeaders(setupA.ownerToken),
+      });
+      assert.equal(res.status, 404);
+    } finally {
+      if (setupA) await teardown(sql, ownerA, setupA.clientId);
+      if (setupB) await teardown(sql, ownerB, setupB.clientId);
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -97,6 +97,11 @@ export async function addCaller(
     }
     const callers = existing[0].allowed_callers as string[];
     if (callers.includes(normalized)) {
+      // Idempotent path also pushes the canonical DB state into the registry
+      // so a stale in-memory copy (e.g. a missed caller-change notification)
+      // converges on every call. Cheap; the registry update is a single map
+      // assignment plus listener fan-out.
+      registry.updateAllowedCallers(agentId, callers);
       return {
         agent_id: agentId,
         principal: normalized,
@@ -148,6 +153,9 @@ export async function removeCaller(
       throw new AdminApiError('Agent policy not found or not authorized.', 404);
     }
     const callers = existing[0].allowed_callers as string[];
+    // Same convergence as addCaller's no-op path: hot-reload the registry
+    // even when nothing changed so a stale in-memory copy lines up with DB.
+    registry.updateAllowedCallers(agentId, callers);
     return {
       agent_id: agentId,
       principal: normalized,

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -1,0 +1,205 @@
+// Deterministic admin operations exposed by the admin agent's LLM tools and
+// by the /admin-api/* HTTP routes. Centralising the logic here means both
+// callers share the same RLS handling, registry hot-reload, and idempotency
+// rules — without an LLM round-trip on the HTTP path.
+
+import type postgres from 'postgres';
+import type { Sql } from './db.js';
+import type { Registry } from './registry.js';
+import { validatePrincipal } from './auth/principal.js';
+import { isAdmin } from './admin-scope.js';
+
+type Tx = postgres.TransactionSql;
+
+export class AdminApiError extends Error {
+  constructor(message: string, public readonly status: number) {
+    super(message);
+    this.name = 'AdminApiError';
+  }
+}
+
+export interface CallerListResult {
+  agent_id: string;
+  owner_principal: string;
+  allowed_callers: string[];
+  is_public: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CallerMutationResult {
+  agent_id: string;
+  principal: string;
+  allowed_callers: string[];
+  /** Set when the operation was a no-op (principal already present / already absent). */
+  message?: string;
+}
+
+export interface ActiveAgentInfo {
+  agent_id: string;
+  client_id: string;
+  agent_name: string;
+  allowed_callers: string[];
+  connected_at: string;
+}
+
+function adminAddresses(): string {
+  return process.env.ADMIN_WALLET_ADDRESSES ?? '';
+}
+
+// Sets the per-transaction RLS context the operator's row-level predicates
+// need. `app.admin_addresses` is read by the SQL helper that implements
+// is_admin() in the database, so it must match the in-process adminWallets
+// set used by isAdmin(). Call inside a db.begin() block before issuing the
+// real query so it stays within the same transaction.
+async function setRlsContext(tx: Tx, principalId: string): Promise<void> {
+  await tx`SELECT set_config('role', 'app_authenticated', true)`;
+  await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
+  await tx`SELECT set_config('app.admin_addresses', ${adminAddresses()}, true)`;
+}
+
+export async function addCaller(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+  agentId: string,
+  principal: string,
+): Promise<CallerMutationResult> {
+  const normalized = validatePrincipal(principal);
+  if (!normalized) {
+    throw new AdminApiError(
+      'Invalid principal format. Expected eth:0x<40 hex>, google:sub:<sub>, google:email:<addr>, or google:domain:<d>.',
+      400,
+    );
+  }
+
+  const result = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      UPDATE agent_policies
+      SET allowed_callers = array_append(allowed_callers, ${normalized}),
+          updated_at = now()
+      WHERE agent_id = ${agentId}
+        AND NOT (${normalized} = ANY(allowed_callers))
+      RETURNING agent_id, owner_principal, allowed_callers
+    `;
+  });
+
+  if (result.length === 0) {
+    // Either: policy missing, principal already present, or RLS blocked the
+    // update. Disambiguate with a follow-up SELECT (still under RLS).
+    const existing = await db.begin(async (tx) => {
+      await setRlsContext(tx, principalId);
+      return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}`;
+    });
+    if (existing.length === 0) {
+      throw new AdminApiError('Agent policy not found or not authorized.', 404);
+    }
+    const callers = existing[0].allowed_callers as string[];
+    if (callers.includes(normalized)) {
+      return {
+        agent_id: agentId,
+        principal: normalized,
+        allowed_callers: callers,
+        message: 'Principal already in allowed callers',
+      };
+    }
+    throw new AdminApiError('Not authorized to modify this agent policy.', 403);
+  }
+
+  const callers = result[0].allowed_callers as string[];
+  registry.updateAllowedCallers(agentId, callers);
+  return { agent_id: agentId, principal: normalized, allowed_callers: callers };
+}
+
+export async function removeCaller(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+  agentId: string,
+  principal: string,
+): Promise<CallerMutationResult> {
+  const normalized = validatePrincipal(principal);
+  if (!normalized) {
+    throw new AdminApiError(
+      'Invalid principal format. Expected eth:0x<40 hex>, google:sub:<sub>, google:email:<addr>, or google:domain:<d>.',
+      400,
+    );
+  }
+
+  const result = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      UPDATE agent_policies
+      SET allowed_callers = array_remove(allowed_callers, ${normalized}),
+          updated_at = now()
+      WHERE agent_id = ${agentId}
+        AND ${normalized} = ANY(allowed_callers)
+      RETURNING agent_id, owner_principal, allowed_callers
+    `;
+  });
+
+  if (result.length === 0) {
+    const existing = await db.begin(async (tx) => {
+      await setRlsContext(tx, principalId);
+      return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}`;
+    });
+    if (existing.length === 0) {
+      throw new AdminApiError('Agent policy not found or not authorized.', 404);
+    }
+    const callers = existing[0].allowed_callers as string[];
+    return {
+      agent_id: agentId,
+      principal: normalized,
+      allowed_callers: callers,
+      message: 'Principal not in allowed callers',
+    };
+  }
+
+  const callers = result[0].allowed_callers as string[];
+  registry.updateAllowedCallers(agentId, callers);
+  return { agent_id: agentId, principal: normalized, allowed_callers: callers };
+}
+
+export async function listCallers(
+  db: Sql,
+  principalId: string,
+  agentId: string,
+): Promise<CallerListResult> {
+  const result = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      SELECT agent_id, owner_principal, allowed_callers, created_at, updated_at
+      FROM agent_policies WHERE agent_id = ${agentId}
+    `;
+  });
+  if (result.length === 0) {
+    throw new AdminApiError('Agent policy not found.', 404);
+  }
+  const policy = result[0];
+  const callers = policy.allowed_callers as string[];
+  return {
+    agent_id: policy.agent_id as string,
+    owner_principal: policy.owner_principal as string,
+    allowed_callers: callers,
+    is_public: callers.length === 0,
+    created_at: policy.created_at instanceof Date ? policy.created_at.toISOString() : policy.created_at as string | undefined,
+    updated_at: policy.updated_at instanceof Date ? policy.updated_at.toISOString() : policy.updated_at as string | undefined,
+  };
+}
+
+export function listActiveAgents(
+  registry: Registry,
+  principalId: string,
+): ActiveAgentInfo[] {
+  const admin = isAdmin(principalId);
+  return registry.listAgents()
+    .filter((a) => admin || a.ownerPrincipal === principalId)
+    .map((a) => ({
+      agent_id: a.agentId,
+      client_id: a.clientId,
+      agent_name: a.agentCard.name,
+      allowed_callers: a.allowedCallers,
+      connected_at: new Date(a.connectedAt).toISOString(),
+    }));
+}

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -18,6 +18,15 @@ export class AdminApiError extends Error {
   }
 }
 
+// Single source of truth for the invalid-principal 400 message. Must stay
+// aligned with the formats validatePrincipal() accepts in auth/principal.ts —
+// in particular a plain `0x<40 hex>` (no eth: prefix) is normalized to
+// eth:0x<…>, so operators hitting this error need to know that's a valid
+// input form.
+const INVALID_PRINCIPAL_MESSAGE =
+  'Invalid principal format. Expected eth:0x<40 hex>, 0x<40 hex>, ' +
+  'google:sub:<sub>, google:email:<addr>, or google:domain:<d>.';
+
 export interface CallerListResult {
   agent_id: string;
   owner_principal: string;
@@ -67,10 +76,7 @@ export async function addCaller(
 ): Promise<CallerMutationResult> {
   const normalized = validatePrincipal(principal);
   if (!normalized) {
-    throw new AdminApiError(
-      'Invalid principal format. Expected eth:0x<40 hex>, google:sub:<sub>, google:email:<addr>, or google:domain:<d>.',
-      400,
-    );
+    throw new AdminApiError(INVALID_PRINCIPAL_MESSAGE, 400);
   }
 
   const result = await db.begin(async (tx) => {
@@ -126,10 +132,7 @@ export async function removeCaller(
 ): Promise<CallerMutationResult> {
   const normalized = validatePrincipal(principal);
   if (!normalized) {
-    throw new AdminApiError(
-      'Invalid principal format. Expected eth:0x<40 hex>, google:sub:<sub>, google:email:<addr>, or google:domain:<d>.',
-      400,
-    );
+    throw new AdminApiError(INVALID_PRINCIPAL_MESSAGE, 400);
   }
 
   const result = await db.begin(async (tx) => {

--- a/packages/server/src/admin-scope.ts
+++ b/packages/server/src/admin-scope.ts
@@ -1,0 +1,19 @@
+// Wallet-only admin scope check, shared between the admin agent (LLM tools)
+// and the deterministic /admin-api/* HTTP routes. Lives in its own module so
+// admin-api.ts and admin.ts can both import it without forming a cycle.
+
+const adminWallets = new Set(
+  (process.env.ADMIN_WALLET_ADDRESSES ?? '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+
+export function isAdmin(principalId: string): boolean {
+  if (!principalId.startsWith('eth:')) return false;
+  return adminWallets.has(principalId.slice('eth:'.length).toLowerCase());
+}
+
+export function getAdminWallets(): string[] {
+  return [...adminWallets];
+}

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -25,9 +25,18 @@ import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
 import { PostgresTaskStore, type ContextAwareTaskStore } from './postgres-task-store.js';
-import { validatePrincipal } from './auth/principal.js';
 import { listCallerTokens, revokeCallerToken } from './auth/caller-token.js';
 import { logEvent } from './log.js';
+import { isAdmin } from './admin-scope.js';
+import {
+  AdminApiError,
+  addCaller,
+  listActiveAgents,
+  listCallers,
+  removeCaller,
+} from './admin-api.js';
+
+export { getAdminWallets } from './admin-scope.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -79,28 +88,6 @@ const ADMIN_NOOP_RUNNER = new InMemoryRunner({
   agent: new NoopBaseAgent(),
   appName: 'vicoop-bridge-admin-noop',
 });
-
-// ── Admin Wallet Check ───────────────────────────────────────────
-
-const adminWallets = new Set(
-  (process.env.ADMIN_WALLET_ADDRESSES ?? '')
-    .split(',')
-    .map((s) => s.trim().toLowerCase())
-    .filter(Boolean),
-);
-
-// Admin scope is wallet-only by design: only `eth:<addr>` principals whose
-// stripped 0x address appears in ADMIN_WALLET_ADDRESSES match. Non-eth
-// principals (e.g. google:sub:…) authenticate fine but never gain admin
-// scope — they get the RLS-scoped self-service view of their own rows.
-function isAdmin(principalId: string): boolean {
-  if (!principalId.startsWith('eth:')) return false;
-  return adminWallets.has(principalId.slice('eth:'.length).toLowerCase());
-}
-
-export function getAdminWallets(): string[] {
-  return [...adminWallets];
-}
 
 // Render principal-kind-specific copy for the "logged in as" line. Email is
 // optional; we surface it for google: principals so the human reading the
@@ -203,23 +190,22 @@ function buildCustomTools(db: Sql, registry: Registry, principalId: string) {
   // through so RLS predicates (owner_principal = current_principal()) match
   // the operator's own rows. The principalId arrives already canonicalized
   // (eth:0x… or google:sub:…) from the http layer, so no normalization
-  // here.
+  // here. The actual implementations live in admin-api.ts and are shared
+  // with the deterministic /admin-api/* HTTP routes; these wrappers translate
+  // AdminApiError into the `{error}` shape the LLM was trained to read.
+  const wrap = async <T>(fn: () => Promise<T>): Promise<T | { error: string }> => {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err instanceof AdminApiError) return { error: err.message };
+      throw err;
+    }
+  };
   return {
     list_active_agents: tool({
       description: 'List currently connected agents with their client identity and connection time. Non-admin users only see their own agents.',
       inputSchema: z.object({}),
-      execute: async () => {
-        const admin = isAdmin(principalId);
-        return registry.listAgents()
-          .filter((a) => admin || a.ownerPrincipal === principalId)
-          .map((a) => ({
-            agent_id: a.agentId,
-            client_id: a.clientId,
-            agent_name: a.agentCard.name,
-            allowed_callers: a.allowedCallers,
-            connected_at: new Date(a.connectedAt).toISOString(),
-          }));
-      },
+      execute: async () => listActiveAgents(registry, principalId),
     }),
 
     add_caller: tool({
@@ -235,43 +221,8 @@ function buildCustomTools(db: Sql, registry: Registry, principalId: string) {
         agent_id: z.string().describe('The agent ID to add the caller to'),
         principal: z.string().describe('Principal string (see tool description)'),
       }),
-      execute: async ({ agent_id, principal }) => {
-        const normalized = validatePrincipal(principal);
-        if (!normalized) {
-          return { error: 'Invalid principal format. See tool description for supported formats.' };
-        }
-        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
-        const result = await db.begin(async (tx) => {
-          await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
-          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
-          return tx`
-            UPDATE agent_policies
-            SET allowed_callers = array_append(allowed_callers, ${normalized}),
-                updated_at = now()
-            WHERE agent_id = ${agent_id}
-              AND NOT (${normalized} = ANY(allowed_callers))
-            RETURNING agent_id, owner_principal, allowed_callers
-          `;
-        });
-        if (result.length === 0) {
-          const adminAddrs = process.env.ADMIN_WALLET_ADDRESSES ?? '';
-          const existing = await db.begin(async (tx) => {
-            await tx`SELECT set_config('role', 'app_authenticated', true)`;
-            await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
-            await tx`SELECT set_config('app.admin_addresses', ${adminAddrs}, true)`;
-            return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agent_id}`;
-          });
-          if (existing.length === 0) return { error: 'Agent policy not found or not authorized.' };
-          if ((existing[0].allowed_callers as string[]).includes(normalized)) {
-            return { agent_id, message: 'Principal already in allowed callers', allowed_callers: existing[0].allowed_callers };
-          }
-          return { error: 'Not authorized to modify this agent policy.' };
-        }
-        const callers = result[0].allowed_callers as string[];
-        registry.updateAllowedCallers(agent_id, callers);
-        return { agent_id, principal: normalized, allowed_callers: callers };
-      },
+      execute: async ({ agent_id, principal }) =>
+        wrap(() => addCaller(db, registry, principalId, agent_id, principal)),
     }),
 
     remove_caller: tool({
@@ -282,32 +233,8 @@ function buildCustomTools(db: Sql, registry: Registry, principalId: string) {
         agent_id: z.string().describe('The agent ID to remove the caller from'),
         principal: z.string().describe('Principal string to remove'),
       }),
-      execute: async ({ agent_id, principal }) => {
-        const normalized = validatePrincipal(principal);
-        if (!normalized) {
-          return { error: 'Invalid principal format. See add_caller description for supported formats.' };
-        }
-        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
-        const result = await db.begin(async (tx) => {
-          await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
-          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
-          return tx`
-            UPDATE agent_policies
-            SET allowed_callers = array_remove(allowed_callers, ${normalized}),
-                updated_at = now()
-            WHERE agent_id = ${agent_id}
-              AND ${normalized} = ANY(allowed_callers)
-            RETURNING agent_id, owner_principal, allowed_callers
-          `;
-        });
-        if (result.length === 0) {
-          return { error: 'Principal not found in allowed callers, agent policy not found, or not authorized.' };
-        }
-        const callers = result[0].allowed_callers as string[];
-        registry.updateAllowedCallers(agent_id, callers);
-        return { agent_id, principal: normalized, allowed_callers: callers };
-      },
+      execute: async ({ agent_id, principal }) =>
+        wrap(() => removeCaller(db, registry, principalId, agent_id, principal)),
     }),
 
     list_callers: tool({
@@ -315,26 +242,7 @@ function buildCustomTools(db: Sql, registry: Registry, principalId: string) {
       inputSchema: z.object({
         agent_id: z.string().describe('The agent ID to list callers for'),
       }),
-      execute: async ({ agent_id }) => {
-        const adminAddresses = process.env.ADMIN_WALLET_ADDRESSES ?? '';
-        const result = await db.begin(async (tx) => {
-          await tx`SELECT set_config('role', 'app_authenticated', true)`;
-          await tx`SELECT set_config('jwt.claims.principal_id', ${principalId}, true)`;
-          await tx`SELECT set_config('app.admin_addresses', ${adminAddresses}, true)`;
-          return tx`
-            SELECT agent_id, owner_principal, allowed_callers, created_at, updated_at
-            FROM agent_policies WHERE agent_id = ${agent_id}
-          `;
-        });
-        if (result.length === 0) return { error: 'Agent policy not found.' };
-        const policy = result[0];
-        return {
-          agent_id: policy.agent_id,
-          owner_principal: policy.owner_principal,
-          allowed_callers: policy.allowed_callers,
-          is_public: (policy.allowed_callers as string[]).length === 0,
-        };
-      },
+      execute: async ({ agent_id }) => wrap(() => listCallers(db, principalId, agent_id)),
     }),
 
     list_caller_tokens: tool({

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -399,16 +399,23 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
         0,
         Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
       );
-      return c.json({
+      // Owner-session responses surface principal_id + email so the CLI
+      // (`vicoop-client login --owner-session`) can confirm and persist the
+      // logged-in identity. Caller-audience responses stay close to the
+      // minimal OAuth shape — third-party caller clients don't need the
+      // bridge to echo user PII back, and the agent owner doesn't gain
+      // anything from learning the caller's email this way (the principal
+      // is matched against allowed_callers server-side).
+      const body: Record<string, unknown> = {
         access_token: issued.rawToken,
         token_type: 'Bearer',
         expires_in: expiresInSec,
-        // The token's principal/email aren't carried in the opaque token
-        // itself, so we surface them here. The CLI uses these to confirm
-        // (and persist) which identity the operator is logged in as.
-        principal_id: row.principal_id,
-        email: row.email ?? null,
-      });
+      };
+      if (audience === 'owner_session') {
+        body.principal_id = row.principal_id;
+        body.email = row.email ?? null;
+      }
+      return c.json(body);
     }
 
     // Unknown status — conservative fallback.

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -403,6 +403,11 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
         access_token: issued.rawToken,
         token_type: 'Bearer',
         expires_in: expiresInSec,
+        // The token's principal/email aren't carried in the opaque token
+        // itself, so we surface them here. The CLI uses these to confirm
+        // (and persist) which identity the operator is logged in as.
+        principal_id: row.principal_id,
+        email: row.email ?? null,
       });
     }
 

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -136,12 +136,19 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
           0,
           Math.floor((issued.expiresAt.getTime() - Date.now()) / 1000),
         );
-        return c.json({
+        // principal_id is echoed only for owner-session bearers, where the
+        // CLI uses it for confirm/persist. Caller-audience exchanges keep
+        // the minimal OAuth shape (the wallet that signed the SIWE already
+        // knows its address — no need to round-trip it).
+        const body: Record<string, unknown> = {
           access_token: issued.rawToken,
           token_type: 'Bearer',
           expires_in: expiresInSec,
-          principal_id: principalId,
-        });
+        };
+        if (audience === 'owner_session') {
+          body.principal_id = principalId;
+        }
+        return c.json(body);
       });
     } catch (err) {
       console.error('[siwe-exchange] transaction failed:', err);

--- a/packages/server/src/auth/siwe-exchange.ts
+++ b/packages/server/src/auth/siwe-exchange.ts
@@ -140,6 +140,7 @@ export function mountSiweExchange(app: Hono, opts: SiweExchangeOptions): void {
           access_token: issued.rawToken,
           token_type: 'Bearer',
           expires_in: expiresInSec,
+          principal_id: principalId,
         });
       });
     } catch (err) {

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -308,14 +308,18 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
+      // Device flow is optional (only mounted when Google OAuth is configured),
+      // so don't point operators at /oauth/device/code on SIWE-only deployments.
+      const acquireHints = deviceFlowEnabled
+        ? '/auth/siwe/exchange (intent=owner_session) or /oauth/device/code (intent=owner_session)'
+        : '/auth/siwe/exchange (intent=owner_session)';
       return {
         ok: false,
         response: c.json(
           {
             error:
               `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
-              `Acquire via /auth/siwe/exchange (intent=owner_session) or ` +
-              `/oauth/device/code (intent=owner_session).`,
+              `Acquire via ${acquireHints}.`,
           },
           401,
         ),

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -11,7 +11,15 @@ import {
   type AgentCardV03,
 } from '@a2x/sdk';
 import type { ClientConnection, Registry } from './registry.js';
-import { createAdminA2XAgent, getAdminWallets } from './admin.js';
+import { createAdminA2XAgent } from './admin.js';
+import { getAdminWallets } from './admin-scope.js';
+import {
+  AdminApiError,
+  addCaller,
+  listActiveAgents,
+  listCallers,
+  removeCaller,
+} from './admin-api.js';
 import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
 import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
 import { mountDeviceFlow } from './auth/device-flow.js';
@@ -286,6 +294,123 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
     const result = await adminHandler.handle(parsed);
     return handleHandlerResult(result, c);
+  });
+
+  // Deterministic admin RPC at /admin-api/*. Same owner_session bearer
+  // requirement as the admin agent at POST '/', but the request never
+  // crosses the LLM — these are direct calls to the same shared functions
+  // (admin-api.ts) the admin agent's tools use. Lets CLI / scripts manage
+  // callers and inspect connected agents without per-call LLM cost.
+  async function authOwnerSession(c: Context): Promise<
+    | { ok: true; principalId: string }
+    | { ok: false; response: Response }
+  > {
+    const authHeader = c.req.header('Authorization');
+    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
+    if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
+      return {
+        ok: false,
+        response: c.json(
+          {
+            error:
+              `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
+              `Acquire via /auth/siwe/exchange (intent=owner_session) or ` +
+              `/oauth/device/code (intent=owner_session).`,
+          },
+          401,
+        ),
+      };
+    }
+    try {
+      const caller = await verifySessionToken(opts.db, bearerToken, {
+        expectedAudience: 'owner_session',
+      });
+      return { ok: true, principalId: caller.principalId };
+    } catch (err) {
+      return {
+        ok: false,
+        response: c.json({ error: `Invalid session token: ${(err as Error).message}` }, 401),
+      };
+    }
+  }
+
+  function adminApiErrorResponse(c: Context, err: unknown): Response {
+    if (err instanceof AdminApiError) {
+      // Cast to a Hono-acceptable status union; AdminApiError uses standard
+      // HTTP codes (400/403/404) that Hono accepts for c.json's second arg.
+      return c.json({ error: err.message }, err.status as 400 | 401 | 403 | 404);
+    }
+    logEvent('admin_api_error', { error: String(err) });
+    return c.json({ error: 'Internal error' }, 500);
+  }
+
+  app.get('/admin-api/agents', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return auth.response;
+    return c.json({ agents: listActiveAgents(opts.registry, auth.principalId) });
+  });
+
+  app.get('/admin-api/agents/:id/callers', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return auth.response;
+    try {
+      const result = await listCallers(opts.db, auth.principalId, c.req.param('id'));
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  app.post('/admin-api/agents/:id/callers', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return auth.response;
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Body must be JSON: { "principal": "<...>" }' }, 400);
+    }
+    const principal =
+      isRecord(body) && typeof body.principal === 'string' ? body.principal : null;
+    if (!principal) {
+      return c.json({ error: 'Body must be JSON: { "principal": "<...>" }' }, 400);
+    }
+    try {
+      const result = await addCaller(
+        opts.db,
+        opts.registry,
+        auth.principalId,
+        c.req.param('id'),
+        principal,
+      );
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  // Principal removal uses ?principal=<urlencoded> rather than a path
+  // segment so colon-delimited principals (eth:0x…, google:email:…@…) and
+  // any future principal kinds with unusual characters survive routing.
+  app.delete('/admin-api/agents/:id/callers', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return auth.response;
+    const principal = c.req.query('principal');
+    if (!principal) {
+      return c.json({ error: 'Query parameter "principal" is required' }, 400);
+    }
+    try {
+      const result = await removeCaller(
+        opts.db,
+        opts.registry,
+        auth.principalId,
+        c.req.param('id'),
+        principal,
+      );
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
   });
 
   // Device flow endpoints (RFC-8628) — optional: only mounted when Google config is provided

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -238,6 +238,57 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // on all subsequent requests.
   mountSiweExchange(app, { sql: opts.db, domain: siweDomain });
 
+  // Single owner-session bearer check shared by POST '/' (admin agent A2A
+  // endpoint) and the /admin-api/* routes. Returns structured success or
+  // failure; each call site formats its own envelope (JSON-RPC for the A2A
+  // route, plain `{error}` for /admin-api). Centralising this prevents the
+  // two from drifting again — e.g. when the device-flow hint became
+  // conditional on deviceFlowEnabled, only one path was updated last time.
+  type OwnerSessionAuthResult =
+    | {
+        ok: true;
+        principalId: string;
+        email: string | undefined;
+        bearerToken: string;
+      }
+    | { ok: false; kind: 'missing' | 'invalid'; message: string };
+
+  async function authOwnerSession(c: Context): Promise<OwnerSessionAuthResult> {
+    const authHeader = c.req.header('Authorization');
+    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
+    if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
+      // Device flow is optional (only mounted when Google OAuth is configured),
+      // so don't point operators at /oauth/device/code on SIWE-only deployments.
+      const acquireHints = deviceFlowEnabled
+        ? '/auth/siwe/exchange (intent=owner_session) or /oauth/device/code (intent=owner_session)'
+        : '/auth/siwe/exchange (intent=owner_session)';
+      return {
+        ok: false,
+        kind: 'missing',
+        message:
+          `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
+          `Acquire via ${acquireHints}.`,
+      };
+    }
+    try {
+      const caller = await verifySessionToken(opts.db, bearerToken, {
+        expectedAudience: 'owner_session',
+      });
+      return {
+        ok: true,
+        principalId: caller.principalId,
+        email: caller.email,
+        bearerToken,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        kind: 'invalid',
+        message: `Invalid session token: ${(err as Error).message}`,
+      };
+    }
+  }
+
   // Root POST — admin agent A2A endpoint. Owner-session-audience only
   // (`vbc_owner_*`); caller-audience tokens (`vbc_caller_*`) are rejected
   // because admin chat is for the resource owner managing their own
@@ -245,38 +296,23 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // what the operator can see; admin scope (`is_admin()`) stays
   // wallet-only by design (issue #79).
   app.post('/', async (c) => {
-    const authHeader = c.req.header('Authorization');
-    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
-    if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: {
-          code: -32001,
-          message:
-            `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
-            `Acquire via /auth/siwe/exchange (intent=owner_session) or ` +
-            `/oauth/device/code (intent=owner_session). ` +
-            `${CALLER_TOKEN_PREFIX}* tokens are not accepted here — those ` +
-            `are for /agents/:id calls.`,
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) {
+      // The A2A endpoint adds an extra hint about caller-audience tokens
+      // because operators commonly try the wrong bearer here when they
+      // already have a /agents/:id one.
+      const message =
+        auth.kind === 'missing'
+          ? `${auth.message} ${CALLER_TOKEN_PREFIX}* tokens are not accepted here — those are for /agents/:id calls.`
+          : auth.message;
+      return c.json(
+        {
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32001, message },
         },
-      }, 401);
-    }
-
-    let principalId: string;
-    let callerEmail: string | undefined;
-    try {
-      const caller = await verifySessionToken(opts.db, bearerToken, {
-        expectedAudience: 'owner_session',
-      });
-      principalId = caller.principalId;
-      callerEmail = caller.email;
-    } catch (err) {
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32001, message: `Invalid session token: ${(err as Error).message}` },
-      }, 401);
+        401,
+      );
     }
 
     const rawBody = await c.req.text();
@@ -286,9 +322,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     if (isRecord(message)) {
       message.metadata = {
         ...(isRecord(message.metadata) ? message.metadata : {}),
-        _principalId: principalId,
-        _bearerToken: bearerToken,
-        ...(callerEmail !== undefined ? { _email: callerEmail } : {}),
+        _principalId: auth.principalId,
+        _bearerToken: auth.bearerToken,
+        ...(auth.email !== undefined ? { _email: auth.email } : {}),
       };
     }
 
@@ -301,41 +337,8 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // crosses the LLM — these are direct calls to the same shared functions
   // (admin-api.ts) the admin agent's tools use. Lets CLI / scripts manage
   // callers and inspect connected agents without per-call LLM cost.
-  async function authOwnerSession(c: Context): Promise<
-    | { ok: true; principalId: string }
-    | { ok: false; response: Response }
-  > {
-    const authHeader = c.req.header('Authorization');
-    const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
-    if (!bearerToken || !bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
-      // Device flow is optional (only mounted when Google OAuth is configured),
-      // so don't point operators at /oauth/device/code on SIWE-only deployments.
-      const acquireHints = deviceFlowEnabled
-        ? '/auth/siwe/exchange (intent=owner_session) or /oauth/device/code (intent=owner_session)'
-        : '/auth/siwe/exchange (intent=owner_session)';
-      return {
-        ok: false,
-        response: c.json(
-          {
-            error:
-              `Authentication required (Bearer ${OWNER_SESSION_PREFIX}* token). ` +
-              `Acquire via ${acquireHints}.`,
-          },
-          401,
-        ),
-      };
-    }
-    try {
-      const caller = await verifySessionToken(opts.db, bearerToken, {
-        expectedAudience: 'owner_session',
-      });
-      return { ok: true, principalId: caller.principalId };
-    } catch (err) {
-      return {
-        ok: false,
-        response: c.json({ error: `Invalid session token: ${(err as Error).message}` }, 401),
-      };
-    }
+  function adminApiUnauthorized(c: Context, auth: Extract<OwnerSessionAuthResult, { ok: false }>): Response {
+    return c.json({ error: auth.message }, 401);
   }
 
   function adminApiErrorResponse(c: Context, err: unknown): Response {
@@ -350,13 +353,13 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   app.get('/admin-api/agents', async (c) => {
     const auth = await authOwnerSession(c);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
     return c.json({ agents: listActiveAgents(opts.registry, auth.principalId) });
   });
 
   app.get('/admin-api/agents/:id/callers', async (c) => {
     const auth = await authOwnerSession(c);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
     try {
       const result = await listCallers(opts.db, auth.principalId, c.req.param('id'));
       return c.json(result);
@@ -367,7 +370,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   app.post('/admin-api/agents/:id/callers', async (c) => {
     const auth = await authOwnerSession(c);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
     let body: unknown;
     try {
       body = await c.req.json();
@@ -398,7 +401,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // any future principal kinds with unusual characters survive routing.
   app.delete('/admin-api/agents/:id/callers', async (c) => {
     const auth = await authOwnerSession(c);
-    if (!auth.ok) return auth.response;
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
     const principal = c.req.query('principal');
     if (!principal) {
       return c.json({ error: 'Query parameter "principal" is required' }, 400);

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -72,7 +72,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         A2A_EXTENSIONS_HEADER,
         A2A_EXTENSIONS_LEGACY_HEADER,
       ],
-      allowMethods: ['GET', 'POST', 'OPTIONS'],
+      allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
       credentials: true,
       maxAge: 600,
     }),


### PR DESCRIPTION
## Summary

- Adds a deterministic HTTP path (`/admin-api/agents`, `/admin-api/agents/:id/callers` GET/POST/DELETE) so operators can manage `allowed_callers` from CLI/scripts without per-call LLM round-trips. The admin agent's LLM tools and these new routes share one implementation in `admin-api.ts`.
- Adds `vicoop-client` subcommands: `login --owner-session`, `add-caller`, `remove-caller`, `list-callers`, `list-agents`. The owner-session bearer is persisted to `~/.vicoop/owner-session.json` (chmod 600); `VICOOP_OWNER_TOKEN` / `VICOOP_BRIDGE` override.
- Device flow + SIWE exchange responses now include `principal_id` so the CLI can confirm and persist the logged-in identity.

## Why two paths

Natural-language admin agent stays for interactive operator chat. The new deterministic path is for scripts/CI — same RLS, same `registry.updateAllowedCallers` hot-reload, no Claude in the loop.

## Docs

- `docs/install-client.md` and `docs/remote-testing.md` show the new CLI path next to the existing curl-into-admin-agent path.
- `docs/local-testing.md` Path B/C now drive policy updates with `vicoop-client login --owner-session` + `add-caller` (hot-reload, no client restart) instead of raw `UPDATE agent_policies` + `pkill`. Path A keeps raw SQL — its identity is "no auth flow at all". The "SQL edits don't hot-reload" gotcha now spells out which path needs the restart. Drive-by: Path C's SIWE exchange now passes `intent=caller` explicitly (the endpoint defaulted to `owner_session` a while back, so the example was issuing the wrong audience for `/agents/:id`).

## Test plan

- [x] `pnpm -r typecheck`
- [x] Server tests excluding pre-broken `siwe-exchange.test.ts` (134/134 pass against local Postgres) — including new `admin-api.test.ts` covering 401/403/404, RLS isolation, idempotent add/remove, and registry hot-reload.
- [x] Client tests (74/74 pass) — new `owner-session.test.ts` (env-vs-file precedence, expiry handling, chmod 600) and `admin-cli.test.ts` (URL/method/body for each subcommand, network-error path, server error surfacing, missing-token hint).
- [x] Claude backend e2e: text smoke, input image (inline + URI), input PDF, send-file (5/5 against the real claude CLI).
- [x] Rebased onto latest `main`; server + client builds clean.
- [ ] Smoke against staging: `vicoop-client login --owner-session --bridge …` → `add-caller` → `list-callers` round-trip with hot-reload visible to a connected agent.

## Notes

`packages/server/src/auth/siwe-exchange.test.ts` "replaying the same SIWE …" was already failing on `main` (default audience switched to `owner_session`; test still calls `verifyCallerToken`). Untouched here — separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)