### PR TITLE
chore(release): switch client tag to @vicoop-bridge/client@*

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -2,7 +2,7 @@
 
 This directory holds [Changesets](https://github.com/changesets/changesets)
 intent files. They drive `@vicoop-bridge/client` versioning, the per-release
-`CHANGELOG.md`, and the `client-v*` GitHub release pipeline.
+`CHANGELOG.md`, and the `@vicoop-bridge/client@*` GitHub release pipeline.
 
 ## When to add a changeset
 
@@ -31,4 +31,4 @@ operator-facing summary. The command writes a markdown file under
    entry in `packages/client/CHANGELOG.md`.
 2. When the Version Packages PR is merged, `scripts/changesets-publish.sh`
    builds the portable client bundle and creates the
-   `client-v<version>` GitHub release.
+   `@vicoop-bridge/client@<version>` GitHub release.

--- a/.changeset/client-tag-cutover.md
+++ b/.changeset/client-tag-cutover.md
@@ -1,0 +1,9 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Switch release tag format from `client-v<version>` to the Changesets monorepo
+standard `@vicoop-bridge/client@<version>`. `install.sh`, `vicoop-client
+upgrade`, and the release workflow now target the new format only; the prior
+`client-v*` releases remain on GitHub but are no longer extended. `--version`
+accepts a bare semver (`0.9.1`), `v0.9.1`, or the full new tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,8 @@ jobs:
       # When pending changesets exist, this opens / refreshes the
       # "Version Packages" PR. When that PR is merged (no pending
       # changesets remain), `publish` runs scripts/changesets-publish.sh,
-      # which builds the bundle and creates the client-v* release.
+      # which builds the bundle and creates the
+      # @vicoop-bridge/client@* release.
       - name: Version PR or publish client release
         uses: changesets/action@v1
         with:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ the client include a changeset describing the change; merging them keeps a
 single "Version Packages" PR up to date with the resulting version + changelog
 entry. Merging that Version PR triggers
 [`.github/workflows/release.yml`](./.github/workflows/release.yml), which
-builds the portable bundle and publishes the `client-v<version>` GitHub
-release.
+builds the portable bundle and publishes the `@vicoop-bridge/client@<version>`
+GitHub release.
 
 Day-to-day flow for contributors:
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -12,7 +12,7 @@ not in the published client bundle yet. The released client currently
 registers `echo`, `openclaw`, and `claude`.
 
 This doc covers the **post-release install path** (the `install.sh`
-one-liner fetching a published `client-v*` bundle). Contrast with:
+one-liner fetching a published `@vicoop-bridge/client@*` bundle). Contrast with:
 
 - [`local-testing.md`](./local-testing.md) — running both bridge and client
   from source against a local Postgres, using `psql` for setup.
@@ -59,8 +59,8 @@ one-liner fetching a published `client-v*` bundle). Contrast with:
 
 ## Step 1 — Install the client bundle
 
-The one-liner downloads the latest `client-v*` release, verifies its
-`.sha256`, and extracts into `$INSTALL_DIR`:
+The one-liner downloads the latest `@vicoop-bridge/client@*` release, verifies
+its `.sha256`, and extracts into `$INSTALL_DIR`:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh \
@@ -74,7 +74,7 @@ would still default to `/data/vicoop-bridge-client`.
 | Env | Default | Purpose |
 |---|---|---|
 | `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
-| `VERSION` | latest `client-v*` | Pin a specific tag, e.g. `client-v0.1.1`. |
+| `VERSION` | latest `@vicoop-bridge/client@*` | Pin a specific tag, e.g. `@vicoop-bridge/client@0.1.1`. |
 | `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
 | `INSTALL_SKIP_SERVICE` | `0` | If `1`, skip the optional systemd unit + env template even on systemd hosts. |
 | `INSTALL_SERVICE_SCOPE` | `auto` | Force `user`, `system`, or `none` instead of auto-detecting by `id -u`. `system` requires root; an explicit `system` without root is refused with a warning. |
@@ -417,7 +417,7 @@ if that file is missing or expired. Admin scope
 
 #### Option A: `vicoop-client` subcommands (recommended for scripts)
 
-These subcommands require **bundle `client-v0.8.0` or newer**. Older
+These subcommands require **bundle version 0.8.0 or newer**. Older
 installs only know the daemon flags; check before using and upgrade if
 needed:
 
@@ -481,15 +481,15 @@ wipes any operator-added cards / files), so it's reserved for bootstrapping.
 
 ```sh
 "$INSTALL_DIR/bin/vicoop-client" upgrade --check      # report latest vs current
-"$INSTALL_DIR/bin/vicoop-client" upgrade              # upgrade to latest client-v*
-"$INSTALL_DIR/bin/vicoop-client" upgrade --version client-v0.2.0   # pin / downgrade
+"$INSTALL_DIR/bin/vicoop-client" upgrade              # upgrade to latest @vicoop-bridge/client@*
+"$INSTALL_DIR/bin/vicoop-client" upgrade --version 0.2.0   # pin / downgrade (bare version, v0.2.0, or @vicoop-bridge/client@0.2.0 all accepted)
 "$INSTALL_DIR/bin/vicoop-client" upgrade --force      # reinstall the resolved target even if already on it
 ```
 
 The upgrade command:
 
