### PR TITLE
fix(client): fold A2A data parts into the prompt instead of rejecting them

### DIFF
--- a/.changeset/data-part-input-folds-to-prompt.md
+++ b/.changeset/data-part-input-folds-to-prompt.md
@@ -1,0 +1,15 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Accept A2A `data` parts on the `codex`, `claude`, and `openclaw` backends (#150). Previously, a task whose message included an `application/json` data part alongside the user text failed immediately with `unsupported_part_kind` (claude/codex) or `unsupported_data_part` (openclaw), surprising callers that attach structured metadata as auxiliary context.
+
+The three backends now serialize each `DataPart.data` into a deterministic, grep-friendly block that is folded into the prompt the LLM sees:
+
+```
+<context kind="application/json">
+{ ...JSON.stringify(data, null, 2)... }
+</context>
+```
+
+For codex/openclaw the block is appended to the prompt text (after any text parts); for claude it is emitted as an additional `type: 'text'` content block following the primary text. Mixed `text+data`, `data`-only, and `text+data+file` messages are all accepted; only a fully empty message still fails with `empty_prompt`. The canonical server agent cards for `codex`, `claude`, and `openclaw` now advertise `application/json` in `defaultInputModes` so callers can discover the capability from the card.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -292,14 +292,12 @@ test('abort propagates SIGTERM and completes as canceled', async () => {
   assert.equal(artifacts.length, 1);
 });
 
-test('rejects data parts as unsupported_part_kind without spawning', async () => {
-  let spawned = 0;
-  const backend = createClaudeBackend({
-    spawn: () => {
-      spawned++;
-      throw new Error('should not spawn');
-    },
+test('data parts are serialized into a tagged JSON text content block', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
   });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
   const { emit, frames } = collect();
   const task: TaskAssignFrame = {
     type: 'task.assign',
@@ -308,15 +306,30 @@ test('rejects data parts as unsupported_part_kind without spawning', async () =>
     message: {
       role: 'user',
       messageId: 'm1',
-      parts: [{ kind: 'data', data: { foo: 'bar' } }],
+      parts: [
+        { kind: 'text', text: 'please review' },
+        { kind: 'data', data: { ticket: 42, priority: 'high' } },
+      ],
     },
   };
   await backend.handle(task, emit, NEVER);
 
-  assert.equal(spawned, 0);
-  const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
-  assert.ok(fail);
-  assert.equal(fail.error.code, 'unsupported_part_kind');
+  const fail = frames.find((f) => f.type === 'task.fail');
+  assert.equal(fail, undefined);
+
+  const child = fake.lastChild()!;
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    message: { content: Array<{ type: string; text?: string }> };
+  };
+  assert.equal(env.message.content.length, 2);
+  assert.equal(env.message.content[0].type, 'text');
+  assert.equal(env.message.content[0].text, 'please review');
+  assert.equal(env.message.content[1].type, 'text');
+  const second = env.message.content[1].text ?? '';
+  assert.match(second, /^<context kind="application\/json">\n/);
+  assert.ok(second.includes('"ticket": 42'));
+  assert.ok(second.includes('"priority": "high"'));
+  assert.ok(second.endsWith('</context>'));
 });
 
 test('rejects FilePart with unsupported MIME (e.g. application/zip)', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -216,6 +216,16 @@ function sha256OfBase64(b64: string): string {
   return createHash('sha256').update(Buffer.from(b64, 'base64')).digest('hex');
 }
 
+function serializeDataPart(data: Record<string, unknown>): string {
+  let body: string;
+  try {
+    body = JSON.stringify(data, null, 2);
+  } catch {
+    return '';
+  }
+  return `<context kind="application/json">\n${body}\n</context>`;
+}
+
 function defaultSpawn(
   command: string,
   args: readonly string[],
@@ -420,6 +430,14 @@ async function mapPartsToContentBlocks(
       }
       continue;
     }
+    if (p.kind === 'data') {
+      // Auxiliary structured metadata. Render as a tagged JSON text block
+      // appended after primary text — Anthropic's API takes one content array
+      // and there's no dedicated data channel for caller-supplied context.
+      const serialized = serializeDataPart(p.data);
+      if (serialized) blocks.push({ type: 'text', text: serialized });
+      continue;
+    }
     if (p.kind === 'file') {
       let bytes = p.file.bytes;
       let mime = p.file.mimeType ?? '';
@@ -488,11 +506,6 @@ async function mapPartsToContentBlocks(
       inboundHashes.add(sha256OfBase64(bytes));
       continue;
     }
-    return {
-      ok: false,
-      code: 'unsupported_part_kind',
-      message: `claude backend does not accept ${p.kind} parts`,
-    };
   }
   // Media-only messages (image/document with no text) are accepted —
   // Anthropic's vision/document path can answer about them without an

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -690,7 +690,7 @@ test('image FilePart.bytes creates temp files and passes --image args', async ()
   assert.deepEqual(removed, ['/tmp/vicoop-codex-test']);
 });
 
-test('unsupported file and data parts fail fast before spawn', async () => {
+test('unsupported file parts fail fast before spawn', async () => {
   let spawned = 0;
   const backend = createCodexBackend({
     spawn: () => {
@@ -699,12 +699,6 @@ test('unsupported file and data parts fail fast before spawn', async () => {
     },
   });
 
-  const dataTask: TaskAssignFrame = {
-    type: 'task.assign',
-    taskId: 't1',
-    contextId: 'c',
-    message: { role: 'user', messageId: 'm1', parts: [{ kind: 'data', data: { foo: 'bar' } }] },
-  };
   const pdfTask: TaskAssignFrame = {
     type: 'task.assign',
     taskId: 't2',
@@ -716,14 +710,69 @@ test('unsupported file and data parts fail fast before spawn', async () => {
     },
   };
 
-  const framesA = collect();
-  const framesB = collect();
-  await backend.handle(dataTask, framesA.emit, NEVER);
-  await backend.handle(pdfTask, framesB.emit, NEVER);
+  const frames = collect();
+  await backend.handle(pdfTask, frames.emit, NEVER);
 
   assert.equal(spawned, 0);
-  assert.equal((framesA.frames[0] as Extract<UpFrame, { type: 'task.fail' }>).error.code, 'unsupported_part_kind');
-  assert.equal((framesB.frames[0] as Extract<UpFrame, { type: 'task.fail' }>).error.code, 'unsupported_file_mime');
+  assert.equal((frames.frames[0] as Extract<UpFrame, { type: 'task.fail' }>).error.code, 'unsupported_file_mime');
+});
+
+test('data parts are serialized into the codex prompt as tagged JSON', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({ spawn: fake.spawn });
+
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't-data',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [
+        { kind: 'text', text: 'summarize' },
+        { kind: 'data', data: { ticket: 42, priority: 'high' } },
+      ],
+    },
+  };
+
+  const { emit, frames } = collect();
+  await backend.handle(task, emit, NEVER);
+
+  const child = fake.lastChild()!;
+  assert.match(child.stdinPayload, /^summarize\n\n<context kind="application\/json">\n/);
+  assert.ok(child.stdinPayload.includes('"ticket": 42'));
+  assert.ok(child.stdinPayload.includes('"priority": "high"'));
+  assert.ok(child.stdinPayload.endsWith('</context>'));
+
+  const failFrame = frames.find((f) => f.type === 'task.fail');
+  assert.equal(failFrame, undefined);
+});
+
+test('data-only message produces a prompt with just the JSON context block', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({ spawn: fake.spawn });
+
+  const task: TaskAssignFrame = {
+    type: 'task.assign',
+    taskId: 't-data-only',
+    contextId: 'c',
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'data', data: { hello: 'world' } }],
+    },
+  };
+
+  const { emit } = collect();
+  await backend.handle(task, emit, NEVER);
+
+  const child = fake.lastChild()!;
+  assert.match(child.stdinPayload, /^<context kind="application\/json">\n/);
+  assert.ok(child.stdinPayload.includes('"hello": "world"'));
 });
 
 test('image materialization failure emits task.fail and cleans temp dir before spawn', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -160,11 +160,20 @@ async function mapPartsToCodexInput(
   },
 ): Promise<MappedInput> {
   const textParts: string[] = [];
+  const dataParts: string[] = [];
   const pendingImages: Array<{ mime: string; bytes: string }> = [];
 
   for (const p of parts) {
     if (p.kind === 'text') {
       if (p.text) textParts.push(p.text);
+      continue;
+    }
+    if (p.kind === 'data') {
+      // Auxiliary structured metadata sent alongside the user text. The codex
+      // CLI has no first-class data-part channel, so fold it into the prompt
+      // as a tagged JSON block — deterministic, visible, and grep-friendly.
+      const serialized = serializeDataPart(p.data);
+      if (serialized) dataParts.push(serialized);
       continue;
     }
     if (p.kind === 'file') {
@@ -196,14 +205,9 @@ async function mapPartsToCodexInput(
       pendingImages.push({ mime, bytes: p.file.bytes });
       continue;
     }
-    return {
-      ok: false,
-      code: 'unsupported_part_kind',
-      message: `codex backend does not accept ${p.kind} parts`,
-    };
   }
 
-  if (textParts.length === 0 && pendingImages.length === 0) {
+  if (textParts.length === 0 && dataParts.length === 0 && pendingImages.length === 0) {
     return { ok: false, code: 'empty_prompt', message: 'no content in message' };
   }
 
@@ -234,7 +238,18 @@ async function mapPartsToCodexInput(
     }
   }
 
-  return { ok: true, prompt: textParts.join('\n\n'), imageFiles, tempDir };
+  const prompt = [...textParts, ...dataParts].join('\n\n');
+  return { ok: true, prompt, imageFiles, tempDir };
+}
+
+function serializeDataPart(data: Record<string, unknown>): string {
+  let body: string;
+  try {
+    body = JSON.stringify(data, null, 2);
+  } catch {
+    return '';
+  }
+  return `<context kind="application/json">\n${body}\n</context>`;
 }
 
 export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -1125,11 +1125,36 @@ test('handle(): non-image file part is forwarded as a non-image attachment (Open
   }
 });
 
