### PR TITLE
feat(server): accept raw SIWE bearer tokens on /agents/:id

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 export const PROTOCOL_VERSION = '0.1';
 export const TRACEABILITY_EXTENSION_URI =
   'https://github.com/a2aproject/a2a-samples/extensions/traceability/v1';
+export const SIWE_BEARER_AUTH_EXTENSION_URI =
+  'https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1';
 
 export const TextPart = z.object({
   kind: z.literal('text'),

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -3,6 +3,7 @@ import type { ClientConnection, Registry } from './registry.js';
 import type { Sql } from './db.js';
 import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
 import { matchPrincipal, type VerifiedCaller } from './auth/principal.js';
+import { verifySiweBearerToken } from './auth/siwe-bearer.js';
 import { logEvent, truncate } from './log.js';
 
 export function getAgentConn(c: Context): ClientConnection {
@@ -16,15 +17,22 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
 export interface AgentAuthOptions {
   sql: Sql;
   deviceFlowEnabled?: boolean;
+  // SIWE domain for the bridge — used to validate raw SIWE bearer tokens
+  // (siwe-bearer-auth/v0.1). When undefined, the SIWE bearer fast-path is
+  // disabled and only opaque vbc_caller_* tokens are accepted.
+  siweDomain?: string;
 }
 
 export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
-  // /agents/:id only accepts caller-audience tokens. Owner-session tokens
-  // (vbc_owner_*) are for self-service surfaces and explicitly rejected
-  // here even if they belong to a principal in allowed_callers.
+  // /agents/:id accepts two bearer shapes (issue #31 + siwe-bearer-auth/v0.1):
+  //   1. Opaque vbc_caller_* (issued by /auth/siwe/exchange or /oauth/token)
+  //   2. base64url-encoded SIWE bearer (self-verifying per siwe-bearer-auth/v0.1).
+  // Owner-session tokens (vbc_owner_*) are for self-service surfaces and
+  // explicitly rejected here even if they belong to a principal in
+  // allowed_callers.
   const acquisitionHint = opts.deviceFlowEnabled
-    ? '/auth/siwe/exchange (SIWE, intent=caller) or /oauth/token (device flow, intent=caller)'
-    : '/auth/siwe/exchange (SIWE, intent=caller)';
+    ? '/auth/siwe/exchange (SIWE, intent=caller), /oauth/token (device flow, intent=caller), or a base64url SIWE bearer per siwe-bearer-auth/v0.1'
+    : '/auth/siwe/exchange (SIWE, intent=caller) or a base64url SIWE bearer per siwe-bearer-auth/v0.1';
 
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
@@ -53,12 +61,50 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         id: null,
         error: {
           code: -32001,
-          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* token)`,
+          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* or SIWE bearer)`,
         },
       }, 401);
     }
 