-1. Queries GitHub releases for the latest `client-v*` tag (or the `--version`
-   you pin).
+1. Queries GitHub releases for the latest `@vicoop-bridge/client@*` tag (or
+   the `--version` you pin).
 2. Downloads `.tgz` + `.sha256` to a temp directory and verifies the checksum.
 3. Extracts into `$INSTALL_DIR.new/` (sibling of the current install).
 4. Copies operator files that don't ship with the bundle — notably any

--- a/install.sh
+++ b/install.sh
@@ -112,10 +112,12 @@ log "installing $VERSION"
 VERSION_NUM="${VERSION#$TAG_PREFIX}"
 # After stripping the prefix, the bare version still has to be safe to
 # interpolate into a local filename and a URL — the prefix check alone
-# wouldn't catch e.g. `@vicoop-bridge/client@0.3.0/../../etc`. Allowed
-# charset mirrors packages/client/src/upgrade.ts's TAG_RE.
+# wouldn't catch e.g. `@vicoop-bridge/client@0.3.0/../../etc`. Mirrors
+# packages/client/src/upgrade.ts's TAG_RE: first char must be alphanumeric
+# (rejects ".0.3.0", "-1", and other option-like names), remaining chars
+# limited to [A-Za-z0-9.+-], and no consecutive dots.
 case "$VERSION_NUM" in
-  ''|*[!A-Za-z0-9.+-]*|*..*)
+  ''|[!A-Za-z0-9]*|*[!A-Za-z0-9.+-]*|*..*)
     die "version contains unsafe characters: $VERSION_NUM"
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,10 @@ if [ -z "$VERSION" ]; then
   # as a misleading "no published release found" later.
   api_json="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30")" \
     || die "GitHub release API request failed"
+  # node exits non-zero on a malformed or non-array payload (rate-limit
+  # error object, abuse-detection response, etc.) so those failures don't
+  # masquerade as "no release found"; an empty stdout with exit 0 is the
+  # genuine no-match case.
   VERSION="$(
     printf '%s' "$api_json" \
       | TAG_PREFIX="$TAG_PREFIX" node -e '
@@ -88,10 +92,24 @@ process.stdin.setEncoding("utf8");
 process.stdin.on("data", (c) => { data += c; });
 process.stdin.on("end", () => {
   let releases;
-  try { releases = JSON.parse(data); } catch { return; }
-  if (!Array.isArray(releases)) return;
+  try {
+    releases = JSON.parse(data);
+  } catch (e) {
+    process.stderr.write(`error: GitHub API response was not valid JSON: ${e.message}\n`);
+    process.exit(1);
+  }
+  if (!Array.isArray(releases)) {
+    const msg = releases && typeof releases.message === "string"
+      ? releases.message
+      : JSON.stringify(releases).slice(0, 200);
+    process.stderr.write(`error: GitHub API returned a non-array payload: ${msg}\n`);
+    process.exit(1);
+  }
   const prefix = process.env.TAG_PREFIX;
-  if (!prefix) return;
+  if (!prefix) {
+    process.stderr.write("error: TAG_PREFIX env var missing\n");
+    process.exit(1);
+  }
   for (const r of releases) {
     if (!r || typeof r.tag_name !== "string") continue;
     if (!r.tag_name.startsWith(prefix)) continue;
@@ -101,7 +119,7 @@ process.stdin.on("end", () => {
   }
 });
 '
-  )"
+  )" || die "failed to parse GitHub release list (see error above)"
   [ -n "$VERSION" ] || die "no published (non-draft, non-prerelease) $TAG_PREFIX* release found in $REPO"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -67,18 +67,44 @@ TAG_PREFIX="@vicoop-bridge/client@"
 
 if [ -z "$VERSION" ]; then
   log "resolving latest $TAG_PREFIX* release from GitHub"
-  # Pull recent releases (default 30) and pick the first tag matching the
-  # changesets monorepo prefix. Avoid /releases/latest because it may point
-  # at a non-client release. Use `#` as the sed delimiter so the `/` inside
-  # the tag prefix doesn't need escaping.
+  # Pull recent releases (default 30) and pick the newest non-draft,
+  # non-prerelease release whose tag matches the changesets monorepo
+  # prefix. Avoid /releases/latest because it may point at a non-client
+  # release. Parse with node (already a hard prereq above) rather than
+  # grepping tag_name, so the draft/prerelease flags are honored the same
+  # way `vicoop-client upgrade` honors them.
   VERSION="$(
     curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
