### PR TITLE
feat(client): inject agent self-identity into claude backend + whoami

### DIFF
--- a/.changeset/agent-self-identity.md
+++ b/.changeset/agent-self-identity.md
@@ -1,0 +1,19 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+claude backend: inject self-identity via `--append-system-prompt` so the
+spawned `claude` recognises its own A2A mention (`@<agentId>@<host>` /
+`acct:<agentId>@<host>`) as a self-reference and responds directly instead
+of calling out to itself via a2a-wallet or any other outbound A2A skill.
+Addresses the failure mode in #128 where a backend Claude tried to a2a-call
+its own canonical address.
+
+New `vicoop-client whoami` subcommand prints the agent's mention, acct,
+A2A endpoint, A2A agent-card URL, and WebFinger URL — useful for operators
+registering this agent on other agents' allowed-caller lists, sharing the
+A2A endpoint with a caller, or pasting into the OpenClaw gateway persona
+(OpenClaw's `chat.send` has no per-message system field, so its persona is
+configured separately on the gateway). `--verify` actually performs the
+WebFinger lookup to confirm the bridge resolves the acct; `--json` emits a
+machine-readable record.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -358,6 +358,43 @@ CLAUDE_CWD="$HOME/vicoop-bridge" \
 process. Set it when the released bundle lives outside the repository you
 want Claude to edit.
 
+The Claude backend also injects a small `--append-system-prompt` on every
+spawned `claude` telling it its own A2A mention (`@<agentId>@<host>`) so
+the model recognises self-references in user messages and doesn't try to
+a2a-call its own address (see #128). No configuration required — it's
+derived from `AGENT_ID` and the host part of `SERVER_URL`.
+
+### Check your agent's mention / acct (any backend)
+
+`vicoop-client whoami` prints the agent's canonical A2A identity — the
+WebFinger acct, the `@<agentId>@<host>` mention, and the WebFinger lookup
+URL. Useful for registering this agent on another agent's `allowed_callers`
+list, or for pasting into the **OpenClaw gateway persona** (OpenClaw's
+`chat.send` has no per-message system field, so its persona is configured
+on the gateway via `openclaw config set ...` — paste the mention there if
+you want self-reference recognition on the OpenClaw backend too).
+
+```sh
+. "$INSTALL_DIR/vicoop-client.env"
+"$INSTALL_DIR/bin/vicoop-client" whoami
+# agentId:    my-agent
+# host:       bridge.example.com
+# mention:    @my-agent@bridge.example.com
+# acct:       acct:my-agent@bridge.example.com
+# a2a:        https://bridge.example.com/agents/my-agent
+# a2a card:   https://bridge.example.com/agents/my-agent/.well-known/agent-card.json
+# webfinger:  https://bridge.example.com/.well-known/webfinger?resource=acct%3A...
+```
+
+`a2a` is the JSON-RPC endpoint another caller would POST to (e.g.
+`a2a-wallet a2a stream <a2a> "...")`. `a2a card` is the agent-card URL —
+useful for confirming the card the bridge advertises for this agent.
+
+`whoami --verify` additionally fetches the WebFinger URL and reports
+whether the bridge actually resolves this agent's acct (useful when
+PUBLIC_URL on the bridge differs from the `SERVER_URL` host you're
+connecting on). `--json` emits a machine-readable record for scripts.
+
 ## Optional: persistence
 
 Only set up persistence after the foreground run connects and the agent

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -387,7 +387,7 @@ you want self-reference recognition on the OpenClaw backend too).
 ```
 
 `a2a` is the JSON-RPC endpoint another caller would POST to (e.g.
-`a2a-wallet a2a stream <a2a> "...")`. `a2a card` is the agent-card URL —
+`a2a-wallet a2a stream <a2a> "..."`). `a2a card` is the agent-card URL —
 useful for confirming the card the bridge advertises for this agent.
 
 `whoami --verify` additionally fetches the WebFinger URL and reports

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -364,6 +364,16 @@ the model recognises self-references in user messages and doesn't try to
 a2a-call its own address (see #128). No configuration required — it's
 derived from `AGENT_ID` and the host part of `SERVER_URL`.
 
+> **Note on host derivation.** The injected mention uses `SERVER_URL`'s
+> host (e.g. `wss://bridge.example.com/ws` → `bridge.example.com`). The
+> bridge's canonical Mentionable/WebFinger domain comes from `PUBLIC_URL`
+> on the server side. If the two differ (e.g. a custom domain in front of
+> a Fly hostname), the model is taught a mention that doesn't match what
+> users see via WebFinger and self-reference detection won't fire. Run
+> `vicoop-client whoami --verify` to confirm the WebFinger lookup actually
+> resolves the agent under the derived host; align `SERVER_URL` with
+> `PUBLIC_URL`'s host if it doesn't.
+
 ### Check your agent's mention / acct (any backend)
 
 `vicoop-client whoami` prints the agent's canonical A2A identity — the

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -650,6 +650,71 @@ test('passes expected argv shape (stream-json, session-id, verbose, extraArgs)',
   assert.equal(child.args.at(-1), 'sonnet');
 });
 
