### PR TITLE
[codex] Add Codex CLI backend

### DIFF
--- a/.changeset/gentle-codex-bridge.md
+++ b/.changeset/gentle-codex-bridge.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Add a first-party Codex CLI backend with text/image input, session resume, trace artifacts, and canonical cards.

--- a/README.md
+++ b/README.md
@@ -47,4 +47,5 @@ bundle being released:
 
 ## Status
 
-Pre-implementation. Design phase only.
+Active development. The client currently ships `echo`, `openclaw`, `claude`,
+and `codex` backends.

--- a/docs/design.md
+++ b/docs/design.md
@@ -21,7 +21,7 @@ External A2A Client
         │
 ┌───────┴─────────────────────┐
 │  vicoop-bridge Client       │   사설망
-│  - backend: echo | openclaw | claude
+│  - backend: echo | openclaw | claude | codex
 │  - backendKind + optional AgentCard override
 │  - task lifecycle 번역       │
 └─────────────────────────────┘
@@ -33,7 +33,7 @@ External A2A Client
 - **Server**는 dispatch 로직을 에이전트 종류에 결합하지 않는다. 다만
   built-in backend의 AgentCard metadata는 `backendKind`로 canonical card를
   선택해 서버 배포만으로 갱신할 수 있다.
-- **Client**가 에이전트별 변환을 담당. Claude Code/Codex 같은 CLI 에이전트는 태스크당 subprocess spawn, `--resume` / `--session-id` 로 세션 유지.
+- **Client**가 에이전트별 변환을 담당. Claude Code/Codex 같은 CLI 에이전트는 태스크당 subprocess spawn과 각 CLI의 resume primitive로 세션 유지.
 - 연결 방향은 항상 Client → Server (아웃바운드).
 
 ## 3. Repo Layout
@@ -79,8 +79,10 @@ vicoop-client \
   --backend claude
   # internally: `claude -p --session-id <ctx> --resume ...`
 
-# Future/custom Codex adapter (not shipped in the current client bundle)
-vicoop-client --backend codex --card ./cards/codex.json
+# Codex CLI
+vicoop-client \
+  --backend codex
+  # internally: `codex exec --json -` / `codex exec resume --json <thread_id> -`
 
 # Generic webhook
 vicoop-client \
@@ -89,9 +91,9 @@ vicoop-client \
   --card ./cards/custom.json
 ```
 
-Shipped built-in backends (`echo`, `openclaw`, `claude`) send a `backendKind`
+Shipped built-in backends (`echo`, `openclaw`, `claude`, `codex`) send a `backendKind`
 and can use the bridge server's canonical AgentCard. `--card` is only needed
-for operator overrides, older server compatibility, or custom/future backends.
+for operator overrides, older server compatibility, or custom backends.
 
 각 backend는 공통 인터페이스를 구현:
 ```ts

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -1,7 +1,7 @@
 # Install vicoop-bridge-client
 
-Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code,
-Codex CLI, with `echo` available for testing) to a deployed vicoop-bridge server. The
+Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code, or
+Codex CLI; `echo` is available for testing) to a deployed vicoop-bridge server. The
 first target is a verified foreground `vicoop-client` process on your host
 that bridges inbound A2A traffic at `POST <bridge>/agents/<your-agent-id>` to
 your local backend. Persistent service setup is optional once the foreground

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -1,15 +1,14 @@
 # Install vicoop-bridge-client
 
 Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code,
-with `echo` available for testing) to a deployed vicoop-bridge server. The
+Codex CLI, with `echo` available for testing) to a deployed vicoop-bridge server. The
 first target is a verified foreground `vicoop-client` process on your host
 that bridges inbound A2A traffic at `POST <bridge>/agents/<your-agent-id>` to
 your local backend. Persistent service setup is optional once the foreground
 run works.
 
-Additional backends (Codex, ...) are described in `docs/design.md` §5 but are
-not in the published client bundle yet. The released client currently
-registers `echo`, `openclaw`, and `claude`.
+Custom backends are described in `docs/design.md` §5. The released client
+currently registers `echo`, `openclaw`, `claude`, and `codex`.
 
 This doc covers the **post-release install path** (the `install.sh`
 one-liner fetching a published `@vicoop-bridge/client@*` bundle). Contrast with:
@@ -56,6 +55,8 @@ one-liner fetching a published `@vicoop-bridge/client@*` bundle). Contrast with:
   task execution still works via the terminal-artifact fallback.
 - For the Claude backend specifically: the local `claude` CLI installed and
   authenticated (`claude --version` should succeed).
+- For the Codex backend specifically: the local `codex` CLI installed and
+  authenticated (`codex --version` should succeed).
 
 ## Step 1 — Install the client bundle
 
@@ -87,6 +88,7 @@ $INSTALL_DIR/
 ├── dist/                    # compiled JS
 ├── cards/openclaw.json      # OpenClaw example card
 ├── cards/claude.json        # Claude Code example card
+├── cards/codex.json         # Codex CLI example card
 ├── cards/echo.json          # Echo test card
 ├── node_modules/            # pruned prod deps
 └── package.json
@@ -267,6 +269,7 @@ Pick the local backend this client should drive:
 
 - `openclaw` — OpenClaw gateway at `OPENCLAW_GATEWAY_URL`
 - `claude` — local Claude Code CLI
+- `codex` — local Codex CLI
 - `echo` — smoke-test backend
 
 For these built-in backends, you normally do **not** pass an agent card file.
@@ -277,7 +280,7 @@ metadata/capability fixes on the faster server deploy path instead of
 requiring every operator to upgrade their client bundle.
 
 The bundle still ships backend-specific starter cards under
-`$INSTALL_DIR/cards/` (`openclaw.json`, `claude.json`, `echo.json`) for
+`$INSTALL_DIR/cards/` (`openclaw.json`, `claude.json`, `codex.json`, `echo.json`) for
 operator overrides and compatibility with older bridge servers. Set
 `AGENT_CARD` only when you intentionally want to override the server card,
 for example to:
@@ -438,6 +441,28 @@ Typical follow-ups from this output:
 
 `--json` emits a machine-readable record of all the same fields for scripts.
 
