### PR TITLE
docs(install-client): macOS persistence + caller subcommand version note

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -370,10 +370,29 @@ systemctl --user enable --now vicoop-client
 ```
 
 For macOS or ad hoc local testing, run the foreground command above directly,
-or wrap it in a detached session (`screen -dmS vicoop-client …` /
-`tmux new -d …`) or a `launchd` plist if you want it to survive the terminal
+or wrap it in a detached session if you want it to survive the terminal
 closing. The bridge does not require systemd; it only needs one live
 `vicoop-client` process connected for the agent id.
+
+`nohup … &` tends to lose stdout/stderr on macOS; prefer `screen` or `tmux`
+with explicit log redirection so failures are recoverable:
+
+```sh
+mkdir -p "$INSTALL_DIR/logs"
+screen -dmS vicoop-client bash -lc ". $INSTALL_DIR/vicoop-client.env && \
+  BACKEND=claude $INSTALL_DIR/bin/vicoop-client \
+  >> $INSTALL_DIR/logs/client.log 2>&1"
+
+# tail the log
+tail -f "$INSTALL_DIR/logs/client.log"
+
+# stop
+screen -S vicoop-client -X quit
+```
+
+`launchd` is the persistent option if you want the client to start at login;
+write a plist under `~/Library/LaunchAgents/` and load it with
+`launchctl load -w`.
 
 ### Restrict who can call your agent
 
@@ -387,13 +406,23 @@ gates only the cross-owner tools.
 
 #### Option A: `vicoop-client` subcommands (recommended for scripts)
 
+These subcommands require **bundle `client-v0.8.0` or newer**. Older
+installs only know the daemon flags; check before using and upgrade if
+needed:
+
+```sh
+vicoop-client -v
+vicoop-client upgrade --check   # report latest vs current
+vicoop-client upgrade           # upgrade in place if behind
+```
+
 ```sh
 # One-time login — saves the bearer to ~/.vicoop/owner-session.json (chmod 600).
 vicoop-client login --owner-session --bridge "$BRIDGE_URL"
 
 # Now any of these work without re-authenticating:
 vicoop-client list-agents
-vicoop-client list-callers "$AGENT_ID"
+vicoop-client list-callers "$AGENT_ID" --json
 vicoop-client add-caller "$AGENT_ID" "eth:0x<40-hex>"
 vicoop-client remove-caller "$AGENT_ID" "google:email:caller@example.com"
 
@@ -401,6 +430,11 @@ vicoop-client remove-caller "$AGENT_ID" "google:email:caller@example.com"
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
 # work too (handy for CI).
 ```
+
+The env file written by Step 4 (`SERVER_URL` / `SERVER_TOKEN` / `AGENT_ID`)
+is a **client** credential and is **not** accepted by these admin commands —
+they only accept an owner-session bearer, which is why `login
+--owner-session` is a separate step.
 
 These talk to the bridge's `/admin-api/*` routes — same logic the admin
 agent's tools run, but without an LLM round-trip per call.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -379,9 +379,9 @@ with explicit log redirection so failures are recoverable:
 
 ```sh
 mkdir -p "$INSTALL_DIR/logs"
-screen -dmS vicoop-client bash -lc ". $INSTALL_DIR/vicoop-client.env && \
-  BACKEND=claude $INSTALL_DIR/bin/vicoop-client \
-  >> $INSTALL_DIR/logs/client.log 2>&1"
+screen -dmS vicoop-client bash -lc ". \"$INSTALL_DIR/vicoop-client.env\" && \
+  BACKEND=claude \"$INSTALL_DIR/bin/vicoop-client\" \
+  >> \"$INSTALL_DIR/logs/client.log\" 2>&1"
 
 # tail the log
 tail -f "$INSTALL_DIR/logs/client.log"
@@ -411,20 +411,20 @@ installs only know the daemon flags; check before using and upgrade if
 needed:
 
 ```sh
-vicoop-client -v
-vicoop-client upgrade --check   # report latest vs current
-vicoop-client upgrade           # upgrade in place if behind
+"$INSTALL_DIR/bin/vicoop-client" -v
+"$INSTALL_DIR/bin/vicoop-client" upgrade --check   # report latest vs current
+"$INSTALL_DIR/bin/vicoop-client" upgrade           # upgrade in place if behind
 ```
 
 ```sh
 # One-time login — saves the bearer to ~/.vicoop/owner-session.json (chmod 600).
-vicoop-client login --owner-session --bridge "$BRIDGE_URL"
+"$INSTALL_DIR/bin/vicoop-client" login --owner-session --bridge "$BRIDGE_URL"
 
 # Now any of these work without re-authenticating:
-vicoop-client list-agents
-vicoop-client list-callers "$AGENT_ID" --json
-vicoop-client add-caller "$AGENT_ID" "eth:0x<40-hex>"
-vicoop-client remove-caller "$AGENT_ID" "google:email:caller@example.com"
+"$INSTALL_DIR/bin/vicoop-client" list-agents
+"$INSTALL_DIR/bin/vicoop-client" list-callers "$AGENT_ID" --json
+"$INSTALL_DIR/bin/vicoop-client" add-caller "$AGENT_ID" "eth:0x<40-hex>"
+"$INSTALL_DIR/bin/vicoop-client" remove-caller "$AGENT_ID" "google:email:caller@example.com"
 
 # Pass --json for machine-readable output, or --bridge / --token to override
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
@@ -433,8 +433,8 @@ vicoop-client remove-caller "$AGENT_ID" "google:email:caller@example.com"
 
 The env file written by Step 4 (`SERVER_URL` / `SERVER_TOKEN` / `AGENT_ID`)
 is a **client** credential and is **not** accepted by these admin commands —
-they only accept an owner-session bearer, which is why `login
---owner-session` is a separate step.
+they only accept an owner-session bearer, which is why
+`login --owner-session` is a separate step.
 
 These talk to the bridge's `/admin-api/*` routes — same logic the admin
 agent's tools run, but without an LLM round-trip per call.


### PR DESCRIPTION
## Summary

Two surgical additions to `docs/install-client.md` to cover the
operational friction reported in #119. #72's only ask (the doc still
calling Claude an unshipped backend) was already addressed in earlier
commits — this PR closes it for tracking.

- macOS persistence: full `screen` example with log path and stop
  command, plus a note that `nohup` loses stdout/stderr on macOS.
- Caller subcommands (`list-callers`, `add-caller`, …): call out the
  `client-v0.8.0+` minimum bundle and recommend `upgrade --check` before
  use.
- Clarify that the Step 4 client env file is **not** an owner-session
  credential, so `login --owner-session` is a separate step.

Closes #119
Closes #72

## Test plan

- [ ] Render the doc and skim the new persistence block
- [ ] Verify the suggested `screen` line works on macOS (start, tail log, quit)
- [ ] Verify `vicoop-client upgrade --check` works on a stale bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)