### PR TITLE
feat(server): correlate caller ↔ accept/reject logs (#128 part B)

### DIFF
--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -5,7 +5,7 @@ import { SiweMessage } from 'siwe';
 import { Wallet } from 'ethers';
 import type { WebSocket } from 'ws';
 import type { AgentCard } from '@vicoop-bridge/protocol';
-import { agentAuthMiddleware, sanitizeErrorDescription } from './agent-auth.js';
+import { agentAuthMiddleware, newRejectionId, sanitizeErrorDescription } from './agent-auth.js';
 import { _resetSiweBearerCacheForTests } from './auth/siwe-bearer.js';
 import { Registry, type ClientConnection } from './registry.js';
 import type { Sql } from './db.js';
@@ -213,4 +213,89 @@ test('sanitizeErrorDescription caps output at 200 chars regardless of input leng
   const out = sanitizeErrorDescription(long);
   assert.equal(out.length, 200);
   assert.equal(out, 'a'.repeat(200));
+});
+
+// Rejection-id observability — issue #128 (B). Each reject branch stamps a
+// short opaque id into both the structured log (asserted indirectly here via
+// the body) and the JSON-RPC error body's `data.rejectionId`, so a caller
+// transcript line can be grepped 1:1 against the bridge log.
+
+const REJECTION_ID_RE = /^rej_[0-9a-f]{8}$/;
+
+test('newRejectionId returns a short opaque rej_-prefixed id', () => {
+  const id = newRejectionId();
+  assert.match(id, REJECTION_ID_RE);
+  // Two consecutive calls must not collide — 32 bits is enough that a flake
+  // is vanishingly unlikely, and this catches obvious mistakes (constant id,
+  // empty suffix) immediately.
+  assert.notEqual(id, newRejectionId());
+});
+
+test('agent_not_connected (404) body carries rejectionId in error.data', async () => {
+  const { app } = buildApp();
+
+  const res = await app.request('/agents/missing', { method: 'POST' });
+  assert.equal(res.status, 404);
+  const body = (await res.json()) as {
+    error: { code: number; data?: { rejectionId?: string } };
+  };
+  assert.equal(body.error.code, -32000);
+  assert.match(body.error.data?.rejectionId ?? '', REJECTION_ID_RE);
+});
+
+test('missing_bearer (401) body carries rejectionId in error.data', async () => {
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', { method: 'POST' });
+  assert.equal(res.status, 401);
+  const body = (await res.json()) as { error: { data?: { rejectionId?: string } } };
+  assert.match(body.error.data?.rejectionId ?? '', REJECTION_ID_RE);
+});
+
+test('bad_token_prefix (401) body carries rejectionId in error.data', async () => {
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer not-a-known-prefix-xyz' },
+  });
+  assert.equal(res.status, 401);
+  const body = (await res.json()) as { error: { data?: { rejectionId?: string } } };
+  assert.match(body.error.data?.rejectionId ?? '', REJECTION_ID_RE);
+});
+
+test('caller_not_authorized (403) body carries rejectionId in error.data', async () => {
+  _resetSiweBearerCacheForTests();
+  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
+  registerAgent(registry, 'restricted', [
+    'eth:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  ]);
+  const bearer = await mintBearer({
+    domain: 'bridge.example',
+    uri: 'https://bridge.example',
+  });
+
+  const res = await app.request('/agents/restricted', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${bearer}` },
+  });
+  assert.equal(res.status, 403);
+  const body = (await res.json()) as { error: { data?: { rejectionId?: string } } };
+  assert.match(body.error.data?.rejectionId ?? '', REJECTION_ID_RE);
+});
+
+test('each rejection gets its own id (no shared / cached id across requests)', async () => {
+  // Two independent rejections in the same process must produce different
+  // ids — guards against accidentally hoisting the id to module scope or
+  // reusing a per-middleware-instance constant.
+  const { app, registry } = buildApp();
+  registerAgent(registry, 'restricted', ['eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+
+  const res1 = await app.request('/agents/restricted', { method: 'POST' });
+  const res2 = await app.request('/agents/restricted', { method: 'POST' });
+  const body1 = (await res1.json()) as { error: { data: { rejectionId: string } } };
+  const body2 = (await res2.json()) as { error: { data: { rejectionId: string } } };
+  assert.notEqual(body1.error.data.rejectionId, body2.error.data.rejectionId);
 });

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -20,6 +20,42 @@ export function getCaller(c: Context): VerifiedCaller | undefined {
 
 const WWW_AUTH_REALM = 'vicoop-bridge';
 
+// Short opaque correlation id stamped into both the structured rejection log
+// and the JSON-RPC error body's `data` field so a caller transcript line
+// like "Caller not authorized for this agent (rejectionId=rej_a1b2c3d4)" can
+// be grepped 1:1 against the bridge's `agent_request_rejected` log. 32 bits
+// of randomness is short enough to be useful in transcripts and large enough
+// that nearby-in-time collisions are vanishingly unlikely.
+//
+// Exported for unit tests.
+export function newRejectionId(): string {
+  return `rej_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
+}
+
+interface RejectionBody {
+  rejectionId: string;
+}
+
+function rejectionErrorBody(
+  code: number,
+  message: string,
+  rejectionId: string,
+): {
+  jsonrpc: '2.0';
+  id: null;
+  error: { code: number; message: string; data: RejectionBody };
+} {
+  return {
+    jsonrpc: '2.0',
+    id: null,
+    error: {
+      code,
+      message,
+      data: { rejectionId },
+    },
+  };
+}
+
 // Cap the error_description so a long upstream err.message can't push the
 // WWW-Authenticate header past common proxy/server limits (often ~8KB total).
 const ERROR_DESCRIPTION_MAX_LEN = 200;
@@ -99,12 +135,13 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
     if (!conn) {
-      logEvent('agent_request_rejected', { agentId, reason: 'agent_not_connected' });
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32000, message: 'Agent not connected' },
-      }, 404);
+      const rejectionId = newRejectionId();
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'agent_not_connected',
+        rejectionId,
+      });
+      return c.json(rejectionErrorBody(-32000, 'Agent not connected', rejectionId), 404);
     }
 
     c.set('agentConn', conn);