+### Codex-specific env
+
+If you're running the Codex backend, set `BACKEND=codex` and optionally set
+`CODEX_CWD` so Codex works against a different repository than the directory
+where `vicoop-client` itself was started:
+
+```sh
+. "$INSTALL_DIR/vicoop-client.env"
+
+BACKEND=codex \
+CODEX_CWD="$HOME/vicoop-bridge" \
+CODEX_SANDBOX_MODE=workspace-write \
+  "$INSTALL_DIR/bin/vicoop-client"
+```
+
+`CODEX_CWD` defaults to the current working directory of the client process.
+The v1 backend accepts text plus inline image `file.bytes` inputs and returns
+text output. `CODEX_SANDBOX_MODE` is optional and accepts `read-only`,
+`workspace-write`, or `danger-full-access`; the client passes it to Codex as
+`-c sandbox_mode="<mode>"` so the same setting applies to fresh and resumed
+Codex sessions.
+
 ## Optional: persistence
 
 Only set up persistence after the foreground run connects and the agent
@@ -574,7 +599,7 @@ The upgrade command:
 3. Extracts into `$INSTALL_DIR.new/` (sibling of the current install).
 4. Copies operator files that don't ship with the bundle — notably any
    `cards/*.json` you added or files placed directly under `$INSTALL_DIR`.
-   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`) are kept for
+   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`, `codex.json`) are kept for
    optional overrides and older server compatibility; they are always
    replaced with the new release's versions.
 5. Runs `node $INSTALL_DIR.new/dist/cli.js --version` as a healthcheck. If it
@@ -692,9 +717,9 @@ device flow and can use the admin agent the same way; admin **scope**
   `["openclaw-a", "openclaw-b", ...]`) and run one `vicoop-client` per id.
   No token rotation needed.
 - **Different backends**: in the published bundle today, pass
-  `--backend openclaw`, `--backend claude`, or `--backend echo`. Set
+  `--backend openclaw`, `--backend claude`, `--backend codex`, or `--backend echo`. Set
   `--card`/`AGENT_CARD` only when you need to override the server's
-  canonical card. Codex and other future backends are still described in
+  canonical card. Custom/future backends are still described in
   `docs/design.md` §5 but are not shipped yet.
 - **Audit/revoke access**: the admin agent exposes `list_caller_tokens`,
   `list_callers`, and `revoke_caller_token` tools; see the tool list in

--- a/packages/client/cards/codex.json
+++ b/packages/client/cards/codex.json
@@ -1,0 +1,34 @@
+{
+  "name": "codex",
+  "description": "OpenAI Codex CLI agent. Spawns the local `codex` binary per task and streams agent messages back as A2A text artifacts. Accepts text and inline image inputs.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Codex command executions.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the Codex CLI responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`.",
+      "tags": ["chat", "assistant", "codex"]
+    }
+  ]
+}

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -429,6 +429,26 @@ test('nonzero exit emits task.fail with stderr tail', async () => {
   assert.match(fail.error.message, /auth required/);
 });
 