-    if (!bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+    let caller: VerifiedCaller;
+    if (bearerToken.startsWith(CALLER_TOKEN_PREFIX)) {
+      try {
+        caller = await verifyCallerToken(opts.sql, bearerToken);
+      } catch (err) {
+        logEvent('agent_request_rejected', {
+          agentId,
+          reason: 'invalid_token',
+          detail: truncate((err as Error).message, 256),
+        });
+        return c.json({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32001, message: `Invalid bearer token: ${(err as Error).message}` },
+        }, 401);
+      }
+    } else if (opts.siweDomain) {
+      // Stateless SIWE bearer per siwe-bearer-auth/v0.1. No callers row is
+      // created — revocation is at the principal level (remove from
+      // allowed_callers) rather than the token level.
+      try {
+        const verified = await verifySiweBearerToken(bearerToken, { domain: opts.siweDomain });
+        caller = { principalId: `eth:${verified.address}` };
+      } catch (err) {
+        logEvent('agent_request_rejected', {
+          agentId,
+          reason: 'invalid_siwe_bearer',
+          detail: truncate((err as Error).message, 256),
+        });
+        return c.json({
+          jsonrpc: '2.0',
+          id: null,
+          error: {
+            code: -32001,
+            message: `Invalid bearer token: ${(err as Error).message}. Acquire one via ${acquisitionHint}.`,
+          },
+        }, 401);
+      }
+    } else {
       logEvent('agent_request_rejected', { agentId, reason: 'bad_token_prefix' });
       return c.json({
         jsonrpc: '2.0',
@@ -67,22 +113,6 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           code: -32001,
           message: `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
         },
-      }, 401);
-    }
-
-    let caller: VerifiedCaller;
-    try {
-      caller = await verifyCallerToken(opts.sql, bearerToken);
-    } catch (err) {
-      logEvent('agent_request_rejected', {
-        agentId,
-        reason: 'invalid_token',
-        detail: truncate((err as Error).message, 256),
-      });
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32001, message: `Invalid bearer token: ${(err as Error).message}` },
       }, 401);
     }
 

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -26,13 +26,23 @@ export interface AgentAuthOptions {
 export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) {
   // /agents/:id accepts two bearer shapes (issue #31 + siwe-bearer-auth/v0.1):
   //   1. Opaque vbc_caller_* (issued by /auth/siwe/exchange or /oauth/token)
-  //   2. base64url-encoded SIWE bearer (self-verifying per siwe-bearer-auth/v0.1).
+  //   2. base64url-encoded SIWE bearer (self-verifying per siwe-bearer-auth/v0.1) —
+  //      only when opts.siweDomain is set; otherwise the fast-path is disabled.
   // Owner-session tokens (vbc_owner_*) are for self-service surfaces and
   // explicitly rejected here even if they belong to a principal in
   // allowed_callers.
-  const acquisitionHint = opts.deviceFlowEnabled
-    ? '/auth/siwe/exchange (SIWE, intent=caller), /oauth/token (device flow, intent=caller), or a base64url SIWE bearer per siwe-bearer-auth/v0.1'
-    : '/auth/siwe/exchange (SIWE, intent=caller) or a base64url SIWE bearer per siwe-bearer-auth/v0.1';
+  const siweEnabled = Boolean(opts.siweDomain);
+  const exchangeHint = '/auth/siwe/exchange (SIWE, intent=caller)';
+  const deviceHint = opts.deviceFlowEnabled
+    ? '/oauth/token (device flow, intent=caller)'
+    : null;
+  const siweBearerHint = siweEnabled ? 'a base64url SIWE bearer per siwe-bearer-auth/v0.1' : null;
+  const acquisitionHint = [exchangeHint, deviceHint, siweBearerHint]
+    .filter((h): h is string => h !== null)
+    .join(', ');
+  const missingBearerMessage = siweEnabled
+    ? `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* or SIWE bearer)`
+    : `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}*)`;
 
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
@@ -61,7 +71,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         id: null,
         error: {
           code: -32001,
-          message: `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* or SIWE bearer)`,
+          message: missingBearerMessage,
         },
       }, 401);
     }

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,7 +1,11 @@
 import type { Context, Next } from 'hono';
 import type { ClientConnection, Registry } from './registry.js';
 import type { Sql } from './db.js';
-import { CALLER_TOKEN_PREFIX, verifyCallerToken } from './auth/caller-token.js';
+import {
+  CALLER_TOKEN_PREFIX,
+  OWNER_SESSION_PREFIX,
+  verifyCallerToken,
+} from './auth/caller-token.js';
 import { matchPrincipal, type VerifiedCaller } from './auth/principal.js';
 import { verifySiweBearerToken } from './auth/siwe-bearer.js';
 import { logEvent, truncate } from './log.js';
@@ -92,6 +96,22 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           error: { code: -32001, message: `Invalid bearer token: ${(err as Error).message}` },
         }, 401);
       }
+    } else if (bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
+      // Owner-session tokens are for self-service surfaces (admin agent /
+      // /graphql) and explicitly not accepted here, even when the principal
+      // is in allowed_callers. Reject up front with a clear message — without
+      // this, the SIWE-bearer branch below would try to decode the opaque
+      // owner-session token as base64url JSON and fail with the misleading
+      // "SIWE bearer token is not valid JSON".
+      logEvent('agent_request_rejected', { agentId, reason: 'owner_session_on_caller_route' });
+      return c.json({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32001,
+          message: `Invalid bearer token: ${OWNER_SESSION_PREFIX}* (owner-session) tokens are not accepted on /agents/:id. Acquire one via ${acquisitionHint}.`,
+        },
+      }, 401);
     } else if (opts.siweDomain) {
       // Stateless SIWE bearer per siwe-bearer-auth/v0.1. No callers row is
       // created — revocation is at the principal level (remove from

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -199,6 +199,40 @@ test('buildAgentA2XAgent overrides a wire-declared SIWE extension with the bridg
   );
 });
 
+test('buildAgentA2XAgent drops a wire-declared SIWE extension on restricted agents without publicUrl', () => {
+  // Without publicUrl the middleware can't accept SIWE bearers (no
+  // siweDomain). Letting a wire-declared SIWE extension pass through here
+  // would advertise auth the server won't actually honor, so it must be
+  // stripped — even though the bridge isn't emitting its own replacement.
+  const agent = buildAgentA2XAgent(
+    fakeConn(
+      {
+        name: 'claude',
+        description: 'Claude Code',
+        version: '0.0.1',
+        protocolVersion: '0.3.0',
+        capabilities: {
+          streaming: true,
+          extensions: [
+            { uri: SIWE_BEARER_AUTH_EXTENSION_URI, description: 'wire-declared', required: true },
+          ],
+        },
+        skills: [],
+      },
+      { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
+    ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: undefined, deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const siweEntries = (card.capabilities.extensions ?? []).filter(
+    (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
+  );
+  assert.equal(siweEntries.length, 0);
+});
+
 test('buildAgentA2XAgent leaves a wire-declared SIWE extension alone when not restricted', () => {
   // Public agent: the bridge does not enforce SIWE auth, so a wire card that
   // happens to declare the URI passes through unchanged.

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -69,8 +69,68 @@ test('buildAgentA2XAgent advertises SIWE bearer-auth extension when restricted',
     (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
   );
   assert.ok(siwe, 'expected SIWE bearer-auth extension to be advertised');
+  // Mirror vicoop-db-agent-builder — fail-closed for clients that don't
+  // understand the URI.
+  assert.equal(siwe.required, true);
   assert.equal((siwe.params as { domain: string }).domain, 'bridge.example');
   assert.equal((siwe.params as { uri: string }).uri, 'https://bridge.example');
+});
+
+test('buildAgentA2XAgent exposes bearerAuth + deviceFlow security schemes when restricted (mirrors dba)', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn(
+      {
+        name: 'claude',
+        description: 'Claude Code',
+        version: '0.0.1',
+        protocolVersion: '0.3.0',
+        capabilities: { streaming: true },
+        skills: [],
+      },
+      { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
+    ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: true },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const schemes = card.securitySchemes ?? {};
+  assert.ok(schemes.bearerAuth, 'expected bearerAuth scheme');
+  assert.equal((schemes.bearerAuth as { type: string }).type, 'http');
+  assert.equal((schemes.bearerAuth as { scheme: string }).scheme, 'bearer');
+  assert.equal((schemes.bearerAuth as { bearerFormat: string }).bearerFormat, 'SIWE');
+  assert.ok(schemes.deviceFlow, 'expected deviceFlow scheme');
+  assert.equal((schemes.deviceFlow as { type: string }).type, 'oauth2');
+  // Both should appear as alternatives in security[].
+  assert.deepEqual(card.security, [{ bearerAuth: [] }, { deviceFlow: [] }]);
+  // Old `bridge` key from before the dba-parity refactor must not survive.
+  assert.equal((schemes as Record<string, unknown>).bridge, undefined);
+});
+
+test('buildAgentA2XAgent omits deviceFlow when device flow is not enabled', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn(
+      {
+        name: 'claude',
+        description: 'Claude Code',
+        version: '0.0.1',
+        protocolVersion: '0.3.0',
+        capabilities: { streaming: true },
+        skills: [],
+      },
+      { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
+    ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const schemes = card.securitySchemes ?? {};
+  assert.ok(schemes.bearerAuth, 'expected bearerAuth scheme');
+  assert.equal((schemes as Record<string, unknown>).deviceFlow, undefined);
+  assert.deepEqual(card.security, [{ bearerAuth: [] }]);
 });
 
 test('buildAgentA2XAgent omits SIWE extension for public agents', () => {

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -1,11 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { InMemoryTaskStore, type AgentCardV03 } from '@a2x/sdk';
-import { TRACEABILITY_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
+import {
+  SIWE_BEARER_AUTH_EXTENSION_URI,
+  TRACEABILITY_EXTENSION_URI,
+  type AgentCard,
+} from '@vicoop-bridge/protocol';
 import { buildAgentA2XAgent } from './agent-card.js';
 import { Registry, type ClientConnection } from './registry.js';
 
-function fakeConn(card: AgentCard): ClientConnection {
+function fakeConn(card: AgentCard, overrides: Partial<ClientConnection> = {}): ClientConnection {
   return {
     agentId: 'claude',
     clientId: 'client-1',
@@ -14,6 +18,7 @@ function fakeConn(card: AgentCard): ClientConnection {
     allowedCallers: [],
     ws: {} as ClientConnection['ws'],
     connectedAt: Date.now(),
+    ...overrides,
   };
 }
 
@@ -39,4 +44,84 @@ test('buildAgentA2XAgent preserves advertised optional extensions', () => {
   assert.deepEqual(card.capabilities.extensions, [
     { uri: TRACEABILITY_EXTENSION_URI, required: false },
   ]);
+});
+
+test('buildAgentA2XAgent advertises SIWE bearer-auth extension when restricted', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn(
+      {
+        name: 'claude',
+        description: 'Claude Code',
+        version: '0.0.1',
+        protocolVersion: '0.3.0',
+        capabilities: { streaming: true },
+        skills: [],
+      },
+      { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
+    ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const siwe = card.capabilities.extensions?.find(
+    (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
+  );
+  assert.ok(siwe, 'expected SIWE bearer-auth extension to be advertised');
+  assert.equal((siwe.params as { domain: string }).domain, 'bridge.example');
+  assert.equal((siwe.params as { uri: string }).uri, 'https://bridge.example');
+});
+
+test('buildAgentA2XAgent omits SIWE extension for public agents', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn({
+      name: 'claude',
+      description: 'Claude Code',
+      version: '0.0.1',
+      protocolVersion: '0.3.0',
+      capabilities: { streaming: true },
+      skills: [],
+    }),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const siwe = card.capabilities.extensions?.find(
+    (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
+  );
+  assert.equal(siwe, undefined);
+});
+
+test('buildAgentA2XAgent does not double-add SIWE extension when wire already declares it', () => {
+  const agent = buildAgentA2XAgent(
+    fakeConn(
+      {
+        name: 'claude',
+        description: 'Claude Code',
+        version: '0.0.1',
+        protocolVersion: '0.3.0',
+        capabilities: {
+          streaming: true,
+          extensions: [
+            { uri: SIWE_BEARER_AUTH_EXTENSION_URI, description: 'wire-declared', required: true },
+          ],
+        },
+        skills: [],
+      },
+      { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
+    ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const siweEntries = (card.capabilities.extensions ?? []).filter(
+    (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
+  );
+  assert.equal(siweEntries.length, 1);
+  assert.equal(siweEntries[0]!.description, 'wire-declared');
 });

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -155,7 +155,9 @@ test('buildAgentA2XAgent omits SIWE extension for public agents', () => {
   assert.equal(siwe, undefined);
 });
 
-test('buildAgentA2XAgent does not double-add SIWE extension when wire already declares it', () => {
+test('buildAgentA2XAgent overrides a wire-declared SIWE extension with the bridge version', () => {
+  // The bridge is authoritative for params (domain / endpoint / hints) and
+  // for `required: true`; a client cannot weaken either via the wire card.
   const agent = buildAgentA2XAgent(
     fakeConn(
       {
@@ -166,13 +168,54 @@ test('buildAgentA2XAgent does not double-add SIWE extension when wire already de
         capabilities: {
           streaming: true,
           extensions: [
-            { uri: SIWE_BEARER_AUTH_EXTENSION_URI, description: 'wire-declared', required: true },
+            {
+              uri: SIWE_BEARER_AUTH_EXTENSION_URI,
+              description: 'wire-declared (downgraded)',
+              required: false,
+            },
           ],
         },
         skills: [],
       },
       { allowedCallers: ['eth:0x0000000000000000000000000000000000000002'] },
     ),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const siweEntries = (card.capabilities.extensions ?? []).filter(
+    (e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI,
+  );
+  assert.equal(siweEntries.length, 1, 'expected exactly one SIWE extension entry');
+  // Bridge-emitted, not wire-declared.
+  assert.equal(siweEntries[0]!.required, true);
+  assert.notEqual(siweEntries[0]!.description, 'wire-declared (downgraded)');
+  assert.equal(
+    (siweEntries[0]!.params as { domain: string }).domain,
+    'bridge.example',
+    'bridge must own the advertised SIWE domain',
+  );
+});
+
+test('buildAgentA2XAgent leaves a wire-declared SIWE extension alone when not restricted', () => {
+  // Public agent: the bridge does not enforce SIWE auth, so a wire card that
+  // happens to declare the URI passes through unchanged.
+  const agent = buildAgentA2XAgent(
+    fakeConn({
+      name: 'claude',
+      description: 'Claude Code',
+      version: '0.0.1',
+      protocolVersion: '0.3.0',
+      capabilities: {
+        streaming: true,
+        extensions: [
+          { uri: SIWE_BEARER_AUTH_EXTENSION_URI, description: 'wire-declared', required: true },
+        ],
+      },
+      skills: [],
+    }),
     new InMemoryTaskStore(),
     new Registry(),
     { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -4,6 +4,7 @@ import {
   OAuth2DeviceCodeAuthorization,
   type TaskStore,
 } from '@a2x/sdk';
+import { SIWE_BEARER_AUTH_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { ClientConnection, Registry } from './registry.js';
 import { WSForwardingExecutor } from './executor.js';
 
@@ -57,8 +58,36 @@ export function buildAgentA2XAgent(
       pushNotifications: wire.capabilities?.pushNotifications ?? false,
     });
 
-  for (const extension of wire.capabilities?.extensions ?? []) {
+  const wireExtensions = wire.capabilities?.extensions ?? [];
+  for (const extension of wireExtensions) {
     a2xAgent.addExtension(extension);
+  }
+
+  // Advertise SIWE bearer-auth (siwe-bearer-auth/v0.1) when this agent is
+  // restricted to a non-empty allowed_callers set. Mentionable / A2A clients
+  // discover this URI to know they can mint a base64url SIWE bearer locally
+  // (no exchange step) and present it directly. Skip when the wire card
+  // already declares it — the client's own opt-in wins.
+  const restricted = conn.allowedCallers.length > 0;
+  const wireDeclaresSiwe = wireExtensions.some((e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI);
+  if (restricted && opts.publicUrl && !wireDeclaresSiwe) {
+    const siweDomain = new URL(opts.publicUrl).host;
+    a2xAgent.addExtension({
+      uri: SIWE_BEARER_AUTH_EXTENSION_URI,
+      description:
+        'Sign-In with Ethereum (EIP-4361) bearer auth. Clients sign a SIWE message locally and present it as a base64url-encoded Bearer token; no exchange step needed.',
+      required: false,
+      params: {
+        domain: siweDomain,
+        uri: opts.publicUrl,
+        maxTokenTtl: '7d',
+        domainBinding: true,
+        usageHint: {
+          mintToken: `a2a-wallet siwe auth --domain ${siweDomain} --uri ${opts.publicUrl} --ttl 1h --json | jq -r '.token'`,
+          sendMessage: `a2a-wallet a2a send --bearer "$TOKEN" ${opts.publicUrl}/agents/${conn.agentId}/.well-known/agent-card.json "Hello"`,
+        },
+      },
+    });
   }
 
   for (const skill of wire.skills ?? []) {

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -77,7 +77,10 @@ export function buildAgentA2XAgent(
   const restricted = conn.allowedCallers.length > 0;
   const wireDeclaresSiwe = wireExtensions.some((e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI);
   if (restricted && opts.publicUrl && !wireDeclaresSiwe) {
-    const siweDomain = new URL(opts.publicUrl).host;
+    // Match http.tsx's siwe domain derivation (.hostname strips the port) so
+    // the advertised domain matches what /auth/siwe/exchange and the bearer
+    // fast-path actually validate against.
+    const siweDomain = new URL(opts.publicUrl).hostname;
     a2xAgent.addExtension({
       uri: SIWE_BEARER_AUTH_EXTENSION_URI,
       description:

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -63,12 +63,21 @@ export function buildAgentA2XAgent(
   // discover this URI to know they can mint a base64url SIWE bearer locally
   // (no exchange step) and present it directly.
   //
-  // The bridge is authoritative for the bridge-side facts in `params`
-  // (domain / exchange URL / usage hints) and for the `required` flag — a
-  // client's wire card cannot weaken either by self-declaring a downgraded
-  // version of the same URI. So when the wire card declares the URI we
-  // suppress its entry and emit our own; non-SIWE wire extensions pass
-  // through unchanged.
+  // For restricted agents the bridge owns the SIWE bearer-auth
+  // advertisement: it is authoritative for the bridge-side facts in `params`
+  // (domain / exchange URL / usage hints) and for the `required` flag, and
+  // — critically — is the only side that knows whether the SIWE-bearer
+  // fast-path is actually wired. The middleware accepts SIWE bearers iff a
+  // siweDomain is configured, which on this layer maps to opts.publicUrl
+  // being set (http.tsx derives one from the other). So for restricted
+  // agents we always strip a wire-declared SIWE entry and re-emit our own
+  // only when publicUrl is set; without publicUrl we drop it entirely so a
+  // wire client can't advertise auth that the server won't accept.
+  //
+  // Public agents pass wire SIWE entries through unchanged: auth isn't
+  // enforced there, so the advertisement is informational and the wire
+  // client's intent (e.g. "I'd like SIWE if you ever restrict me") is
+  // preserved.
   //
   // `required: true` matches vicoop-db-agent-builder's advertisement so
   // Mentionable clients that fail-closed on unknown required extensions
@@ -79,8 +88,10 @@ export function buildAgentA2XAgent(
   const restricted = conn.allowedCallers.length > 0;
   const bridgeWillEmitSiwe = restricted && Boolean(opts.publicUrl);
   for (const extension of wireExtensions) {
-    if (bridgeWillEmitSiwe && extension.uri === SIWE_BEARER_AUTH_EXTENSION_URI) {
-      // Drop the wire-declared SIWE entry — the bridge owns this advertisement.
+    if (restricted && extension.uri === SIWE_BEARER_AUTH_EXTENSION_URI) {
+      // Bridge owns this advertisement on restricted agents — drop wire
+      // entry whether or not we re-emit our own (the latter is gated by
+      // publicUrl).
       continue;
     }
     a2xAgent.addExtension(extension);

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -68,6 +68,12 @@ export function buildAgentA2XAgent(
   // discover this URI to know they can mint a base64url SIWE bearer locally
   // (no exchange step) and present it directly. Skip when the wire card
   // already declares it — the client's own opt-in wins.
+  //
+  // `required: true` matches vicoop-db-agent-builder's advertisement so
+  // Mentionable clients that fail-closed on unknown required extensions
+  // behave identically across both hosts. Clients that don't understand
+  // the URI can still authenticate via the opaque vbc_caller_* path on
+  // the bridge.
   const restricted = conn.allowedCallers.length > 0;
   const wireDeclaresSiwe = wireExtensions.some((e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI);
   if (restricted && opts.publicUrl && !wireDeclaresSiwe) {
@@ -76,7 +82,7 @@ export function buildAgentA2XAgent(
       uri: SIWE_BEARER_AUTH_EXTENSION_URI,
       description:
         'Sign-In with Ethereum (EIP-4361) bearer auth. Clients sign a SIWE message locally and present it as a base64url-encoded Bearer token; no exchange step needed.',
-      required: false,
+      required: true,
       params: {
         domain: siweDomain,
         uri: opts.publicUrl,
@@ -99,26 +105,52 @@ export function buildAgentA2XAgent(
     });
   }
 
-  if (conn.allowedCallers.length > 0) {
+  if (restricted) {
     // Auth is enforced upstream at the route layer (agentAuthMiddleware);
-    // we invoke `handler.handle()` without a RequestContext so a2x's
-    // per-request authenticate path is skipped. The schemes here are
-    // advertised on the AgentCard for spec-compliant card consumers
-    // but their `validator` callbacks are never reached at runtime.
-    if (opts.deviceFlowEnabled && opts.publicUrl) {
+    // the schemes here are advertised on the AgentCard for spec-compliant
+    // card consumers but their `validator` callbacks are never reached at
+    // runtime.
+    //
+    // Schema mirrors vicoop-db-agent-builder so Mentionable clients that
+    // key off `securitySchemes.{bearerAuth,deviceFlow}` find the same
+    // shape on both hosts:
+    //   bearerAuth — http+bearer+bearerFormat:SIWE; the client signs a
+    //                SIWE message locally and presents it directly.
+    //   deviceFlow — oauth2+deviceCode (Google); only advertised when the
+    //                deployment actually mounts the device-flow endpoints.
+    // `security` lists the schemes as alternatives (OR), so a caller may
+    // satisfy either.
+    if (opts.publicUrl) {
       a2xAgent.addSecurityScheme(
-        'bridge',
-        new OAuth2DeviceCodeAuthorization({
-          deviceAuthorizationUrl: `${opts.publicUrl}/oauth/device/code`,
-          tokenUrl: `${opts.publicUrl}/oauth/token`,
-          scopes: {},
+        'bearerAuth',
+        new HttpBearerAuthorization({
+          scheme: 'bearer',
+          bearerFormat: 'SIWE',
           description:
-            'Bridge-issued opaque bearer token. Acquire via /oauth/token (Google device flow) or /auth/siwe/exchange (SIWE).',
+            'Sign-In with Ethereum (EIP-4361) bearer auth. Sign a SIWE message and present it as a base64url-encoded Bearer token, or exchange it at POST /auth/siwe/exchange for an opaque vbc_caller_* token first.',
         }),
       );
+      a2xAgent.addSecurityRequirement({ bearerAuth: [] });
+
+      if (opts.deviceFlowEnabled) {
+        a2xAgent.addSecurityScheme(
+          'deviceFlow',
+          new OAuth2DeviceCodeAuthorization({
+            deviceAuthorizationUrl: `${opts.publicUrl}/oauth/device/code`,
+            tokenUrl: `${opts.publicUrl}/oauth/token`,
+            scopes: {},
+            description:
+              'Bridge-issued opaque bearer token (vbc_caller_*) via Google OAuth device flow.',
+          }),
+        );
+        a2xAgent.addSecurityRequirement({ deviceFlow: [] });
+      }
     } else {
+      // No publicUrl configured (typically local dev with custom hostname):
+      // SIWE bearer fast-path can't run without a stable domain, so fall
+      // back to advertising opaque-only bearer auth.
       a2xAgent.addSecurityScheme(
-        'bridge',
+        'bearerAuth',
         new HttpBearerAuthorization({
           scheme: 'bearer',
           bearerFormat: 'Opaque',
@@ -126,8 +158,8 @@ export function buildAgentA2XAgent(
             'Bridge-issued opaque bearer token (vbc_caller_*). Acquire via POST /auth/siwe/exchange by signing a SIWE message.',
         }),
       );
+      a2xAgent.addSecurityRequirement({ bearerAuth: [] });
     }
-    a2xAgent.addSecurityRequirement({ bridge: [] });
   }
 
   return a2xAgent;

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -58,29 +58,38 @@ export function buildAgentA2XAgent(
       pushNotifications: wire.capabilities?.pushNotifications ?? false,
     });
 
-  const wireExtensions = wire.capabilities?.extensions ?? [];
-  for (const extension of wireExtensions) {
-    a2xAgent.addExtension(extension);
-  }
-
   // Advertise SIWE bearer-auth (siwe-bearer-auth/v0.1) when this agent is
   // restricted to a non-empty allowed_callers set. Mentionable / A2A clients
   // discover this URI to know they can mint a base64url SIWE bearer locally
-  // (no exchange step) and present it directly. Skip when the wire card
-  // already declares it — the client's own opt-in wins.
+  // (no exchange step) and present it directly.
+  //
+  // The bridge is authoritative for the bridge-side facts in `params`
+  // (domain / exchange URL / usage hints) and for the `required` flag — a
+  // client's wire card cannot weaken either by self-declaring a downgraded
+  // version of the same URI. So when the wire card declares the URI we
+  // suppress its entry and emit our own; non-SIWE wire extensions pass
+  // through unchanged.
   //
   // `required: true` matches vicoop-db-agent-builder's advertisement so
   // Mentionable clients that fail-closed on unknown required extensions
   // behave identically across both hosts. Clients that don't understand
   // the URI can still authenticate via the opaque vbc_caller_* path on
   // the bridge.
+  const wireExtensions = wire.capabilities?.extensions ?? [];
   const restricted = conn.allowedCallers.length > 0;
-  const wireDeclaresSiwe = wireExtensions.some((e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI);
-  if (restricted && opts.publicUrl && !wireDeclaresSiwe) {
+  const bridgeWillEmitSiwe = restricted && Boolean(opts.publicUrl);
+  for (const extension of wireExtensions) {
+    if (bridgeWillEmitSiwe && extension.uri === SIWE_BEARER_AUTH_EXTENSION_URI) {
+      // Drop the wire-declared SIWE entry — the bridge owns this advertisement.
+      continue;
+    }
+    a2xAgent.addExtension(extension);
+  }
+  if (bridgeWillEmitSiwe) {
     // Match http.tsx's siwe domain derivation (.hostname strips the port) so
     // the advertised domain matches what /auth/siwe/exchange and the bearer
     // fast-path actually validate against.
-    const siweDomain = new URL(opts.publicUrl).hostname;
+    const siweDomain = new URL(opts.publicUrl!).hostname;
     a2xAgent.addExtension({
       uri: SIWE_BEARER_AUTH_EXTENSION_URI,
       description:

--- a/packages/server/src/auth/siwe-bearer.test.ts
+++ b/packages/server/src/auth/siwe-bearer.test.ts
@@ -95,3 +95,17 @@ test('verifySiweBearerToken caches verified results', async () => {
   const b = await verifySiweBearerToken(token, { domain: 'bridge.example' });
   assert.equal(a.address, b.address);
 });
+
+test('verifySiweBearerToken re-checks domain on cache hit', async () => {
+  _resetSiweBearerCacheForTests();
+  const token = await mintBearer({ domain: 'bridge.example', uri: 'https://bridge.example' });
+  // First call seeds the cache with the verified domain.
+  await verifySiweBearerToken(token, { domain: 'bridge.example' });
+  // Second call with a stricter domain must reject even though the token is
+  // already verified — otherwise a cached entry could bypass a tightened
+  // domain check from a different caller.
+  await assert.rejects(
+    () => verifySiweBearerToken(token, { domain: 'attacker.example' }),
+    /domain mismatch/i,
+  );
+});

--- a/packages/server/src/auth/siwe-bearer.test.ts
+++ b/packages/server/src/auth/siwe-bearer.test.ts
@@ -1,0 +1,97 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SiweMessage } from 'siwe';
+import { Wallet } from 'ethers';
+import {
+  decodeSiweBearerToken,
+  verifySiweBearerToken,
+  _resetSiweBearerCacheForTests,
+} from './siwe-bearer.js';
+
+// Anvil account #0 — well-known test key, never used for anything real.
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_ADDRESS_LOWER = '0xf39fd6e51aad88f6f4ce6ab8827279cffFb92266'.toLowerCase();
+
+async function mintBearer(opts: {
+  domain: string;
+  uri: string;
+  issuedAt?: Date;
+  expirationTime?: Date;
+}): Promise<string> {
+  const wallet = new Wallet(TEST_PRIVATE_KEY);
+  const issuedAt = opts.issuedAt ?? new Date();
+  const expirationTime = opts.expirationTime ?? new Date(Date.now() + 60 * 60 * 1000);
+  const msg = new SiweMessage({
+    domain: opts.domain,
+    address: wallet.address,
+    statement: 'siwe-bearer test',
+    uri: opts.uri,
+    version: '1',
+    chainId: 1,
+    nonce: crypto.randomUUID().replace(/-/g, ''),
+    issuedAt: issuedAt.toISOString(),
+    expirationTime: expirationTime.toISOString(),
+  });
+  const message = msg.prepareMessage();
+  const signature = await wallet.signMessage(message);
+  const json = JSON.stringify({ message, signature });
+  return Buffer.from(json, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+test('decodeSiweBearerToken decodes a base64url JSON envelope', () => {
+  const json = JSON.stringify({ message: 'hello', signature: '0xabc' });
+  const token = Buffer.from(json, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  const decoded = decodeSiweBearerToken(token);
+  assert.equal(decoded.message, 'hello');
+  assert.equal(decoded.signature, '0xabc');
+});
+
+test('decodeSiweBearerToken rejects malformed envelopes', () => {
+  assert.throws(() => decodeSiweBearerToken('!!!not base64!!!'));
+  const noFields = Buffer.from('{}', 'utf-8').toString('base64url');
+  assert.throws(() => decodeSiweBearerToken(noFields), /missing message or signature/);
+});
+
+test('verifySiweBearerToken recovers the signing address', async () => {
+  _resetSiweBearerCacheForTests();
+  const token = await mintBearer({ domain: 'bridge.example', uri: 'https://bridge.example' });
+  const verified = await verifySiweBearerToken(token, { domain: 'bridge.example' });
+  assert.equal(verified.address, TEST_ADDRESS_LOWER);
+});
+
+test('verifySiweBearerToken rejects domain mismatch', async () => {
+  _resetSiweBearerCacheForTests();
+  const token = await mintBearer({ domain: 'bridge.example', uri: 'https://bridge.example' });
+  await assert.rejects(
+    () => verifySiweBearerToken(token, { domain: 'attacker.example' }),
+    /domain mismatch/i,
+  );
+});
+
+test('verifySiweBearerToken rejects expired tokens', async () => {
+  _resetSiweBearerCacheForTests();
+  const past = new Date(Date.now() - 10 * 60 * 1000);
+  const token = await mintBearer({
+    domain: 'bridge.example',
+    uri: 'https://bridge.example',
+    issuedAt: new Date(past.getTime() - 60 * 1000),
+    expirationTime: past,
+  });
+  await assert.rejects(() => verifySiweBearerToken(token, { domain: 'bridge.example' }));
+});
+
+test('verifySiweBearerToken caches verified results', async () => {
+  _resetSiweBearerCacheForTests();
+  const token = await mintBearer({ domain: 'bridge.example', uri: 'https://bridge.example' });
+  const a = await verifySiweBearerToken(token, { domain: 'bridge.example' });
+  const b = await verifySiweBearerToken(token, { domain: 'bridge.example' });
+  assert.equal(a.address, b.address);
+});

--- a/packages/server/src/auth/siwe-bearer.ts
+++ b/packages/server/src/auth/siwe-bearer.ts
@@ -5,8 +5,9 @@
 // `message` is an EIP-4361 SIWE message string. Unlike the opaque
 // `vbc_caller_*` tokens issued by /auth/siwe/exchange (issue #31), these are
 // stateless: every request re-runs signature recovery + TTL + domain checks.
-// We cache by raw token string to avoid re-verifying the same bearer on
-// every request from the same caller.
+// To avoid re-verifying the same bearer on every request from the same
+// caller, we keep an in-process cache keyed by the bearer's SHA-256 digest
+// (see `tokenCacheKey` below).
 
 import { createHash } from 'node:crypto';
 import { SiweMessage } from 'siwe';

--- a/packages/server/src/auth/siwe-bearer.ts
+++ b/packages/server/src/auth/siwe-bearer.ts
@@ -1,0 +1,105 @@
+// Self-verifiable SIWE bearer tokens per
+// https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1
+//
+// A SIWE bearer is base64url(JSON.stringify({ message, signature })) where
+// `message` is an EIP-4361 SIWE message string. Unlike the opaque
+// `vbc_caller_*` tokens issued by /auth/siwe/exchange (issue #31), these are
+// stateless: every request re-runs signature recovery + TTL + domain checks.
+// We cache by raw token string to avoid re-verifying the same bearer on
+// every request from the same caller.
+
+import { SiweMessage } from 'siwe';
+import { verifySiweMessage } from '../siwe-token.js';
+
+export interface DecodedSiweBearer {
+  message: string;
+  signature: string;
+}
+
+export function decodeSiweBearerToken(token: string): DecodedSiweBearer {
+  let base64 = token.replace(/-/g, '+').replace(/_/g, '/');
+  const padLength = (4 - (base64.length % 4)) % 4;
+  base64 += '='.repeat(padLength);
+  let json: string;
+  try {
+    json = Buffer.from(base64, 'base64').toString('utf-8');
+  } catch {
+    throw new Error('Failed to decode SIWE bearer token');
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error('SIWE bearer token is not valid JSON');
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    typeof (parsed as { message?: unknown }).message !== 'string' ||
+    typeof (parsed as { signature?: unknown }).signature !== 'string'
+  ) {
+    throw new Error('SIWE bearer token missing message or signature');
+  }
+  return parsed as DecodedSiweBearer;
+}
+
+interface CacheEntry {
+  address: string;
+  expiresAt: number;
+}
+
+const CACHE_MAX_ENTRIES = 10_000;
+const CACHE_SWEEP_INTERVAL_MS = 60_000;
+const verifyCache = new Map<string, CacheEntry>();
+let lastSweep = 0;
+
+function maybeSweep() {
+  const now = Date.now();
+  if (now - lastSweep < CACHE_SWEEP_INTERVAL_MS && verifyCache.size <= CACHE_MAX_ENTRIES) return;
+  lastSweep = now;
+  for (const [k, v] of verifyCache) {
+    if (v.expiresAt <= now) verifyCache.delete(k);
+  }
+  while (verifyCache.size > CACHE_MAX_ENTRIES) {
+    const oldest = verifyCache.keys().next().value;
+    if (oldest === undefined) break;
+    verifyCache.delete(oldest);
+  }
+}
+
+export interface VerifySiweBearerOptions {
+  domain?: string;
+}
+
+export interface VerifiedSiweBearer {
+  address: string;
+}
+
+// Decode + verify a SIWE bearer token. Returns the recovered Ethereum address
+// (lowercased). Throws on any failure (decode, signature, TTL, domain, expiry).
+export async function verifySiweBearerToken(
+  token: string,
+  opts: VerifySiweBearerOptions = {},
+): Promise<VerifiedSiweBearer> {
+  maybeSweep();
+  const cached = verifyCache.get(token);
+  if (cached && cached.expiresAt > Date.now()) {
+    return { address: cached.address };
+  }
+  const { message, signature } = decodeSiweBearerToken(token);
+  const address = await verifySiweMessage(message, signature, { domain: opts.domain });
+  const parsed = new SiweMessage(message);
+  const expiresAt = parsed.expirationTime
+    ? new Date(parsed.expirationTime).getTime()
+    : Date.now() + 60_000;
+  verifyCache.set(token, { address: address.toLowerCase(), expiresAt });
+  return { address: address.toLowerCase() };
+}
+
+// Test-only: clear the in-memory cache so unit tests can exercise the
+// verification path repeatedly with the same token without seeing stale
+// hits. Not exported via index — call via the relative import.
+export function _resetSiweBearerCacheForTests(): void {
+  verifyCache.clear();
+  lastSweep = 0;
+}

--- a/packages/server/src/auth/siwe-bearer.ts
+++ b/packages/server/src/auth/siwe-bearer.ts
@@ -45,6 +45,7 @@ export function decodeSiweBearerToken(token: string): DecodedSiweBearer {
 
 interface CacheEntry {
   address: string;
+  domain: string;
   expiresAt: number;
 }
 
@@ -52,6 +53,13 @@ interface CacheEntry {
 // not a true LRU — it bounds memory and TTL-evicts expired entries, which
 // matches dba's siwe-token.ts and is sufficient for our usage pattern (a
 // caller signs once and reuses the same token for the SIWE TTL).
+//
+// We cache the verified domain alongside the address so a cache hit can
+// re-check it if the caller passes a different `opts.domain`. Without this
+// re-check a token whose first verification accepted any domain (or domain
+// undefined) would cache-bypass a stricter domain check on subsequent
+// calls. In practice opts.domain is fixed (siweDomain from http.tsx), but
+// the function is exported and could be reused.
 const CACHE_MAX_ENTRIES = 10_000;
 const CACHE_SWEEP_INTERVAL_MS = 60_000;
 const verifyCache = new Map<string, CacheEntry>();
@@ -88,16 +96,27 @@ export async function verifySiweBearerToken(
   maybeSweep();
   const cached = verifyCache.get(token);
   if (cached && cached.expiresAt > Date.now()) {
+    if (opts.domain && cached.domain !== opts.domain.toLowerCase()) {
+      throw new Error(
+        `SIWE domain mismatch: expected ${opts.domain}, got ${cached.domain}`,
+      );
+    }
     return { address: cached.address };
   }
   const { message, signature } = decodeSiweBearerToken(token);
   const address = await verifySiweMessage(message, signature, { domain: opts.domain });
   // verifySiweMessage already enforces presence and validity of expirationTime,
-  // so re-parsing here is just to read the value back out for the cache TTL.
+  // so re-parsing here is just to read the value back out for the cache TTL +
+  // the verified domain (so a later call with a different opts.domain doesn't
+  // pass on the cached result).
   const parsed = new SiweMessage(message);
   const expiresAt = new Date(parsed.expirationTime!).getTime();
   const lower = address.toLowerCase();
-  verifyCache.set(token, { address: lower, expiresAt });
+  verifyCache.set(token, {
+    address: lower,
+    domain: parsed.domain.toLowerCase(),
+    expiresAt,
+  });
   return { address: lower };
 }
 

--- a/packages/server/src/auth/siwe-bearer.ts
+++ b/packages/server/src/auth/siwe-bearer.ts
@@ -48,6 +48,10 @@ interface CacheEntry {
   expiresAt: number;
 }
 
+// FIFO cache (Map insertion order). We don't promote on access, so this is
+// not a true LRU — it bounds memory and TTL-evicts expired entries, which
+// matches dba's siwe-token.ts and is sufficient for our usage pattern (a
+// caller signs once and reuses the same token for the SIWE TTL).
 const CACHE_MAX_ENTRIES = 10_000;
 const CACHE_SWEEP_INTERVAL_MS = 60_000;
 const verifyCache = new Map<string, CacheEntry>();
@@ -88,12 +92,13 @@ export async function verifySiweBearerToken(
   }
   const { message, signature } = decodeSiweBearerToken(token);
   const address = await verifySiweMessage(message, signature, { domain: opts.domain });
+  // verifySiweMessage already enforces presence and validity of expirationTime,
+  // so re-parsing here is just to read the value back out for the cache TTL.
   const parsed = new SiweMessage(message);
-  const expiresAt = parsed.expirationTime
-    ? new Date(parsed.expirationTime).getTime()
-    : Date.now() + 60_000;
-  verifyCache.set(token, { address: address.toLowerCase(), expiresAt });
-  return { address: address.toLowerCase() };
+  const expiresAt = new Date(parsed.expirationTime!).getTime();
+  const lower = address.toLowerCase();
+  verifyCache.set(token, { address: lower, expiresAt });
+  return { address: lower };
 }
 
 // Test-only: clear the in-memory cache so unit tests can exercise the

--- a/packages/server/src/auth/siwe-bearer.ts
+++ b/packages/server/src/auth/siwe-bearer.ts
@@ -8,6 +8,7 @@
 // We cache by raw token string to avoid re-verifying the same bearer on
 // every request from the same caller.
 
+import { createHash } from 'node:crypto';
 import { SiweMessage } from 'siwe';
 import { verifySiweMessage } from '../siwe-token.js';
 
@@ -54,6 +55,13 @@ interface CacheEntry {
 // matches dba's siwe-token.ts and is sufficient for our usage pattern (a
 // caller signs once and reuses the same token for the SIWE TTL).
 //
+// Cache keys are SHA-256 hex digests of the bearer token, not the raw
+// token itself. SIWE bearers are base64url-encoded JSON with embedded
+// signatures and can run several hundred bytes each; an attacker hammering
+// the route with distinct tokens could otherwise pin up to MAX_ENTRIES *
+// header_size bytes in memory until TTL eviction. The 64-char digest
+// keeps each key fixed-size regardless of input.
+//
 // We cache the verified domain alongside the address so a cache hit can
 // re-check it if the caller passes a different `opts.domain`. Without this
 // re-check a token whose first verification accepted any domain (or domain
@@ -64,6 +72,10 @@ const CACHE_MAX_ENTRIES = 10_000;
 const CACHE_SWEEP_INTERVAL_MS = 60_000;
 const verifyCache = new Map<string, CacheEntry>();
 let lastSweep = 0;
+
+function tokenCacheKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 function maybeSweep() {
   const now = Date.now();
@@ -94,7 +106,8 @@ export async function verifySiweBearerToken(
   opts: VerifySiweBearerOptions = {},
 ): Promise<VerifiedSiweBearer> {
   maybeSweep();
-  const cached = verifyCache.get(token);
+  const cacheKey = tokenCacheKey(token);
+  const cached = verifyCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     if (opts.domain && cached.domain !== opts.domain.toLowerCase()) {
       throw new Error(
@@ -112,7 +125,7 @@ export async function verifySiweBearerToken(
   const parsed = new SiweMessage(message);
   const expiresAt = new Date(parsed.expirationTime!).getTime();
   const lower = address.toLowerCase();
-  verifyCache.set(token, {
+  verifyCache.set(cacheKey, {
     address: lower,
     domain: parsed.domain.toLowerCase(),
     expiresAt,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -339,6 +339,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   const authMw = agentAuthMiddleware(opts.registry, {
     sql: opts.db,
     deviceFlowEnabled,
+    siweDomain,
   });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);


### PR DESCRIPTION
## Summary

- Add a stateless SIWE bearer fast-path to `agentAuthMiddleware`: decode → verify (signature, TTL, domain) → derive `eth:0x…` principal → continue. Verified results are cached in-memory (10k entries, FIFO + TTL eviction, 60s sweep) to avoid re-recovery on identical bearers.
- Mirror vicoop-db-agent-builder's auth advertisement on the per-agent AgentCard so Mentionable / A2A clients keying off `securitySchemes.{bearerAuth, deviceFlow}` see the same shape on both hosts:
  - `bearerAuth` — `http`+`bearer`+`bearerFormat: SIWE`
  - `deviceFlow` — `oauth2`+`deviceCode` (only when device flow is mounted)
  - `security` lists both as alternatives (OR)
  - `capabilities.extensions[]` advertises `siwe-bearer-auth/v0.1` with `required: true`
- Drops the conflated `bridge` security scheme from the card. The opaque `vbc_caller_*` token path on `agentAuthMiddleware` is unchanged — clients with existing opaque tokens keep working.

## Why

A Mentionable client that authenticates against vicoop-db-agent-builder failed against the bridge because:
1. The bridge previously rejected anything not prefixed `vbc_caller_*`, blocking spec-compliant raw SIWE bearers.
2. The agent card didn't advertise the SIWE bearer-auth extension URI, so spec-aware clients had no way to discover the path.
3. Where dba surfaces `securitySchemes.bearerAuth` (http+bearer+SIWE) and `securitySchemes.deviceFlow`, the bridge surfaced a single conflated `bridge` key that key-name-keyed clients couldn't recognize.

## Trade-offs

- SIWE-bearer callers do not get a `callers` row, so revocation is at the principal level (remove from `allowed_callers`) rather than the token level. The unified opaque-token model from #31 still applies to the existing path. Per the [siwe-bearer-auth/v0.1 spec](https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1), bearer tokens are self-verifying and need no server-side session.
- Extension `required: true` matches dba; clients that don't understand the URI fail closed at the Mentionable layer, but can still authenticate via the opaque-token path on the bridge directly.

## Test plan

- [x] Unit: `siwe-bearer.test.ts` covers decode, verify, domain mismatch, expiry, cache.
- [x] Unit: `agent-card.test.ts` covers extension advertisement, `bearerAuth`/`deviceFlow` schemes, `deviceFlow` omission when device flow disabled, no-double-add when wire card declares the URI.
- [x] `pnpm typecheck` clean across all packages.
- [x] Deployed to `vicoop-bridge-server.fly.dev` and verified end-to-end with `a2a-wallet siwe auth ... | a2a-wallet a2a send --bearer ...`.
- [x] Negative paths: domain mismatch → 401 "SIWE domain mismatch", unauthorized wallet → 403 "Caller not authorized", garbage token → 401 "not valid JSON".
- [x] Card shape on production matches vicoop-db-agent-builder: `securitySchemes.{bearerAuth, deviceFlow}`, `security: [{bearerAuth:[]}, {deviceFlow:[]}]`, SIWE extension `required: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