@@ -116,18 +153,16 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const authHeader = c.req.header('Authorization');
     const bearerToken = authHeader?.match(/^Bearer\s+(.+)$/i)?.[1] ?? null;
     if (!bearerToken) {
-      logEvent('agent_request_rejected', { agentId, reason: 'missing_bearer' });
+      const rejectionId = newRejectionId();
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'missing_bearer',
+        rejectionId,
+      });
       // Per RFC 6750 §3.1, no error code when the request lacks any
       // authentication information — only the challenge realm.
       setWWWAuthenticate(c);
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: {
-          code: -32001,
-          message: missingBearerMessage,
-        },
-      }, 401);
+      return c.json(rejectionErrorBody(-32001, missingBearerMessage, rejectionId), 401);
     }
 
     let caller: VerifiedCaller;
@@ -135,9 +170,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       try {
         caller = await verifyCallerToken(opts.sql, bearerToken);
       } catch (err) {
+        const rejectionId = newRejectionId();
         logEvent('agent_request_rejected', {
           agentId,
           reason: 'invalid_token',
+          rejectionId,
           detail: truncate((err as Error).message, 256),
         });
         // Don't surface raw err.message in either WWW-Authenticate (commonly
@@ -149,11 +186,14 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           error: 'invalid_token',
           description: 'invalid bearer token',
         });