+test('signal exit emits task.fail without code null wording', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStderr('codex: interrupted\n');
+      setImmediate(() => child.finish(null, 'SIGTERM'));
+    });
+  });
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'codex_exit_nonzero');
+  assert.match(fail.error.message, /terminated by signal SIGTERM/);
+  assert.doesNotMatch(fail.error.message, /code null/);
+  assert.match(fail.error.message, /interrupted/);
+});
+
 test('abort kills the child and emits canceled completion', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1,0 +1,570 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  createCodexBackend,
+  type CodexChildHandle,
+  type CodexSpawnOptions,
+} from './codex.js';
+import {
+  TRACEABILITY_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
+
+const NEVER: AbortSignal = new AbortController().signal;
+
+interface FakeChild extends CodexChildHandle {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd?: string;
+  killed: boolean;
+  killSignal: NodeJS.Signals | null;
+  stdinPayload: string;
+  stdinClosed: boolean;
+  emitStdout(text: string): void;
+  emitStderr(text: string): void;
+  finish(code: number | null, sig?: NodeJS.Signals | null): void;
+}
+
+interface FakeSpawn {
+  spawn: (cmd: string, args: readonly string[], options: CodexSpawnOptions) => CodexChildHandle;
+  children: FakeChild[];
+  lastChild: () => FakeChild | null;
+}
+
+function makeFakeSpawn(configure: (child: FakeChild, index: number) => void): FakeSpawn {
+  const children: FakeChild[] = [];
+  return {
+    children,
+    spawn(command, args, options) {
+      const stdoutEmitter = new EventEmitter();
+      const stderrEmitter = new EventEmitter();
+      const closeListeners: Array<(code: number | null, sig: NodeJS.Signals | null) => void> = [];
+      let closed = false;
+
+      const mkReadable = (em: EventEmitter) =>
+        ({
+          on(event: string, cb: (...a: unknown[]) => void) {
+            em.on(event, cb);
+          },
+        }) as unknown as NodeJS.ReadableStream;
+
+      const stdinChunks: string[] = [];
+      const stdin: NodeJS.WritableStream = {
+        write(chunk: unknown): boolean {
+          stdinChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Buffer).toString('utf8'));
+          return true;
+        },
+        end(chunk?: unknown) {
+          if (chunk !== undefined) {
+            stdinChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Buffer).toString('utf8'));
+          }
+          (child as { stdinClosed: boolean }).stdinClosed = true;
+          return stdin;
+        },
+        on() { return stdin; },
+        once() { return stdin; },
+        emit() { return false; },
+      } as unknown as NodeJS.WritableStream;
+
+      const child: FakeChild = {
+        command,
+        args,
+        cwd: options.cwd,
+        stdin,
+        stdout: mkReadable(stdoutEmitter),
+        stderr: mkReadable(stderrEmitter),
+        killed: false,
+        killSignal: null,
+        get stdinPayload() {
+          return stdinChunks.join('');
+        },
+        stdinClosed: false,
+        kill(sig?: NodeJS.Signals) {
+          this.killed = true;
+          this.killSignal = sig ?? 'SIGTERM';
+          queueMicrotask(() => {
+            if (closed) return;
+            closed = true;
+            for (const l of closeListeners) l(null, this.killSignal);
+          });
+          return true;
+        },
+        on(
+          event: 'close' | 'error',
+          listener:
+            | ((code: number | null, signal: NodeJS.Signals | null) => void)
+            | ((err: Error) => void),
+        ) {
+          if (event === 'close') {
+            closeListeners.push(listener as (c: number | null, s: NodeJS.Signals | null) => void);
+          }
+        },
+        emitStdout(text) {
+          stdoutEmitter.emit('data', Buffer.from(text, 'utf8'));
+        },
+        emitStderr(text) {
+          stderrEmitter.emit('data', Buffer.from(text, 'utf8'));
+        },
+        finish(code, sig = null) {
+          if (closed) return;
+          closed = true;
+          for (const l of closeListeners) l(code, sig);
+        },
+      };
+      children.push(child);
+      configure(child, children.length - 1);
+      return child;
+    },
+    lastChild: () => children.at(-1) ?? null,
+  };
+}
+
+function scriptedSpawn(linesByRun: readonly (readonly string[])[], exitCode = 0): FakeSpawn {
+  return makeFakeSpawn((child, index) => {
+    setImmediate(() => {
+      for (const l of linesByRun[index] ?? []) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
+      setImmediate(() => child.finish(exitCode));
+    });
+  });
+}
+
+function assign(text: string, contextId = 'ctx-1'): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId: `task-${Math.random().toString(36).slice(2, 8)}`,
+    contextId,
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'text', text }],
+    },
+  };
+}
+
+function collect(): { emit: (f: UpFrame) => void; frames: UpFrame[] } {
+  const frames: UpFrame[] = [];
+  return { emit: (f) => frames.push(f), frames };
+}
+
+function textOf(frame: UpFrame): string {
+  if (frame.type === 'task.artifact') {
+    const p = frame.artifact.parts[0];
+    return p?.kind === 'text' ? p.text : '';
+  }
+  if (frame.type === 'task.complete') {
+    const p = frame.status.message?.parts[0];
+    return p?.kind === 'text' ? p.text : '';
+  }
+  return '';
+}
+
+test('text-only task spawns codex exec --json - and writes prompt to stdin', async () => {
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'hello' } }),
+    ],
+  ]);
+
+  const backend = createCodexBackend({ spawn: fake.spawn, cwd: '/repo' });
+  const { emit, frames } = collect();
+  await backend.handle(assign('say hi'), emit, NEVER);
+
+  const child = fake.lastChild()!;
+  assert.equal(child.command, 'codex');
+  assert.deepEqual(child.args, ['exec', '--json', '-']);
+  assert.equal(child.cwd, '/repo');
+  assert.equal(child.stdinPayload, 'say hi');
+  assert.equal(child.stdinClosed, true);
+
+  assert.deepEqual(
+    frames.map((f) => f.type),
+    ['task.status', 'task.artifact', 'task.complete'],
+  );
+  assert.equal(textOf(frames[1]), 'hello');
+  assert.equal(textOf(frames[2]), 'hello');
+});
+
+test('parses trailing JSONL event without final newline', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStdout(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'tail' } }));
+      setImmediate(() => child.finish(0));
+    });
+  });
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+
+  const artifact = frames.find((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact');
+  assert.ok(artifact);
+  assert.equal(textOf(artifact), 'tail');
+});
+
+
+test('thread.started id is reused via codex exec resume on the same contextId', async () => {
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first' } }),
+    ],
+    [
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'second' } }),
+    ],
+  ]);
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(assign('one', 'ctx'), collect().emit, NEVER);
+  await backend.handle(assign('two', 'ctx'), collect().emit, NEVER);
+
+  assert.deepEqual(fake.children[0].args, ['exec', '--json', '-']);
+  assert.deepEqual(fake.children[1].args, ['exec', 'resume', '--json', 'thread-a', '-']);
+});
+
+test('sandboxMode is passed as a Codex config override on initial and resume runs', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' })],
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'again' } })],
+  ]);
+
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    sandboxMode: 'read-only',
+  });
+  await backend.handle(assign('one', 'ctx'), collect().emit, NEVER);
+  await backend.handle(assign('two', 'ctx'), collect().emit, NEVER);
+
+  assert.deepEqual(fake.children[0].args, [
+    'exec',
+    '--json',
+    '-c',
+    'sandbox_mode="read-only"',
+    '-',
+  ]);
+  assert.deepEqual(fake.children[1].args, [
+    'exec',
+    'resume',
+    '--json',
+    '-c',
+    'sandbox_mode="read-only"',
+    'thread-a',
+    '-',
+  ]);
+});
+
+test('extraArgs follow sandboxMode config so tests/operators can override it', async () => {
+  const fake = scriptedSpawn([[JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' })]]);
+
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    sandboxMode: 'read-only',
+    extraArgs: ['-c', 'sandbox_mode="workspace-write"'],
+  });
+  await backend.handle(assign('one'), collect().emit, NEVER);
+
+  assert.deepEqual(fake.lastChild()!.args, [
+    'exec',
+    '--json',
+    '-c',
+    'sandbox_mode="read-only"',
+    '-c',
+    'sandbox_mode="workspace-write"',
+    '-',
+  ]);
+});
+
+test('distinct contextIds get distinct sessions', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' })],
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-b' })],
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'again' } })],
+  ]);
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(assign('one', 'ctx-a'), collect().emit, NEVER);
+  await backend.handle(assign('two', 'ctx-b'), collect().emit, NEVER);
+  await backend.handle(assign('again', 'ctx-a'), collect().emit, NEVER);
+
+  assert.deepEqual(fake.children[2].args, ['exec', 'resume', '--json', 'thread-a', '-']);
+});
+
+test('session TTL expiry starts a new codex exec run', async () => {
+  let now = 0;
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' })],
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-b' })],
+  ]);
+
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    sessionTtlMs: 5_000,
+    now: () => now,
+  });
+  await backend.handle(assign('one', 'ctx'), collect().emit, NEVER);
+  now = 6_000;
+  await backend.handle(assign('two', 'ctx'), collect().emit, NEVER);
+
+  assert.deepEqual(fake.children[1].args, ['exec', '--json', '-']);
+});
+
+test('abort after image materialization completes before spawn and cleans temp dir', async () => {
+  let spawned = 0;
+  const removed: string[] = [];
+  const controller = new AbortController();
+  const backend = createCodexBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+    mkdtemp: async () => '/tmp/vicoop-codex-test',
+    writeFile: async () => {
+      controller.abort();
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: Buffer.from('png').toString('base64') } }],
+    },
+  };
+
+  const { emit, frames } = collect();
+  await backend.handle(task, emit, controller.signal);
+
+  assert.equal(spawned, 0);
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-test']);
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].type, 'task.complete');
+  assert.equal((frames[0] as Extract<UpFrame, { type: 'task.complete' }>).status.state, 'canceled');
+});
+
+test('resume spawn failure rolls back TTL refresh for the existing session', async () => {
+  let now = 0;
+  let calls = 0;
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' })],
+    [JSON.stringify({ type: 'thread.started', thread_id: 'thread-b' })],
+  ]);
+  const backend = createCodexBackend({
+    sessionTtlMs: 5_000,
+    now: () => now,
+    spawn: (command, args, options) => {
+      calls++;
+      if (calls === 2) throw new Error('spawn failed');
+      return fake.spawn(command, args, options);
+    },
+  });
+
+  await backend.handle(assign('one', 'ctx'), collect().emit, NEVER);
+  now = 4_000;
+  const failed = collect();
+  await backend.handle(assign('two', 'ctx'), failed.emit, NEVER);
+  now = 6_000;
+  await backend.handle(assign('three', 'ctx'), collect().emit, NEVER);
+
+  const fail = failed.frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.equal(fail?.error.code, 'spawn_failed');
+  assert.deepEqual(fake.children[1].args, ['exec', '--json', '-']);
+});
+
+test('command_execution emits trace artifact only when traceability is requested', async () => {
+  const line = JSON.stringify({
+    type: 'item.completed',
+    item: {
+      type: 'command_execution',
+      command: 'npm test',
+      aggregated_output: 'ok',
+      exit_code: 0,
+      status: 'completed',
+    },
+  });
+
+  const withoutTrace = scriptedSpawn([[line]]);
+  const backendA = createCodexBackend({ spawn: withoutTrace.spawn });
+  const framesA = collect();
+  await backendA.handle(assign('x'), framesA.emit, NEVER);
+  assert.equal(framesA.frames.filter((f) => f.type === 'task.artifact').length, 0);
+
+  const withTrace = scriptedSpawn([[line]]);
+  const backendB = createCodexBackend({ spawn: withTrace.spawn });
+  const framesB = collect();
+  await backendB.handle(
+    { ...assign('x'), requestedExtensions: [TRACEABILITY_EXTENSION_URI] },
+    framesB.emit,
+    NEVER,
+  );
+  const artifact = framesB.frames.find((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact');
+  assert.ok(artifact);
+  assert.equal(artifact.artifact.name, 'codex-command-execution');
+  assert.equal(artifact.artifact.metadata?.traceType, 'command-execution');
+  assert.match(textOf(artifact), /npm test/);
+});
+
+test('nonzero exit emits task.fail with stderr tail', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStderr('codex: auth required\n');
+      setImmediate(() => child.finish(2));
+    });
+  });
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+
+  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
+  assert.ok(fail);
+  assert.equal(fail.error.code, 'codex_exit_nonzero');
+  assert.match(fail.error.message, /code 2/);
+  assert.match(fail.error.message, /auth required/);
+});
+
+test('abort kills the child and emits canceled completion', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStdout(JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'partial' } }) + '\n');
+    });
+  });
+
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const controller = new AbortController();
+  const { emit, frames } = collect();
+  const runP = backend.handle(assign('x'), emit, controller.signal);
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+  controller.abort();
+  await runP;
+
+  assert.ok(fake.lastChild()?.killed);
+  assert.equal(fake.lastChild()?.killSignal, 'SIGTERM');
+  const last = frames.at(-1) as Extract<UpFrame, { type: 'task.complete' }>;
+  assert.equal(last.type, 'task.complete');
+  assert.equal(last.status.state, 'canceled');
+});
+
+test('image FilePart.bytes creates temp files and passes --image args', async () => {
+  const fake = scriptedSpawn([[JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })]]);
+  const written: Array<{ path: string; data: Buffer }> = [];
+  const removed: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-test',
+    writeFile: async (filePath, data) => {
+      written.push({ path: String(filePath), data: Buffer.from(data as Buffer) });
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [
+        { kind: 'text', text: 'what is this?' },
+        { kind: 'file', file: { mimeType: 'image/png', bytes: Buffer.from('png').toString('base64') } },
+      ],
+    },
+  };
+
+  await backend.handle(task, collect().emit, NEVER);
+
+  assert.equal(written.length, 1);
+  assert.equal(written[0].path, '/tmp/vicoop-codex-test/image-1.png');
+  assert.equal(written[0].data.toString('utf8'), 'png');
+  assert.deepEqual(fake.lastChild()!.args, [
+    'exec',
+    '--json',
+    '--image',
+    '/tmp/vicoop-codex-test/image-1.png',
+    '-',
+  ]);
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-test']);
+});
+
+test('unsupported file and data parts fail fast before spawn', async () => {
+  let spawned = 0;
+  const backend = createCodexBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+  });
+
+  const dataTask: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't1',
+    contextId: 'c',
+    message: { role: 'user', messageId: 'm1', parts: [{ kind: 'data', data: { foo: 'bar' } }] },
+  };
+  const pdfTask: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't2',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm2',
+      parts: [{ kind: 'file', file: { mimeType: 'application/pdf', bytes: 'JVBERi0K' } }],
+    },
+  };
+
+  const framesA = collect();
+  const framesB = collect();
+  await backend.handle(dataTask, framesA.emit, NEVER);
+  await backend.handle(pdfTask, framesB.emit, NEVER);
+
+  assert.equal(spawned, 0);
+  assert.equal((framesA.frames[0] as Extract<UpFrame, { type: 'task.fail' }>).error.code, 'unsupported_part_kind');
+  assert.equal((framesB.frames[0] as Extract<UpFrame, { type: 'task.fail' }>).error.code, 'unsupported_file_mime');
+});
+
+test('image materialization failure emits task.fail and cleans temp dir before spawn', async () => {
+  let spawned = 0;
+  const removed: string[] = [];
+  const backend = createCodexBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+    mkdtemp: async () => '/tmp/vicoop-codex-test',
+    writeFile: async () => {
+      throw new Error('disk full');
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: Buffer.from('png').toString('base64') } }],
+    },
+  };
+
+  const { emit, frames } = collect();
+  await backend.handle(task, emit, NEVER);
+
+  assert.equal(spawned, 0);
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-test']);
+  const fail = frames[0] as Extract<UpFrame, { type: 'task.fail' }>;
+  assert.equal(fail.type, 'task.fail');
+  assert.equal(fail.error.code, 'input_file_write_failed');
+  assert.match(fail.error.message, /disk full/);
+});

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -546,15 +546,18 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
           rollbackFreshThread();
           rollbackResumeRefresh();
           const detail = stderrTail.trim();
