### PR TITLE
feat(client): forward --settings JSON to claude -p for sandbox enable

### DIFF
--- a/.changeset/claude-sandbox-settings.md
+++ b/.changeset/claude-sandbox-settings.md
@@ -1,0 +1,26 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Claude backend now forwards an operator-supplied Claude Code settings
+JSON to every spawned `claude -p` via `--settings <json>`. The new
+`CLAUDE_SETTINGS_JSON` env var (read by the daemon's `pickBackend`)
+accepts a top-level JSON object that is serialized verbatim on the
+argv — primary use case is enabling the OS-level sandbox (Seatbelt on
+macOS, bubblewrap on Linux) in non-interactive mode, where the
+`/sandbox` slash command is unavailable and on-disk `settings.json`
+is awkward on systemd `DynamicUser=yes` hosts.
+
+The backend does not validate or merge defaults: operators set the
+shape they want. Malformed JSON or a non-object value fails loud at
+startup (exit 1, named error on stderr) so a typo in a sandbox
+profile surfaces before any task runs unsandboxed. The flag sits
+between identity args and operator `extraArgs`, so an `extraArgs`-
+supplied `--settings` would still win if both are set.
+
+When the `send_file` MCP server is enabled, operators that turn on
+`sandbox.network.allowManagedDomainsOnly` must allow the loopback
+host themselves — the URL is chosen lazily per task, so the backend
+does not rewrite the operator's JSON to inject it.
+
+Closes #138.

--- a/.changeset/claude-sandbox-settings.md
+++ b/.changeset/claude-sandbox-settings.md
@@ -5,9 +5,11 @@
 Claude backend now forwards an operator-supplied Claude Code settings
 JSON to every spawned `claude -p` via `--settings <json>`. The new
 `CLAUDE_SETTINGS_JSON` env var (read by the daemon's `pickBackend`)
-accepts a top-level JSON object that is serialized verbatim on the
-argv — primary use case is enabling the OS-level sandbox (Seatbelt on
-macOS, bubblewrap on Linux) in non-interactive mode, where the
+accepts a top-level JSON object; it is parsed at startup, re-serialized
+with `JSON.stringify`, and forwarded as `--settings <json>` on every
+spawn (whitespace and key order may change but the semantic value is
+preserved). Primary use case is enabling the OS-level sandbox (Seatbelt
+on macOS, bubblewrap on Linux) in non-interactive mode, where the
 `/sandbox` slash command is unavailable and on-disk `settings.json`
 is awkward on systemd `DynamicUser=yes` hosts.
 

--- a/.changeset/claude-sandbox-settings.md
+++ b/.changeset/claude-sandbox-settings.md
@@ -38,8 +38,8 @@ two layers in the same `--settings` JSON:
    Claude's own internal file tools.
 
 A vetted starter profile that keeps common dev tooling (`gh`, `git`,
-`npm`) working while blocking SSH keys, cloud credentials, `.env`
-files, and DNS-shaped exfil tools (CVE-2025-55284 pattern):
+`npm`/`pnpm`) working while blocking SSH keys, cloud credentials,
+`.env` files, and DNS-shaped exfil tools (CVE-2025-55284 pattern):
 
 ```json
 {
@@ -49,9 +49,16 @@ files, and DNS-shaped exfil tools (CVE-2025-55284 pattern):
     "allowUnsandboxedCommands": false,
     "filesystem": {
       "denyRead": ["~/.ssh", "~/.aws", "~/.gnupg", "~/.netrc"],
-      "allowWrite": ["/tmp/vicoop"]
+      "allowWrite": ["/tmp/vicoop", "~/.npm", "~/.cache/pnpm"]
     },
-    "network": { "allowManagedDomainsOnly": true }
+    "network": {
+      "allowManagedDomainsOnly": true,
+      "allowedDomains": [
+        "github.com", "api.github.com", "codeload.github.com",
+        "objects.githubusercontent.com", "uploads.github.com",
+        "registry.npmjs.org"
+      ]
+    }
   },
   "permissions": {
     "deny": [
@@ -71,6 +78,22 @@ proxy does not terminate TLS), and `allowUnsandboxedCommands:false`
 is required to neutralise the documented `dangerouslyDisableSandbox`
 escape hatch (the Ona writeup showed Claude self-disabling the
 sandbox when caught).
+
+### Non-obvious gotchas (verified empirically on Seatbelt + claude 2.1.139)
+
+- **`allowedDomains` must be nested under `sandbox.network`.** Placing
+  it at `sandbox.allowedDomains` is silently ignored — every outbound
+  request still gets a proxy 403. Easy to miss because no error fires.
+- **`npm`/`pnpm` need their cache dirs in `allowWrite`.** With only
+  `/tmp/vicoop` allowed, even `npm view <pkg>` fails with EPERM at the
+  cache-write step _after_ the registry fetch succeeds. Add `~/.npm`
+  and/or `~/.cache/pnpm`.
+- **`gh` cannot read its macOS Keychain token under Seatbelt.**
+  `gh auth status` fails regardless of network policy. If the agent
+  needs `gh`, inject the token via `GH_TOKEN` env on the systemd unit
+  (a fine-grained PAT scoped to the repos the agent actually touches)
+  — matches Anthropic's recommended "credential-injecting proxy"
+  pattern.
 
 ### Observability via OpenTelemetry
 

--- a/.changeset/claude-sandbox-settings.md
+++ b/.changeset/claude-sandbox-settings.md
@@ -23,4 +23,63 @@ When the `send_file` MCP server is enabled, operators that turn on
 host themselves — the URL is chosen lazily per task, so the backend
 does not rewrite the operator's JSON to inject it.
 
+### Two-layer hardening: sandbox is necessary but not sufficient
+
+Empirically (Claude Code 2.1.139): `{"sandbox":{"enabled":true}}`
+alone does **not** block reads outside the working directory — the
+sandbox's default read policy is permissive, and the built-in
+Read/Edit/Write tools bypass the OS sandbox entirely (only Bash
+subprocesses are isolated). Operators that want real isolation need
+two layers in the same `--settings` JSON:
+
+1. `sandbox.filesystem.denyRead` / `allowRead` — blocks Bash
+   subprocess reads (covers `gh`, `git`, `npm`, `kubectl`, etc.).
+2. `permissions.deny` rules for `Read(...)` / `Edit(...)` — blocks
+   Claude's own internal file tools.
+
+A vetted starter profile that keeps common dev tooling (`gh`, `git`,
+`npm`) working while blocking SSH keys, cloud credentials, `.env`
+files, and DNS-shaped exfil tools (CVE-2025-55284 pattern):
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": true,
+    "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "denyRead": ["~/.ssh", "~/.aws", "~/.gnupg", "~/.netrc"],
+      "allowWrite": ["/tmp/vicoop"]
+    },
+    "network": { "allowManagedDomainsOnly": true }
+  },
+  "permissions": {
+    "deny": [
+      "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(~/.netrc)",
+      "Read(**/.env*)",
+      "Bash(ping:*)", "Bash(nslookup:*)", "Bash(dig:*)",
+      "Bash(host:*)", "Bash(curl:*)", "Bash(wget:*)",
+      "Bash(nc:*)", "Bash(socat:*)"
+    ]
+  }
+}
+```
+
+This is a starting point, not a guarantee — broader `network.allowedDomains`
+opens domain-fronting paths the built-in proxy cannot inspect (the
+proxy does not terminate TLS), and `allowUnsandboxedCommands:false`
+is required to neutralise the documented `dangerouslyDisableSandbox`
+escape hatch (the Ona writeup showed Claude self-disabling the
+sandbox when caught).
+
+### Observability via OpenTelemetry
+
+`claude-code` is OTEL-native; the bridge daemon inherits its env
+verbatim. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` plus
+`OTEL_LOG_TOOL_DETAILS=1`, `OTEL_LOG_TOOL_CONTENT=1`, and
+`OTEL_LOG_USER_PROMPTS=1` on the systemd unit (see install.sh env
+template) gives a queryable trace of every tool call, file read,
+and user prompt — usable as an audit trail since the agent cannot
+tamper with it once exported.
+
 Closes #138.

--- a/install.sh
+++ b/install.sh
@@ -428,12 +428,30 @@ BACKEND=openclaw
 # Inline --settings JSON forwarded to every \`claude -p\` (issue #138).
 # Enables the OS-level sandbox (Seatbelt on macOS, bubblewrap on Linux)
 # AND permission-rule deny lists for Claude's internal Read/Edit (which
-# the OS sandbox does not cover). The example below is a starter profile
-# vetted against gh/git/npm — broaden filesystem.allowRead and
-# network.allowedDomains as your agent's toolchain requires. Single line
-# only (systemd EnvironmentFile is one assignment per line); compact your
-# JSON before pasting.
-#CLAUDE_SETTINGS_JSON={"sandbox":{"enabled":true,"failIfUnavailable":true,"allowUnsandboxedCommands":false,"filesystem":{"denyRead":["~/.ssh","~/.aws","~/.gnupg","~/.netrc"],"allowWrite":["/tmp/vicoop"]},"network":{"allowManagedDomainsOnly":true}},"permissions":{"deny":["Read(~/.ssh/**)","Read(~/.aws/**)","Read(~/.netrc)","Read(**/.env*)","Bash(ping:*)","Bash(nslookup:*)","Bash(dig:*)","Bash(host:*)","Bash(curl:*)","Bash(wget:*)","Bash(nc:*)","Bash(socat:*)"]}}
+# the OS sandbox does not cover). Single line only (systemd EnvironmentFile
+# is one assignment per line); compact your JSON before pasting.
+#
+# Starter profile vetted on macOS Seatbelt with claude 2.1.139. Three
+# non-obvious gotchas were verified empirically and folded in below:
+#
+#   1. allowedDomains MUST be nested under sandbox.network. Placing it at
+#      sandbox.allowedDomains is silently ignored.
+#   2. npm/pnpm need ~/.npm and ~/.cache/pnpm in allowWrite or every
+#      registry fetch fails at the cache-write step (EPERM), even with
+#      the registry domain allowed.
+#   3. \`gh\` cannot read its macOS Keychain token under Seatbelt
+#      (\`gh auth status\` fails regardless of network). If the agent needs
+#      gh, inject the token via env: GH_TOKEN=<pat> on this systemd unit.
+#
+# Broaden filesystem.allowWrite, network.allowedDomains, and the
+# permission deny list as your agent's toolchain requires.
+#CLAUDE_SETTINGS_JSON={"sandbox":{"enabled":true,"failIfUnavailable":true,"allowUnsandboxedCommands":false,"filesystem":{"denyRead":["~/.ssh","~/.aws","~/.gnupg","~/.netrc"],"allowWrite":["/tmp/vicoop","~/.npm","~/.cache/pnpm"]},"network":{"allowManagedDomainsOnly":true,"allowedDomains":["github.com","api.github.com","codeload.github.com","objects.githubusercontent.com","uploads.github.com","registry.npmjs.org"]}},"permissions":{"deny":["Read(~/.ssh/**)","Read(~/.aws/**)","Read(~/.netrc)","Read(**/.env*)","Bash(ping:*)","Bash(nslookup:*)","Bash(dig:*)","Bash(host:*)","Bash(curl:*)","Bash(wget:*)","Bash(nc:*)","Bash(socat:*)"]}}
+
+# Personal access token injected when the agent uses \`gh\` — Seatbelt
+# blocks Keychain access so the stored gh credential is unreachable
+# inside the sandbox. Use a fine-grained PAT scoped to the repos the
+# agent actually needs.
+#GH_TOKEN=
 
 # --- Observability (optional, OpenTelemetry) ---
 # claude-code is OTEL-native. The bridge daemon just inherits these

--- a/install.sh
+++ b/install.sh
@@ -417,6 +417,34 @@ BACKEND=openclaw
 #OPENCLAW_GATEWAY_TOKEN=
 #OPENCLAW_AGENT=main
 #OPENCLAW_TASK_TIMEOUT_MS=
+
+# --- Claude-backend-only (uncomment if BACKEND=claude) ---
+# Working directory for the spawned claude subprocess. Defaults to the
+# daemon's pwd. Set this to a dedicated work tree so sandbox.filesystem
+# default write rules (cwd-only) and Read tool defaults are scoped to a
+# directory that does NOT contain operator credentials.
+#CLAUDE_CWD=/srv/agent-work
+
+# Inline --settings JSON forwarded to every \`claude -p\` (issue #138).
+# Enables the OS-level sandbox (Seatbelt on macOS, bubblewrap on Linux)
+# AND permission-rule deny lists for Claude's internal Read/Edit (which
+# the OS sandbox does not cover). The example below is a starter profile
+# vetted against gh/git/npm — broaden filesystem.allowRead and
+# network.allowedDomains as your agent's toolchain requires. Single line
+# only (systemd EnvironmentFile is one assignment per line); compact your
+# JSON before pasting.
+#CLAUDE_SETTINGS_JSON={"sandbox":{"enabled":true,"failIfUnavailable":true,"allowUnsandboxedCommands":false,"filesystem":{"denyRead":["~/.ssh","~/.aws","~/.gnupg","~/.netrc"],"allowWrite":["/tmp/vicoop"]},"network":{"allowManagedDomainsOnly":true}},"permissions":{"deny":["Read(~/.ssh/**)","Read(~/.aws/**)","Read(~/.netrc)","Read(**/.env*)","Bash(ping:*)","Bash(nslookup:*)","Bash(dig:*)","Bash(host:*)","Bash(curl:*)","Bash(wget:*)","Bash(nc:*)","Bash(socat:*)"]}}
+
+# --- Observability (optional, OpenTelemetry) ---
+# claude-code is OTEL-native. The bridge daemon just inherits these
+# variables and claude exports tool-call / prompt traces directly. Point
+# OTEL_EXPORTER_OTLP_ENDPOINT at your collector and the SIEM gets a
+# queryable, tamper-evident audit trail (the agent cannot suppress
+# exported spans). All four vars are needed for full fidelity.
+#OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.local:4317
+#OTEL_LOG_TOOL_DETAILS=1
+#OTEL_LOG_TOOL_CONTENT=1
+#OTEL_LOG_USER_PROMPTS=1
 ENVF
     env_created="new"
   else

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -689,6 +689,24 @@ test('omits --settings when settings option is not provided', async () => {
   assert.equal(child.args.indexOf('--settings'), -1);
 });
 
+test('createClaudeBackend throws a named error if settings is not JSON-serializable', () => {
+  // Circular reference — JSON.stringify throws TypeError. The wrapped Error
+  // must name the option so an operator can find the misconfiguration
+  // quickly instead of debugging a raw stack trace from inside the backend.
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+  assert.throws(
+    () => createClaudeBackend({ settings: circular }),
+    /createClaudeBackend: failed to serialize `settings` option/,
+  );
+
+  // BigInt — different throw inside JSON.stringify, same wrapper outside.
+  assert.throws(
+    () => createClaudeBackend({ settings: { token: 1n as unknown as number } }),
+    /createClaudeBackend: failed to serialize `settings` option/,
+  );
+});
+
 test('--settings precedes extraArgs so operator extraArgs can override', async () => {
   const fake = scriptedSpawn({
     lines: [JSON.stringify({ type: 'result', result: 'ok' })],

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -706,6 +706,19 @@ test('createClaudeBackend throws a named error if settings is not JSON-serializa
     () => createClaudeBackend({ settings: { token: 1n } }),
     /createClaudeBackend: failed to serialize `settings` option/,
   );
+
+  // `toJSON()` that returns undefined — JSON.stringify returns undefined
+  // (no throw), which would otherwise stringify-coerce to "undefined" in
+  // argv. The post-stringify type check must catch this.
+  const toJsonReturnsUndefined: Record<string, unknown> = {
+    toJSON() {
+      return undefined;
+    },
+  };
+  assert.throws(
+    () => createClaudeBackend({ settings: toJsonReturnsUndefined }),
+    /serialized to `undefined`/,
+  );
 });
 
 test('--settings precedes extraArgs so operator extraArgs can override', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -701,8 +701,9 @@ test('createClaudeBackend throws a named error if settings is not JSON-serializa
   );
 
   // BigInt — different throw inside JSON.stringify, same wrapper outside.
+  // `settings` is `Record<string, unknown>`, so `1n` slots in as-is.
   assert.throws(
-    () => createClaudeBackend({ settings: { token: 1n as unknown as number } }),
+    () => createClaudeBackend({ settings: { token: 1n } }),
     /createClaudeBackend: failed to serialize `settings` option/,
   );
 });

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -650,6 +650,67 @@ test('passes expected argv shape (stream-json, session-id, verbose, extraArgs)',
   assert.equal(child.args.at(-1), 'sonnet');
 });
 
+test('injects --settings <json> when settings option is provided', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const settings = {
+    sandbox: {
+      enabled: true,
+      failIfUnavailable: true,
+      allowUnsandboxedCommands: false,
+    },
+  };
+  const backend = createClaudeBackend({ spawn: fake.spawn, settings });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const idx = child.args.indexOf('--settings');
+  assert.ok(idx !== -1, 'expected --settings flag');
+  // The serialized JSON must round-trip exactly (no shell escaping — spawn
+  // takes an argv array, claude reads it as a single argument).
+  assert.deepEqual(JSON.parse(String(child.args[idx + 1])), settings);
+});
+
+test('omits --settings when settings option is not provided', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(child.args.indexOf('--settings'), -1);
+});
+
+test('--settings precedes extraArgs so operator extraArgs can override', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    settings: { sandbox: { enabled: true } },
+    extraArgs: ['--model', 'sonnet'],
+  });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const settingsIdx = child.args.indexOf('--settings');
+  const modelIdx = child.args.indexOf('--model');
+  assert.ok(settingsIdx !== -1);
+  assert.ok(modelIdx !== -1);
+  assert.ok(settingsIdx < modelIdx, '--settings must appear before extraArgs');
+});
+
 test('injects --append-system-prompt with self-identity mention when identity is provided', async () => {
   const fake = scriptedSpawn({
     lines: [JSON.stringify({ type: 'result', result: 'ok' })],

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -78,6 +78,17 @@ export interface ClaudeBackendOptions {
   // directly instead of attempting an outbound A2A call to its own address.
   // See issue #128 for the failure mode this prevents.
   identity?: AgentIdentity;
+  // Inline Claude Code settings JSON forwarded to each spawned `claude` via
+  // `--settings <json>`. Primary use case is enabling the OS-level sandbox
+  // (Seatbelt on macOS, bubblewrap on Linux) in `-p` mode, where the
+  // `/sandbox` slash command is unavailable. See issue #138.
+  //
+  // The object is serialized verbatim — the backend does not validate shape
+  // or merge defaults. Operators that want sandbox-on-by-default with the
+  // local `send_file` MCP server reachable must include the loopback host in
+  // `sandbox.network` themselves; the URL is dynamic per task so the backend
+  // cannot pre-populate it without rewriting the operator's JSON.
+  settings?: Record<string, unknown>;
 }
 
 // Kept short and behaviour-focused. The risk we're guarding against is
@@ -510,6 +521,12 @@ export function createClaudeBackend(
   const identityArgs: readonly string[] = opts.identity
     ? ['--append-system-prompt', buildSelfIdentitySystemPrompt(opts.identity)]
     : [];
+  // Serialize once at backend construction so per-task spawn stays cheap and
+  // a malformed settings object (e.g. a circular reference) fails loud at
+  // setup time rather than producing a corrupted argv on the first task.
+  const settingsArgs: readonly string[] = opts.settings
+    ? ['--settings', JSON.stringify(opts.settings)]
+    : [];
 
   // Lazy: first task that needs the MCP server starts it; backends that
   // never see send_file enabled don't open a port.
@@ -640,6 +657,7 @@ export function createClaudeBackend(
             ]
           : []),
         ...identityArgs,
+        ...settingsArgs,
         ...extraArgs,
       ];
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -83,11 +83,16 @@ export interface ClaudeBackendOptions {
   // (Seatbelt on macOS, bubblewrap on Linux) in `-p` mode, where the
   // `/sandbox` slash command is unavailable. See issue #138.
   //
-  // The object is serialized verbatim — the backend does not validate shape
-  // or merge defaults. Operators that want sandbox-on-by-default with the
-  // local `send_file` MCP server reachable must include the loopback host in
-  // `sandbox.network` themselves; the URL is dynamic per task so the backend
-  // cannot pre-populate it without rewriting the operator's JSON.
+  // The object is serialized with `JSON.stringify` at backend construction
+  // and must therefore be JSON-safe: `BigInt` values throw, `undefined` /
+  // functions / symbols drop, and `NaN` / `Infinity` become `null`. The
+  // backend does not validate shape or merge defaults — operators that want
+  // sandbox-on-by-default with the local `send_file` MCP server reachable
+  // must include the loopback host in `sandbox.network` themselves; the URL
+  // is dynamic per task so the backend cannot pre-populate it without
+  // rewriting the operator's JSON. Serialization failures surface as a
+  // thrown Error from `createClaudeBackend(...)` so misconfiguration is
+  // visible at startup rather than as a corrupted argv on the first task.
   settings?: Record<string, unknown>;
 }
 
@@ -522,11 +527,23 @@ export function createClaudeBackend(
     ? ['--append-system-prompt', buildSelfIdentitySystemPrompt(opts.identity)]
     : [];
   // Serialize once at backend construction so per-task spawn stays cheap and
-  // a malformed settings object (e.g. a circular reference) fails loud at
-  // setup time rather than producing a corrupted argv on the first task.
-  const settingsArgs: readonly string[] = opts.settings
-    ? ['--settings', JSON.stringify(opts.settings)]
-    : [];
+  // a malformed settings object (circular reference, BigInt value, etc.)
+  // fails loud at setup time rather than producing a corrupted argv on the
+  // first task. The wrapper Error name-checks the option and surfaces the
+  // underlying `JSON.stringify` message so a misconfiguration is actionable
+  // without the operator having to read a raw stack trace.
+  const settingsArgs: readonly string[] = ((): readonly string[] => {
+    if (!opts.settings) return [];
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(opts.settings);
+    } catch (err) {
+      throw new Error(
+        `createClaudeBackend: failed to serialize \`settings\` option as JSON for --settings argv: ${errorMessage(err)}`,
+      );
+    }
+    return ['--settings', serialized];
+  })();
 
   // Lazy: first task that needs the MCP server starts it; backends that
   // never see send_file enabled don't open a port.

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -534,12 +534,25 @@ export function createClaudeBackend(
   // without the operator having to read a raw stack trace.
   const settingsArgs: readonly string[] = ((): readonly string[] => {
     if (!opts.settings) return [];
-    let serialized: string;
+    let serialized: string | undefined;
     try {
       serialized = JSON.stringify(opts.settings);
     } catch (err) {
       throw new Error(
         `createClaudeBackend: failed to serialize \`settings\` option as JSON for --settings argv: ${errorMessage(err)}`,
+      );
+    }
+    // JSON.stringify can return `undefined` even without throwing — e.g. a
+    // top-level `toJSON()` that returns undefined, or the value being a bare
+    // function/symbol. Without this guard the argv would carry `undefined`
+    // which the child spawn coerces to the string "undefined", silently
+    // running claude with a bogus --settings payload. Surface the same
+    // named error so callers can't miss it.
+    if (typeof serialized !== 'string') {
+      throw new Error(
+        'createClaudeBackend: `settings` option serialized to `undefined` ' +
+          '(toJSON returned undefined, or value was a function/symbol); ' +
+          'pass a JSON-safe object for --settings argv',
       );
     }
     return ['--settings', serialized];

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -65,6 +65,31 @@ function parseClientArgs(argv: string[]): Args {
   return resolved;
 }
 
+// Parse the operator's inline `--settings` JSON for the claude backend. The
+// primary use case is enabling the OS-level sandbox in `-p` mode (issue #138),
+// where the `/sandbox` slash command is unavailable and `settings.json` on
+// disk is awkward on systemd-`DynamicUser` hosts. We fail loud on malformed
+// JSON rather than silently dropping it — a syntax error in a sandbox config
+// is exactly the kind of bug an operator wants surfaced at startup, not
+// after the first task already ran with no sandbox at all.
+function parseClaudeSettingsEnv(raw: string | undefined): Record<string, unknown> | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error(`CLAUDE_SETTINGS_JSON is not valid JSON: ${msg}`);
+    process.exit(1);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    console.error('CLAUDE_SETTINGS_JSON must be a JSON object');
+    process.exit(1);
+  }
+  return parsed as Record<string, unknown>;
+}
+
 function pickBackend(name: string, args: Args): Backend {
   switch (name) {
     case 'echo':
@@ -80,6 +105,7 @@ function pickBackend(name: string, args: Args): Backend {
       return createClaudeBackend({
         cwd: process.env.CLAUDE_CWD?.trim() || undefined,
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
+        settings: parseClaudeSettingsEnv(process.env.CLAUDE_SETTINGS_JSON),
       });
     default:
       throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude)`);


### PR DESCRIPTION
Closes #138.

## Summary

- New `settings?: Record<string, unknown>` option on the claude backend → emitted on argv as `--settings <json>` (between identity args and `extraArgs`, so operator `extraArgs` can still override).
- New `CLAUDE_SETTINGS_JSON` env knob in the daemon CLI (`pickBackend('claude')`). Malformed JSON or a non-object value exits 1 with a named error before the daemon ever connects.
- `install.sh` systemd env template now ships a `Claude-backend-only` block with `CLAUDE_CWD`, a starter `CLAUDE_SETTINGS_JSON` profile, optional `GH_TOKEN`, and OpenTelemetry exporter envs — operators can uncomment what they need.
- Primary use case: enabling the OS-level sandbox (Seatbelt / bubblewrap) in `-p` mode where `/sandbox` is unavailable and an on-disk `~/.claude/settings.json` is awkward (notably under systemd `DynamicUser=yes`).

## Two-layer hardening — sandbox alone is not enough

Empirically confirmed on Claude Code 2.1.139: `{"sandbox":{"enabled":true}}` alone does **not** block reads outside the working directory. The sandbox's default read policy is permissive, and the built-in Read/Edit/Write tools bypass the OS sandbox entirely (only Bash subprocesses are isolated). Operators that want real isolation need two layers in the same `--settings` JSON:

1. `sandbox.filesystem.denyRead` / `allowRead` — blocks Bash subprocess reads (covers `gh`, `git`, `npm`, `kubectl`, etc.)
2. `permissions.deny` rules for `Read(...)` / `Edit(...)` — blocks Claude's own internal file tools (these are not sandbox-covered per [the docs](https://code.claude.com/docs/en/sandboxing))

The starter profile shipped in `install.sh`:

```json
{
  "sandbox": {
    "enabled": true, "failIfUnavailable": true, "allowUnsandboxedCommands": false,
    "filesystem": {
      "denyRead": ["~/.ssh", "~/.aws", "~/.gnupg", "~/.netrc"],
      "allowWrite": ["/tmp/vicoop", "~/.npm", "~/.cache/pnpm"]
    },
    "network": {
      "allowManagedDomainsOnly": true,
      "allowedDomains": [
        "github.com", "api.github.com", "codeload.github.com",
        "objects.githubusercontent.com", "uploads.github.com",
        "registry.npmjs.org"
      ]
    }
  },
  "permissions": {
    "deny": [
      "Read(~/.ssh/**)", "Read(~/.aws/**)", "Read(~/.netrc)", "Read(**/.env*)",
      "Bash(ping:*)", "Bash(nslookup:*)", "Bash(dig:*)", "Bash(host:*)",
      "Bash(curl:*)", "Bash(wget:*)", "Bash(nc:*)", "Bash(socat:*)"
    ]
  }
}
```

`allowUnsandboxedCommands:false` is required to neutralise the documented `dangerouslyDisableSandbox` escape hatch — the [Ona writeup](https://ona.com/stories/how-claude-code-escapes-its-own-denylist-and-sandbox) showed Claude self-disabling its sandbox when caught.

## Non-obvious gotchas (verified empirically)

Three failure modes that degrade silently and would otherwise cost an operator a debugging afternoon. All folded into the install.sh template:

- **`allowedDomains` must be nested under `sandbox.network`.** Top-level `sandbox.allowedDomains` is silently ignored; every outbound request still gets a proxy 403 with no hint why.
- **`npm`/`pnpm` need their cache dirs in `allowWrite`.** With only `/tmp/vicoop` allowed, even `npm view <pkg>` fails with EPERM at the cache-write step _after_ the registry fetch succeeds — looks like a network problem but isn't.
- **`gh` cannot read its macOS Keychain token under Seatbelt** (`gh auth status` fails regardless of network policy). If the agent needs `gh`, inject the token via `GH_TOKEN` env on the systemd unit (a fine-grained PAT scoped to the repos the agent actually touches). This matches Anthropic's recommended credential-injecting pattern from the [secure-deployment guide](https://code.claude.com/docs/en/agent-sdk/secure-deployment).

## Out of scope (issue #138 follow-ups)

- `install.sh` does not yet pre-check `bubblewrap`/`socat` on Linux hosts (the existing prereq block at install.sh:48-50 only verifies `curl`/`tar`/`node`).
- No container / microVM wrapper — Anthropic's secure-deployment guide recommends `--network none` containers with credential-injecting egress proxies; that is a deployment-architecture change worth a separate track.
- The backend does **not** auto-merge the `send_file` MCP loopback URL into `sandbox.network`. The URL is chosen lazily per task; operators that set `allowManagedDomainsOnly: true` must include the loopback host themselves. Documented in the option's docstring.
- No sandbox-shape validation — that is Claude Code's job; the backend stays a thin pass-through.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — all 273 tests pass, including 3 new tests for argv shape
- [x] daemon CLI exits 1 with `CLAUDE_SETTINGS_JSON is not valid JSON` / `must be a JSON object` on malformed input
- [x] Valid JSON passes through and daemon proceeds to WS connect with no parse-stage error
- [x] **Credential protection verified end-to-end:** Bash `ls ~/.ssh` → `Operation not permitted` (OS sandbox); Read tool on `~/.ssh/known_hosts` → `permission settings denied`; cwd-local `.env` decoy → blocked by `Read(**/.env*)`. `permissions.deny` rules held firm even under `--permission-mode bypassPermissions`.
- [x] **Dev-tool compat verified:** `gh --version`, `git`, `npm`, `node` all work; `git config --get user.email` reads `~/.gitconfig` (not denied); `git ls-remote github.com/...` works once `github.com` is in `allowedDomains`; `npm view <pkg>` works once `~/.npm` is in `allowWrite`. All three gotchas above were discovered through this testing and documented.
- [x] `sh -n install.sh` passes; embedded JSON validates (`python3 -m json.tool` round-trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)