### PR TITLE
feat(client): clearer upgrade restart guidance and unknown-subcommand hint

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -475,8 +475,8 @@ version takes effect — `upgrade` cannot signal a process it didn't start.
 To check for stragglers, run `pgrep -fl 'vicoop-client|dist/cli\.js'` and kill
 any old process before starting the new one. Multiple client processes
 connecting with the **same `SERVER_TOKEN`** for one `AGENT_ID` collide and
-the older WS is closed with code 4009 (harmless but noisy); see
-`docs/local-testing.md` Troubleshooting for the same note.
+the older WS is closed with code 4009 (harmless but noisy); see the Gotchas
+section of `docs/local-testing.md` for the same note.
 
 ## Troubleshooting
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -369,9 +369,11 @@ systemctl --user daemon-reload
 systemctl --user enable --now vicoop-client
 ```
 
-For macOS or ad hoc local testing, use the foreground command above or your
-normal process supervisor. The bridge does not require systemd; it only needs
-one live `vicoop-client` process connected for the agent id.
+For macOS or ad hoc local testing, run the foreground command above directly,
+or wrap it in a detached session (`screen -dmS vicoop-client …` / `tmux new
+-d …`) or a `launchd` plist if you want it to survive the terminal closing.
+The bridge does not require systemd; it only needs one live `vicoop-client`
+process connected for the agent id.
 
 ### Restrict who can call your agent
 
@@ -465,6 +467,15 @@ belong to `install.sh`; if a release ever changes the unit layout, re-run
 `install.sh` once to refresh the scaffolding. Note that `FORCE=1` deletes
 everything under `$INSTALL_DIR` first — back up any operator-added cards or
 files before running it.
+
+**Manual restart on non-systemd hosts.** The atomic swap leaves your running
+client process attached to the previous bundle. Stop it and start it again
+with your usual command (foreground / screen / tmux / launchd) so the new
+version takes effect — `upgrade` cannot signal a process it didn't start.
+To check for stragglers during a manual restart, run
+`pgrep -fl 'vicoop-client|dist/cli.js'`; if two clients end up live for the
+same `AGENT_ID`, the bridge keeps the newest WS and closes the older one
+with close code 4009, which is harmless but noisy.
 
 ## Troubleshooting
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -370,10 +370,10 @@ systemctl --user enable --now vicoop-client
 ```
 
 For macOS or ad hoc local testing, run the foreground command above directly,
-or wrap it in a detached session (`screen -dmS vicoop-client …` / `tmux new
--d …`) or a `launchd` plist if you want it to survive the terminal closing.
-The bridge does not require systemd; it only needs one live `vicoop-client`
-process connected for the agent id.
+or wrap it in a detached session (`screen -dmS vicoop-client …` /
+`tmux new -d …`) or a `launchd` plist if you want it to survive the terminal
+closing. The bridge does not require systemd; it only needs one live
+`vicoop-client` process connected for the agent id.
 
 ### Restrict who can call your agent
 
@@ -472,10 +472,11 @@ files before running it.
 client process attached to the previous bundle. Stop it and start it again
 with your usual command (foreground / screen / tmux / launchd) so the new
 version takes effect — `upgrade` cannot signal a process it didn't start.
-To check for stragglers during a manual restart, run
-`pgrep -fl 'vicoop-client|dist/cli.js'`; if two clients end up live for the
-same `AGENT_ID`, the bridge keeps the newest WS and closes the older one
-with close code 4009, which is harmless but noisy.
+To check for stragglers, run `pgrep -fl 'vicoop-client|dist/cli.js'` and kill
+any old process before starting the new one. Multiple client processes
+connecting with the **same `SERVER_TOKEN`** for one `AGENT_ID` collide and
+the older WS is closed with code 4009 (harmless but noisy); see
+`docs/local-testing.md` Troubleshooting for the same note.
 
 ## Troubleshooting
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -472,7 +472,7 @@ files before running it.
 client process attached to the previous bundle. Stop it and start it again
 with your usual command (foreground / screen / tmux / launchd) so the new
 version takes effect — `upgrade` cannot signal a process it didn't start.