-          const sigPart = exit.signal ? ` (signal ${exit.signal})` : '';
           const detailPart = detail ? `: ${detail.slice(-500)}` : '';
           const stdinPart = stdinError ? ` [stdin: ${errorMessage(stdinError)}]` : '';
+          const exitMessage =
+            exit.code === null && exit.signal
+              ? `codex terminated by signal ${exit.signal}${detailPart}${stdinPart}`
+              : `codex exited with code ${exit.code}${exit.signal ? ` (signal ${exit.signal})` : ''}${detailPart}${stdinPart}`;
           emit({
             type: 'task.fail',
             taskId: task.taskId,
             error: {
               code: 'codex_exit_nonzero',
-              message: `codex exited with code ${exit.code}${sigPart}${detailPart}${stdinPart}`,
+              message: exitMessage,
             },
           });
           return;

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -1,0 +1,606 @@
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { TRACEABILITY_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
+import type { Backend } from '../backend.js';
+import { INPUT_FILE_MAX_BYTES, INPUT_IMAGE_MIME } from './fetch-uri-file.js';
+
+export interface CodexChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
+  readonly stdout: NodeJS.ReadableStream | null;
+  readonly stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface CodexSpawnOptions {
+  cwd?: string;
+}
+
+export type CodexSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: CodexSpawnOptions,
+) => CodexChildHandle;
+
+export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+export interface CodexBackendOptions {
+  command?: string;
+  cwd?: string;
+  sandboxMode?: CodexSandboxMode;
+  extraArgs?: readonly string[];
+  spawn?: CodexSpawnFn;
+  stderrCaptureBytes?: number;
+  sessionTtlMs?: number;
+  now?: () => number;
+  heartbeatMs?: number;
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
+  mkdtemp?: (prefix: string) => Promise<string>;
+  writeFile?: (file: string, data: Buffer) => Promise<void>;
+  rm?: (file: string, options: { recursive: boolean; force: boolean }) => Promise<void>;
+}
+
+interface SessionEntry {
+  threadId: string;
+  lastUsedAt: number;
+  writeId: number;
+}
+
+interface CodexEvent {
+  type?: unknown;
+  thread_id?: unknown;
+  item?: {
+    type?: unknown;
+    text?: unknown;
+    command?: unknown;
+    aggregated_output?: unknown;
+    exit_code?: unknown;
+    status?: unknown;
+  };
+}
+
+type MappedInput =
+  | { ok: true; prompt: string; imageFiles: string[]; tempDir: string | null }
+  | { ok: false; code: string; message: string };
+
+const DEFAULT_HEARTBEAT_MS = 30_000;
+const COMMAND_TRACE_MAX_CHARS = 2_000;
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable>';
+  }
+}
+
+function decodedBase64Size(b64: string): number {
+  if (b64.length === 0) return 0;
+  let pad = 0;
+  if (b64.endsWith('==')) pad = 2;
+  else if (b64.endsWith('=')) pad = 1;
+  return Math.max(0, Math.floor((b64.length * 3) / 4) - pad);
+}
+
+function traceabilityRequested(task: {
+  requestedExtensions?: readonly string[];
+  message?: { extensions?: readonly string[] };
+}): boolean {
+  return (
+    task.requestedExtensions?.includes(TRACEABILITY_EXTENSION_URI) === true ||
+    task.message?.extensions?.includes(TRACEABILITY_EXTENSION_URI) === true
+  );
+}
+
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: CodexSpawnOptions,
+): CodexChildHandle {
+  return nodeSpawn(command, Array.from(args), {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  }) as ChildProcess;
+}
+
+function imageExtForMime(mime: string): string {
+  switch (mime) {
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/png':
+      return '.png';
+    case 'image/gif':
+      return '.gif';
+    case 'image/webp':
+      return '.webp';
+    default:
+      return '.img';
+  }
+}
+
+function clipTo(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function commandSummary(item: NonNullable<CodexEvent['item']>): string {
+  const command = typeof item.command === 'string' ? item.command : '<unknown command>';
+  const status = typeof item.status === 'string' ? item.status : 'unknown';
+  const exit = typeof item.exit_code === 'number' ? item.exit_code : null;
+  const output = typeof item.aggregated_output === 'string' ? item.aggregated_output.trim() : '';
+  const head = exit === null ? `${command} (${status})` : `${command} (${status}, exit ${exit})`;
+  return clipTo(output ? `${head}\n${output}` : head, COMMAND_TRACE_MAX_CHARS);
+}
+
+async function mapPartsToCodexInput(
+  parts: readonly Part[],
+  io: {
+    mkdtemp: (prefix: string) => Promise<string>;
+    writeFile: (file: string, data: Buffer) => Promise<void>;
+    rm: (file: string, options: { recursive: boolean; force: boolean }) => Promise<void>;
+  },
+): Promise<MappedInput> {
+  const textParts: string[] = [];
+  const pendingImages: Array<{ mime: string; bytes: string }> = [];
+
+  for (const p of parts) {
+    if (p.kind === 'text') {
+      if (p.text) textParts.push(p.text);
+      continue;
+    }
+    if (p.kind === 'file') {
+      const mime = p.file.mimeType ?? '';
+      if (!p.file.bytes) {
+        return {
+          ok: false,
+          code: p.file.uri ? 'unsupported_file_uri' : 'invalid_file_part',
+          message: p.file.uri
+            ? 'codex backend v1 requires inline FilePart bytes; file.uri is not supported'
+            : 'codex backend FilePart must carry inline bytes',
+        };
+      }
+      if (!INPUT_IMAGE_MIME.has(mime)) {
+        return {
+          ok: false,
+          code: 'unsupported_file_mime',
+          message: `codex backend accepts image/{png,jpeg,webp,gif} (got ${mime || 'unknown'})`,
+        };
+      }
+      const decodedSize = decodedBase64Size(p.file.bytes);
+      if (decodedSize > INPUT_FILE_MAX_BYTES) {
+        return {
+          ok: false,
+          code: 'file_too_large',
+          message: `FilePart exceeds INPUT_FILE_MAX_BYTES (${decodedSize} > ${INPUT_FILE_MAX_BYTES})`,
+        };
+      }
+      pendingImages.push({ mime, bytes: p.file.bytes });
+      continue;
+    }
+    return {
+      ok: false,
+      code: 'unsupported_part_kind',
+      message: `codex backend does not accept ${p.kind} parts`,
+    };
+  }
+
+  if (textParts.length === 0 && pendingImages.length === 0) {
+    return { ok: false, code: 'empty_prompt', message: 'no content in message' };
+  }
+
+  let tempDir: string | null = null;
+  const imageFiles: string[] = [];
+  if (pendingImages.length > 0) {
+    try {
+      tempDir = await io.mkdtemp(path.join(os.tmpdir(), 'vicoop-codex-'));
+      for (let i = 0; i < pendingImages.length; i++) {
+        const image = pendingImages[i];
+        const filePath = path.join(tempDir, `image-${i + 1}${imageExtForMime(image.mime)}`);
+        await io.writeFile(filePath, Buffer.from(image.bytes, 'base64'));
+        imageFiles.push(filePath);
+      }
+    } catch (err) {
+      if (tempDir) {
+        try {
+          await io.rm(tempDir, { recursive: true, force: true });
+        } catch {
+          // Best-effort cleanup before surfacing the input failure.
+        }
+      }
+      return {
+        ok: false,
+        code: 'input_file_write_failed',
+        message: `failed to materialize codex image input: ${errorMessage(err)}`,
+      };
+    }
+  }
+
+  return { ok: true, prompt: textParts.join('\n\n'), imageFiles, tempDir };
+}
+
+export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
+  const command = opts.command ?? 'codex';
+  const cwd = opts.cwd;
+  const sandboxMode = opts.sandboxMode;
+  const extraArgs = opts.extraArgs ?? [];
+  const spawnFn = opts.spawn ?? defaultSpawn;
+  const stderrCap = opts.stderrCaptureBytes ?? 8192;
+  const sessionTtlMs = opts.sessionTtlMs ?? 60 * 60 * 1000;
+  const now = opts.now ?? Date.now;
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const setIntervalImpl = opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalImpl = opts.clearIntervalFn ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+  const mkdtemp = opts.mkdtemp ?? fs.mkdtemp;
+  const writeFile = opts.writeFile ?? fs.writeFile;
+  const rm = opts.rm ?? fs.rm;
+
+  const sessions = new Map<string, SessionEntry>();
+  let writeCounter = 0;
+
+  function evictExpired(cutoff: number): void {
+    for (const [key, entry] of sessions) {
+      if (entry.lastUsedAt < cutoff) sessions.delete(key);
+    }
+  }
+
+  return {
+    name: 'codex',
+
+    async handle(task, rawEmit, signal) {
+      let lastEmitAt = now();
+      const emit: typeof rawEmit = (frame) => {
+        lastEmitAt = now();
+        rawEmit(frame);
+      };
+
+      if (signal.aborted) {
+        emit({
+          type: 'task.complete',
+          taskId: task.taskId,
+          status: { state: 'canceled', timestamp: new Date().toISOString() },
+        });
+        return;
+      }
+
+      const mapped = await mapPartsToCodexInput(task.message.parts, { mkdtemp, writeFile, rm });
+      if (!mapped.ok) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: { code: mapped.code, message: mapped.message },
+        });
+        return;
+      }
+
+      try {
+        if (signal.aborted) {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+
+        const tNow = now();
+        if (sessionTtlMs > 0) evictExpired(tNow - sessionTtlMs);
+        const existing = sessionTtlMs > 0 ? sessions.get(task.contextId) : undefined;
+        const isResume = existing !== undefined;
+        let writeId = 0;
+        if (existing && sessionTtlMs > 0) {
+          writeId = ++writeCounter;
+          sessions.set(task.contextId, {
+            threadId: existing.threadId,
+            lastUsedAt: tNow,
+            writeId,
+          });
+        }
+
+        const optionArgs = [
+          '--json',
+          ...(sandboxMode ? ['-c', `sandbox_mode=${JSON.stringify(sandboxMode)}`] : []),
+          ...mapped.imageFiles.flatMap((filePath) => ['--image', filePath]),
+          ...extraArgs,
+        ];
+        const args: string[] = [
+          'exec',
+          ...(isResume ? ['resume', ...optionArgs, existing.threadId] : optionArgs),
+          '-',
+        ];
+
+        let observedThreadId: string | null = null;
+
+        const maybeStoreThread = (threadId: string): void => {
+          if (isResume || sessionTtlMs <= 0) return;
+          observedThreadId = threadId;
+          writeId = ++writeCounter;
+          sessions.set(task.contextId, { threadId, lastUsedAt: now(), writeId });
+        };
+
+        const rollbackResumeRefresh = (): void => {
+          if (!isResume || sessionTtlMs <= 0) return;
+          const cur = sessions.get(task.contextId);
+          if (cur?.threadId === existing.threadId && cur.writeId === writeId) {
+            sessions.set(task.contextId, {
+              threadId: existing.threadId,
+              lastUsedAt: existing.lastUsedAt,
+              writeId: ++writeCounter,
+            });
+          }
+        };
+
+        const rollbackFreshThread = (): void => {
+          if (isResume || sessionTtlMs <= 0 || !observedThreadId) return;
+          const cur = sessions.get(task.contextId);
+          if (cur?.threadId === observedThreadId && cur.writeId === writeId) {
+            sessions.delete(task.contextId);
+          }
+        };
+
+        emit({
+          type: 'task.status',
+          taskId: task.taskId,
+          status: { state: 'working', timestamp: new Date().toISOString() },
+        });
+
+        let child: CodexChildHandle;
+        try {
+          child = spawnFn(command, args, { cwd });
+        } catch (err) {
+          rollbackResumeRefresh();
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: { code: 'spawn_failed', message: errorMessage(err) },
+          });
+          return;
+        }
+
+        let stdinError: unknown = null;
+        if (!child.stdin) {
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            /* best effort */
+          }
+          rollbackResumeRefresh();
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: {
+              code: 'spawn_no_stdin',
+              message: 'spawned codex has no stdin pipe; cannot deliver user prompt',
+            },
+          });
+          return;
+        }
+
+        child.stdin.on('error', (err: unknown) => {
+          if (!stdinError) stdinError = err;
+        });
+        try {
+          child.stdin.end(mapped.prompt);
+        } catch (err) {
+          stdinError = err;
+        }
+
+        let emittedAnyArtifact = false;
+        let finalText: string | null = null;
+        let stderrTail = '';
+        let aborted = false;
+        let settled = false;
+        const emitTraceArtifacts = traceabilityRequested(task);
+
+        const emitAgentArtifact = (text: string): void => {
+          if (!text) return;
+          emit({
+            type: 'task.artifact',
+            taskId: task.taskId,
+            artifact: {
+              artifactId: randomUUID(),
+              name: 'codex-message',
+              parts: [{ kind: 'text', text }],
+            },
+            lastChunk: true,
+          });
+          emittedAnyArtifact = true;
+        };
+
+        const emitCommandTrace = (item: NonNullable<CodexEvent['item']>): void => {
+          if (!emitTraceArtifacts) return;
+          emit({
+            type: 'task.artifact',
+            taskId: task.taskId,
+            artifact: {
+              artifactId: randomUUID(),
+              name: 'codex-command-execution',
+              parts: [
+                { kind: 'text', text: commandSummary(item) },
+                {
+                  kind: 'data',
+                  data: {
+                    command: typeof item.command === 'string' ? item.command : undefined,
+                    status: typeof item.status === 'string' ? item.status : undefined,
+                    exitCode: typeof item.exit_code === 'number' ? item.exit_code : undefined,
+                  },
+                },
+              ],
+              extensions: [TRACEABILITY_EXTENSION_URI],
+              metadata: { traceType: 'command-execution' },
+            },
+            lastChunk: true,
+          });
+          emittedAnyArtifact = true;
+        };
+
+        const handleEvent = (evt: CodexEvent): void => {
+          if (settled) return;
+          if (evt.type === 'thread.started' && typeof evt.thread_id === 'string') {
+            maybeStoreThread(evt.thread_id);
+            return;
+          }
+          if (evt.type !== 'item.completed' || !evt.item) return;
+          if (evt.item.type === 'agent_message' && typeof evt.item.text === 'string') {
+            finalText = evt.item.text;
+            emitAgentArtifact(evt.item.text);
+            return;
+          }
+          if (evt.item.type === 'command_execution') {
+            emitCommandTrace(evt.item);
+          }
+        };
+
+        const onAbort = (): void => {
+          if (aborted) return;
+          aborted = true;
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            /* best effort */
+          }
+        };
+        signal.addEventListener('abort', onAbort);
+
+        let stdoutBuf = '';
+        child.stdout?.on('data', (chunk: Buffer | string) => {
+          stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          let nl: number;
+          while ((nl = stdoutBuf.indexOf('\n')) !== -1) {
+            const line = stdoutBuf.slice(0, nl).trim();
+            stdoutBuf = stdoutBuf.slice(nl + 1);
+            if (!line) continue;
+            try {
+              handleEvent(JSON.parse(line) as CodexEvent);
+            } catch {
+              // Ignore non-JSON chatter defensively.
+            }
+          }
+        });
+
+        child.stderr?.on('data', (chunk: Buffer | string) => {
+          stderrTail += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          if (stderrTail.length > stderrCap) stderrTail = stderrTail.slice(-stderrCap);
+        });
+
+        let heartbeatHandle: unknown = null;
+        if (heartbeatMs > 0) {
+          heartbeatHandle = setIntervalImpl(() => {
+            if (settled || aborted) return;
+            if (now() - lastEmitAt < heartbeatMs) return;
+            emit({
+              type: 'task.status',
+              taskId: task.taskId,
+              status: { state: 'working', timestamp: new Date().toISOString() },
+            });
+          }, heartbeatMs);
+        }
+
+        const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: unknown }>((resolve) => {
+          child.on('error', (err) => resolve({ code: null, signal: null, error: err }));
+          child.on('close', (code, sig) => resolve({ code, signal: sig }));
+        });
+
+        signal.removeEventListener('abort', onAbort);
+        if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
+
+        const trailing = stdoutBuf.trim();
+        if (trailing) {
+          try {
+            handleEvent(JSON.parse(trailing) as CodexEvent);
+          } catch {
+            // ignore
+          }
+        }
+        settled = true;
+
+        if (aborted) {
+          rollbackFreshThread();
+          rollbackResumeRefresh();
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+
+        if (exit.error) {
+          rollbackFreshThread();
+          rollbackResumeRefresh();
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: { code: 'spawn_failed', message: errorMessage(exit.error) },
+          });
+          return;
+        }
+
+        if (exit.code !== 0) {
+          rollbackFreshThread();
+          rollbackResumeRefresh();
+          const detail = stderrTail.trim();
+          const sigPart = exit.signal ? ` (signal ${exit.signal})` : '';
+          const detailPart = detail ? `: ${detail.slice(-500)}` : '';
+          const stdinPart = stdinError ? ` [stdin: ${errorMessage(stdinError)}]` : '';
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: {
+              code: 'codex_exit_nonzero',
+              message: `codex exited with code ${exit.code}${sigPart}${detailPart}${stdinPart}`,
+            },
+          });
+          return;
+        }
+
+        const completeText = finalText ?? '';
+        const parts: Part[] = completeText ? [{ kind: 'text', text: completeText }] : [];
+        if (!emittedAnyArtifact && completeText) {
+          emit({
+            type: 'task.artifact',
+            taskId: task.taskId,
+            artifact: {
+              artifactId: randomUUID(),
+              name: 'codex-result',
+              parts,
+            },
+            lastChunk: true,
+          });
+        }
+
+        emit({
+          type: 'task.complete',
+          taskId: task.taskId,
+          status: {
+            state: 'completed',
+            timestamp: new Date().toISOString(),
+            ...(parts.length
+              ? {
+                  message: {
+                    role: 'agent',
+                    messageId: randomUUID(),
+                    parts,
+                  },
+                }
+              : {}),
+          },
+        });
+      } finally {
+        if (mapped.tempDir) {
+          try {
+            await rm(mapped.tempDir, { recursive: true, force: true });
+          } catch {
+            // Best-effort cleanup; task result should not fail after the child settled.
+          }
+        }
+      }
+    },
+  };
+}

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -5,6 +5,7 @@ import { Client } from './client.js';
 import { echoBackend } from './backends/echo.js';
 import { createOpenclawBackend } from './backends/openclaw.js';
 import { createClaudeBackend } from './backends/claude.js';