+test('injects --append-system-prompt with self-identity mention when identity is provided', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    identity: { agentId: '6eec0b6e-claude', host: 'vicoop-bridge-server.fly.dev' },
+  });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const idx = child.args.indexOf('--append-system-prompt');
+  assert.ok(idx !== -1, 'expected --append-system-prompt in argv');
+  const prompt = String(child.args[idx + 1]);
+  assert.match(prompt, /@6eec0b6e-claude@vicoop-bridge-server\.fly\.dev/);
+  assert.match(prompt, /acct:6eec0b6e-claude@vicoop-bridge-server\.fly\.dev/);
+});
+
+test('omits --append-system-prompt when no identity is configured', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(
+    child.args.indexOf('--append-system-prompt'),
+    -1,
+    'no identity → no system prompt args',
+  );
+});
+
+test('identity args precede extraArgs so operator extraArgs override', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    identity: { agentId: 'me', host: 'example.com' },
+    extraArgs: ['--append-system-prompt', 'OPERATOR'],
+  });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  // claude applies multiple --append-system-prompt occurrences in order, so
+  // the operator-supplied one must appear LATER than the identity one.
+  const occurrences: number[] = [];
+  child.args.forEach((a, i) => {
+    if (a === '--append-system-prompt') occurrences.push(i);
+  });
+  assert.equal(occurrences.length, 2);
+  assert.ok(occurrences[1] > occurrences[0]);
+  assert.equal(child.args[occurrences[1] + 1], 'OPERATOR');
+});
+
 test('passes configured cwd through to the Claude subprocess', async () => {
   const fake = scriptedSpawn({
     lines: [JSON.stringify({ type: 'result', result: 'ok' })],

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -658,7 +658,11 @@ test('injects --append-system-prompt with self-identity mention when identity is
 
   const backend = createClaudeBackend({
     spawn: fake.spawn,
-    identity: { agentId: '6eec0b6e-claude', host: 'vicoop-bridge-server.fly.dev' },
+    identity: {
+      agentId: '6eec0b6e-claude',
+      host: 'vicoop-bridge-server.fly.dev',
+      httpOrigin: 'https://vicoop-bridge-server.fly.dev',
+    },
   });
   await backend.handle(assign('hi'), collect().emit, NEVER);
 
@@ -697,7 +701,7 @@ test('identity args precede extraArgs so operator extraArgs override', async () 
 
   const backend = createClaudeBackend({
     spawn: fake.spawn,
-    identity: { agentId: 'me', host: 'example.com' },
+    identity: { agentId: 'me', host: 'example.com', httpOrigin: 'https://example.com' },
     extraArgs: ['--append-system-prompt', 'OPERATOR'],
   });
   await backend.handle(assign('hi'), collect().emit, NEVER);

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2,6 +2,7 @@ import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
 import { TRACEABILITY_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { formatAcct, formatMention, type AgentIdentity } from '../identity.js';
 import {
   startSendFileMcpServer,
   type SendFileMcpOptions,
@@ -71,6 +72,25 @@ export interface ClaudeBackendOptions {
   // Fetch uri-only inbound FileParts under the shared HTTPS/SSRF/size/MIME
   // policy. Enabled by default; set enabled:false to require inline bytes.
   fetchUriPolicy?: FetchUriPolicy;
+  // Agent's own A2A identity. When present, an `--append-system-prompt` is
+  // injected on every spawned `claude` so the model can recognise its own
+  // mention (`@<agentId>@<host>`) / acct in user messages and respond
+  // directly instead of attempting an outbound A2A call to its own address.
+  // See issue #128 for the failure mode this prevents.
+  identity?: AgentIdentity;
+}
+
+// Kept short and behaviour-focused. The risk we're guarding against is
+// concrete: a Claude-as-caller skill (a2a-wallet) interpreting the agent's
+// own mention as an external destination. Anything beyond self-reference
+// detection belongs in the operator-controlled prompt, not here.
+export function buildSelfIdentitySystemPrompt(id: AgentIdentity): string {
+  const mention = formatMention(id);
+  const acct = formatAcct(id);
+  return [
+    `You are an A2A agent reachable as the mention \`${mention}\` (${acct}).`,
+    `If a user message references this mention or acct, treat it as a self-reference and respond directly — do not invoke any outbound A2A tool or skill (e.g. a2a-wallet) to contact this address as if it were a separate agent.`,
+  ].join(' ');
 }
 
 interface SessionEntry {
@@ -484,6 +504,12 @@ export function createClaudeBackend(
     opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
       ? opts.sendFileMcp
       : null;
+  // Static per-backend args (placed before extraArgs so an operator-supplied
+  // `--append-system-prompt` in extraArgs concatenates AFTER ours rather than
+  // being ignored — claude appends each occurrence in order).
+  const identityArgs: readonly string[] = opts.identity
+    ? ['--append-system-prompt', buildSelfIdentitySystemPrompt(opts.identity)]
+    : [];
 
   // Lazy: first task that needs the MCP server starts it; backends that
   // never see send_file enabled don't open a port.
@@ -613,6 +639,7 @@ export function createClaudeBackend(
               }),
             ]
           : []),
+        ...identityArgs,
         ...extraArgs,
       ];
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -16,6 +16,8 @@ import {
   runListCallers,
   runRemoveCaller,
 } from './admin-cli.js';
+import { runWhoami } from './whoami.js';
+import { deriveIdentity } from './identity.js';
 
 interface Args {
   server: string;
@@ -28,7 +30,7 @@ interface Args {
 const DAEMON_USAGE =
   'vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude> [--card <path>]';
 const SUBCOMMAND_LIST =
-  'subcommands: login, setup, upgrade, list-agents, list-callers, add-caller, remove-caller (run any with --help)';
+  'subcommands: login, setup, upgrade, list-agents, list-callers, add-caller, remove-caller, whoami (run any with --help)';
 
 function parseClientArgs(argv: string[]): Args {
   const out: Partial<Args> = {};
@@ -63,15 +65,21 @@ function parseClientArgs(argv: string[]): Args {
   return resolved;
 }
 
-function pickBackend(name: string): Backend {
+function pickBackend(name: string, args: Args): Backend {
   switch (name) {
     case 'echo':
       return echoBackend;
     case 'openclaw':
+      // openclaw's persona / system prompt lives in the gateway-side config
+      // (`/data/openclaw.json`), not in a per-message field on `chat.send`.
+      // Self-identity is surfaced via `vicoop-client whoami` so operators can
+      // paste it into their gateway persona; the bridge has no wire-protocol
+      // hook to inject it from here.
       return createOpenclawBackend();
     case 'claude':
       return createClaudeBackend({
         cwd: process.env.CLAUDE_CWD?.trim() || undefined,
+        identity: deriveIdentity(args.agentId, args.server) ?? undefined,
       });
     default:
       throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude)`);
@@ -90,7 +98,7 @@ function runClient(argv: string[]): void {
     agentId: args.agentId,
     agentCard,
     backendKind: args.backend,
-    backend: pickBackend(args.backend),
+    backend: pickBackend(args.backend, args),
   });
 
   client.start();
@@ -182,6 +190,10 @@ async function main(): Promise<void> {
 
   if (argv[0] === 'list-agents') {
     process.exit(await runListAgents(argv.slice(1)));
+  }
+
+  if (argv[0] === 'whoami') {
+    process.exit(await runWhoami(argv.slice(1)));
   }
 
   // A bare word (not a flag) here is an unrecognised subcommand. Catch it so

--- a/packages/client/src/identity.test.ts
+++ b/packages/client/src/identity.test.ts
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  a2aCardUrl,
+  a2aEndpoint,
+  deriveIdentity,
+  formatAcct,
+  formatMention,
+  hostFromServerUrl,
+  isValidMentionableLocal,
+  webfingerUrl,
+} from './identity.js';
+
+test('isValidMentionableLocal accepts letters, digits, dot, hyphen, underscore', () => {
+  for (const ok of ['claude', 'agent-1', 'a_b', '6eec0b6e-claude', 'a.b']) {
+    assert.equal(isValidMentionableLocal(ok), true, `expected valid: ${ok}`);
+  }
+});
+
+test('isValidMentionableLocal rejects unsafe / out-of-charset locals', () => {
+  for (const bad of ['', '.', '..', 'foo@bar', 'a/b', 'a\nb', 'a b', 'a'.repeat(65)]) {
+    assert.equal(isValidMentionableLocal(bad), false, `expected invalid: ${JSON.stringify(bad)}`);
+  }
+});
+
+test('formatMention / formatAcct render the canonical strings', () => {
+  const id = { agentId: 'claude', host: 'bridge.example.com' };
+  assert.equal(formatMention(id), '@claude@bridge.example.com');
+  assert.equal(formatAcct(id), 'acct:claude@bridge.example.com');
+});
+
+test('a2aEndpoint / a2aCardUrl render the bridge routes for this agent', () => {
+  const id = { agentId: '6eec0b6e-claude', host: 'bridge.example.com' };
+  assert.equal(a2aEndpoint(id), 'https://bridge.example.com/agents/6eec0b6e-claude');
+  assert.equal(
+    a2aCardUrl(id),
+    'https://bridge.example.com/agents/6eec0b6e-claude/.well-known/agent-card.json',
+  );
+});
+
+test('webfingerUrl percent-encodes the acct resource', () => {
+  const id = { agentId: 'a', host: 'h.example' };
+  const url = webfingerUrl(id);
+  assert.equal(
+    url,
+    'https://h.example/.well-known/webfinger?resource=acct%3Aa%40h.example',
+  );
+});
+
+test('hostFromServerUrl returns hostname for ws / wss / http urls', () => {
+  assert.equal(hostFromServerUrl('wss://bridge.example.com/ws'), 'bridge.example.com');
+  assert.equal(hostFromServerUrl('ws://localhost:8787/ws'), 'localhost');
+  assert.equal(hostFromServerUrl('https://bridge.example.com'), 'bridge.example.com');
+});
+
+test('hostFromServerUrl returns null for malformed input', () => {
+  assert.equal(hostFromServerUrl('not a url'), null);
+  assert.equal(hostFromServerUrl(''), null);
+});
+
+test('deriveIdentity returns null when agentId is not a valid local', () => {
+  assert.equal(
+    deriveIdentity('bad/agent', 'wss://bridge.example.com/ws'),
+    null,
+  );
+});
+
+test('deriveIdentity returns null when host cannot be derived', () => {
+  assert.equal(deriveIdentity('claude', 'not-a-url'), null);
+});
+
+test('deriveIdentity returns a populated identity on the happy path', () => {
+  assert.deepEqual(
+    deriveIdentity('claude', 'wss://bridge.example.com/ws'),
+    { agentId: 'claude', host: 'bridge.example.com' },
+  );
+});

--- a/packages/client/src/identity.test.ts
+++ b/packages/client/src/identity.test.ts
@@ -73,6 +73,23 @@ test('hostFromServerUrl returns null for malformed input', () => {
   assert.equal(hostFromServerUrl(''), null);
 });
 
+test('hostFromServerUrl re-wraps IPv6 literals in brackets', () => {
+  // URL.hostname strips `[ ]`. The mention/acct form needs them back so
+  // `acct:foo@[::1]` follows RFC 7565 / RFC 3986 and matches the bridge's
+  // own Mentionable expectation.
+  assert.equal(hostFromServerUrl('wss://[::1]/ws'), '[::1]');
+  assert.equal(hostFromServerUrl('ws://[fe80::1]:8787/ws'), '[fe80::1]');
+});
+
+test('deriveIdentity renders the IPv6 mention correctly end-to-end', () => {
+  const id = deriveIdentity('agent', 'ws://[::1]:8787/ws');
+  assert.ok(id);
+  assert.equal(formatMention(id), '@agent@[::1]');
+  assert.equal(formatAcct(id), 'acct:agent@[::1]');
+  // The HTTP origin keeps brackets via URL.host.
+  assert.equal(id.httpOrigin, 'http://[::1]:8787');
+});
+
 test('httpOriginFromServerUrl maps ws→http and wss→https, preserving port', () => {
   assert.equal(httpOriginFromServerUrl('ws://localhost:8787/ws'), 'http://localhost:8787');
   assert.equal(httpOriginFromServerUrl('wss://bridge.example.com/ws'), 'https://bridge.example.com');

--- a/packages/client/src/identity.test.ts
+++ b/packages/client/src/identity.test.ts
@@ -7,9 +7,12 @@ import {
   formatAcct,
   formatMention,
   hostFromServerUrl,
+  httpOriginFromServerUrl,
   isValidMentionableLocal,
   webfingerUrl,
 } from './identity.js';
+
+const HTTPS = 'https://bridge.example.com';
 
 test('isValidMentionableLocal accepts letters, digits, dot, hyphen, underscore', () => {
   for (const ok of ['claude', 'agent-1', 'a_b', '6eec0b6e-claude', 'a.b']) {
@@ -24,13 +27,13 @@ test('isValidMentionableLocal rejects unsafe / out-of-charset locals', () => {
 });
 
 test('formatMention / formatAcct render the canonical strings', () => {
-  const id = { agentId: 'claude', host: 'bridge.example.com' };
+  const id = { agentId: 'claude', host: 'bridge.example.com', httpOrigin: HTTPS };
   assert.equal(formatMention(id), '@claude@bridge.example.com');
   assert.equal(formatAcct(id), 'acct:claude@bridge.example.com');
 });
 
 test('a2aEndpoint / a2aCardUrl render the bridge routes for this agent', () => {
-  const id = { agentId: '6eec0b6e-claude', host: 'bridge.example.com' };
+  const id = { agentId: '6eec0b6e-claude', host: 'bridge.example.com', httpOrigin: HTTPS };
   assert.equal(a2aEndpoint(id), 'https://bridge.example.com/agents/6eec0b6e-claude');
   assert.equal(
     a2aCardUrl(id),
@@ -38,11 +41,23 @@ test('a2aEndpoint / a2aCardUrl render the bridge routes for this agent', () => {
   );
 });
 
-test('webfingerUrl percent-encodes the acct resource', () => {
-  const id = { agentId: 'a', host: 'h.example' };
-  const url = webfingerUrl(id);
+test('a2aEndpoint percent-encodes agentId so an out-of-charset id still yields a valid URL', () => {
+  const id = { agentId: 'bad/agent', host: 'bridge.example.com', httpOrigin: HTTPS };
+  assert.equal(a2aEndpoint(id), 'https://bridge.example.com/agents/bad%2Fagent');
+});
+
+test('webfingerUrl uses httpOrigin (preserving ws→http and port)', () => {
+  const id = { agentId: 'a', host: 'localhost', httpOrigin: 'http://localhost:8787' };
   assert.equal(
-    url,
+    webfingerUrl(id),
+    'http://localhost:8787/.well-known/webfinger?resource=acct%3Aa%40localhost',
+  );
+});
+
+test('webfingerUrl percent-encodes the acct resource', () => {
+  const id = { agentId: 'a', host: 'h.example', httpOrigin: 'https://h.example' };
+  assert.equal(
+    webfingerUrl(id),
     'https://h.example/.well-known/webfinger?resource=acct%3Aa%40h.example',
   );
 });
@@ -58,6 +73,25 @@ test('hostFromServerUrl returns null for malformed input', () => {
   assert.equal(hostFromServerUrl(''), null);
 });
 
+test('httpOriginFromServerUrl maps ws→http and wss→https, preserving port', () => {
+  assert.equal(httpOriginFromServerUrl('ws://localhost:8787/ws'), 'http://localhost:8787');
+  assert.equal(httpOriginFromServerUrl('wss://bridge.example.com/ws'), 'https://bridge.example.com');
+  assert.equal(
+    httpOriginFromServerUrl('wss://bridge.example.com:9443/ws'),
+    'https://bridge.example.com:9443',
+  );
+});
+
+test('httpOriginFromServerUrl passes through http(s) URLs unchanged at the origin', () => {
+  assert.equal(httpOriginFromServerUrl('https://bridge.example.com'), 'https://bridge.example.com');
+  assert.equal(httpOriginFromServerUrl('http://localhost:8787/'), 'http://localhost:8787');
+});
+
+test('httpOriginFromServerUrl returns null for malformed input', () => {
+  assert.equal(httpOriginFromServerUrl('not a url'), null);
+  assert.equal(httpOriginFromServerUrl(''), null);
+});
+
 test('deriveIdentity returns null when agentId is not a valid local', () => {
   assert.equal(
     deriveIdentity('bad/agent', 'wss://bridge.example.com/ws'),
@@ -69,9 +103,16 @@ test('deriveIdentity returns null when host cannot be derived', () => {
   assert.equal(deriveIdentity('claude', 'not-a-url'), null);
 });
 
-test('deriveIdentity returns a populated identity on the happy path', () => {
+test('deriveIdentity carries both hostname and httpOrigin on the happy path', () => {
   assert.deepEqual(
     deriveIdentity('claude', 'wss://bridge.example.com/ws'),
-    { agentId: 'claude', host: 'bridge.example.com' },
+    { agentId: 'claude', host: 'bridge.example.com', httpOrigin: 'https://bridge.example.com' },
+  );
+});
+
+test('deriveIdentity preserves port for local dev (ws → http)', () => {
+  assert.deepEqual(
+    deriveIdentity('claude', 'ws://localhost:8787/ws'),
+    { agentId: 'claude', host: 'localhost', httpOrigin: 'http://localhost:8787' },
   );
 });

--- a/packages/client/src/identity.ts
+++ b/packages/client/src/identity.ts
@@ -1,0 +1,74 @@
+// Mirrors server/src/mentionable.ts:LOCAL_RE. Kept locally instead of imported
+// from @vicoop-bridge/protocol to avoid pulling server internals into the
+// client bundle; the regex is small and the validation rule is part of the
+// public mention surface.
+const LOCAL_RE = /^[A-Za-z0-9._-]{1,64}$/;
+
+export function isValidMentionableLocal(local: string): boolean {
+  if (local === '.' || local === '..') return false;
+  return LOCAL_RE.test(local);
+}
+
+export interface AgentIdentity {
+  agentId: string;
+  host: string;
+}
+
+// `<agentId>@<host>` — the canonical mention form a user types in the bridge
+// playground (with a leading `@`). Used by the claude backend's self-reference
+// system prompt and by the `whoami` CLI.
+export function formatMention(id: AgentIdentity): string {
+  return `@${id.agentId}@${id.host}`;
+}
+
+// `acct:<agentId>@<host>` — the RFC 7565 form, used as the `resource` query
+// parameter when looking the agent up via WebFinger.
+export function formatAcct(id: AgentIdentity): string {
+  return `acct:${id.agentId}@${id.host}`;
+}
+
+// WebFinger lookup URL, useful for sanity-checking that the bridge actually
+// resolves this agent's acct from outside.
+export function webfingerUrl(id: AgentIdentity): string {
+  const acct = encodeURIComponent(formatAcct(id));
+  return `https://${id.host}/.well-known/webfinger?resource=${acct}`;
+}
+
+// A2A JSON-RPC endpoint for this agent — what a caller POSTs to via
+// `a2a-wallet a2a stream` etc. The corresponding agent card lives one path
+// segment deeper (see `a2aCardUrl`).
+export function a2aEndpoint(id: AgentIdentity): string {
+  return `https://${id.host}/agents/${id.agentId}`;
+}
+
+// Agent card JSON URL served by the bridge for this agent (see
+// `packages/server/src/http.tsx` — route `/agents/:id/.well-known/agent-card.json`).
+// `a2a-wallet a2a card <endpoint>` derives this URL itself from the endpoint,
+// so most operators don't need to type it directly, but printing it makes
+// the discovery path explicit.
+export function a2aCardUrl(id: AgentIdentity): string {
+  return `${a2aEndpoint(id)}/.well-known/agent-card.json`;
+}
+
+// Best-effort host derivation from the bridge WebSocket URL. The bridge's
+// WebFinger surface is rooted at the same hostname as the WS endpoint in the
+// usual deployment (`wss://<host>/ws` ↔ `https://<host>/.well-known/...`); if
+// PUBLIC_URL is configured to a different host on the server side the derived
+// mention will not resolve via WebFinger and `whoami` will say so.
+export function hostFromServerUrl(serverUrl: string): string | null {
+  try {
+    return new URL(serverUrl).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+export function deriveIdentity(
+  agentId: string,
+  serverUrl: string,
+): AgentIdentity | null {
+  const host = hostFromServerUrl(serverUrl);
+  if (!host) return null;
+  if (!isValidMentionableLocal(agentId)) return null;
+  return { agentId, host };
+}

--- a/packages/client/src/identity.ts
+++ b/packages/client/src/identity.ts
@@ -62,12 +62,29 @@ export function a2aCardUrl(id: AgentIdentity): string {
 // Best-effort host derivation from the bridge WebSocket URL. Hostname only
 // (no port) — used for the mention/acct subject. See `httpOriginFromServerUrl`
 // for the URL-building counterpart.
+//
+// IPv6 literals are returned bracketed (`[::1]`) so the `acct:` form follows
+// RFC 7565 / RFC 3986 host-with-brackets convention and matches the bridge's
+// own Mentionable surface, which expects bracketed IPv6 hosts (see
+// `packages/server/src/well-known.ts` `isIpLiteral`). The WHATWG URL spec
+// keeps the brackets on `hostname` for IPv6 — Node 24+ does — but some older
+// Node/embedder implementations stripped them, so we re-wrap defensively when
+// the hostname looks like a bare IPv6 literal.
 export function hostFromServerUrl(serverUrl: string): string | null {
+  let url: URL;
   try {
-    return new URL(serverUrl).hostname || null;
+    url = new URL(serverUrl);
   } catch {
     return null;
   }
+  const hostname = url.hostname;
+  if (!hostname) return null;
+  // Any `:` in a hostname is unambiguously an IPv6 literal (legal hostnames
+  // can't contain `:`). If it's already bracketed, leave it; otherwise wrap.
+  if (hostname.includes(':') && !hostname.startsWith('[')) {
+    return `[${hostname}]`;
+  }
+  return hostname;
 }
 
 // HTTP(S) origin counterpart to `hostFromServerUrl`. ws↔http / wss↔https

--- a/packages/client/src/identity.ts
+++ b/packages/client/src/identity.ts
@@ -64,12 +64,14 @@ export function a2aCardUrl(id: AgentIdentity): string {
 // for the URL-building counterpart.
 //
 // IPv6 literals are returned bracketed (`[::1]`) so the `acct:` form follows
-// RFC 7565 / RFC 3986 host-with-brackets convention and matches the bridge's
-// own Mentionable surface, which expects bracketed IPv6 hosts (see
-// `packages/server/src/well-known.ts` `isIpLiteral`). The WHATWG URL spec
-// keeps the brackets on `hostname` for IPv6 — Node 24+ does — but some older
-// Node/embedder implementations stripped them, so we re-wrap defensively when
-// the hostname looks like a bare IPv6 literal.
+// the RFC 7565 / RFC 3986 host-with-brackets convention and matches the
+// bridge's own Mentionable surface (see `packages/server/src/well-known.ts`
+// `isIpLiteral`).
+//
+// Different URL parsers disagree on whether `URL.hostname` includes the
+// brackets — some surface a bare `::1`, others keep `[::1]`. We normalise to
+// the bracketed form regardless: if the hostname contains `:` (which a legal
+// DNS hostname cannot) and is not already bracketed, wrap it.
 export function hostFromServerUrl(serverUrl: string): string | null {
   let url: URL;
   try {
@@ -79,8 +81,6 @@ export function hostFromServerUrl(serverUrl: string): string | null {
   }
   const hostname = url.hostname;
   if (!hostname) return null;
-  // Any `:` in a hostname is unambiguously an IPv6 literal (legal hostnames
-  // can't contain `:`). If it's already bracketed, leave it; otherwise wrap.
   if (hostname.includes(':') && !hostname.startsWith('[')) {
     return `[${hostname}]`;
   }

--- a/packages/client/src/identity.ts
+++ b/packages/client/src/identity.ts
@@ -11,7 +11,14 @@ export function isValidMentionableLocal(local: string): boolean {
 
 export interface AgentIdentity {
   agentId: string;
+  // Hostname only (no scheme, no port). Used in the mention/acct subject
+  // (`@<agentId>@<host>` / `acct:<agentId>@<host>`).
   host: string;
+  // HTTP(S) origin of the bridge (`scheme://host[:port]`). Used to build
+  // WebFinger / A2A / agent-card URLs. Carried separately from `host` so a
+  // dev deployment on `ws://localhost:8787` resolves to `http://localhost:8787`
+  // for URLs while the mention stays `<agentId>@localhost`.
+  httpOrigin: string;
 }
 
 // `<agentId>@<host>` — the canonical mention form a user types in the bridge
@@ -31,14 +38,16 @@ export function formatAcct(id: AgentIdentity): string {
 // resolves this agent's acct from outside.
 export function webfingerUrl(id: AgentIdentity): string {
   const acct = encodeURIComponent(formatAcct(id));
-  return `https://${id.host}/.well-known/webfinger?resource=${acct}`;
+  return `${id.httpOrigin}/.well-known/webfinger?resource=${acct}`;
 }
 
 // A2A JSON-RPC endpoint for this agent — what a caller POSTs to via
 // `a2a-wallet a2a stream` etc. The corresponding agent card lives one path
-// segment deeper (see `a2aCardUrl`).
+// segment deeper (see `a2aCardUrl`). `agentId` is %-encoded defensively even
+// though valid Mentionable locals never require it, so the URL stays valid
+// when whoami is asked to print an out-of-charset id.
 export function a2aEndpoint(id: AgentIdentity): string {
-  return `https://${id.host}/agents/${id.agentId}`;
+  return `${id.httpOrigin}/agents/${encodeURIComponent(id.agentId)}`;
 }
 
 // Agent card JSON URL served by the bridge for this agent (see
@@ -50,11 +59,9 @@ export function a2aCardUrl(id: AgentIdentity): string {
   return `${a2aEndpoint(id)}/.well-known/agent-card.json`;
 }
 
-// Best-effort host derivation from the bridge WebSocket URL. The bridge's
-// WebFinger surface is rooted at the same hostname as the WS endpoint in the
-// usual deployment (`wss://<host>/ws` ↔ `https://<host>/.well-known/...`); if
-// PUBLIC_URL is configured to a different host on the server side the derived
-// mention will not resolve via WebFinger and `whoami` will say so.
+// Best-effort host derivation from the bridge WebSocket URL. Hostname only
+// (no port) — used for the mention/acct subject. See `httpOriginFromServerUrl`
+// for the URL-building counterpart.
 export function hostFromServerUrl(serverUrl: string): string | null {
   try {
     return new URL(serverUrl).hostname || null;
@@ -63,12 +70,30 @@ export function hostFromServerUrl(serverUrl: string): string | null {
   }
 }
 
+// HTTP(S) origin counterpart to `hostFromServerUrl`. ws↔http / wss↔https
+// (`URL.protocol` is `ws:`/`wss:`/`http:`/`https:`), preserving the port so
+// dev deployments like `ws://localhost:8787` get the correct
+// `http://localhost:8787` for WebFinger / A2A URLs.
+export function httpOriginFromServerUrl(serverUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(serverUrl);
+  } catch {
+    return null;
+  }
+  if (!url.hostname) return null;
+  const scheme =
+    url.protocol === 'wss:' || url.protocol === 'https:' ? 'https' : 'http';
+  return `${scheme}://${url.host}`;
+}
+
 export function deriveIdentity(
   agentId: string,
   serverUrl: string,
 ): AgentIdentity | null {
   const host = hostFromServerUrl(serverUrl);
-  if (!host) return null;
+  const httpOrigin = httpOriginFromServerUrl(serverUrl);
+  if (!host || !httpOrigin) return null;
   if (!isValidMentionableLocal(agentId)) return null;
-  return { agentId, host };
+  return { agentId, host, httpOrigin };
 }

--- a/packages/client/src/whoami.test.ts
+++ b/packages/client/src/whoami.test.ts
@@ -1,34 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
-import { runWhoami } from './whoami.js';
+import { runWhoami, type WhoamiIO } from './whoami.js';
 
-// Capture stdout/stderr for the duration of a single runWhoami() call. The
-// CLI writes via process.stdout.write directly, so we replace those at the
-// fd-stream level rather than mocking console.
-function captureIO<T>(fn: () => Promise<T>): Promise<{
-  result: T;
-  stdout: string;
-  stderr: string;
-}> {
-  const origOut = process.stdout.write.bind(process.stdout);
-  const origErr = process.stderr.write.bind(process.stderr);
+// Inject a buffered IO so the test runner's TAP output on the real
+// process.stdout stays untouched. Globally overriding `process.stdout.write`
+// (the previous approach) silently swallowed most test events under
+// `node --test`.
+function makeIO(): WhoamiIO & { readStdout: () => string; readStderr: () => string } {
   let out = '';
   let err = '';
-  process.stdout.write = ((s: string | Uint8Array) => {
-    out += typeof s === 'string' ? s : Buffer.from(s).toString('utf8');
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((s: string | Uint8Array) => {
-    err += typeof s === 'string' ? s : Buffer.from(s).toString('utf8');
-    return true;
-  }) as typeof process.stderr.write;
-  return fn()
-    .then((result) => ({ result, stdout: out, stderr: err }))
-    .finally(() => {
-      process.stdout.write = origOut;
-      process.stderr.write = origErr;
-    });
+  return {
+    stdout: (s) => {
+      out += s;
+    },
+    stderr: (s) => {
+      err += s;
+    },
+    readStdout: () => out,
+    readStderr: () => err,
+  };
 }
 
 // Spin up a real HTTP server so --verify hits a deterministic local
@@ -69,15 +60,18 @@ function withWebfingerServer<T>(
 }
 
 test('whoami prints mention / acct / webfinger URL on happy path', async () => {
-  const { result, stdout } = await captureIO(() =>
-    runWhoami([
+  const io = makeIO();
+  const result = await runWhoami(
+    [
       '--agentId',
       '6eec0b6e-claude',
       '--server',
       'wss://vicoop-bridge-server.fly.dev/ws',
-    ]),
+    ],
+    io,
   );
   assert.equal(result, 0);
+  const stdout = io.readStdout();
   assert.match(stdout, /agentId:\s*6eec0b6e-claude/);
   assert.match(stdout, /host:\s*vicoop-bridge-server\.fly\.dev/);
   assert.match(stdout, /mention:\s*@6eec0b6e-claude@vicoop-bridge-server\.fly\.dev/);
@@ -97,17 +91,13 @@ test('whoami prints mention / acct / webfinger URL on happy path', async () => {
 });
 
 test('whoami --json emits a parseable record', async () => {
-  const { result, stdout } = await captureIO(() =>
-    runWhoami([
-      '--agentId',
-      'me',
-      '--server',
-      'wss://h.example/ws',
-      '--json',
-    ]),
+  const io = makeIO();
+  const result = await runWhoami(
+    ['--agentId', 'me', '--server', 'wss://h.example/ws', '--json'],
+    io,
   );
   assert.equal(result, 0);
-  const parsed = JSON.parse(stdout);
+  const parsed = JSON.parse(io.readStdout());
   assert.equal(parsed.agentId, 'me');
   assert.equal(parsed.host, 'h.example');
   assert.equal(parsed.httpOrigin, 'https://h.example');
@@ -121,17 +111,13 @@ test('whoami --json emits a parseable record', async () => {
 });
 
 test('whoami preserves scheme+port for local dev (ws → http, port retained)', async () => {
-  const { result, stdout } = await captureIO(() =>
-    runWhoami([
-      '--agentId',
-      'me',
-      '--server',
-      'ws://localhost:8787/ws',
-      '--json',
-    ]),
+  const io = makeIO();
+  const result = await runWhoami(
+    ['--agentId', 'me', '--server', 'ws://localhost:8787/ws', '--json'],
+    io,
   );
   assert.equal(result, 0);
-  const parsed = JSON.parse(stdout);
+  const parsed = JSON.parse(io.readStdout());
   assert.equal(parsed.httpOrigin, 'http://localhost:8787');
   assert.equal(parsed.a2aEndpoint, 'http://localhost:8787/agents/me');
   assert.equal(
@@ -145,9 +131,10 @@ test('whoami exits 1 with usage when agentId / server are missing', async () => 
   delete process.env.AGENT_ID;
   delete process.env.SERVER_URL;
   try {
-    const { result, stderr } = await captureIO(() => runWhoami([]));
+    const io = makeIO();
+    const result = await runWhoami([], io);
     assert.equal(result, 1);
-    assert.match(stderr, /missing required/);
+    assert.match(io.readStderr(), /missing required/);
   } finally {
     if (prev.agent !== undefined) process.env.AGENT_ID = prev.agent;
     if (prev.server !== undefined) process.env.SERVER_URL = prev.server;
@@ -155,18 +142,15 @@ test('whoami exits 1 with usage when agentId / server are missing', async () => 
 });
 
 test('whoami warns and exits 2 when agentId is not a Mentionable local', async () => {
-  const { result, stderr, stdout } = await captureIO(() =>
-    runWhoami([
-      '--agentId',
-      'bad/agent',
-      '--server',
-      'wss://h.example/ws',
-    ]),
+  const io = makeIO();
+  const result = await runWhoami(
+    ['--agentId', 'bad/agent', '--server', 'wss://h.example/ws'],
+    io,
   );
   assert.equal(result, 2);
-  assert.match(stderr, /not a valid Mentionable local-part/);
+  assert.match(io.readStderr(), /not a valid Mentionable local-part/);
   // Even with an invalid id, the printed URL must be valid (encoded).
-  assert.match(stdout, /a2a:\s*https:\/\/h\.example\/agents\/bad%2Fagent/);
+  assert.match(io.readStdout(), /a2a:\s*https:\/\/h\.example\/agents\/bad%2Fagent/);
 });
 
 test('whoami --verify treats a matching JRD subject as success', async () => {
@@ -180,17 +164,33 @@ test('whoami --verify treats a matching JRD subject as success', async () => {
     },
     async (origin) => {
       const url = new URL(origin);
-      const { result, stdout } = await captureIO(() =>
-        runWhoami([
-          '--agentId',
-          'me',
-          '--server',
-          `ws://${url.host}/ws`,
-          '--verify',
-        ]),
+      const io = makeIO();
+      const result = await runWhoami(
+        ['--agentId', 'me', '--server', `ws://${url.host}/ws`, '--verify'],
+        io,
       );
       assert.equal(result, 0);
-      assert.match(stdout, /webfinger ok/);
+      assert.match(io.readStdout(), /webfinger ok/);
+    },
+  );
+});
+
+test('whoami --verify treats subject as case-insensitive (matches server)', async () => {
+  await withWebfingerServer(
+    (_req, res) => {
+      // Server may return mixed case for the local part — the bridge's
+      // lookup is case-insensitive on scheme+local+domain.
+      res.json({ subject: 'ACCT:Me@127.0.0.1', aliases: [] });
+    },
+    async (origin) => {
+      const url = new URL(origin);
+      const io = makeIO();
+      const result = await runWhoami(
+        ['--agentId', 'me', '--server', `ws://${url.host}/ws`, '--verify'],
+        io,
+      );
+      assert.equal(result, 0);
+      assert.match(io.readStdout(), /webfinger ok/);
     },
   );
 });
@@ -203,16 +203,13 @@ test('whoami --verify exits 3 when the JRD subject does not match the requested 
     },
     async (origin) => {
       const url = new URL(origin);
-      const { result, stdout } = await captureIO(() =>
-        runWhoami([
-          '--agentId',
-          'me',
-          '--server',
-          `ws://${url.host}/ws`,
-          '--verify',
-        ]),
+      const io = makeIO();
+      const result = await runWhoami(
+        ['--agentId', 'me', '--server', `ws://${url.host}/ws`, '--verify'],
+        io,
       );
       assert.equal(result, 3);
+      const stdout = io.readStdout();
       assert.match(stdout, /webfinger FAILED/);
       assert.match(stdout, /subject mismatch/);
     },
@@ -224,17 +221,13 @@ test('whoami --verify exits 3 with HTTP <status> when WebFinger returns 404', as
     (_req, res) => res.json({ error: 'not found' }, 404),
     async (origin) => {
       const url = new URL(origin);
-      const { result, stdout } = await captureIO(() =>
-        runWhoami([
-          '--agentId',
-          'me',
-          '--server',
-          `ws://${url.host}/ws`,
-          '--verify',
-        ]),
+      const io = makeIO();
+      const result = await runWhoami(
+        ['--agentId', 'me', '--server', `ws://${url.host}/ws`, '--verify'],
+        io,
       );
       assert.equal(result, 3);
-      assert.match(stdout, /webfinger FAILED:\s*HTTP 404/);
+      assert.match(io.readStdout(), /webfinger FAILED:\s*HTTP 404/);
     },
   );
 });

--- a/packages/client/src/whoami.test.ts
+++ b/packages/client/src/whoami.test.ts
@@ -216,9 +216,18 @@ test('whoami --verify exits 3 when the JRD subject does not match the requested 
   );
 });
 
-test('whoami --verify exits 3 with HTTP <status> when WebFinger returns 404', async () => {
+test('whoami --verify surfaces the server-provided error reason on non-2xx', async () => {
   await withWebfingerServer(
-    (_req, res) => res.json({ error: 'not found' }, 404),
+    (_req, res) =>
+      // Real shape returned by `mountWellKnown` when Mentionable is
+      // ineligible — operators should see this verbatim instead of just
+      // "HTTP 404".
+      res.json(
+        {
+          error: 'webfinger not available (PUBLIC_URL must be HTTPS with a multi-label hostname)',
+        },
+        404,
+      ),
     async (origin) => {
       const url = new URL(origin);
       const io = makeIO();
@@ -227,7 +236,45 @@ test('whoami --verify exits 3 with HTTP <status> when WebFinger returns 404', as
         io,
       );
       assert.equal(result, 3);
-      assert.match(io.readStdout(), /webfinger FAILED:\s*HTTP 404/);
+      const stdout = io.readStdout();
+      assert.match(stdout, /webfinger FAILED:\s*HTTP 404/);
+      assert.match(stdout, /PUBLIC_URL must be HTTPS/);
     },
   );
+});
+
+test('whoami --verify still surfaces a bare status when the body is not JSON', async () => {
+  await new Promise<void>((resolve, reject) => {
+    const server = createServer((_req, res) => {
+      res.statusCode = 502;
+      res.setHeader('Content-Type', 'text/plain');
+      res.end('bad gateway');
+    });
+    server.listen(0, '127.0.0.1', async () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('no address'));
+        return;
+      }
+      try {
+        const io = makeIO();
+        const result = await runWhoami(
+          [
+            '--agentId',
+            'me',
+            '--server',
+            `ws://127.0.0.1:${addr.port}/ws`,
+            '--verify',
+          ],
+          io,
+        );
+        assert.equal(result, 3);
+        assert.match(io.readStdout(), /webfinger FAILED:\s*HTTP 502/);
+        server.close(() => resolve());
+      } catch (e) {
+        server.close(() => reject(e));
+      }
+    });
+  });
 });

--- a/packages/client/src/whoami.test.ts
+++ b/packages/client/src/whoami.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { createServer, type Server } from 'node:http';
 import { runWhoami } from './whoami.js';
 
 // Capture stdout/stderr for the duration of a single runWhoami() call. The
@@ -28,6 +29,43 @@ function captureIO<T>(fn: () => Promise<T>): Promise<{
       process.stdout.write = origOut;
       process.stderr.write = origErr;
     });
+}
+
+// Spin up a real HTTP server so --verify hits a deterministic local
+// endpoint instead of touching the network.
+function withWebfingerServer<T>(
+  handler: (req: { resource: string }, res: { json: (body: unknown, status?: number) => void }) => void,
+  fn: (origin: string) => Promise<T>,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const server: Server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      const resource = url.searchParams.get('resource') ?? '';
+      const wrapped = {
+        json: (body: unknown, status = 200) => {
+          res.statusCode = status;
+          res.setHeader('Content-Type', 'application/jrd+json');
+          res.end(JSON.stringify(body));
+        },
+      };
+      handler({ resource }, wrapped);
+    });
+    server.listen(0, '127.0.0.1', async () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close();
+        reject(new Error('no address'));
+        return;
+      }
+      const origin = `http://127.0.0.1:${addr.port}`;
+      try {
+        const out = await fn(origin);
+        server.close(() => resolve(out));
+      } catch (e) {
+        server.close(() => reject(e));
+      }
+    });
+  });
 }
 
 test('whoami prints mention / acct / webfinger URL on happy path', async () => {
@@ -72,12 +110,33 @@ test('whoami --json emits a parseable record', async () => {
   const parsed = JSON.parse(stdout);
   assert.equal(parsed.agentId, 'me');
   assert.equal(parsed.host, 'h.example');
+  assert.equal(parsed.httpOrigin, 'https://h.example');
   assert.equal(parsed.mention, '@me@h.example');
   assert.equal(parsed.acct, 'acct:me@h.example');
   assert.equal(parsed.a2aEndpoint, 'https://h.example/agents/me');
   assert.equal(
     parsed.a2aCardUrl,
     'https://h.example/agents/me/.well-known/agent-card.json',
+  );
+});
+
+test('whoami preserves scheme+port for local dev (ws → http, port retained)', async () => {
+  const { result, stdout } = await captureIO(() =>
+    runWhoami([
+      '--agentId',
+      'me',
+      '--server',
+      'ws://localhost:8787/ws',
+      '--json',
+    ]),
+  );
+  assert.equal(result, 0);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.httpOrigin, 'http://localhost:8787');
+  assert.equal(parsed.a2aEndpoint, 'http://localhost:8787/agents/me');
+  assert.equal(
+    parsed.webfingerUrl,
+    'http://localhost:8787/.well-known/webfinger?resource=acct%3Ame%40localhost',
   );
 });
 
@@ -96,7 +155,7 @@ test('whoami exits 1 with usage when agentId / server are missing', async () => 
 });
 
 test('whoami warns and exits 2 when agentId is not a Mentionable local', async () => {
-  const { result, stderr } = await captureIO(() =>
+  const { result, stderr, stdout } = await captureIO(() =>
     runWhoami([
       '--agentId',
       'bad/agent',
@@ -106,4 +165,76 @@ test('whoami warns and exits 2 when agentId is not a Mentionable local', async (
   );
   assert.equal(result, 2);
   assert.match(stderr, /not a valid Mentionable local-part/);
+  // Even with an invalid id, the printed URL must be valid (encoded).
+  assert.match(stdout, /a2a:\s*https:\/\/h\.example\/agents\/bad%2Fagent/);
+});
+
+test('whoami --verify treats a matching JRD subject as success', async () => {
+  await withWebfingerServer(
+    ({ resource }, res) => {
+      assert.equal(resource, 'acct:me@127.0.0.1');
+      res.json({
+        subject: 'acct:me@127.0.0.1',
+        aliases: ['https://127.0.0.1/agents/me'],
+      });
+    },
+    async (origin) => {
+      const url = new URL(origin);
+      const { result, stdout } = await captureIO(() =>
+        runWhoami([
+          '--agentId',
+          'me',
+          '--server',
+          `ws://${url.host}/ws`,
+          '--verify',
+        ]),
+      );
+      assert.equal(result, 0);
+      assert.match(stdout, /webfinger ok/);
+    },
+  );
+});
+
+test('whoami --verify exits 3 when the JRD subject does not match the requested acct', async () => {
+  await withWebfingerServer(
+    (_req, res) => {
+      // Wrong subject — pretend the server pointed us at a different agent.
+      res.json({ subject: 'acct:somebody-else@127.0.0.1', aliases: [] });
+    },
+    async (origin) => {
+      const url = new URL(origin);
+      const { result, stdout } = await captureIO(() =>
+        runWhoami([
+          '--agentId',
+          'me',
+          '--server',
+          `ws://${url.host}/ws`,
+          '--verify',
+        ]),
+      );
+      assert.equal(result, 3);
+      assert.match(stdout, /webfinger FAILED/);
+      assert.match(stdout, /subject mismatch/);
+    },
+  );
+});
+
+test('whoami --verify exits 3 with HTTP <status> when WebFinger returns 404', async () => {
+  await withWebfingerServer(
+    (_req, res) => res.json({ error: 'not found' }, 404),
+    async (origin) => {
+      const url = new URL(origin);
+      const { result, stdout } = await captureIO(() =>
+        runWhoami([
+          '--agentId',
+          'me',
+          '--server',
+          `ws://${url.host}/ws`,
+          '--verify',
+        ]),
+      );
+      assert.equal(result, 3);
+      assert.match(stdout, /webfinger FAILED:\s*HTTP 404/);
+    },
+  );
 });

--- a/packages/client/src/whoami.test.ts
+++ b/packages/client/src/whoami.test.ts
@@ -1,0 +1,109 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runWhoami } from './whoami.js';
+
+// Capture stdout/stderr for the duration of a single runWhoami() call. The
+// CLI writes via process.stdout.write directly, so we replace those at the
+// fd-stream level rather than mocking console.
+function captureIO<T>(fn: () => Promise<T>): Promise<{
+  result: T;
+  stdout: string;
+  stderr: string;
+}> {
+  const origOut = process.stdout.write.bind(process.stdout);
+  const origErr = process.stderr.write.bind(process.stderr);
+  let out = '';
+  let err = '';
+  process.stdout.write = ((s: string | Uint8Array) => {
+    out += typeof s === 'string' ? s : Buffer.from(s).toString('utf8');
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((s: string | Uint8Array) => {
+    err += typeof s === 'string' ? s : Buffer.from(s).toString('utf8');
+    return true;
+  }) as typeof process.stderr.write;
+  return fn()
+    .then((result) => ({ result, stdout: out, stderr: err }))
+    .finally(() => {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+    });
+}
+
+test('whoami prints mention / acct / webfinger URL on happy path', async () => {
+  const { result, stdout } = await captureIO(() =>
+    runWhoami([
+      '--agentId',
+      '6eec0b6e-claude',
+      '--server',
+      'wss://vicoop-bridge-server.fly.dev/ws',
+    ]),
+  );
+  assert.equal(result, 0);
+  assert.match(stdout, /agentId:\s*6eec0b6e-claude/);
+  assert.match(stdout, /host:\s*vicoop-bridge-server\.fly\.dev/);
+  assert.match(stdout, /mention:\s*@6eec0b6e-claude@vicoop-bridge-server\.fly\.dev/);
+  assert.match(stdout, /acct:\s*acct:6eec0b6e-claude@vicoop-bridge-server\.fly\.dev/);
+  assert.match(
+    stdout,
+    /a2a:\s*https:\/\/vicoop-bridge-server\.fly\.dev\/agents\/6eec0b6e-claude\b/,
+  );
+  assert.match(
+    stdout,
+    /a2a card:\s*https:\/\/vicoop-bridge-server\.fly\.dev\/agents\/6eec0b6e-claude\/\.well-known\/agent-card\.json/,
+  );
+  assert.match(
+    stdout,
+    /webfinger:\s*https:\/\/vicoop-bridge-server\.fly\.dev\/\.well-known\/webfinger\?resource=acct%3A6eec0b6e-claude%40vicoop-bridge-server\.fly\.dev/,
+  );
+});
+
+test('whoami --json emits a parseable record', async () => {
+  const { result, stdout } = await captureIO(() =>
+    runWhoami([
+      '--agentId',
+      'me',
+      '--server',
+      'wss://h.example/ws',
+      '--json',
+    ]),
+  );
+  assert.equal(result, 0);
+  const parsed = JSON.parse(stdout);
+  assert.equal(parsed.agentId, 'me');
+  assert.equal(parsed.host, 'h.example');
+  assert.equal(parsed.mention, '@me@h.example');
+  assert.equal(parsed.acct, 'acct:me@h.example');
+  assert.equal(parsed.a2aEndpoint, 'https://h.example/agents/me');
+  assert.equal(
+    parsed.a2aCardUrl,
+    'https://h.example/agents/me/.well-known/agent-card.json',
+  );
+});
+
+test('whoami exits 1 with usage when agentId / server are missing', async () => {
+  const prev = { agent: process.env.AGENT_ID, server: process.env.SERVER_URL };
+  delete process.env.AGENT_ID;
+  delete process.env.SERVER_URL;
+  try {
+    const { result, stderr } = await captureIO(() => runWhoami([]));
+    assert.equal(result, 1);
+    assert.match(stderr, /missing required/);
+  } finally {
+    if (prev.agent !== undefined) process.env.AGENT_ID = prev.agent;
+    if (prev.server !== undefined) process.env.SERVER_URL = prev.server;
+  }
+});
+
+test('whoami warns and exits 2 when agentId is not a Mentionable local', async () => {
+  const { result, stderr } = await captureIO(() =>
+    runWhoami([
+      '--agentId',
+      'bad/agent',
+      '--server',
+      'wss://h.example/ws',
+    ]),
+  );
+  assert.equal(result, 2);
+  assert.match(stderr, /not a valid Mentionable local-part/);
+});

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -25,6 +25,23 @@ interface ParsedArgs {
   help: boolean;
 }
 
+// Output sinks are injectable so tests don't have to mutate global
+// process.stdout/stderr — overriding `process.stdout.write` collides with
+// node:test's TAP emitter and silently drops most test events.
+export interface WhoamiIO {
+  stdout: (s: string) => void;
+  stderr: (s: string) => void;
+}
+
+const defaultIO: WhoamiIO = {
+  stdout: (s) => {
+    process.stdout.write(s);
+  },
+  stderr: (s) => {
+    process.stderr.write(s);
+  },
+};
+
 // Default timeout for `--verify`. Long enough to ride out a slow handshake
 // against a sleeping fly machine but short enough to give a clear failure
 // instead of hanging an operator's terminal indefinitely.
@@ -114,8 +131,11 @@ async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
       return { ok: false, status: res.status, error: 'response missing subject', aliases };
     }
     // RFC 7033 §4.4 requires `subject` to identify the resource the response
-    // describes. WebFinger's acct case-folding is host-only, so compare the
-    // local part case-sensitively and the host case-insensitively.
+    // describes. The bridge's WebFinger lookup is case-insensitive on
+    // scheme + local + domain (see `packages/server/src/well-known.test.ts`
+    // "matches case-insensitively on scheme + domain + local"), so we
+    // compare case-insensitively here to align — a subject that round-trips
+    // through the server may come back with different casing than we sent.
     if (subject.toLowerCase() !== expectedSubject.toLowerCase()) {
       return {
         ok: false,
@@ -133,27 +153,25 @@ async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
   }
 }
 
-function printText(r: WhoamiResult): void {
+function printText(r: WhoamiResult, io: WhoamiIO): void {
   const pad = (k: string) => k.padEnd(12);
-  process.stdout.write(`${pad('agentId:')}${r.agentId}\n`);
-  process.stdout.write(`${pad('host:')}${r.host}\n`);
-  process.stdout.write(`${pad('mention:')}${r.mention}\n`);
-  process.stdout.write(`${pad('acct:')}${r.acct}\n`);
-  process.stdout.write(`${pad('a2a:')}${r.a2aEndpoint}\n`);
-  process.stdout.write(`${pad('a2a card:')}${r.a2aCardUrl}\n`);
-  process.stdout.write(`${pad('webfinger:')}${r.webfingerUrl}\n`);
+  io.stdout(`${pad('agentId:')}${r.agentId}\n`);
+  io.stdout(`${pad('host:')}${r.host}\n`);
+  io.stdout(`${pad('mention:')}${r.mention}\n`);
+  io.stdout(`${pad('acct:')}${r.acct}\n`);
+  io.stdout(`${pad('a2a:')}${r.a2aEndpoint}\n`);
+  io.stdout(`${pad('a2a card:')}${r.a2aCardUrl}\n`);
+  io.stdout(`${pad('webfinger:')}${r.webfingerUrl}\n`);
   if (r.verify) {
-    process.stdout.write('\n');
+    io.stdout('\n');
     if (r.verify.ok) {
-      process.stdout.write(`webfinger ok (subject=${r.verify.subject ?? '?'})\n`);
+      io.stdout(`webfinger ok (subject=${r.verify.subject ?? '?'})\n`);
       for (const a of r.verify.aliases ?? []) {
-        process.stdout.write(`  alias: ${a}\n`);
+        io.stdout(`  alias: ${a}\n`);
       }
     } else {
-      process.stdout.write(
-        `webfinger FAILED: ${r.verify.error ?? 'unknown error'}\n`,
-      );
-      process.stdout.write(
+      io.stdout(`webfinger FAILED: ${r.verify.error ?? 'unknown error'}\n`);
+      io.stdout(
         '  (the bridge may not have this agentId connected, or its PUBLIC_URL host differs from --server host)\n',
       );
     }
@@ -173,21 +191,21 @@ function buildResult(id: AgentIdentity): WhoamiResult {
   };
 }
 
-export async function runWhoami(argv: string[]): Promise<number> {
+export async function runWhoami(argv: string[], io: WhoamiIO = defaultIO): Promise<number> {
   const parsed = parseArgs(argv);
   if ('error' in parsed) {
-    process.stderr.write(`${parsed.error}\n${USAGE}\n`);
+    io.stderr(`${parsed.error}\n${USAGE}\n`);
     return 1;
   }
   if (parsed.help) {
-    process.stdout.write(`${USAGE}\n`);
+    io.stdout(`${USAGE}\n`);
     return 0;
   }
 
   const agentId = parsed.agentId ?? process.env.AGENT_ID;
   const server = parsed.server ?? process.env.SERVER_URL;
   if (!agentId || !server) {
-    process.stderr.write(
+    io.stderr(
       `missing required: ${[!agentId && 'agentId', !server && 'server'].filter(Boolean).join(', ')}\n${USAGE}\n`,
     );
     return 1;
@@ -196,11 +214,11 @@ export async function runWhoami(argv: string[]): Promise<number> {
   const host = hostFromServerUrl(server);
   const httpOrigin = httpOriginFromServerUrl(server);
   if (!host || !httpOrigin) {
-    process.stderr.write(`could not derive host from --server: ${server}\n`);
+    io.stderr(`could not derive host from --server: ${server}\n`);
     return 1;
   }
   if (!isValidMentionableLocal(agentId)) {
-    process.stderr.write(
+    io.stderr(
       `agentId "${agentId}" is not a valid Mentionable local-part (must match [A-Za-z0-9._-]{1,64} and not be . or ..). ` +
         'WebFinger lookup will not resolve.\n',
     );
@@ -210,9 +228,9 @@ export async function runWhoami(argv: string[]): Promise<number> {
     // a parseable (if non-resolving) URL.
     const result = buildResult({ agentId, host, httpOrigin });
     if (parsed.json) {
-      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      io.stdout(`${JSON.stringify(result, null, 2)}\n`);
     } else {
-      printText(result);
+      printText(result, io);
     }
     return 2;
   }
@@ -220,7 +238,7 @@ export async function runWhoami(argv: string[]): Promise<number> {
   const id = deriveIdentity(agentId, server);
   if (!id) {
     // Should not be reachable given the explicit checks above; defensive.
-    process.stderr.write('could not derive agent identity\n');
+    io.stderr('could not derive agent identity\n');
     return 1;
   }
   const result = buildResult(id);
@@ -228,9 +246,9 @@ export async function runWhoami(argv: string[]): Promise<number> {
     result.verify = await verifyWebfinger(id);
   }
   if (parsed.json) {
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    io.stdout(`${JSON.stringify(result, null, 2)}\n`);
   } else {
-    printText(result);
+    printText(result, io);
   }
   return result.verify && !result.verify.ok ? 3 : 0;
 }

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -1,0 +1,202 @@
+// `vicoop-client whoami` — print the agent's own A2A identity
+// (mention / acct / WebFinger URL) so operators can confirm what string
+// to paste into other agents' allowed-callers or into their backend's
+// persona/system prompt, and optionally verify the bridge actually
+// resolves it via WebFinger.
+
+import {
+  a2aCardUrl,
+  a2aEndpoint,
+  deriveIdentity,
+  formatAcct,
+  formatMention,
+  hostFromServerUrl,
+  isValidMentionableLocal,
+  webfingerUrl,
+  type AgentIdentity,
+} from './identity.js';
+
+interface ParsedArgs {
+  agentId?: string;
+  server?: string;
+  json: boolean;
+  verify: boolean;
+  help: boolean;
+}
+
+const USAGE =
+  'usage: vicoop-client whoami [--agentId <id>] [--server <ws://...>] [--json] [--verify]\n' +
+  '  agentId / server fall back to AGENT_ID / SERVER_URL env vars.';
+
+function parseArgs(args: string[]): ParsedArgs | { error: string } {
+  const out: ParsedArgs = { json: false, verify: false, help: false };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--json') {
+      out.json = true;
+      continue;
+    }
+    if (a === '--verify') {
+      out.verify = true;
+      continue;
+    }
+    if (a === '-h' || a === '--help') {
+      out.help = true;
+      continue;
+    }
+    if (a === '--agentId' || a === '--server') {
+      const v = args[i + 1];
+      if (v === undefined) return { error: `${a} requires a value` };
+      if (a === '--agentId') out.agentId = v;
+      else out.server = v;
+      i++;
+      continue;
+    }
+    return { error: `unknown argument: ${a}` };
+  }
+  return out;
+}
+
+interface WhoamiResult {
+  agentId: string;
+  host: string;
+  mention: string;
+  acct: string;
+  a2aEndpoint: string;
+  a2aCardUrl: string;
+  webfingerUrl: string;
+  verify?: VerifyResult;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+  subject?: string;
+  aliases?: string[];
+}
+
+// Calls WebFinger and reports whether the bridge resolves this acct. A miss
+// here usually means the bridge isn't connected to a client agent with this
+// agentId, or the bridge's PUBLIC_URL host differs from the WS host the
+// client is connecting on.
+async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
+  const url = webfingerUrl(id);
+  try {
+    const res = await fetch(url, { headers: { Accept: 'application/jrd+json' } });
+    if (!res.ok) {
+      return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+    }
+    const body = (await res.json()) as { subject?: unknown; aliases?: unknown };
+    const subject = typeof body.subject === 'string' ? body.subject : undefined;
+    const aliases = Array.isArray(body.aliases)
+      ? body.aliases.filter((x): x is string => typeof x === 'string')
+      : undefined;
+    return { ok: true, status: res.status, subject, aliases };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function printText(r: WhoamiResult): void {
+  const pad = (k: string) => k.padEnd(12);
+  process.stdout.write(`${pad('agentId:')}${r.agentId}\n`);
+  process.stdout.write(`${pad('host:')}${r.host}\n`);
+  process.stdout.write(`${pad('mention:')}${r.mention}\n`);
+  process.stdout.write(`${pad('acct:')}${r.acct}\n`);
+  process.stdout.write(`${pad('a2a:')}${r.a2aEndpoint}\n`);
+  process.stdout.write(`${pad('a2a card:')}${r.a2aCardUrl}\n`);
+  process.stdout.write(`${pad('webfinger:')}${r.webfingerUrl}\n`);
+  if (r.verify) {
+    process.stdout.write('\n');
+    if (r.verify.ok) {
+      process.stdout.write(`webfinger ok (subject=${r.verify.subject ?? '?'})\n`);
+      for (const a of r.verify.aliases ?? []) {
+        process.stdout.write(`  alias: ${a}\n`);
+      }
+    } else {
+      process.stdout.write(
+        `webfinger FAILED: ${r.verify.error ?? 'unknown error'}\n`,
+      );
+      process.stdout.write(
+        '  (the bridge may not have this agentId connected, or its PUBLIC_URL host differs from --server host)\n',
+      );
+    }
+  }
+}
+
+export async function runWhoami(argv: string[]): Promise<number> {
+  const parsed = parseArgs(argv);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${USAGE}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${USAGE}\n`);
+    return 0;
+  }
+
+  const agentId = parsed.agentId ?? process.env.AGENT_ID;
+  const server = parsed.server ?? process.env.SERVER_URL;
+  if (!agentId || !server) {
+    process.stderr.write(
+      `missing required: ${[!agentId && 'agentId', !server && 'server'].filter(Boolean).join(', ')}\n${USAGE}\n`,
+    );
+    return 1;
+  }
+
+  const host = hostFromServerUrl(server);
+  if (!host) {
+    process.stderr.write(`could not derive host from --server: ${server}\n`);
+    return 1;
+  }
+  if (!isValidMentionableLocal(agentId)) {
+    process.stderr.write(
+      `agentId "${agentId}" is not a valid Mentionable local-part (must match [A-Za-z0-9._-]{1,64} and not be . or ..). ` +
+        'WebFinger lookup will not resolve.\n',
+    );
+    // Continue printing so operators see what they have configured — but flag
+    // it via a non-zero exit so scripts can branch on validity.
+    const id: AgentIdentity = { agentId, host };
+    const result: WhoamiResult = {
+      agentId,
+      host,
+      mention: formatMention(id),
+      acct: formatAcct(id),
+      a2aEndpoint: a2aEndpoint(id),
+      a2aCardUrl: a2aCardUrl(id),
+      webfingerUrl: webfingerUrl(id),
+    };
+    if (parsed.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      printText(result);
+    }
+    return 2;
+  }
+
+  const id = deriveIdentity(agentId, server);
+  if (!id) {
+    // Should not be reachable given the explicit checks above; defensive.
+    process.stderr.write('could not derive agent identity\n');
+    return 1;
+  }
+  const result: WhoamiResult = {
+    agentId: id.agentId,
+    host: id.host,
+    mention: formatMention(id),
+    acct: formatAcct(id),
+    a2aEndpoint: a2aEndpoint(id),
+    a2aCardUrl: a2aCardUrl(id),
+    webfingerUrl: webfingerUrl(id),
+  };
+  if (parsed.verify) {
+    result.verify = await verifyWebfinger(id);
+  }
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    printText(result);
+  }
+  return result.verify && !result.verify.ok ? 3 : 0;
+}

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -11,6 +11,7 @@ import {
   formatAcct,
   formatMention,
   hostFromServerUrl,
+  httpOriginFromServerUrl,
   isValidMentionableLocal,
   webfingerUrl,
   type AgentIdentity,
@@ -23,6 +24,11 @@ interface ParsedArgs {
   verify: boolean;
   help: boolean;
 }
+
+// Default timeout for `--verify`. Long enough to ride out a slow handshake
+// against a sleeping fly machine but short enough to give a clear failure
+// instead of hanging an operator's terminal indefinitely.
+const VERIFY_TIMEOUT_MS = 10_000;
 
 const USAGE =
   'usage: vicoop-client whoami [--agentId <id>] [--server <ws://...>] [--json] [--verify]\n' +
@@ -60,6 +66,7 @@ function parseArgs(args: string[]): ParsedArgs | { error: string } {
 interface WhoamiResult {
   agentId: string;
   host: string;
+  httpOrigin: string;
   mention: string;
   acct: string;
   a2aEndpoint: string;
@@ -76,14 +83,25 @@ interface VerifyResult {
   aliases?: string[];
 }
 
-// Calls WebFinger and reports whether the bridge resolves this acct. A miss
-// here usually means the bridge isn't connected to a client agent with this
-// agentId, or the bridge's PUBLIC_URL host differs from the WS host the
-// client is connecting on.
+// Calls WebFinger and reports whether the bridge actually resolves this
+// agent. A miss usually means the bridge isn't connected to a client agent
+// with this agentId, or its PUBLIC_URL host differs from the WS host being
+// used here. We treat the lookup as failed unless the JRD's `subject` matches
+// the requested acct — a generic 200 with an unrelated subject would
+// otherwise look like a successful resolution.
 async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
   const url = webfingerUrl(id);
+  const expectedSubject = formatAcct(id);
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(new Error(`timeout after ${VERIFY_TIMEOUT_MS}ms`)),
+    VERIFY_TIMEOUT_MS,
+  );
   try {
-    const res = await fetch(url, { headers: { Accept: 'application/jrd+json' } });
+    const res = await fetch(url, {
+      headers: { Accept: 'application/jrd+json' },
+      signal: controller.signal,
+    });
     if (!res.ok) {
       return { ok: false, status: res.status, error: `HTTP ${res.status}` };
     }
@@ -92,9 +110,26 @@ async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
     const aliases = Array.isArray(body.aliases)
       ? body.aliases.filter((x): x is string => typeof x === 'string')
       : undefined;
+    if (!subject) {
+      return { ok: false, status: res.status, error: 'response missing subject', aliases };
+    }
+    // RFC 7033 §4.4 requires `subject` to identify the resource the response
+    // describes. WebFinger's acct case-folding is host-only, so compare the
+    // local part case-sensitively and the host case-insensitively.
+    if (subject.toLowerCase() !== expectedSubject.toLowerCase()) {
+      return {
+        ok: false,
+        status: res.status,
+        error: `subject mismatch: expected "${expectedSubject}", got "${subject}"`,
+        subject,
+        aliases,
+      };
+    }
     return { ok: true, status: res.status, subject, aliases };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -125,6 +160,19 @@ function printText(r: WhoamiResult): void {
   }
 }
 
+function buildResult(id: AgentIdentity): WhoamiResult {
+  return {
+    agentId: id.agentId,
+    host: id.host,
+    httpOrigin: id.httpOrigin,
+    mention: formatMention(id),
+    acct: formatAcct(id),
+    a2aEndpoint: a2aEndpoint(id),
+    a2aCardUrl: a2aCardUrl(id),
+    webfingerUrl: webfingerUrl(id),
+  };
+}
+
 export async function runWhoami(argv: string[]): Promise<number> {
   const parsed = parseArgs(argv);
   if ('error' in parsed) {
@@ -146,7 +194,8 @@ export async function runWhoami(argv: string[]): Promise<number> {
   }
 
   const host = hostFromServerUrl(server);
-  if (!host) {
+  const httpOrigin = httpOriginFromServerUrl(server);
+  if (!host || !httpOrigin) {
     process.stderr.write(`could not derive host from --server: ${server}\n`);
     return 1;
   }
@@ -156,17 +205,10 @@ export async function runWhoami(argv: string[]): Promise<number> {
         'WebFinger lookup will not resolve.\n',
     );
     // Continue printing so operators see what they have configured — but flag
-    // it via a non-zero exit so scripts can branch on validity.
-    const id: AgentIdentity = { agentId, host };
-    const result: WhoamiResult = {
-      agentId,
-      host,
-      mention: formatMention(id),
-      acct: formatAcct(id),
-      a2aEndpoint: a2aEndpoint(id),
-      a2aCardUrl: a2aCardUrl(id),
-      webfingerUrl: webfingerUrl(id),
-    };
+    // it via a non-zero exit so scripts can branch on validity. URL helpers
+    // %-encode `agentId` defensively, so an out-of-charset id still yields
+    // a parseable (if non-resolving) URL.
+    const result = buildResult({ agentId, host, httpOrigin });
     if (parsed.json) {
       process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     } else {
@@ -181,15 +223,7 @@ export async function runWhoami(argv: string[]): Promise<number> {
     process.stderr.write('could not derive agent identity\n');
     return 1;
   }
-  const result: WhoamiResult = {
-    agentId: id.agentId,
-    host: id.host,
-    mention: formatMention(id),
-    acct: formatAcct(id),
-    a2aEndpoint: a2aEndpoint(id),
-    a2aCardUrl: a2aCardUrl(id),
-    webfingerUrl: webfingerUrl(id),
-  };
+  const result = buildResult(id);
   if (parsed.verify) {
     result.verify = await verifyWebfinger(id);
   }

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -120,7 +120,22 @@ async function verifyWebfinger(id: AgentIdentity): Promise<VerifyResult> {
       signal: controller.signal,
     });
     if (!res.ok) {
-      return { ok: false, status: res.status, error: `HTTP ${res.status}` };
+      // The bridge's well-known routes return `{ error: <reason> }` on 4xx
+      // (see `packages/server/src/well-known.ts` — e.g. "webfinger not
+      // available (PUBLIC_URL must be HTTPS with a multi-label hostname)").
+      // Surface that reason so operators know whether the agent isn't
+      // connected, PUBLIC_URL differs, or Mentionable is disabled entirely.
+      let detail = `HTTP ${res.status}`;
+      try {
+        const body = (await res.json()) as { error?: unknown };
+        if (typeof body.error === 'string' && body.error.length > 0) {
+          detail = `HTTP ${res.status}: ${body.error}`;
+        }
+      } catch {
+        // Non-JSON body — keep the bare status. Don't fail verify just
+        // because the error response wasn't shaped as we expected.
+      }
+      return { ok: false, status: res.status, error: detail };
     }
     const body = (await res.json()) as { subject?: unknown; aliases?: unknown };
     const subject = typeof body.subject === 'string' ? body.subject : undefined;


### PR DESCRIPTION
## Summary

Addresses the root cause surfaced in #128: when the Claude backend spawned by `vicoop-client` was asked something whose body contained its **own** canonical mention (`@<agentId>@<host>`), it didn't recognise the self-reference and tried to a2a-call the address through the `a2a-wallet` skill — which then got a 403 because the agent's own wallet wasn't in its own `allowed_callers`. That misleading 403 ended up in the local Claude transcript and got mixed up with a separate, legitimately completed task in #128's debugging session.

This PR injects identity into the spawned `claude` process so the model knows what its own address is.

- **Claude backend**: every spawned `claude` now gets `--append-system-prompt "You are an A2A agent reachable as @<agentId>@<host> (acct:...). If a user message references this mention or acct, treat it as a self-reference …"`. The identity is derived from `AGENT_ID` and the host part of `SERVER_URL`; no extra config required.
- **OpenClaw backend**: no in-band injection — `chat.send` has no per-message system field; OpenClaw's persona is configured server-side via `openclaw config set …`. Operators paste self-identity into their persona using the new `whoami` subcommand (documented in `docs/install-client.md`).
- **`vicoop-client whoami` subcommand**: prints `agentId`, `host`, `mention`, `acct`, `a2a` (endpoint), `a2a card` (agent-card URL), and `webfinger` URL. `--json` for scripts, `--verify` to actually hit WebFinger and confirm the bridge resolves the agent (useful when bridge PUBLIC_URL differs from the WS host).

Does **not** address part (B) of #128 (observability — accept-path `principalId`, rejection ids). That's a separate follow-up.

## Test plan

- [x] `pnpm -r typecheck` — all packages clean
- [x] `pnpm -r build` — all packages build
- [x] `node --import tsx --test packages/client/src/identity.test.ts packages/client/src/whoami.test.ts packages/client/src/backends/claude.test.ts` — 53/53 pass (3 new claude backend cases asserting the identity arg flow, 9 identity helpers, 4 whoami)
- [ ] Manual: run `vicoop-client whoami` against a connected agent, confirm output matches the connected bridge's WebFinger
- [ ] Manual: from a different Claude Code session, send `@<agentId>@<host> 안녕` to a `claude`-backed agent and confirm the backend now answers directly instead of trying to a2a-call itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)