-test('handle(): data part fails fast with unsupported_data_part without touching the gateway', async () => {
-  let chatSendSeen = false;
+test('handle(): data part is folded into the chat.send message as a tagged JSON block', async () => {
+  let observedMessage: string | undefined;
   const fake = await createFakeGateway({
-    onRequest: (_sock, req) => {
-      if (req.method === 'chat.send') chatSendSeen = true;
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        observedMessage = (req.params as { message?: string } | undefined)?.message;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { runId: 'run-data', status: 'started' },
+          }),
+        );
+        setImmediate(() => {
+          sock.send(
+            JSON.stringify({
+              type: 'event',
+              event: 'chat',
+              payload: {
+                runId: 'run-data',
+                sessionKey: 'agent:main:ctx-t1',
+                seq: 1,
+                state: 'final',
+                message: { text: 'ok' },
+              },
+            }),
+          );
+        });
+      }
     },
   });
   try {
@@ -1150,11 +1175,11 @@ test('handle(): data part fails fast with unsupported_data_part without touching
     };
     await backend.handle(task, (f) => frames.push(f), NEVER);
     const fail = frames.find((f) => f.type === 'task.fail');
-    assert.ok(fail, 'unsupported data part must fail the task');
-    assert.equal(fail!.error.code, 'unsupported_data_part');
-    // Give any racing chat.send a chance to land so the assertion is meaningful.
-    await new Promise((r) => setTimeout(r, 30));
-    assert.equal(chatSendSeen, false, 'gateway must not see chat.send for malformed input');
+    assert.equal(fail, undefined, 'data parts must no longer fail the task');
+    assert.ok(observedMessage, 'chat.send must have been called with a message');
+    assert.match(observedMessage!, /^context\n<context kind="application\/json">\n/);
+    assert.ok(observedMessage!.includes('"hello": "world"'));
+    assert.ok(observedMessage!.endsWith('</context>'));
   } finally {
     await fake.close();
   }

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -974,16 +974,29 @@ test('mapPartsToChatInput: missing mimeType is rejected (gateway needs it for sn
   assert.match(result.error.message, /mimeType/);
 });
 