+import { createCodexBackend, type CodexSandboxMode } from './backends/codex.js';
 import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
@@ -28,9 +29,14 @@ interface Args {
 }
 
 const DAEMON_USAGE =
-  'vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude> [--card <path>]';
+  'vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude|codex> [--card <path>]';
 const SUBCOMMAND_LIST =
   'subcommands: login, setup, upgrade, list-agents, list-callers, add-caller, remove-caller, whoami (run any with --help)';
+const CODEX_SANDBOX_MODES = new Set<CodexSandboxMode>([
+  'read-only',
+  'workspace-write',
+  'danger-full-access',
+]);
 
 function parseClientArgs(argv: string[]): Args {
   const out: Partial<Args> = {};
@@ -90,6 +96,17 @@ function parseClaudeSettingsEnv(raw: string | undefined): Record<string, unknown
   return parsed as Record<string, unknown>;
 }
 
+function parseCodexSandboxMode(raw: string | undefined): CodexSandboxMode | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  if (CODEX_SANDBOX_MODES.has(trimmed as CodexSandboxMode)) {
+    return trimmed as CodexSandboxMode;
+  }
+  throw new Error(
+    `CODEX_SANDBOX_MODE must be one of: ${Array.from(CODEX_SANDBOX_MODES).join(', ')}`,
+  );
+}
+
 function pickBackend(name: string, args: Args): Backend {
   switch (name) {
     case 'echo':
@@ -107,8 +124,13 @@ function pickBackend(name: string, args: Args): Backend {
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         settings: parseClaudeSettingsEnv(process.env.CLAUDE_SETTINGS_JSON),
       });
+    case 'codex':
+      return createCodexBackend({
+        cwd: process.env.CODEX_CWD?.trim() || undefined,
+        sandboxMode: parseCodexSandboxMode(process.env.CODEX_SANDBOX_MODE),
+      });
     default:
-      throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude)`);
+      throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude, codex)`);
   }
 }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -102,9 +102,10 @@ function parseCodexSandboxMode(raw: string | undefined): CodexSandboxMode | unde
   if (CODEX_SANDBOX_MODES.has(trimmed as CodexSandboxMode)) {
     return trimmed as CodexSandboxMode;
   }