-      | grep -o '"tag_name":[[:space:]]*"@vicoop-bridge/client@[^"]*"' \
-      | head -n1 \
-      | sed -E 's#.*"(@vicoop-bridge/client@[^"]+)".*#\1#'
+      | node -e '
+let data = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c) => { data += c; });
+process.stdin.on("end", () => {
+  let releases;
+  try { releases = JSON.parse(data); } catch { return; }
+  if (!Array.isArray(releases)) return;
+  const prefix = "@vicoop-bridge/client@";
+  for (const r of releases) {
+    if (!r || typeof r.tag_name !== "string") continue;
+    if (!r.tag_name.startsWith(prefix)) continue;
+    if (r.draft || r.prerelease) continue;
+    process.stdout.write(r.tag_name);
+    return;
+  }
+});
+'
   )"
-  [ -n "$VERSION" ] || die "no $TAG_PREFIX* release found in $REPO"
+  [ -n "$VERSION" ] || die "no published (non-draft, non-prerelease) $TAG_PREFIX* release found in $REPO"
 fi
+
+# Defense in depth: even when the operator pins VERSION via env, refuse to
+# proceed if it doesn't carry the expected prefix. Otherwise the
+# `${VERSION#$TAG_PREFIX}` expansion below leaves arbitrary characters in
+# VERSION_NUM, which then lands in the archive filename and URL.
+case "$VERSION" in
+  "$TAG_PREFIX"*) ;;
+  *) die "VERSION must start with $TAG_PREFIX (got: $VERSION)" ;;
+esac
 
 log "installing $VERSION"
 

--- a/install.sh
+++ b/install.sh
@@ -6,14 +6,15 @@
 #
 # Environment overrides:
 #   INSTALL_DIR           Target directory (default: /data/vicoop-bridge-client)
-#   VERSION               Specific tag to install, e.g. client-v0.1.0 (default: latest client-v* release)
+#   VERSION               Specific tag to install, e.g. @vicoop-bridge/client@0.1.0
+#                         (default: latest @vicoop-bridge/client@* release)
 #   FORCE                 If "1", overwrite a non-empty INSTALL_DIR
 #   INSTALL_SKIP_SERVICE  If "1", skip systemd unit registration
 #   INSTALL_SERVICE_SCOPE Override detection: "auto" | "user" | "system" | "none" (default: auto)
 #
 # What it does:
 #   1. Verifies prerequisites (Linux warning, Node.js >= 20, curl, tar, sha256 tool).
-#   2. Resolves the latest (or pinned) client-v* GitHub release.
+#   2. Resolves the latest (or pinned) @vicoop-bridge/client@* GitHub release.
 #   3. Downloads the .tgz + .sha256 and verifies integrity.
 #   4. Extracts the bundle into INSTALL_DIR.
 #   5. On systemd hosts, drops an optional vicoop-client.service unit + env
@@ -62,25 +63,32 @@ else
 fi
 
 # ---- 2. Resolve release tag -------------------------------------------------
+TAG_PREFIX="@vicoop-bridge/client@"
+
 if [ -z "$VERSION" ]; then
-  log "resolving latest client-v* release from GitHub"
-  # Pull recent releases (default 30) and pick the first tag matching client-v*.
-  # Avoid /releases/latest because it may point at a non-client release.
+  log "resolving latest $TAG_PREFIX* release from GitHub"
+  # Pull recent releases (default 30) and pick the first tag matching the
+  # changesets monorepo prefix. Avoid /releases/latest because it may point
+  # at a non-client release. Use `#` as the sed delimiter so the `/` inside
+  # the tag prefix doesn't need escaping.
   VERSION="$(
     curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
-      | grep -o '"tag_name":[[:space:]]*"client-v[^"]*"' \
+      | grep -o '"tag_name":[[:space:]]*"@vicoop-bridge/client@[^"]*"' \
       | head -n1 \
-      | sed -E 's/.*"(client-v[^"]+)".*/\1/'
+      | sed -E 's#.*"(@vicoop-bridge/client@[^"]+)".*#\1#'
   )"
-  [ -n "$VERSION" ] || die "no client-v* release found in $REPO"
+  [ -n "$VERSION" ] || die "no $TAG_PREFIX* release found in $REPO"
 fi
 
 log "installing $VERSION"
 
-VERSION_NUM="${VERSION#client-v}"
+VERSION_NUM="${VERSION#$TAG_PREFIX}"
 ARCHIVE="vicoop-bridge-client-$VERSION_NUM.tgz"
 CHECKSUM="$ARCHIVE.sha256"
-BASE_URL="https://github.com/$REPO/releases/download/$VERSION"
+# GitHub's release-download endpoint takes the tag as one path segment. The
+# tag contains `/` and `@`; percent-encode both so the URL doesn't split.
+ENCODED_TAG="$(printf '%s' "$VERSION" | sed -e 's#@#%40#g' -e 's#/#%2F#g')"
+BASE_URL="https://github.com/$REPO/releases/download/$ENCODED_TAG"
 
 # ---- 3. Prepare install dir -------------------------------------------------
 PARENT_DIR="$(dirname "$INSTALL_DIR")"