-        return c.json({
-          jsonrpc: '2.0',
-          id: null,
-          error: { code: -32001, message: `Invalid bearer token. Acquire one via ${acquisitionHint}.` },
-        }, 401);
+        return c.json(
+          rejectionErrorBody(
+            -32001,
+            `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
+            rejectionId,
+          ),
+          401,
+        );
       }
     } else if (bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
       // Owner-session tokens are for self-service surfaces (admin agent /
@@ -162,19 +202,24 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       // this, the SIWE-bearer branch below would try to decode the opaque
       // owner-session token as base64url JSON and fail with the misleading
       // "SIWE bearer token is not valid JSON".
-      logEvent('agent_request_rejected', { agentId, reason: 'owner_session_on_caller_route' });
+      const rejectionId = newRejectionId();
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'owner_session_on_caller_route',
+        rejectionId,
+      });
       setWWWAuthenticate(c, {
         error: 'invalid_token',
         description: `${OWNER_SESSION_PREFIX}* tokens are not accepted on /agents/:id`,
       });
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: {
-          code: -32001,
-          message: `Invalid bearer token: ${OWNER_SESSION_PREFIX}* (owner-session) tokens are not accepted on /agents/:id. Acquire one via ${acquisitionHint}.`,
-        },
-      }, 401);
+      return c.json(
+        rejectionErrorBody(
+          -32001,
+          `Invalid bearer token: ${OWNER_SESSION_PREFIX}* (owner-session) tokens are not accepted on /agents/:id. Acquire one via ${acquisitionHint}.`,
+          rejectionId,
+        ),
+        401,
+      );
     } else if (opts.siweDomain) {
       // Stateless SIWE bearer per siwe-bearer-auth/v0.1. No callers row is
       // created — revocation is at the principal level (remove from
@@ -183,9 +228,11 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         const verified = await verifySiweBearerToken(bearerToken, { domain: opts.siweDomain });
         caller = { principalId: `eth:${verified.address}` };
       } catch (err) {
+        const rejectionId = newRejectionId();
         logEvent('agent_request_rejected', {
           agentId,
           reason: 'invalid_siwe_bearer',
+          rejectionId,
           detail: truncate((err as Error).message, 256),
         });
         // Stable public strings in both the header and the JSON body —
@@ -197,47 +244,53 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           error: 'invalid_token',
           description: 'invalid SIWE bearer',
         });
-        return c.json({
-          jsonrpc: '2.0',
-          id: null,
-          error: {
-            code: -32001,
-            message: `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
-          },
-        }, 401);
+        return c.json(
+          rejectionErrorBody(
+            -32001,
+            `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
+            rejectionId,
+          ),
+          401,
+        );
       }
     } else {
-      logEvent('agent_request_rejected', { agentId, reason: 'bad_token_prefix' });
+      const rejectionId = newRejectionId();
+      logEvent('agent_request_rejected', {
+        agentId,
+        reason: 'bad_token_prefix',
+        rejectionId,
+      });
       setWWWAuthenticate(c, {
         error: 'invalid_token',
         description: `expected ${CALLER_TOKEN_PREFIX}* prefix`,
       });
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: {
-          code: -32001,
-          message: `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
-        },
-      }, 401);
+      return c.json(
+        rejectionErrorBody(
+          -32001,
+          `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
+          rejectionId,
+        ),
+        401,
+      );
     }
 
     const allowed = conn.allowedCallers.some((entry) => matchPrincipal(entry, caller));
     if (!allowed) {
+      const rejectionId = newRejectionId();
       logEvent('agent_request_rejected', {
         agentId,
         reason: 'caller_not_authorized',
+        rejectionId,
         principalId: caller.principalId,
       });
       setWWWAuthenticate(c, {
         error: 'insufficient_scope',
         description: 'caller not in allowed list',
       });
-      return c.json({
-        jsonrpc: '2.0',
-        id: null,
-        error: { code: -32001, message: 'Caller not authorized for this agent' },
-      }, 403);
+      return c.json(
+        rejectionErrorBody(-32001, 'Caller not authorized for this agent', rejectionId),
+        403,
+      );
     }
 
     c.set('caller', caller);

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -1,0 +1,236 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { WebSocket } from 'ws';
+import { TaskState, type Message, type Task, type TaskStore } from '@a2x/sdk';
+import { parseDownFrame, type AgentCard } from '@vicoop-bridge/protocol';
+import { Registry, type ClientConnection } from './registry.js';
+import { WSForwardingExecutor, stripInternalMetadata } from './executor.js';
+
+// Issue #128 (B): the /agents/:id route stashes the verified caller's
+// principalId on `message.metadata._principalId`. The executor must (1)
+// thread that into the task binding so accept-path logs in ws.ts include
+// it, and (2) strip the `_`-prefixed keys before the WS frame leaves the
+// bridge so the connected client never sees server-internal caller
+// identity over the wire.
+
+function makeAgentCard(): AgentCard {
+  return {
+    name: 't',
+    version: '0',
+    protocolVersion: '0.3.0',
+  };
+}
+
+function noopTaskStore(): TaskStore {
+  // The strip/binding behavior under test runs before any taskStore call,
+  // and the test pushes a terminal status so the executor's persistence
+  // path (taskStore.updateTask) only fires after assertions land — stubs
+  // are sufficient.
+  return {
+    save: async () => {},
+    load: async () => undefined,
+    updateTask: async () => {},
+  } as unknown as TaskStore;
+}
+
+function makeWsCapture(): { ws: WebSocket; sent: string[] } {
+  const sent: string[] = [];
+  const ws = {
+    close: () => undefined,
+    send: (data: string | Buffer) =>
+      sent.push(typeof data === 'string' ? data : data.toString('utf-8')),
+  } as unknown as WebSocket;
+  return { ws, sent };
+}
+
+test('stripInternalMetadata drops underscore-prefixed keys', () => {
+  assert.deepEqual(stripInternalMetadata({ _principalId: 'eth:0xabc', foo: 'bar' }), {
+    foo: 'bar',
+  });
+});
+
+test('stripInternalMetadata returns undefined when only `_*` keys present', () => {
+  // Important: undefined (not {}) so the executor can spread it conditionally
+  // and keep the WS frame's `metadata` field absent — matching the wire shape
+  // for messages that had no metadata in the first place.
+  assert.equal(stripInternalMetadata({ _principalId: 'eth:0xabc' }), undefined);
+});
+
+test('stripInternalMetadata returns undefined for undefined input', () => {
+  assert.equal(stripInternalMetadata(undefined), undefined);
+});
+
+test('stripInternalMetadata preserves a regular metadata object as-is', () => {
+  assert.deepEqual(stripInternalMetadata({ keepMe: 1, nested: { x: 2 } }), {
+    keepMe: 1,
+    nested: { x: 2 },
+  });
+});
+
+test('executor records principalId in binding and strips _principalId from outgoing WS frame', async () => {
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  const conn: ClientConnection = {
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  };
+  registry.registerAgent(conn);
+
+  const executor = new WSForwardingExecutor('a1', registry, noopTaskStore());
+  const task = {
+    id: 't-1',
+    contextId: 'ctx-1',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-1',
+    metadata: { _principalId: 'eth:0xabc', userField: 'keep' },
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  // Kick the generator so executeStream reaches the bindTask + sendToAgent
+  // calls (both run before the first `yield`).
+  const firstEvent = gen.next();
+
+  const binding = registry.getBinding('t-1');
+  assert.ok(binding, 'expected binding to be registered before first yield');
+  assert.equal(binding.principalId, 'eth:0xabc');
+  assert.equal(binding.agentId, 'a1');
+
+  // The WS frame must NOT carry server-internal `_*` keys — the connected
+  // client should only see caller-supplied metadata.
+  assert.equal(sent.length, 1, 'expected exactly one task.assign frame');
+  const frame = parseDownFrame(sent[0]!);
+  assert.equal(frame.type, 'task.assign');
+  if (frame.type === 'task.assign') {
+    const md = frame.message.metadata;
+    assert.ok(md, 'expected non-underscore metadata to survive');
+    assert.equal(
+      (md as Record<string, unknown>)._principalId,
+      undefined,
+      '_principalId must be stripped before the WS frame leaves the bridge',
+    );
+    assert.equal((md as Record<string, unknown>).userField, 'keep');
+  }
+
+  // Push a terminal status so the generator returns without hanging.
+  binding.sink.pushStatus({
+    taskId: 't-1',
+    contextId: 'ctx-1',
+    final: true,
+    status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+  });
+  binding.sink.finish();
+  await firstEvent;
+  for await (const _event of gen) void _event;
+});
+
+test('executor omits message.metadata entirely when the only entry was _principalId', async () => {
+  // Wire-compat guarantee: a message that had no caller-visible metadata
+  // before injection must look identical on the wire after stripping. A
+  // present-but-empty `metadata: {}` would surprise clients that rely on
+  // `metadata === undefined` as a "no metadata" sentinel.
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a2',
+    clientId: 'c2',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const executor = new WSForwardingExecutor('a2', registry, noopTaskStore());
+  const task = {
+    id: 't-2',
+    contextId: 'ctx-2',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-2',
+    metadata: { _principalId: 'eth:0xabc' },
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  const firstEvent = gen.next();
+
+  const frame = parseDownFrame(sent[0]!);
+  assert.equal(frame.type, 'task.assign');
+  if (frame.type === 'task.assign') {
+    assert.equal(frame.message.metadata, undefined);
+  }
+
+  const binding = registry.getBinding('t-2')!;
+  binding.sink.pushStatus({
+    taskId: 't-2',
+    contextId: 'ctx-2',
+    final: true,
+    status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+  });
+  binding.sink.finish();
+  await firstEvent;
+  for await (const _event of gen) void _event;
+});
+
+test('executor binding has no principalId when message metadata is absent', async () => {
+  // Public-agent path: no auth middleware, no _principalId injection. The
+  // binding's principalId stays undefined and downstream ws.ts log lines
+  // omit the field — confirms the additive change doesn't accidentally
+  // stamp a placeholder.
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a3',
+    clientId: 'c3',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const executor = new WSForwardingExecutor('a3', registry, noopTaskStore());
+  const task = {
+    id: 't-3',
+    contextId: 'ctx-3',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-3',
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  const firstEvent = gen.next();
+
+  const binding = registry.getBinding('t-3');
+  assert.ok(binding);
+  assert.equal(binding.principalId, undefined);
+
+  // Frame still goes out, metadata absent.
+  const frame = parseDownFrame(sent[0]!);
+  assert.equal(frame.type, 'task.assign');
+  if (frame.type === 'task.assign') {
+    assert.equal(frame.message.metadata, undefined);
+  }
+
+  binding.sink.pushStatus({
+    taskId: 't-3',
+    contextId: 'ctx-3',
+    final: true,
+    status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+  });
+  binding.sink.finish();
+  await firstEvent;
+  for await (const _event of gen) void _event;
+});

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -37,6 +37,28 @@ const NOOP_RUNNER = new InMemoryRunner({
 });
 
 /**
+ * Drop server-internal `_`-prefixed metadata keys (e.g. `_principalId`)
+ * before forwarding a message to the connected client. The convention is
+ * shared with the admin route — `_`-prefix means "bridge-internal context,
+ * not for downstream". Returns undefined when nothing meaningful survives so
+ * the WS frame omits the metadata field entirely (preserving the
+ * pre-existing wire shape for messages that had no metadata).
+ *
+ * Exported for unit tests.
+ */
+export function stripInternalMetadata(
+  metadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (metadata === undefined) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key.startsWith('_')) continue;
+    out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
  * AgentExecutor that forwards A2A requests to a WebSocket-connected
  * client and pipes the client's task.* frames back as A2A streaming
  * events.
@@ -88,7 +110,23 @@ export class WSForwardingExecutor extends AgentExecutor {
       finish: () => queue.end(),
     };
 
-    this.registry.bindTask({ agentId: this.agentId, taskId, contextId, sink });
+    // The /agents/:id route stashes server-internal context on
+    // `message.metadata` under `_`-prefixed keys (matching the admin route's
+    // `_principalId` / `_bearerToken` convention). `_principalId` flows into
+    // the binding so accept-path logs in ws.ts can correlate caller →
+    // completed task without exposing it to the client agent over the wire.
+    const rawMetadata = (message as { metadata?: Record<string, unknown> }).metadata;
+    const principalId =
+      typeof rawMetadata?._principalId === 'string' ? rawMetadata._principalId : undefined;
+    const forwardMetadata = stripInternalMetadata(rawMetadata);
+
+    this.registry.bindTask({
+      agentId: this.agentId,
+      taskId,
+      contextId,
+      sink,
+      ...(principalId !== undefined ? { principalId } : {}),
+    });
 
     const sent = this.registry.sendToAgent(this.agentId, {
       type: 'task.assign',
@@ -101,14 +139,19 @@ export class WSForwardingExecutor extends AgentExecutor {
         // the parts through as-is.
         parts: message.parts as never,
         messageId: message.messageId,
-        ...(message.metadata !== undefined ? { metadata: message.metadata } : {}),
+        ...(forwardMetadata !== undefined ? { metadata: forwardMetadata } : {}),
         ...(message.extensions !== undefined ? { extensions: message.extensions } : {}),
       },
       ...(message.extensions !== undefined ? { requestedExtensions: message.extensions } : {}),
     });
 
     if (!sent) {
-      logEvent('task_unreachable', { agentId: this.agentId, taskId, contextId });
+      logEvent('task_unreachable', {
+        agentId: this.agentId,
+        taskId,
+        contextId,
+        ...(principalId !== undefined ? { principalId } : {}),
+      });
       const failEvent: TaskStatusUpdateEvent = {
         taskId,
         contextId,

--- a/packages/server/src/http.test.ts
+++ b/packages/server/src/http.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { stripCallerSuppliedInternalKeys } from './http.js';
+
+// Boundary-scrub regression for issue #128 (B):
+//   A caller can put `_principalId` (or any other `_`-prefixed key) in the
+//   request body's `message.metadata`. Downstream — the executor's binding
+//   stamp + admin executor's auth resolve — treats `_*` keys as trusted
+//   bridge-internal context. Without scrubbing at the HTTP boundary the
+//   caller would spoof those fields. On public agents the auth middleware
+//   doesn't inject anything, so a spoofed `_principalId` would flow into
+//   `binding.principalId` and downstream `task_*` logs untouched.
+
+test('stripCallerSuppliedInternalKeys removes _-prefixed keys from message.metadata in place', () => {
+  const message: Record<string, unknown> = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm1',
+    metadata: {
+      _principalId: 'eth:victim',
+      _bearerToken: 'vbc_caller_stolen',
+      userField: 'keep',
+    },
+  };
+  stripCallerSuppliedInternalKeys(message);
+  assert.deepEqual(message.metadata, { userField: 'keep' });
+});
+
+test('stripCallerSuppliedInternalKeys deletes metadata entirely when only _-prefixed keys were present', () => {
+  // Wire-shape guarantee: a message whose only metadata was caller-supplied
+  // spoofs must look identical to a bare message on the wire — no
+  // surprise empty `metadata: {}` for clients that key off
+  // `metadata === undefined` as a "no metadata" sentinel.
+  const message: Record<string, unknown> = {
+    role: 'user',
+    parts: [],
+    messageId: 'm2',
+    metadata: { _principalId: 'eth:victim' },
+  };
+  stripCallerSuppliedInternalKeys(message);
+  assert.equal('metadata' in message, false);
+});
+
+test('stripCallerSuppliedInternalKeys is a no-op when metadata is absent', () => {
+  const message: Record<string, unknown> = {
+    role: 'user',
+    parts: [],
+    messageId: 'm3',
+  };
+  stripCallerSuppliedInternalKeys(message);
+  assert.equal('metadata' in message, false);
+});
+
+test('stripCallerSuppliedInternalKeys is a no-op when metadata has no _-prefixed keys', () => {
+  const message: Record<string, unknown> = {
+    role: 'user',
+    parts: [],
+    messageId: 'm4',
+    metadata: { foo: 'bar', nested: { _looksInternal: 'but is not top-level' } },
+  };
+  stripCallerSuppliedInternalKeys(message);
+  // Top-level only — nested `_looksInternal` is the caller's own data and
+  // must survive (the convention is about top-level keys downstream code
+  // reads, not arbitrary nested structure).
+  assert.deepEqual(message.metadata, {
+    foo: 'bar',
+    nested: { _looksInternal: 'but is not top-level' },
+  });
+});
+
+test('stripCallerSuppliedInternalKeys leaves non-record metadata untouched', () => {
+  // Defensive: caller might send `metadata: null` or `metadata: "junk"` —
+  // those aren't records, downstream code already handles them as absent,
+  // and the strip must not crash or coerce them.
+  const messageNull: Record<string, unknown> = {
+    role: 'user',
+    parts: [],
+    messageId: 'm5',
+    metadata: null,
+  };
+  stripCallerSuppliedInternalKeys(messageNull);
+  assert.equal(messageNull.metadata, null);
+
+  const messageStr: Record<string, unknown> = {
+    role: 'user',
+    parts: [],
+    messageId: 'm6',
+    metadata: 'not-an-object',
+  };
+  stripCallerSuppliedInternalKeys(messageStr);
+  assert.equal(messageStr.metadata, 'not-an-object');
+});

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -54,6 +54,35 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Drop caller-supplied `_`-prefixed keys from `message.metadata` in place at
+ * the HTTP boundary. The `_*` convention marks bridge-internal context
+ * (`_principalId`, `_bearerToken`, `_email`) that downstream code — the
+ * executor's binding stamp, the admin executor's auth resolve — treats as
+ * trusted. Without this strip, a caller could put `_principalId:
+ * eth:victim` in their request body and it would (on public agents, where
+ * the auth middleware doesn't inject one) flow through to the task binding
+ * and downstream `task_*` logs as if it had been verified.
+ *
+ * Mutates `message.metadata` so the existing downstream code (which reads
+ * `message.metadata` directly) sees the scrubbed object. Removes the
+ * metadata field entirely when only `_*` keys were present, so the WS frame
+ * keeps its pre-existing wire shape for messages that arrived bare.
+ *
+ * Exported for unit tests.
+ */
+export function stripCallerSuppliedInternalKeys(message: Record<string, unknown>): void {
+  if (!isRecord(message.metadata)) return;
+  for (const key of Object.keys(message.metadata)) {
+    if (key.startsWith('_')) {
+      delete (message.metadata as Record<string, unknown>)[key];
+    }
+  }
+  if (Object.keys(message.metadata).length === 0) {
+    delete message.metadata;
+  }
+}
+
 export function createHttpApp(opts: ServerHttpOptions): Hono {
   const app = new Hono();
 
@@ -500,6 +529,15 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
           : [];
         message.extensions = [...new Set([...existing, ...requestedExtensions])];
       }
+      // Drop any caller-supplied `_*` metadata BEFORE injecting the verified
+      // `_principalId`. Without this scrub, a public-agent caller (where
+      // `caller` is undefined and the injection block below is a no-op)
+      // could put `_principalId: eth:victim` in their request body and have
+      // it stamped into the binding + downstream `task_*` logs as if it had
+      // been verified. The strip runs unconditionally so it also covers the
+      // restricted-agent case for any future `_*` consumer beyond
+      // `_principalId`.
+      stripCallerSuppliedInternalKeys(message);
       // Stash caller identity under the `_principalId` convention so the
       // WSForwardingExecutor can thread it into the task binding for
       // accept-path log correlation (issue #128). Stripped before the WS

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -20,7 +20,7 @@ import {
   listCallers,
   removeCaller,
 } from './admin-api.js';
-import { agentAuthMiddleware, getAgentConn } from './agent-auth.js';
+import { agentAuthMiddleware, getAgentConn, getCaller } from './agent-auth.js';
 import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
 import { mountDeviceFlow } from './auth/device-flow.js';
 import { mountDeviceUi } from './auth/device-ui.js';
@@ -475,9 +475,15 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
+    // caller is undefined for public agents (allowedCallers.length === 0) —
+    // the middleware short-circuits before parsing the bearer in that case.
+    // For restricted agents it's always populated; otherwise the middleware
+    // would have returned 401/403 before reaching this handler.
+    const caller = getCaller(c);
     logEvent('agent_request', {
       agentId: conn.agentId,
       hasAuth: !!c.req.header('Authorization'),
+      ...(caller !== undefined ? { principalId: caller.principalId } : {}),
     });
 
     const rawBody = await c.req.text();
@@ -487,11 +493,23 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_LEGACY_HEADER)),
     ];
     const message = parsed.params?.message;
-    if (requestedExtensions.length > 0 && isRecord(message)) {
-      const existing = Array.isArray(message.extensions)
-        ? message.extensions.filter((v: unknown): v is string => typeof v === 'string')
-        : [];
-      message.extensions = [...new Set([...existing, ...requestedExtensions])];
+    if (isRecord(message)) {
+      if (requestedExtensions.length > 0) {
+        const existing = Array.isArray(message.extensions)
+          ? message.extensions.filter((v: unknown): v is string => typeof v === 'string')
+          : [];
+        message.extensions = [...new Set([...existing, ...requestedExtensions])];
+      }
+      // Stash caller identity under the `_principalId` convention so the
+      // WSForwardingExecutor can thread it into the task binding for
+      // accept-path log correlation (issue #128). Stripped before the WS
+      // frame leaves the bridge — the connected client never sees `_*` keys.
+      if (caller !== undefined) {
+        message.metadata = {
+          ...(isRecord(message.metadata) ? message.metadata : {}),
+          _principalId: caller.principalId,
+        };
+      }
     }
     const handler = getHandlerForConn(conn);
     const result = await handler.handle(parsed);

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -30,6 +30,11 @@ export interface TaskBinding {
   taskId: string;
   contextId: string;
   sink: TaskSink;
+  // principalId of the caller that originated this task (post-auth). Optional
+  // because the admin-route path (POST '/') binds tasks too and keeps caller
+  // identity in its own metadata; only the /agents/:id route currently
+  // threads it through the binding for accept-path log correlation.
+  principalId?: string;
 }
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -31,9 +31,10 @@ export interface TaskBinding {
   contextId: string;
   sink: TaskSink;
   // principalId of the caller that originated this task (post-auth). Optional
-  // because the admin-route path (POST '/') binds tasks too and keeps caller
-  // identity in its own metadata; only the /agents/:id route currently
-  // threads it through the binding for accept-path log correlation.
+  // because public agents (allowedCallers.length === 0) skip the auth
+  // middleware entirely, so there is no verified caller to record. The admin
+  // route does not create TaskBindings — it has its own executor
+  // (AdminA2XExecutor) that never calls registry.bindTask().
   principalId?: string;
 }
 

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -306,6 +306,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           agentId: b.agentId,
           taskId: frame.taskId,
           state: frame.status.state,
+          ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
         });
         break;
       }
@@ -335,6 +336,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           taskId: frame.taskId,
           errorCode: frame.error.code,
           errorMessage: truncate(frame.error.message, 256),
+          ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
         });
         break;
       }


### PR DESCRIPTION
## Summary

Addresses part **(B) 관측성 보강** of #128 (per [this comment](https://github.com/planetarium/vicoop-bridge/issues/128#issuecomment-4419106876)). PR #129 handles part (A) — the self-reference root cause. This PR makes it possible to answer, after the fact, *"Did this exact inbound request get rejected at the bridge, or did it reach the client/backend?"*

### Accept path — `principalId` everywhere
- `/agents/:id` stashes the verified `caller.principalId` on `message.metadata._principalId`, reusing the existing `_*`-prefix convention (admin route's `_principalId` / `_bearerToken` / `_email`).
- `WSForwardingExecutor` reads it, threads it into the `TaskBinding`, and strips `_*` keys before the outgoing WS frame so the connected client never sees server-internal caller identity over the wire.
- `agent_request`, `task_completed`, `task_failed_by_client`, and `task_unreachable` log lines now carry `principalId` when present — full request lifecycle is greppable by caller.

### Reject path — short `rejectionId` in body + log
- Every `agent_request_rejected` branch (all 7: `agent_not_connected`, `missing_bearer`, `invalid_token`, `owner_session_on_caller_route`, `invalid_siwe_bearer`, `bad_token_prefix`, `caller_not_authorized`) emits a short opaque `rejectionId` of shape `rej_<8 hex>`.
- The id appears in both the structured `agent_request_rejected` log and the JSON-RPC error body's `data.rejectionId`, so a caller transcript line can be matched 1:1 against the bridge log.

### Wire-compat
- WS frame stays byte-identical when no `_*` metadata existed (no surprise empty-`metadata: {}` for clients that key off `metadata === undefined`).
- Existing JSON-RPC error bodies pick up an additive `data.rejectionId`; existing tests that assert on `error.message` are unaffected.

## Test plan

- [x] `pnpm -r typecheck` — clean across all packages
- [x] `pnpm -r build` — all packages build
- [x] `pnpm --filter @vicoop-bridge/server test` — 168 pass (was 155; +13 new across `executor.test.ts` and `agent-auth.test.ts`)
- [x] New tests cover: `stripInternalMetadata` correctness (returns `undefined` when only `_*` keys survive), executor binding records `principalId`, WS frame `metadata._principalId` stripped, public-agent path has `binding.principalId === undefined`, `newRejectionId` format + uniqueness, `rejectionId` surfaces in error.data for `agent_not_connected` (404), `missing_bearer` / `bad_token_prefix` (401), `caller_not_authorized` (403), and distinct id per request.
- [ ] Manual: hit `/agents/<id>` with a wrong bearer, grep server logs for the `rejectionId` echoed in the response body — should find exactly one `agent_request_rejected` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)