### PR TITLE
feat(server): advertise RFC 6750 WWW-Authenticate on /agents/:id auth failures

### DIFF
--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -1,11 +1,43 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { Hono } from 'hono';
+import { SiweMessage } from 'siwe';
+import { Wallet } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { AgentCard } from '@vicoop-bridge/protocol';
 import { agentAuthMiddleware } from './agent-auth.js';
+import { _resetSiweBearerCacheForTests } from './auth/siwe-bearer.js';
 import { Registry, type ClientConnection } from './registry.js';
 import type { Sql } from './db.js';
+
+// Anvil account #0 — well-known test key, mirrors siwe-bearer.test.ts.
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+const TEST_ADDRESS_LOWER = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266';
+
+async function mintBearer(opts: { domain: string; uri: string }): Promise<string> {
+  const wallet = new Wallet(TEST_PRIVATE_KEY);
+  const issuedAt = new Date();
+  const expirationTime = new Date(Date.now() + 60 * 60 * 1000);
+  const msg = new SiweMessage({
+    domain: opts.domain,
+    address: wallet.address,
+    statement: 'agent-auth test',
+    uri: opts.uri,
+    version: '1',
+    chainId: 1,
+    nonce: crypto.randomUUID().replace(/-/g, ''),
+    issuedAt: issuedAt.toISOString(),
+    expirationTime: expirationTime.toISOString(),
+  });
+  const message = msg.prepareMessage();
+  const signature = await wallet.signMessage(message);
+  const json = JSON.stringify({ message, signature });
+  return Buffer.from(json, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
 
 // The reject paths exercised here never touch postgres — the middleware short-
 // circuits on missing/malformed bearer headers before reaching verifyCallerToken
@@ -123,6 +155,34 @@ test('unknown agent returns 404 without auth challenge', async () => {
   assert.equal(res.status, 404);
   // 404 is not an auth failure, so RFC 6750 challenge shouldn't be added.
   assert.equal(res.headers.get('WWW-Authenticate'), null);
+});
+
+test('caller not in allowedCallers responds 403 with WWW-Authenticate error="insufficient_scope"', async () => {
+  _resetSiweBearerCacheForTests();
+  // The agent only allows a different principal — the bearer's address is
+  // valid SIWE but not on the allow list, so the middleware must reach the
+  // caller_not_authorized branch (403).
+  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
+  registerAgent(registry, 'restricted', [
+    'eth:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  ]);
+  // Sanity: the minted bearer's address differs from the allowed principal.
+  assert.notEqual(TEST_ADDRESS_LOWER, '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+
+  const bearer = await mintBearer({
+    domain: 'bridge.example',
+    uri: 'https://bridge.example',
+  });
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+  assert.equal(res.status, 403);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge);
+  assert.match(challenge, /^Bearer realm="vicoop-bridge"/);
+  assert.match(challenge, /error="insufficient_scope"/);
+  assert.match(challenge, /error_description="caller not in allowed list"/);
 });
 
 test('error_description is length-capped so a long upstream message cannot blow up the header', async () => {

--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -5,7 +5,7 @@ import { SiweMessage } from 'siwe';
 import { Wallet } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { AgentCard } from '@vicoop-bridge/protocol';
-import { agentAuthMiddleware } from './agent-auth.js';
+import { agentAuthMiddleware, sanitizeErrorDescription } from './agent-auth.js';
 import { _resetSiweBearerCacheForTests } from './auth/siwe-bearer.js';
 import { Registry, type ClientConnection } from './registry.js';
 import type { Sql } from './db.js';
@@ -122,7 +122,7 @@ test('owner-session token on caller route responds with WWW-Authenticate error="
   assert.match(challenge, /error_description="vbc_owner_\* tokens are not accepted on \/agents\/:id"/);
 });
 
-test('invalid SIWE bearer (siweDomain on) responds with WWW-Authenticate error="invalid_token"', async () => {
+test('invalid SIWE bearer (siweDomain on) responds with WWW-Authenticate error="invalid_token" and stable description', async () => {
   const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
   registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
 
@@ -137,6 +137,10 @@ test('invalid SIWE bearer (siweDomain on) responds with WWW-Authenticate error="
   assert.ok(challenge);
   assert.match(challenge, /^Bearer realm="vicoop-bridge"/);
   assert.match(challenge, /error="invalid_token"/);
+  // Description is a stable public string, not the raw upstream err.message,
+  // so detail (e.g. "SIWE bearer token is not valid JSON") can't leak via
+  // proxy access logs.
+  assert.match(challenge, /error_description="invalid SIWE bearer"/);
 });
 
 test('public agent (no allowedCallers) passes through without WWW-Authenticate', async () => {
@@ -185,25 +189,21 @@ test('caller not in allowedCallers responds 403 with WWW-Authenticate error="ins
   assert.match(challenge, /error_description="caller not in allowed list"/);
 });
 
-test('error_description is length-capped so a long upstream message cannot blow up the header', async () => {
-  // SIWE verify failures bubble up err.message into error_description; we
-  // can't easily inject an arbitrary long message here, so just assert the
-  // header stays within a sane bound on the realistic failure case.
-  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
-  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+// Direct unit tests for sanitizeErrorDescription. All call sites in the
+// middleware now feed stable hand-authored strings, but the sanitize + cap
+// remains as defense-in-depth — these tests pin that contract.
+test('sanitizeErrorDescription drops chars outside the RFC 6749 §4.1.2.1 set', () => {
+  // Strip `"` (0x22), `\` (0x5C), control chars, and anything > 0x7E.
+  assert.equal(sanitizeErrorDescription('hello'), 'hello');
+  assert.equal(sanitizeErrorDescription('with "quotes"'), 'with quotes');
+  assert.equal(sanitizeErrorDescription('with\\backslash'), 'withbackslash');
+  assert.equal(sanitizeErrorDescription('line\nbreak\ttab'), 'linebreaktab');
+  assert.equal(sanitizeErrorDescription('non-ascii: ✓ 한글'), 'non-ascii:  ');
+});
 
-  const res = await app.request('/agents/restricted', {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${'a'.repeat(4096)}` },
-  });
-  assert.equal(res.status, 401);
-  const challenge = res.headers.get('WWW-Authenticate');
-  assert.ok(challenge);
-  // Header total stays well under common 8KB limits; the cap inside
-  // sanitizeErrorDescription keeps error_description bounded at 200 chars.
-  assert.ok(challenge.length < 512, `expected challenge < 512 chars, got ${challenge.length}`);
-  const match = challenge.match(/error_description="([^"]*)"/);
-  if (match) {
-    assert.ok(match[1].length <= 200, `expected description <= 200 chars, got ${match[1].length}`);
-  }
+test('sanitizeErrorDescription caps output at 200 chars regardless of input length', () => {
+  const long = 'a'.repeat(5000);
+  const out = sanitizeErrorDescription(long);
+  assert.equal(out.length, 200);
+  assert.equal(out, 'a'.repeat(200));
 });

--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -141,6 +141,13 @@ test('invalid SIWE bearer (siweDomain on) responds with WWW-Authenticate error="
   // so detail (e.g. "SIWE bearer token is not valid JSON") can't leak via
   // proxy access logs.
   assert.match(challenge, /error_description="invalid SIWE bearer"/);
+
+  // The JSON body must also not leak the underlying verifier err.message —
+  // unauthenticated callers receive this directly. Detail stays in logEvent.
+  const body = (await res.json()) as { error: { message: string } };
+  assert.doesNotMatch(body.error.message, /not valid JSON/i);
+  assert.doesNotMatch(body.error.message, /SIWE bearer token/i);
+  assert.match(body.error.message, /^Invalid bearer token\./);
 });
 
 test('public agent (no allowedCallers) passes through without WWW-Authenticate', async () => {

--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Hono } from 'hono';
+import type { WebSocket } from 'ws';
+import type { AgentCard } from '@vicoop-bridge/protocol';
+import { agentAuthMiddleware } from './agent-auth.js';
+import { Registry, type ClientConnection } from './registry.js';
+import type { Sql } from './db.js';
+
+// The reject paths exercised here never touch postgres — the middleware short-
+// circuits on missing/malformed bearer headers before reaching verifyCallerToken
+// or verifySessionToken. A stub Sql is sufficient.
+const stubSql = {} as Sql;
+
+function fakeAgentCard(name: string): AgentCard {
+  return { name, version: '0.0.1', protocolVersion: '0.3.0' };
+}
+
+function registerAgent(
+  registry: Registry,
+  agentId: string,
+  allowedCallers: string[],
+): void {
+  const conn: ClientConnection = {
+    agentId,
+    clientId: 'client-1',
+    ownerPrincipal: 'eth:0x0000000000000000000000000000000000000001',
+    agentCard: fakeAgentCard(agentId),
+    allowedCallers,
+    ws: { close() {} } as unknown as WebSocket,
+    connectedAt: Date.now(),
+  };
+  registry.registerAgent(conn);
+}
+
+function buildApp(opts: { siweDomain?: string } = {}): { app: Hono; registry: Registry } {
+  const registry = new Registry();
+  const app = new Hono();
+  const mw = agentAuthMiddleware(registry, {
+    sql: stubSql,
+    deviceFlowEnabled: false,
+    siweDomain: opts.siweDomain,
+  });
+  app.post('/agents/:id', mw, (c) => c.json({ ok: true }));
+  return { app, registry };
+}
+
+test('missing bearer responds with WWW-Authenticate realm and no error code (RFC 6750 §3.1)', async () => {
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', { method: 'POST' });
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge, 'expected WWW-Authenticate header');
+  assert.equal(challenge, 'Bearer realm="vicoop-bridge"');
+});
+
+test('bad token prefix responds with WWW-Authenticate error="invalid_token"', async () => {
+  // siweDomain undefined so non-vbc_* bearers fall through to bad_token_prefix
+  // instead of the SIWE branch.
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer not-a-known-prefix-xyz' },
+  });
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge);
+  assert.match(challenge, /^Bearer realm="vicoop-bridge"/);
+  assert.match(challenge, /error="invalid_token"/);
+  assert.match(challenge, /error_description="expected vbc_caller_\* prefix"/);
+});
+
+test('owner-session token on caller route responds with WWW-Authenticate error="invalid_token"', async () => {
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer vbc_owner_deadbeef' },
+  });
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge);
+  assert.match(challenge, /error="invalid_token"/);
+  assert.match(challenge, /error_description="vbc_owner_\* tokens are not accepted on \/agents\/:id"/);
+});
+
+test('invalid SIWE bearer (siweDomain on) responds with WWW-Authenticate error="invalid_token"', async () => {
+  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    // Anything that's not vbc_caller_*/vbc_owner_* goes through the SIWE
+    // bearer fast-path when siweDomain is set; a junk value will fail verify.
+    headers: { Authorization: 'Bearer not-a-real-siwe-bearer' },
+  });
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge);
+  assert.match(challenge, /^Bearer realm="vicoop-bridge"/);
+  assert.match(challenge, /error="invalid_token"/);
+});
+
+test('public agent (no allowedCallers) passes through without WWW-Authenticate', async () => {
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'public', []);
+
+  const res = await app.request('/agents/public', { method: 'POST' });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('WWW-Authenticate'), null);
+});
+
+test('unknown agent returns 404 without auth challenge', async () => {
+  const { app } = buildApp();
+
+  const res = await app.request('/agents/missing', { method: 'POST' });
+  assert.equal(res.status, 404);
+  // 404 is not an auth failure, so RFC 6750 challenge shouldn't be added.
+  assert.equal(res.headers.get('WWW-Authenticate'), null);
+});

--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -9,7 +9,8 @@ import type { Sql } from './db.js';
 
 // The reject paths exercised here never touch postgres — the middleware short-
 // circuits on missing/malformed bearer headers before reaching verifyCallerToken
-// or verifySessionToken. A stub Sql is sufficient.
+// (vbc_caller_* branch) or verifySiweBearerToken (SIWE branch). A stub Sql is
+// sufficient.
 const stubSql = {} as Sql;
 
 function fakeAgentCard(name: string): AgentCard {
@@ -122,4 +123,27 @@ test('unknown agent returns 404 without auth challenge', async () => {
   assert.equal(res.status, 404);
   // 404 is not an auth failure, so RFC 6750 challenge shouldn't be added.
   assert.equal(res.headers.get('WWW-Authenticate'), null);
+});
+
+test('error_description is length-capped so a long upstream message cannot blow up the header', async () => {
+  // SIWE verify failures bubble up err.message into error_description; we
+  // can't easily inject an arbitrary long message here, so just assert the
+  // header stays within a sane bound on the realistic failure case.
+  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${'a'.repeat(4096)}` },
+  });
+  assert.equal(res.status, 401);
+  const challenge = res.headers.get('WWW-Authenticate');
+  assert.ok(challenge);
+  // Header total stays well under common 8KB limits; the cap inside
+  // sanitizeErrorDescription keeps error_description bounded at 200 chars.
+  assert.ok(challenge.length < 512, `expected challenge < 512 chars, got ${challenge.length}`);
+  const match = challenge.match(/error_description="([^"]*)"/);
+  if (match) {
+    assert.ok(match[1].length <= 200, `expected description <= 200 chars, got ${match[1].length}`);
+  }
 });

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -140,10 +140,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_token',
           detail: truncate((err as Error).message, 256),
         });
-        // Don't surface raw err.message in WWW-Authenticate — the
-        // verifyCallerToken path can throw SQL/connection errors, and the
-        // header is commonly captured by proxy access logs. Detailed cause is
-        // already in the structured logEvent above.
+        // Don't surface raw err.message in either WWW-Authenticate (commonly
+        // captured by proxy access logs) or the JSON-RPC body (returned to
+        // unauthenticated callers) — the verifyCallerToken path can throw
+        // SQL/connection errors. Detailed cause stays in the structured
+        // logEvent above for diagnostics.
         setWWWAuthenticate(c, {
           error: 'invalid_token',
           description: 'invalid bearer token',
@@ -151,7 +152,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         return c.json({
           jsonrpc: '2.0',
           id: null,
-          error: { code: -32001, message: `Invalid bearer token: ${(err as Error).message}` },
+          error: { code: -32001, message: `Invalid bearer token. Acquire one via ${acquisitionHint}.` },
         }, 401);
       }
     } else if (bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
@@ -187,9 +188,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_siwe_bearer',
           detail: truncate((err as Error).message, 256),
         });
-        // Stable, public description — siwe-bearer verification can surface
-        // low-level library/parse errors that we don't want to echo into a
-        // header that proxies routinely log.
+        // Stable public strings in both the header and the JSON body —
+        // siwe-bearer verification can surface low-level library/parse
+        // errors that we don't want to echo into a header that proxies
+        // routinely log, nor into a body returned to unauthenticated callers.
+        // Detailed cause stays in the structured logEvent above.
         setWWWAuthenticate(c, {
           error: 'invalid_token',
           description: 'invalid SIWE bearer',
@@ -199,7 +202,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           id: null,
           error: {
             code: -32001,
-            message: `Invalid bearer token: ${(err as Error).message}. Acquire one via ${acquisitionHint}.`,
+            message: `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
           },
         }, 401);
       }

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -28,7 +28,12 @@ const ERROR_DESCRIPTION_MAX_LEN = 200;
 // i.e. printable ASCII excluding `"` and `\`. Anything outside that range is
 // dropped so the header stays a valid quoted-string without escape handling.
 // Output is also length-capped to keep total header size bounded.
-function sanitizeErrorDescription(value: string): string {
+//
+// Exported for direct unit testing — all call sites inside this module feed
+// it stable, hand-authored strings (never raw upstream err.message) to avoid
+// leaking internal SQL/verifier details via WWW-Authenticate (often captured
+// by access logs). The sanitize + cap remains as defense-in-depth.
+export function sanitizeErrorDescription(value: string): string {
   let out = '';
   for (const ch of value) {
     if (out.length >= ERROR_DESCRIPTION_MAX_LEN) break;
@@ -135,9 +140,13 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_token',
           detail: truncate((err as Error).message, 256),
         });
+        // Don't surface raw err.message in WWW-Authenticate — the
+        // verifyCallerToken path can throw SQL/connection errors, and the
+        // header is commonly captured by proxy access logs. Detailed cause is
+        // already in the structured logEvent above.
         setWWWAuthenticate(c, {
           error: 'invalid_token',
-          description: (err as Error).message,
+          description: 'invalid bearer token',
         });
         return c.json({
           jsonrpc: '2.0',
@@ -178,9 +187,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_siwe_bearer',
           detail: truncate((err as Error).message, 256),
         });
+        // Stable, public description — siwe-bearer verification can surface
+        // low-level library/parse errors that we don't want to echo into a
+        // header that proxies routinely log.
         setWWWAuthenticate(c, {
           error: 'invalid_token',
-          description: (err as Error).message,
+          description: 'invalid SIWE bearer',
         });
         return c.json({
           jsonrpc: '2.0',

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -18,6 +18,42 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
   return c.get('caller') as VerifiedCaller | undefined;
 }
 
+const WWW_AUTH_REALM = 'vicoop-bridge';
+
+// RFC 6749 §4.1.2.1 restricts error_description to %x20-21 / %x23-5B / %x5D-7E,
+// i.e. printable ASCII excluding `"` and `\`. Anything outside that range is
+// dropped so the header stays a valid quoted-string without escape handling.
+function sanitizeErrorDescription(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    const code = ch.charCodeAt(0);
+    if (
+      code === 0x20 ||
+      code === 0x21 ||
+      (code >= 0x23 && code <= 0x5b) ||
+      (code >= 0x5d && code <= 0x7e)
+    ) {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+function setWWWAuthenticate(
+  c: Context,
+  opts: {
+    error?: 'invalid_token' | 'insufficient_scope';
+    description?: string;
+  } = {},
+): void {
+  const parts = [`realm="${WWW_AUTH_REALM}"`];
+  if (opts.error) parts.push(`error="${opts.error}"`);
+  if (opts.description) {
+    parts.push(`error_description="${sanitizeErrorDescription(opts.description)}"`);
+  }
+  c.header('WWW-Authenticate', `Bearer ${parts.join(', ')}`);
+}
+
 export interface AgentAuthOptions {
   sql: Sql;
   deviceFlowEnabled?: boolean;
@@ -70,6 +106,9 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken) {
       logEvent('agent_request_rejected', { agentId, reason: 'missing_bearer' });
+      // Per RFC 6750 §3.1, no error code when the request lacks any
+      // authentication information — only the challenge realm.
+      setWWWAuthenticate(c);
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -90,6 +129,10 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_token',
           detail: truncate((err as Error).message, 256),
         });
+        setWWWAuthenticate(c, {
+          error: 'invalid_token',
+          description: (err as Error).message,
+        });
         return c.json({
           jsonrpc: '2.0',
           id: null,
@@ -104,6 +147,10 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       // owner-session token as base64url JSON and fail with the misleading
       // "SIWE bearer token is not valid JSON".
       logEvent('agent_request_rejected', { agentId, reason: 'owner_session_on_caller_route' });
+      setWWWAuthenticate(c, {
+        error: 'invalid_token',
+        description: `${OWNER_SESSION_PREFIX}* tokens are not accepted on /agents/:id`,
+      });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -125,6 +172,10 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           reason: 'invalid_siwe_bearer',
           detail: truncate((err as Error).message, 256),
         });
+        setWWWAuthenticate(c, {
+          error: 'invalid_token',
+          description: (err as Error).message,
+        });
         return c.json({
           jsonrpc: '2.0',
           id: null,
@@ -136,6 +187,10 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       }
     } else {
       logEvent('agent_request_rejected', { agentId, reason: 'bad_token_prefix' });
+      setWWWAuthenticate(c, {
+        error: 'invalid_token',
+        description: `expected ${CALLER_TOKEN_PREFIX}* prefix`,
+      });
       return c.json({
         jsonrpc: '2.0',
         id: null,
@@ -152,6 +207,10 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         agentId,
         reason: 'caller_not_authorized',
         principalId: caller.principalId,
+      });
+      setWWWAuthenticate(c, {
+        error: 'insufficient_scope',
+        description: 'caller not in allowed list',
       });
       return c.json({
         jsonrpc: '2.0',

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -20,12 +20,18 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
 
 const WWW_AUTH_REALM = 'vicoop-bridge';
 
+// Cap the error_description so a long upstream err.message can't push the
+// WWW-Authenticate header past common proxy/server limits (often ~8KB total).
+const ERROR_DESCRIPTION_MAX_LEN = 200;
+
 // RFC 6749 §4.1.2.1 restricts error_description to %x20-21 / %x23-5B / %x5D-7E,
 // i.e. printable ASCII excluding `"` and `\`. Anything outside that range is
 // dropped so the header stays a valid quoted-string without escape handling.
+// Output is also length-capped to keep total header size bounded.
 function sanitizeErrorDescription(value: string): string {
   let out = '';
   for (const ch of value) {
+    if (out.length >= ERROR_DESCRIPTION_MAX_LEN) break;
     const code = ch.charCodeAt(0);
     if (
       code === 0x20 ||


### PR DESCRIPTION
## Summary

Addresses the server-side scope of #116. `agentAuthMiddleware` already returns JSON-RPC error envelopes for unauthenticated/forbidden requests, but did not include a `WWW-Authenticate` challenge header. RFC 6750 §3 SHOULDs it for bearer-protected resources, and sibling protocols (MCP) treat it as the standard auth-failure signal.

After this PR every 401/403 from `/agents/:id` carries an RFC 6750 Bearer challenge, so well-behaved clients (any fetch-based SDK, browsers reading 401 bodies, curl with `--fail-with-body`) can surface a clear auth error instead of a generic "protocol mismatch" diagnostic.

The original issue also proposed returning SSE-framed error bodies for streaming requests; investigation (see [issue comment](https://github.com/planetarium/vicoop-bridge/issues/116#issuecomment-4417216346)) showed that's not a real best practice — native EventSource can't read non-200 bodies regardless of content-type, and fetch-based SDKs already see the JSON body. So this PR keeps the existing JSON envelope and only adds the standard challenge header. UI-side error surfacing remains as a separate follow-up.

## Mapping

| Reject path | Status | Challenge |
| --- | --- | --- |
| `missing_bearer` | 401 | `Bearer realm="vicoop-bridge"` (per §3.1: no error code when auth info absent) |
| `invalid_token` / `owner_session_on_caller_route` / `invalid_siwe_bearer` / `bad_token_prefix` | 401 | `error="invalid_token"` + sanitized `error_description` |
| `caller_not_authorized` | 403 | `error="insufficient_scope"` |
| `agent_not_connected` | 404 | none (not an auth failure) |

`error_description` is filtered to the RFC 6749 §4.1.2.1 char set (printable ASCII excluding `"` and `\`) so the quoted-string stays valid without escape handling.

## Test plan

- [x] `pnpm typecheck` (packages/server)
- [x] `pnpm test` — 152 pass / 25 skipped (DATABASE_URL-gated) / 0 fail
- [x] New `agent-auth.test.ts` covers: missing_bearer, bad_token_prefix, owner_session_on_caller_route, invalid_siwe_bearer, public-passthrough, unknown-agent (404 has no challenge)
- [ ] Manual: hit a restricted agent with `curl -i -X POST .../agents/:id` and confirm `WWW-Authenticate: Bearer ...` is present on 401/403

🤖 Generated with [Claude Code](https://claude.com/claude-code)