--- a/install.sh
+++ b/install.sh
@@ -73,8 +73,15 @@ if [ -z "$VERSION" ]; then
   # release. Parse with node (already a hard prereq above) rather than
   # grepping tag_name, so the draft/prerelease flags are honored the same
   # way `vicoop-client upgrade` honors them.
+  #
+  # `set -e` doesn't catch failures on the upstream end of a POSIX-sh
+  # pipeline, so curl is run on its own first — otherwise a network /
+  # rate-limit error would let node read empty input, exit 0, and surface
+  # as a misleading "no published release found" later.
+  api_json="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30")" \
+    || die "GitHub release API request failed"
   VERSION="$(
-    curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
+    printf '%s' "$api_json" \
       | TAG_PREFIX="$TAG_PREFIX" node -e '
 let data = "";
 process.stdin.setEncoding("utf8");

--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,7 @@ if [ -z "$VERSION" ]; then
   # way `vicoop-client upgrade` honors them.
   VERSION="$(
     curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30" \
-      | node -e '
+      | TAG_PREFIX="$TAG_PREFIX" node -e '
 let data = "";
 process.stdin.setEncoding("utf8");
 process.stdin.on("data", (c) => { data += c; });
@@ -83,7 +83,8 @@ process.stdin.on("end", () => {
   let releases;
   try { releases = JSON.parse(data); } catch { return; }
   if (!Array.isArray(releases)) return;
-  const prefix = "@vicoop-bridge/client@";
+  const prefix = process.env.TAG_PREFIX;
+  if (!prefix) return;
   for (const r of releases) {
     if (!r || typeof r.tag_name !== "string") continue;
     if (!r.tag_name.startsWith(prefix)) continue;
@@ -109,6 +110,15 @@ esac
 log "installing $VERSION"
 
 VERSION_NUM="${VERSION#$TAG_PREFIX}"
+# After stripping the prefix, the bare version still has to be safe to
+# interpolate into a local filename and a URL — the prefix check alone
+# wouldn't catch e.g. `@vicoop-bridge/client@0.3.0/../../etc`. Allowed
+# charset mirrors packages/client/src/upgrade.ts's TAG_RE.
+case "$VERSION_NUM" in
+  ''|*[!A-Za-z0-9.+-]*|*..*)
+    die "version contains unsafe characters: $VERSION_NUM"
+    ;;
+esac
 ARCHIVE="vicoop-bridge-client-$VERSION_NUM.tgz"
 CHECKSUM="$ARCHIVE.sha256"
 # GitHub's release-download endpoint takes the tag as one path segment. The

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -115,11 +115,11 @@ async function runUpgradeCmd(args: string[]): Promise<number> {
     else if (a === '--version') {
       version = args[++i];
       if (!version) {
-        console.error('--version requires a value (e.g. 0.3.0, v0.3.0, or client-v0.3.0)');
+        console.error('--version requires a value (e.g. 0.3.0, v0.3.0, or @vicoop-bridge/client@0.3.0)');
         return 1;
       }
     } else if (a === '-h' || a === '--help') {
-      console.log('usage: vicoop-client upgrade [--check] [--force] [--version <X.Y.Z | vX.Y.Z | client-vX.Y.Z>]');
+      console.log('usage: vicoop-client upgrade [--check] [--force] [--version <X.Y.Z | vX.Y.Z | @vicoop-bridge/client@X.Y.Z>]');
       return 0;
     } else {
       console.error(`unknown argument to upgrade: ${a}`);

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -9,6 +9,10 @@ test('normalizeTag accepts full tag, bare version, and v-prefixed version', () =
   assert.equal(normalizeTag('@vicoop-bridge/client@0.3.0'), '@vicoop-bridge/client@0.3.0');
   assert.equal(normalizeTag('0.3.0'), '@vicoop-bridge/client@0.3.0');
   assert.equal(normalizeTag('v0.3.0'), '@vicoop-bridge/client@0.3.0');
+  // Full tag with a stray `v` after the prefix should normalize the same as
+  // the bare-v form — otherwise the archive filename would carry the `v`
+  // and miss the real release asset.
+  assert.equal(normalizeTag('@vicoop-bridge/client@v0.3.0'), '@vicoop-bridge/client@0.3.0');
   assert.equal(normalizeTag('1.0.0-alpha.1'), '@vicoop-bridge/client@1.0.0-alpha.1');
   assert.equal(normalizeTag('1.0.0+build.sha'), '@vicoop-bridge/client@1.0.0+build.sha');
 });

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -6,24 +6,29 @@ import { join } from 'node:path';
 import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File, stripSuidBits } from './upgrade.js';
 
 test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
-  assert.equal(normalizeTag('client-v0.3.0'), 'client-v0.3.0');
-  assert.equal(normalizeTag('0.3.0'), 'client-v0.3.0');
-  assert.equal(normalizeTag('v0.3.0'), 'client-v0.3.0');
-  assert.equal(normalizeTag('1.0.0-alpha.1'), 'client-v1.0.0-alpha.1');
-  assert.equal(normalizeTag('1.0.0+build.sha'), 'client-v1.0.0+build.sha');
+  assert.equal(normalizeTag('@vicoop-bridge/client@0.3.0'), '@vicoop-bridge/client@0.3.0');
+  assert.equal(normalizeTag('0.3.0'), '@vicoop-bridge/client@0.3.0');
+  assert.equal(normalizeTag('v0.3.0'), '@vicoop-bridge/client@0.3.0');
+  assert.equal(normalizeTag('1.0.0-alpha.1'), '@vicoop-bridge/client@1.0.0-alpha.1');
+  assert.equal(normalizeTag('1.0.0+build.sha'), '@vicoop-bridge/client@1.0.0+build.sha');
 });
 
 test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () => {
   for (const bad of [
     '../etc/passwd',
-    'client-v../0.3.0',
-    'client-v0.3.0/../../etc',
-    'client-v..',
+    '@vicoop-bridge/client@../0.3.0',
+    '@vicoop-bridge/client@0.3.0/../../etc',
+    '@vicoop-bridge/client@..',
     '0.3.0/../evil',
-    'client-v 0.3.0',
-    'client-v0.3.0;rm -rf /',
-    'client-v0.3.0\nfoo',
-    'client-v',
+    '@vicoop-bridge/client@ 0.3.0',
+    '@vicoop-bridge/client@0.3.0;rm -rf /',
+    '@vicoop-bridge/client@0.3.0\nfoo',
+    '@vicoop-bridge/client@',
+    // Slash anywhere inside the version segment would split the URL path.
+    '@vicoop-bridge/client@0.3.0/extra',
+    // Wrong scope shouldn't squeak through — `startsWith` check + the
+    // anchored regex must agree.
+    '@evil/client@0.3.0',
     '',
   ]) {
     assert.throws(() => normalizeTag(bad), /invalid version/, `expected rejection for ${JSON.stringify(bad)}`);

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -17,6 +17,16 @@ test('normalizeTag accepts full tag, bare version, and v-prefixed version', () =
   assert.equal(normalizeTag('1.0.0+build.sha'), '@vicoop-bridge/client@1.0.0+build.sha');
 });
 
+test('normalizeTag wrong-scope error names the expected prefix, not a doubled string', () => {
+  // The error should call out the bad prefix on the raw input, not show a
+  // confusing post-normalization string like
+  // "@vicoop-bridge/client@@evil/client@0.3.0".
+  assert.throws(
+    () => normalizeTag('@evil/client@0.3.0'),
+    /expected tag to start with @vicoop-bridge\/client@/,
+  );
+});
+
 test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () => {
   for (const bad of [
     '../etc/passwd',
@@ -33,6 +43,7 @@ test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () 
     // Wrong scope shouldn't squeak through — `startsWith` check + the
     // anchored regex must agree.
     '@evil/client@0.3.0',
+    '@vicoop-bridge/server@0.3.0',
     '',
   ]) {
     assert.throws(() => normalizeTag(bad), /invalid version/, `expected rejection for ${JSON.stringify(bad)}`);

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -349,7 +349,18 @@ async function resolveLatestTag(): Promise<string> {
     API_TIMEOUT_MS,
   );
   if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
-  const releases = (await res.json()) as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
+  const body = (await res.json()) as unknown;
+  // GitHub returns an object (`{ message, documentation_url, ... }`) for
+  // rate-limit / abuse / auth errors with a 2xx-shaped body on some legacy
+  // paths, so don't trust the HTTP status alone — confirm we got an array
+  // before iterating, otherwise `for...of` would throw "X is not
+  // iterable" which is harder to act on than the upstream error message.
+  if (!Array.isArray(body)) {
+    const msg = (body as { message?: unknown })?.message;
+    const detail = typeof msg === 'string' ? msg : JSON.stringify(body).slice(0, 200);
+    throw new Error(`GitHub API returned a non-array payload at ${url}: ${detail}`);
+  }
+  const releases = body as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
   for (const r of releases) {
     if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith(TAG_PREFIX)) continue;
     // Skip drafts (no uploaded assets — the .tgz download would 404) and

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -336,7 +336,7 @@ function assertSafeTag(tag: string, raw: string = tag): void {
   // encodeURIComponent before being used.
   if (!TAG_RE.test(tag) || tag.includes('..')) {
     throw new Error(
-      `invalid version '${raw}': expected ${TAG_PREFIX}<X.Y.Z> with only [A-Za-z0-9.+-] in the version (no '..'), got '${tag}'`,
+      `invalid version '${raw}': expected ${TAG_PREFIX}<version> with only [A-Za-z0-9.+-] in the version (no '..'), got '${tag}'`,
     );
   }
 }

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -300,6 +300,14 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 }
 
 export function normalizeTag(v: string): string {
+  // A leading `@` signals the operator meant to pass a full scoped tag. If
+  // the prefix doesn't match (e.g. `@evil/client@0.3.0`), surface that
+  // directly — otherwise the prefix is prepended unconditionally and
+  // assertSafeTag's "got" value reads like the double-prefixed
+  // `@vicoop-bridge/client@@evil/client@0.3.0`, which is hard to parse.
+  if (v.startsWith('@') && !v.startsWith(TAG_PREFIX)) {
+    throw new Error(`invalid version '${v}': expected tag to start with ${TAG_PREFIX}`);
+  }
   // Peel the prefix if present so the leading-`v` strip applies whether the
   // operator typed the bare version, the v-prefixed bare version, or the
   // full tag (`@vicoop-bridge/client@v0.3.0` should resolve the same as

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -44,12 +44,20 @@ const API_TIMEOUT_MS = 15_000;
 // this window and can Ctrl-C sooner.
 const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
-// Accepted release-tag shape. Restrictive on purpose: the tag is interpolated
-// into local filenames (archive name, temp path joins) and an external URL,
-// so we want to reject anything that could path-traverse or smuggle shell
-// metacharacters before it's used. Permissive enough for semver-ish tags
-// including pre-release/build suffixes (`client-v1.0.0-rc.1`, `...+sha.abc`).
-const TAG_RE = /^client-v[A-Za-z0-9][A-Za-z0-9.+\-]*$/;
+// Fixed prefix used by changesets/action for monorepo package releases. The
+// version portion (after the prefix) is what gets interpolated into local
+// filenames; the prefix itself only appears in the GitHub download URL and is
+// url-encoded there (the `/` would otherwise split the URL path).
+const TAG_PREFIX = '@vicoop-bridge/client@';
+
+// Accepted release-tag shape. Restrictive on purpose: the version portion is
+// interpolated into local filenames (archive name, temp path joins), so we
+// reject anything that could path-traverse or smuggle shell metacharacters
+// before it's used. The literal `/` in the prefix is the only `/` allowed;
+// the version character class still excludes it. Permissive enough for
+// semver-ish tags including pre-release/build suffixes
+// (`@vicoop-bridge/client@1.0.0-rc.1`, `...+sha.abc`).
+const TAG_RE = /^@vicoop-bridge\/client@[A-Za-z0-9][A-Za-z0-9.+\-]*$/;
 
 // Top-level entries a legitimate release bundle must contain. Missing any one
 // of these is taken as "not an installed bundle" and aborts upgrade before
@@ -76,7 +84,7 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
   const targetTag = opts.version
     ? normalizeTag(opts.version)
     : await resolveLatestTag();
-  const targetVersion = targetTag.replace(/^client-v/, '');
+  const targetVersion = versionFromTag(targetTag);
   log(`target:  ${targetVersion} (${targetTag})`);
 
   if (opts.check) {
@@ -130,7 +138,9 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
     try {
       const archiveName = `vicoop-bridge-client-${targetVersion}.tgz`;
       const checksumName = `${archiveName}.sha256`;
-      const baseUrl = `https://github.com/${REPO}/releases/download/${targetTag}`;
+      // The tag contains `/` and `@`; both must be percent-encoded as a single
+      // path segment so the URL points at one release, not into a subpath.
+      const baseUrl = `https://github.com/${REPO}/releases/download/${encodeURIComponent(targetTag)}`;
 
       log(`downloading ${archiveName}`);
       await download(`${baseUrl}/${archiveName}`, join(dlDir, archiveName));
@@ -285,21 +295,29 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 }
 
 export function normalizeTag(v: string): string {
-  const candidate = v.startsWith('client-v') ? v : `client-v${v.replace(/^v/, '')}`;
+  const candidate = v.startsWith(TAG_PREFIX) ? v : `${TAG_PREFIX}${v.replace(/^v/, '')}`;
   assertSafeTag(candidate, v);
   return candidate;
 }
 
+function versionFromTag(tag: string): string {
+  // assertSafeTag is the gate that proves the prefix is present; callers
+  // should only pass tags that have already passed that check.
+  return tag.slice(TAG_PREFIX.length);
+}
+
 function assertSafeTag(tag: string, raw: string = tag): void {
-  // The tag is interpolated into local paths (archive name / temp joins) and
-  // an outbound URL. Reject anything that could path-traverse or inject shell
-  // metacharacters before it reaches `join(dlDir, ...)`. The regex is
-  // intentionally looser than strict semver — we want to accept future
-  // pre-release and build-metadata variants that GitHub might tag — so the
-  // error describes the literal character set rather than implying semver.
+  // The bare version portion of the tag is interpolated into local paths
+  // (archive name / temp joins); reject anything that could path-traverse or
+  // inject shell metacharacters before it reaches `join(dlDir, ...)`. The
+  // version regex is intentionally looser than strict semver — we want to
+  // accept future pre-release and build-metadata variants — so the error
+  // describes the literal character set rather than implying semver. The
+  // single `/` in the prefix is fine because the download URL goes through
+  // encodeURIComponent before being used.
   if (!TAG_RE.test(tag) || tag.includes('..')) {
     throw new Error(
-      `invalid version '${raw}': expected a client-v* tag with only [A-Za-z0-9.+-] (no '..'), got '${tag}'`,
+      `invalid version '${raw}': expected ${TAG_PREFIX}<X.Y.Z> with only [A-Za-z0-9.+-] in the version (no '..'), got '${tag}'`,
     );
   }
 }
@@ -314,11 +332,11 @@ async function resolveLatestTag(): Promise<string> {
   if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
   const releases = (await res.json()) as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
   for (const r of releases) {
-    if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith('client-v')) continue;
+    if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith(TAG_PREFIX)) continue;
     // Skip drafts (no uploaded assets — the .tgz download would 404) and
     // prereleases (assets exist but operators on the default channel don't
-    // want them). `--version client-vX.Y.Z-rc.1` still lets an operator
-    // pin an explicit prerelease when they want to test one.
+    // want them). `--version <tag>` with an explicit prerelease tag still
+    // lets an operator pin one when they want to test it.
     if (r.draft === true || r.prerelease === true) continue;
     // Defensively validate the API response — a future rename or a
     // compromised upstream shouldn't get to interpolate arbitrary strings
@@ -326,7 +344,7 @@ async function resolveLatestTag(): Promise<string> {
     assertSafeTag(r.tag_name);
     return r.tag_name;
   }
-  throw new Error(`no published (non-draft, non-prerelease) client-v* release found in ${REPO}`);
+  throw new Error(`no published (non-draft, non-prerelease) ${TAG_PREFIX}* release found in ${REPO}`);
 }
 
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -57,7 +57,12 @@ const TAG_PREFIX = '@vicoop-bridge/client@';
 // the version character class still excludes it. Permissive enough for
 // semver-ish tags including pre-release/build suffixes
 // (`@vicoop-bridge/client@1.0.0-rc.1`, `...+sha.abc`).
-const TAG_RE = /^@vicoop-bridge\/client@[A-Za-z0-9][A-Za-z0-9.+\-]*$/;
+//
+// Derived from TAG_PREFIX so the prefix lives in one place. `@` and `/`
+// aren't regex metacharacters in JavaScript, so interpolating the prefix
+// verbatim is safe; if the prefix ever picks up a real metacharacter (`.`
+// `*` `?` etc.) this needs explicit escaping.
+const TAG_RE = new RegExp(`^${TAG_PREFIX}[A-Za-z0-9][A-Za-z0-9.+\\-]*$`);
 
 // Top-level entries a legitimate release bundle must contain. Missing any one
 // of these is taken as "not an installed bundle" and aborts upgrade before
@@ -295,7 +300,13 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
 }
 
 export function normalizeTag(v: string): string {
-  const candidate = v.startsWith(TAG_PREFIX) ? v : `${TAG_PREFIX}${v.replace(/^v/, '')}`;
+  // Peel the prefix if present so the leading-`v` strip applies whether the
+  // operator typed the bare version, the v-prefixed bare version, or the
+  // full tag (`@vicoop-bridge/client@v0.3.0` should resolve the same as
+  // `@vicoop-bridge/client@0.3.0`). Without this peel, the full-tag form
+  // would slip a `v` into the archive filename and miss the real asset.
+  const versionPart = (v.startsWith(TAG_PREFIX) ? v.slice(TAG_PREFIX.length) : v).replace(/^v/, '');
+  const candidate = `${TAG_PREFIX}${versionPart}`;
   assertSafeTag(candidate, v);
   return candidate;
 }

--- a/scripts/changesets-publish.sh
+++ b/scripts/changesets-publish.sh
@@ -67,7 +67,10 @@ else
   fi
   if [[ -n "${remote_commit_sha}" && "${remote_commit_sha}" != "${TARGET_SHA}" ]]; then
     echo "error: tag ${TAG} already exists at ${remote_commit_sha} but expected ${TARGET_SHA}" >&2
-    echo "delete the tag (e.g. 'gh api -X DELETE repos/<owner>/<repo>/git/refs/tags/${TAG}') and rerun." >&2
+    # The tag contains `/` and `@`, so a `gh api refs/tags/${TAG}` URL would
+    # be malformed without percent-encoding. `git push --delete` operates on
+    # the tag name directly and handles either character fine.
+    echo "delete the tag (e.g. 'git push --delete origin ${TAG}') and rerun." >&2
     exit 1
   fi
 

--- a/scripts/changesets-publish.sh
+++ b/scripts/changesets-publish.sh
@@ -4,7 +4,7 @@
 # work) and on every other main push that has no changesets to consume
 # (where there's nothing to do). The script reads the current
 # `packages/client/package.json` version and converges the corresponding
-# `client-v<version>` GitHub release into one of three states:
+# `@vicoop-bridge/client@<version>` GitHub release into one of three states:
 #
 #   - complete: release exists with both expected assets attached → exit 0
 #   - partial:  release exists but assets are missing or out of date →
@@ -21,7 +21,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
 
 VERSION="$(node -p "require('./packages/client/package.json').version")"
-TAG="client-v${VERSION}"
+TAG="@vicoop-bridge/client@${VERSION}"
 ARCHIVE="dist-release/vicoop-bridge-client-${VERSION}.tgz"
 CHECKSUM="${ARCHIVE}.sha256"
 ARCHIVE_NAME="$(basename "${ARCHIVE}")"
@@ -76,9 +76,9 @@ else
   # commit landing on main mid-job can't make the tag point somewhere else;
   # CI sets GITHUB_SHA, falling back to HEAD for local invocations.
   # `--generate-notes` pulls in the commit/PR summary since the previous
-  # client-v* tag; the per-version CHANGELOG.md entry written by
-  # changesets/action lives in packages/client/CHANGELOG.md for anyone who
-  # wants the structured form.
+  # @vicoop-bridge/client@* tag; the per-version CHANGELOG.md entry written
+  # by changesets/action lives in packages/client/CHANGELOG.md for anyone
+  # who wants the structured form.
   # Pass exact filenames — globbing dist-release/ would also pick up
   # artifacts left by previous local runs and upload them as extra assets.
   gh release create "${TAG}" \
@@ -90,7 +90,7 @@ else
 fi
 
 # Marker line that changesets/action greps for to set its `published` output.
-# Use the actual workspace package name so anything reading the action's
-# `publishedPackages` output sees a real identifier; the GitHub release tag
-# itself remains `client-v<version>`.
-echo "🦋 New tag: @vicoop-bridge/client@${VERSION}"
+# This now matches the actual release tag, so the action's tag-push step
+# won't chase a non-existent local tag the way it did under the legacy
+# client-v* scheme.
+echo "🦋 New tag: ${TAG}"

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -7,7 +7,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 TAG="$1"
-VERSION="${TAG#client-v}"
+VERSION="${TAG#@vicoop-bridge/client@}"
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/dist-release"
 WORK_DIR="$OUT_DIR/work"

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -7,7 +7,24 @@ if [[ $# -ne 1 ]]; then
 fi
 
 TAG="$1"
-VERSION="${TAG#@vicoop-bridge/client@}"
+TAG_PREFIX="@vicoop-bridge/client@"
+
+# Caller passes the full tag (changesets-publish.sh does this) so the
+# README and archive name agree on the version. Fail fast if it doesn't
+# carry the expected prefix or if the stripped version has anything that
+# could path-traverse / inject shell metacharacters into BUNDLE_DIR or
+# ARCHIVE_PATH below.
+case "$TAG" in
+  "$TAG_PREFIX"*) ;;
+  *) echo "error: TAG must start with $TAG_PREFIX (got: $TAG)" >&2; exit 1 ;;
+esac
+VERSION="${TAG#$TAG_PREFIX}"
+case "$VERSION" in
+  ''|*[!A-Za-z0-9.+-]*|*..*)
+    echo "error: version portion contains unsafe characters: $VERSION" >&2
+    exit 1
+    ;;
+esac
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/dist-release"
 WORK_DIR="$OUT_DIR/work"

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -19,8 +19,11 @@ case "$TAG" in
   *) echo "error: TAG must start with $TAG_PREFIX (got: $TAG)" >&2; exit 1 ;;
 esac
 VERSION="${TAG#$TAG_PREFIX}"