-  throw new Error(
-    `CODEX_SANDBOX_MODE must be one of: ${Array.from(CODEX_SANDBOX_MODES).join(', ')}`,
+  console.error(
+    `CODEX_SANDBOX_MODE must be one of: ${Array.from(CODEX_SANDBOX_MODES).join(', ')} (got ${JSON.stringify(trimmed)})`,
   );
+  process.exit(1);
 }
 
 function pickBackend(name: string, args: Args): Backend {

--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -19,6 +19,19 @@ test('resolves canonical server card from backendKind when inline card is absent
   );
 });
 
+test('resolves canonical codex server card from backendKind', () => {
+  const result = resolveHelloAgentCard(frame({ backendKind: 'codex' }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.source, 'canonical');
+  assert.equal(result.ok && result.agentCard.name, 'codex');
+  assert.deepEqual(
+    result.ok && result.agentCard.defaultInputModes,
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+  );
+  assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
+});
+
 test('inline card overrides backendKind', () => {
   const inline = {
     name: 'operator-custom',

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -13,6 +13,7 @@ function readCanonicalCard(kind: string): AgentCardType {
 const canonicalCards = new Map<string, AgentCardType>(
   Object.entries({
     claude: readCanonicalCard('claude'),
+    codex: readCanonicalCard('codex'),
     echo: readCanonicalCard('echo'),
     openclaw: readCanonicalCard('openclaw'),
   }),

--- a/packages/server/src/cards/codex.json
+++ b/packages/server/src/cards/codex.json
@@ -1,0 +1,34 @@
+{
+  "name": "codex",
+  "description": "OpenAI Codex CLI agent. Spawns the local `codex` binary per task and streams agent messages back as A2A text artifacts. Accepts text and inline image inputs.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Codex command executions.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the Codex CLI responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`.",
+      "tags": ["chat", "assistant", "codex"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a first-party Codex CLI backend that runs `codex exec --json -` and resumes with `codex exec resume --json <thread_id> -`.
- Map A2A text plus inline image inputs to Codex stdin/`--image`, emit agent messages as text artifacts, and expose command executions as opt-in trace artifacts.
- Add `CODEX_SANDBOX_MODE` (`read-only`, `workspace-write`, `danger-full-access`) and pass it as `-c sandbox_mode=...` so fresh and resumed Codex sessions use the same sandbox setting.
- Register Codex in the client CLI, canonical server cards, docs, and release changeset.

## Validation

- `pnpm --filter @vicoop-bridge/client test`
- `pnpm --filter @vicoop-bridge/server test`
- `pnpm -r typecheck`
- `CODEX_SANDBOX_MODE=nope pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts --server ws://127.0.0.1:1 --token t --agentId a --backend codex` exits 1 with the expected validation error
- Live Codex smoke: `printf 'Reply exactly: OK\\n' | codex exec --json --sandbox read-only --skip-git-repo-check -`\n- Live Codex config smoke: `codex exec --json -c 'sandbox_mode="read-only"' --skip-git-repo-check -`, then `codex exec resume --json -c 'sandbox_mode="read-only"' --skip-git-repo-check <thread_id> -`\n\nCloses #140