-To check for stragglers, run `pgrep -fl 'vicoop-client|dist/cli.js'` and kill
+To check for stragglers, run `pgrep -fl 'vicoop-client|dist/cli\.js'` and kill
 any old process before starting the new one. Multiple client processes
 connecting with the **same `SERVER_TOKEN`** for one `AGENT_ID` collide and
 the older WS is closed with code 4009 (harmless but noisy); see

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -143,7 +143,13 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (argv[0] === '--help' || argv[0] === '-h' || argv[0] === 'help') {
+  // Bare `help` is an explicit top-level help request. We defer `-h`/`--help`
+  // until after subcommand routing so e.g. `vicoop-client login --help` lets
+  // runLogin handle its own usage, and so a daemon invocation that includes
+  // `--help` anywhere in argv (`--server ... --help`) still hits this path
+  // instead of confusing parseClientArgs (which treats every `--key` as
+  // taking a value).
+  if (argv[0] === 'help') {
     process.stdout.write(`${SUBCOMMAND_LIST}\n`);
     process.stdout.write(`daemon mode: ${DAEMON_USAGE}\n`);
     process.exit(0);
@@ -187,6 +193,15 @@ async function main(): Promise<void> {
     console.error(SUBCOMMAND_LIST);
     console.error(`daemon mode: ${DAEMON_USAGE}`);
     process.exit(1);
+  }
+
+  // Daemon-mode help: `--help`/`-h` anywhere in argv prints usage. parseClientArgs
+  // would otherwise consume the next token (e.g. `--token`) as `--help`'s value
+  // and surface a confusing "missing required args" error.
+  if (argv.includes('--help') || argv.includes('-h')) {
+    process.stdout.write(`${SUBCOMMAND_LIST}\n`);
+    process.stdout.write(`daemon mode: ${DAEMON_USAGE}\n`);
+    process.exit(0);
   }
 
   // Default path: long-running daemon. Do not exit — client.start() keeps the

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -162,6 +162,19 @@ async function main(): Promise<void> {
     process.exit(await runListAgents(argv.slice(1)));
   }
 
+  // A bare word (not a flag) here is an unrecognised subcommand. Catch it so
+  // operators on an older bundle calling a newer subcommand get a clear
+  // upgrade hint instead of a confusing "missing required args" from the
+  // default client path.
+  if (argv[0] && !argv[0].startsWith('-')) {
+    console.error(`unknown command: ${argv[0]}`);
+    console.error(
+      `this client (${clientVersion}) does not recognise that subcommand. ` +
+        'It may be available in a newer release — run `vicoop-client upgrade --check`.',
+    );
+    process.exit(1);
+  }
+
   // Default path: long-running daemon. Do not exit — client.start() keeps the
   // event loop alive and signal handlers will call process.exit on shutdown.
   runClient(argv);

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -24,6 +24,11 @@ interface Args {
   backend: string;
 }
 
+const DAEMON_USAGE =
+  'vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude> [--card <path>]';
+const SUBCOMMAND_LIST =
+  'subcommands: login, upgrade, list-agents, list-callers, add-caller, remove-caller (run any with --help)';
+
 function parseClientArgs(argv: string[]): Args {
   const out: Partial<Args> = {};
   for (let i = 0; i < argv.length; i++) {
@@ -51,7 +56,7 @@ function parseClientArgs(argv: string[]): Args {
   const missing = Object.entries(required).filter(([, v]) => !v).map(([k]) => k);
   if (missing.length) {
     console.error(`missing required args: ${missing.join(', ')}`);
-    console.error('usage: vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude> [--card <path>]');
+    console.error(`usage: ${DAEMON_USAGE}`);
     process.exit(1);
   }
   return resolved;
@@ -138,6 +143,12 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
+  if (argv[0] === '--help' || argv[0] === '-h' || argv[0] === 'help') {
+    process.stdout.write(`${SUBCOMMAND_LIST}\n`);
+    process.stdout.write(`daemon mode: ${DAEMON_USAGE}\n`);
+    process.exit(0);
+  }
+
   if (argv[0] === 'upgrade') {
     process.exit(await runUpgradeCmd(argv.slice(1)));
   }
@@ -165,13 +176,16 @@ async function main(): Promise<void> {
   // A bare word (not a flag) here is an unrecognised subcommand. Catch it so
   // operators on an older bundle calling a newer subcommand get a clear
   // upgrade hint instead of a confusing "missing required args" from the
-  // default client path.
+  // default client path. Also include the subcommand list and daemon usage
+  // so plain typos still see actionable syntax guidance.
   if (argv[0] && !argv[0].startsWith('-')) {
     console.error(`unknown command: ${argv[0]}`);
     console.error(
       `this client (${clientVersion}) does not recognise that subcommand. ` +
         'It may be available in a newer release — run `vicoop-client upgrade --check`.',
     );
+    console.error(SUBCOMMAND_LIST);
+    console.error(`daemon mode: ${DAEMON_USAGE}`);
     process.exit(1);
   }
 

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -273,7 +273,10 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
       err('systemctl try-restart failed; restart the service manually');
     }
   } else {
-    log('no systemd unit detected — restart your client manually to pick up the new version');
+    log(
+      'no systemd unit detected — your running client (if any) keeps the previous bundle ' +
+        'until you stop it and start it again with your usual command',
+    );
   }
 
   log(`upgraded ${clientVersion} -> ${targetVersion}`);


### PR DESCRIPTION
## Summary

- `cli.ts`: catch a bare unknown subcommand and print a `vicoop-client upgrade --check` hint, so operators on an older bundle calling a newer subcommand (`list-callers`, etc.) get a clear nudge instead of falling through to the daemon path with a confusing `missing required args` error.
- `upgrade.ts`: replace the vague "restart your client manually" line on non-systemd hosts with a message that spells out the running client keeps the previous bundle until the operator stops and starts it again.
- `docs/install-client.md`: macOS persistence section gains concrete detached-session examples (`screen` / `tmux` / `launchd`), and the upgrade section gains a manual-restart note + `pgrep -fl 'vicoop-client|dist/cli.js'` check for stray duplicates.

Addresses items #1, #3, #4, and #5 from #119. Item #2 (owner-session login) is already self-documenting via `admin-cli.ts:78-83`, which the unknown-subcommand hint now routes 0.7.x users toward.

Discussed and ruled out: scanning live PIDs from `upgrade` itself. No mainstream CLI does that as a heuristic — the established patterns are OS-level tools (needrestart/checkrestart) or pidfile contracts (daemon-pid, daemon-control), neither of which we want to take on for this scope. Message + doc note is the proportionate fix.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` (232 passing)
- [x] Manual smoke: `vicoop-client foo` → `unknown command: foo … run \`vicoop-client upgrade --check\`` (exit 1)
- [x] Manual smoke: `vicoop-client --version`, `vicoop-client upgrade --help`, no-arg invocation, `--server …` invocation all unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)