+# Mirrors packages/client/src/upgrade.ts's TAG_RE: first char must be
+# alphanumeric (no ".x" or "-x"), remaining chars limited to
+# [A-Za-z0-9.+-], and no consecutive dots.
 case "$VERSION" in
-  ''|*[!A-Za-z0-9.+-]*|*..*)
+  ''|[!A-Za-z0-9]*|*[!A-Za-z0-9.+-]*|*..*)
     echo "error: version portion contains unsafe characters: $VERSION" >&2
     exit 1
     ;;


### PR DESCRIPTION
## Summary

- Cut over from the custom `client-v*` GitHub release tag to the changesets/action monorepo standard `@vicoop-bridge/client@<version>`. Closes #126.
- `install.sh`, `vicoop-client upgrade`, and the release workflow now target the new format only; the prior `client-v*` releases remain on GitHub but are no longer extended.
- The `🦋 New tag:` marker line in `scripts/changesets-publish.sh` now matches the tag we actually push, so `changesets/action` no longer fails by chasing a non-existent local tag.

## Safety notes

- `upgrade.ts` separates the **tag** (used only in the GitHub download URL, run through `encodeURIComponent`) from the **bare version** (used in archive filenames and temp paths). Allowing the literal `/` in the new prefix does not loosen the path-traversal defense — the version character class still excludes `/`.
- `install.sh` percent-encodes `@` and `/` when constructing the download URL for the same reason.
- The existing complete/partial/missing convergence in `changesets-publish.sh` is preserved; rerunning the publish step on a partial release still repairs it.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` (238/238 passing; `normalizeTag` tests cover the new format + tightened rejection cases for `/` injection and wrong-scope prefixes)
- [ ] Verify the next Changesets-driven release on `main` actually produces an `@vicoop-bridge/client@<version>` GitHub release with both `.tgz` and `.sha256` attached
- [ ] After that release exists, run `vicoop-client upgrade --check` from an installed bundle to confirm the new discovery path returns the right tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)