-test('mapPartsToChatInput: data part is rejected since OpenClaw has no structured input surface', async () => {
+test('mapPartsToChatInput: data part is serialized into the chat message as a tagged JSON block', async () => {
   const result = await mapPartsToChatInput([
     { kind: 'text', text: 'context follows' },
     { kind: 'data', data: { foo: 'bar', n: 42 } },
   ]);
-  assert.equal(result.ok, false);
-  if (result.ok) return;
-  assert.equal(result.error.code, 'unsupported_data_part');
-  // Error should identify the offending part index (index 1 here).
-  assert.match(result.error.message, /part\[1\]/);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.input.attachments, []);
+  const msg = result.input.message;
+  assert.match(msg, /^context follows\n<context kind="application\/json">\n/);
+  assert.ok(msg.includes('"foo": "bar"'));
+  assert.ok(msg.includes('"n": 42'));
+  assert.ok(msg.endsWith('</context>'));
+});
+
+test('mapPartsToChatInput: data-only message produces a chat message with just the JSON context block', async () => {
+  const result = await mapPartsToChatInput([
+    { kind: 'data', data: { hello: 'world' } },
+  ]);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.match(result.input.message, /^<context kind="application\/json">\n/);
+  assert.ok(result.input.message.includes('"hello": "world"'));
 });
 
 test('handle(): image file part is forwarded to chat.send as attachments', async () => {

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -363,8 +363,9 @@ class GatewayClient {
 //
 // `file.uri` inputs are fetched by the bridge under the shared inbound file
 // safety policy, then forwarded as the same base64 attachment shape as
-// caller-inline `file.bytes`. `kind: 'data'` remains out of scope because
-// OpenClaw has no structured-input surface for it.
+// caller-inline `file.bytes`. `kind: 'data'` is folded into the chat
+// message text as a tagged JSON block because OpenClaw has no structured-
+// input surface for it.
 interface OpenclawChatInput {
   message: string;
   attachments: Array<{
@@ -382,6 +383,16 @@ interface PartMappingError {
 
 function isImageMime(mime: string | undefined): boolean {
   return typeof mime === 'string' && mime.toLowerCase().startsWith('image/');
+}
+
+function serializeDataPart(data: Record<string, unknown>): string {
+  let body: string;
+  try {
+    body = JSON.stringify(data, null, 2);
+  } catch {
+    return '';
+  }
+  return `<context kind="application/json">\n${body}\n</context>`;
 }
 
 // Exported for unit testing; shape matches what `handle()` feeds into
@@ -459,13 +470,12 @@ export async function mapPartsToChatInput(
       continue;
     }
     if (p.kind === 'data') {
-      return {
-        ok: false,
-        error: {
-          code: 'unsupported_data_part',
-          message: `part[${idx}]: data parts are not supported by the openclaw backend; serialize to a text part if the agent should see structured input`,
-        },
-      };
+      // Auxiliary structured metadata; serialize into the chat message as a
+      // tagged JSON block so the agent sees the context even though OpenClaw
+      // has no first-class data-part channel.
+      const serialized = serializeDataPart(p.data);
+      if (serialized) textBits.push(serialized);
+      continue;
     }
   }
   return {

--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -15,7 +15,7 @@ test('resolves canonical server card from backendKind when inline card is absent
   assert.equal(result.ok && result.agentCard.name, 'claude');
   assert.deepEqual(
     result.ok && result.agentCard.defaultInputModes,
-    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/pdf'],
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/pdf', 'application/json'],
   );
 });
 
@@ -27,7 +27,7 @@ test('resolves canonical codex server card from backendKind', () => {
   assert.equal(result.ok && result.agentCard.name, 'codex');
   assert.deepEqual(
     result.ok && result.agentCard.defaultInputModes,
-    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp'],
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/json'],
   );
   assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
 });

--- a/packages/server/src/cards/claude.json
+++ b/packages/server/src/cards/claude.json
@@ -19,7 +19,8 @@
     "image/jpeg",
     "image/gif",
     "image/webp",
-    "application/pdf"
+    "application/pdf",
+    "application/json"
   ],
   "defaultOutputModes": [
     "text/plain",
@@ -33,7 +34,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`.",
+      "description": "Ask a question or give an instruction in natural language; the Claude Code CLI responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks.",
       "tags": ["chat", "assistant", "claude"]
     }
   ]

--- a/packages/server/src/cards/codex.json
+++ b/packages/server/src/cards/codex.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "description": "OpenAI Codex CLI agent. Spawns the local `codex` binary per task and streams agent messages back as A2A text artifacts. Accepts text and inline image inputs.",
+  "description": "OpenAI Codex CLI agent. Spawns the local `codex` binary per task and streams agent messages back as A2A text artifacts. Accepts text, inline image, and JSON data part inputs.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": {
@@ -18,7 +18,8 @@
     "image/png",
     "image/jpeg",
     "image/gif",
-    "image/webp"
+    "image/webp",
+    "application/json"
   ],
   "defaultOutputModes": [
     "text/plain"
@@ -27,7 +28,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the Codex CLI responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`.",
+      "description": "Ask a question or give an instruction in natural language; the Codex CLI responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks.",
       "tags": ["chat", "assistant", "codex"]
     }
   ]

--- a/packages/server/src/cards/openclaw.json
+++ b/packages/server/src/cards/openclaw.json
@@ -10,7 +10,8 @@
     "image/jpeg",
     "image/gif",
     "image/webp",
-    "application/pdf"
+    "application/pdf",
+    "application/json"
   ],
   "defaultOutputModes": [
     "text/plain",
@@ -39,7 +40,7 @@
     {
       "id": "chat",
       "name": "chat",
-      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
+      "description": "Ask a question or give an instruction in natural language; the agent responds with text. Optionally include inline image (image/{png,jpeg,gif,webp}) or PDF (application/pdf) parts as `file.bytes`. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the chat message as tagged JSON blocks. When the operator enables outbound file delivery, replies may also include file artifacts (images, PDFs, structured data, archives, audio, video, or other binary types).",
       "tags": ["chat", "assistant"]
     }
   ]


### PR DESCRIPTION
Fixes #150.

## Summary

- Codex, Claude, and OpenClaw backends now accept A2A messages that include `kind: 'data'` parts. Each `DataPart.data` is serialized via `JSON.stringify(..., null, 2)` and folded into the prompt as a tagged context block:

  ```
  <context kind="application/json">
  { ...JSON... }
  </context>
  ```

  Codex/OpenClaw append the block to the prompt text (after any text parts); Claude emits it as an additional `type: 'text'` content block following the primary text. Mixed `text+data`, `data`-only, and `text+data+file` messages are all accepted; only a fully empty message still fails with `empty_prompt`.

- Canonical server agent cards for `codex`, `claude`, and `openclaw` now list `application/json` in `defaultInputModes` so callers can discover the capability from the card; skill descriptions mention the JSON-context folding behavior. `card-resolver` tests are updated to match.

- Drops the now-dead `unsupported_part_kind` / `unsupported_data_part` rejection branches. The `Part` discriminated union (`text | file | data`) is fully exhausted in each backend's input mapper.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client exec tsx --test src/backends/codex.test.ts` — 22/22 pass, including two new data-part tests (mixed `text+data` + `data`-only).
- [x] New claude / openclaw data-part tests added.
- [x] `pnpm --filter @vicoop-bridge/server test` — 174 pass / 26 skip; updated card-resolver assertions.
- [x] End-to-end: built `@vicoop-bridge/client` from this branch, registered a fresh `claude-test-…` agent against `wss://vicoop-bridge-server.fly.dev`, posted an A2A `message/send` whose parts included `{kind:'text', …}` + `{kind:'data', data:{ticket:42, priority:'high'}}` — task `completed` (previously `task.fail code=unsupported_part_kind`). A follow-up request asking Claude to read the data back returned `ticket=42, priority=high`, confirming the JSON block reaches the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)