### PR TITLE
feat(client): A2A openai-compat extension on claude backend (turn 1 + multi-turn)

### DIFF
--- a/.changeset/openai-compat-extension-claude.md
+++ b/.changeset/openai-compat-extension-claude.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Implement the A2A [openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `claude` backend. When an inbound `Message.metadata` carries the extension key, the client lifts `system` / `tools` / `tool_choice` out of the payload and folds them into a per-task `--append-system-prompt` that teaches the spawned `claude` to emit a `{"tool_calls":[{"id":"call_…","function":{"name":"…","arguments":{…}}}]}` envelope when it decides to call a function. Envelope replies are detected at every assistant turn and surfaced as an A2A `data` part artifact (`extensions: ["…/openai-compat/v1"]`) so the upstream OpenAI-compatible gateway can forward them verbatim as `tool_calls`; non-envelope turns continue to stream as text artifacts.
+
+`tool_choice` is honored at the prompt level: `"auto"` adds a soft directive, `"required"` and `{type:"function", function:{name}}` mandate the envelope, and `"none"` suppresses the envelope contract entirely and instructs the model to answer in natural language. The `claude` agent card now advertises the extension URI under `capabilities.extensions[]`, so cooperating gateways can discover the capability from a card fetch. Tasks that do not carry the extension metadata key are unchanged — no system-prompt injection, no envelope detection.

--- a/.changeset/openai-compat-multi-turn.md
+++ b/.changeset/openai-compat-multi-turn.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Extend the [openai-compat/v1 A2A extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) handling on the `claude` backend with multi-turn `tool_call_history` support (per the consensus on [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30)). When the metadata payload carries a `tool_call_history` array — an OpenAI-shaped record of prior `assistant.tool_calls` and `role:"tool"` returns — the bridge renders it as a `<tool_call_history>...</tool_call_history>` JSON block and prepends it to the user content sent to `claude`, so the model can pick up the conversation where it left off after the gateway executed a tool externally.
+
+The bridge replays the history unconditionally on every turn (stateless-gateway contract): even when `--resume` brings the model's own prior turn into session memory, the wire history is the source of truth and gets injected. The SYSTEM_INSTRUCTION grows by one paragraph explaining the block format and pinning an anti-loop directive — the model must NOT repeat any call whose `tool_call_id` already appears in the history, otherwise tool turns chain forever. Whole-array validation: a malformed entry drops the entire history rather than leaving a hole, since `tool_call_id` pairings depend on order.

--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -10,6 +10,11 @@
         "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
         "description": "Opt-in execution trace stream for Claude Code tool calls and tool-result media.",
         "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
       }
     ]
   },

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'node:events';
 import {
   buildOpenAICompatSystemPrompt,
   createClaudeBackend,
+  formatToolCallHistory,
   parseOpenAICompatMetadata,
   summarizeToolInput,
   tryParseToolCallsEnvelope,
@@ -2052,4 +2053,210 @@ test('extension off: a coincidental {"tool_calls":[...]} text stays a text artif
   );
   assert.equal(artifacts.length, 1);
   assert.equal(artifacts[0].artifact.parts[0].kind, 'text');
+});
+
+// ---------------------------------------------------------------------------
+// openai-compat extension: multi-turn (tool_call_history)
+// ---------------------------------------------------------------------------
+
+const SAMPLE_HISTORY: ReadonlyArray<Record<string, unknown>> = [
+  {
+    role: 'assistant',
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  },
+  {
+    role: 'tool',
+    tool_call_id: 'call_abc',
+    name: 'get_weather',
+    content: '{"temp":15,"cond":"sunny"}',
+  },
+];
+
+test('parseOpenAICompatMetadata: accepts well-formed tool_call_history', () => {
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: SAMPLE_HISTORY,
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.tool_call_history?.length, 2);
+  // assistant entry preserves tool_calls verbatim.
+  const a = m.tool_call_history![0];
+  assert.equal(a.role, 'assistant');
+  if (a.role !== 'assistant') throw new Error('expected assistant entry');
+  assert.equal(a.tool_calls.length, 1);
+  // tool entry preserves content as string + optional name.
+  const t = m.tool_call_history![1];
+  assert.equal(t.role, 'tool');
+  if (t.role !== 'tool') throw new Error('expected tool entry');
+  assert.equal(t.tool_call_id, 'call_abc');
+  assert.equal(t.name, 'get_weather');
+  assert.equal(t.content, '{"temp":15,"cond":"sunny"}');
+});
+
+test('parseOpenAICompatMetadata: tool entry without optional name is accepted', () => {
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tool_call_history: [
+        { role: 'tool', tool_call_id: 'call_x', content: 'ok' },
+      ],
+    },
+  });
+  assert.ok(m);
+  const t = m.tool_call_history![0];
+  if (t.role !== 'tool') throw new Error('expected tool entry');
+  assert.equal(t.name, undefined);
+});
+
+test('parseOpenAICompatMetadata: malformed history entry drops the whole array', () => {
+  // assistant.tool_calls must be a non-empty array — strict-or-nothing means
+  // an empty array poisons the whole history, since the parse is whole-array
+  // and order matters for pairings.
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: [
+        { role: 'assistant', tool_calls: [] },
+        { role: 'tool', tool_call_id: 'call_a', content: 'ok' },
+      ],
+    },
+  });
+  // tools survived; history dropped → still a valid metadata (not null).
+  assert.ok(m);
+  assert.equal(m.tool_call_history, undefined);
+  assert.equal(m.tools?.length, 1);
+});
+
+test('parseOpenAICompatMetadata: tool entry missing content drops the whole array', () => {
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: [
+        { role: 'assistant', tool_calls: [{ id: 'call_a', function: { name: 'f' } }] },
+        // Missing `content` — invalid.
+        { role: 'tool', tool_call_id: 'call_a' },
+      ],
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.tool_call_history, undefined);
+});
+
+test('parseOpenAICompatMetadata: empty history is treated as absent', () => {
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: [],
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.tool_call_history, undefined);
+});
+
+test('parseOpenAICompatMetadata: history-only payload (no tools/system) still returns metadata', () => {
+  // Tolerant degradation: gateway sent only history, no tools schema. Bridge
+  // can still replay; model will answer naturally without tool affordances.
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: { tool_call_history: SAMPLE_HISTORY },
+  });
+  assert.ok(m);
+  assert.equal(m.tool_call_history?.length, 2);
+  assert.equal(m.tools, undefined);
+});
+
+test('buildOpenAICompatSystemPrompt: includes the tool_call_history paragraph when tools are present', () => {
+  const prompt = buildOpenAICompatSystemPrompt({ tools: SAMPLE_TOOLS });
+  assert.match(prompt, /<tool_call_history>\.\.\.<\/tool_call_history>/);
+  // Anti-loop directive must survive any future wording revisions to this
+  // paragraph — the model needs to be told not to repeat calls already in
+  // the history, otherwise tool turns chain forever.
+  assert.match(prompt, /Do NOT repeat a call whose tool_call_id already appears in the history/);
+});
+
+test('buildOpenAICompatSystemPrompt: omits the history paragraph when tools are absent', () => {
+  // No tools → no envelope contract → no history paragraph either; the
+  // paragraph references a tool_calls envelope that wouldn't be valid.
+  const prompt = buildOpenAICompatSystemPrompt({ system: 'Be terse.' });
+  assert.doesNotMatch(prompt, /<tool_call_history>/);
+});
+
+test('formatToolCallHistory: wraps the JSON array verbatim', () => {
+  const rendered = formatToolCallHistory([
+    { role: 'assistant', tool_calls: [{ id: 'call_x', function: { name: 'f' } }] },
+    { role: 'tool', tool_call_id: 'call_x', content: 'ok' },
+  ]);
+  assert.match(rendered, /^<tool_call_history>\n/);
+  assert.match(rendered, /\n<\/tool_call_history>$/);
+  // Pretty-printed JSON makes the structure scannable for the model and for
+  // operators reading bridge logs; the test pins indentation to lock in the
+  // contract.
+  assert.match(rendered, /"role": "assistant"/);
+  assert.match(rendered, /"tool_call_id": "call_x"/);
+});
+
+test('multi-turn: history block is prepended to the user content sent to claude', async () => {
+  // We need to inspect the stdin payload claude received, which carries the
+  // user message envelope as JSON — see the existing `assign(...)` flow.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('continue, please', {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: SAMPLE_HISTORY,
+    }),
+    emit,
+    NEVER,
+  );
+
+  const child = fake.lastChild();
+  assert.ok(child, 'expected a spawned child');
+  // The envelope is a single JSON line on stdin; parse it back to inspect
+  // the content block order.
+  const envelope = JSON.parse(child.stdinPayload.trim()) as {
+    message: { content: Array<{ type: string; text?: string }> };
+  };
+  assert.equal(envelope.message.content[0].type, 'text');
+  // First block is the history; the user's actual prompt is second.
+  assert.match(envelope.message.content[0].text ?? '', /^<tool_call_history>/);
+  assert.match(envelope.message.content[0].text ?? '', /"role": "assistant"/);
+  assert.equal(envelope.message.content[1].type, 'text');
+  assert.equal(envelope.message.content[1].text, 'continue, please');
+});
+
+test('multi-turn: absent tool_call_history leaves the user content untouched', async () => {
+  // First-turn / no-history path: only the user text reaches claude, no
+  // injected XML wrapper. Guards against the history block leaking onto
+  // tasks that didn't ask for it.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('what is the weather in Seoul?', { tools: SAMPLE_TOOLS }),
+    emit,
+    NEVER,
+  );
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const envelope = JSON.parse(child.stdinPayload.trim()) as {
+    message: { content: Array<{ type: string; text?: string }> };
+  };
+  assert.equal(envelope.message.content.length, 1);
+  assert.equal(envelope.message.content[0].text, 'what is the weather in Seoul?');
 });

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -5,12 +5,16 @@ import os from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import {
+  buildOpenAICompatSystemPrompt,
   createClaudeBackend,
+  parseOpenAICompatMetadata,
   summarizeToolInput,
+  tryParseToolCallsEnvelope,
   type ClaudeChildHandle,
   type ClaudeSpawnOptions,
 } from './claude.js';
 import {
+  OPENAI_COMPAT_EXTENSION_URI,
   TRACEABILITY_EXTENSION_URI,
   type TaskAssignFrame,
   type UpFrame,
@@ -1725,4 +1729,327 @@ test('send_file MCP: tool call landing during an in-flight task emits a task.art
 
   await server.close();
   await fs.rm(realRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// openai-compat extension
+// ---------------------------------------------------------------------------
+
+const SAMPLE_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get the current weather for a city.',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+function assignWithOpenAICompat(
+  text: string,
+  payload: Record<string, unknown>,
+): TaskAssignFrame {
+  return {
+    ...assign(text),
+    message: {
+      ...assign(text).message,
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: payload },
+    },
+  };
+}
+
+test('parseOpenAICompatMetadata: absent / wrong-shape / empty payload returns null', () => {
+  assert.equal(parseOpenAICompatMetadata(undefined), null);
+  assert.equal(parseOpenAICompatMetadata({}), null);
+  // Wrong shape (array / scalar / null) is treated as absent so callers do
+  // not have to defend against trash from a non-cooperating sender.
+  assert.equal(
+    parseOpenAICompatMetadata({ [OPENAI_COMPAT_EXTENSION_URI]: [] as unknown as Record<string, unknown> }),
+    null,
+  );
+  assert.equal(
+    parseOpenAICompatMetadata({ [OPENAI_COMPAT_EXTENSION_URI]: 'nope' as unknown as Record<string, unknown> }),
+    null,
+  );
+  // Object present but no actionable fields → still null.
+  assert.equal(parseOpenAICompatMetadata({ [OPENAI_COMPAT_EXTENSION_URI]: {} }), null);
+  // Empty tools array is treated as absent — there's nothing for the model
+  // to call, and emitting the envelope contract on no functions is noise.
+  assert.equal(
+    parseOpenAICompatMetadata({ [OPENAI_COMPAT_EXTENSION_URI]: { tools: [] } }),
+    null,
+  );
+});
+
+test('parseOpenAICompatMetadata: picks up system / tools / tool_choice and drops blank system', () => {
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      system: 'You are concise.',
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'auto',
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.system, 'You are concise.');
+  assert.equal(m.tool_choice, 'auto');
+  assert.equal(m.tools?.length, 1);
+
+  // Empty-string system is treated as absent so the assembler doesn't emit
+  // a blank section before the tool envelope.
+  const m2 = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: { system: '', tools: SAMPLE_TOOLS },
+  });
+  assert.ok(m2);
+  assert.equal(m2.system, undefined);
+  assert.equal(m2.tools?.length, 1);
+});
+
+test('buildOpenAICompatSystemPrompt: includes tools JSON and tool_choice line when tools present', () => {
+  const prompt = buildOpenAICompatSystemPrompt({
+    system: 'You are concise.',
+    tools: SAMPLE_TOOLS,
+    tool_choice: 'auto',
+  });
+  // User system precedes the envelope contract.
+  assert.match(prompt, /^You are concise\./);
+  // Envelope contract is present verbatim — the exact phrasing is the
+  // contract the LLM is being trained against at runtime; changing it
+  // without intent breaks parsing on the model side.
+  assert.match(prompt, /"tool_calls":\[\{"id":"call_<unique>"/);
+  // tools JSON inlined.
+  assert.match(prompt, /"name": "get_weather"/);
+  // tool_choice descriptor appended.
+  assert.match(prompt, /tool_choice="auto"/);
+});
+
+test('buildOpenAICompatSystemPrompt: forced-function tool_choice surfaces the name', () => {
+  const prompt = buildOpenAICompatSystemPrompt({
+    tools: SAMPLE_TOOLS,
+    tool_choice: { type: 'function', function: { name: 'get_weather' } },
+  });
+  assert.match(prompt, /calls the function named "get_weather"/);
+});
+
+test('buildOpenAICompatSystemPrompt: tool_choice="none" suppresses the envelope contract', () => {
+  const prompt = buildOpenAICompatSystemPrompt({
+    system: 'Stay polite.',
+    tools: SAMPLE_TOOLS,
+    tool_choice: 'none',
+  });
+  assert.match(prompt, /^Stay polite\./);
+  // No envelope contract emitted — instead the explicit "do not emit"
+  // directive runs so the gateway's intent is preserved.
+  assert.doesNotMatch(prompt, /"tool_calls":\[\{"id":"call_<unique>"/);
+  assert.match(prompt, /tool_choice="none"/);
+});
+
+test('buildOpenAICompatSystemPrompt: system only (no tools) returns just the user system', () => {
+  const prompt = buildOpenAICompatSystemPrompt({ system: 'Be terse.' });
+  assert.equal(prompt, 'Be terse.');
+});
+
+test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves unknown keys', () => {
+  const out = tryParseToolCallsEnvelope(
+    JSON.stringify({
+      tool_calls: [
+        { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+      ],
+      // Unknown keys (e.g. model name, usage) ride along verbatim — the
+      // gateway is responsible for stripping anything it doesn't expect.
+      _model: 'claude',
+    }),
+  );
+  assert.ok(out);
+  assert.equal(out.tool_calls.length, 1);
+  assert.equal((out as { _model?: string })._model, 'claude');
+});
+
+test('tryParseToolCallsEnvelope: rejects prose, non-objects, and missing tool_calls', () => {
+  assert.equal(tryParseToolCallsEnvelope(''), null);
+  assert.equal(tryParseToolCallsEnvelope('I will not call any tool.'), null);
+  // Prose before the brace short-circuits the parse — keeps the cost off
+  // the JSON.parse on conversational turns.
+  assert.equal(
+    tryParseToolCallsEnvelope('Sure! {"tool_calls":[{"id":"call_x"}]}'),
+    null,
+  );
+  // Trimmed whitespace is fine; the model occasionally pads with newlines.
+  assert.ok(tryParseToolCallsEnvelope('  \n{"tool_calls":[]}\n  '));
+  // Top-level array is not the envelope shape.
+  assert.equal(tryParseToolCallsEnvelope('[]'), null);
+  // Object without tool_calls or with non-array tool_calls is not envelope.
+  assert.equal(tryParseToolCallsEnvelope('{"foo":1}'), null);
+  assert.equal(tryParseToolCallsEnvelope('{"tool_calls":"nope"}'), null);
+  // Malformed JSON falls through to null rather than throwing.
+  assert.equal(tryParseToolCallsEnvelope('{"tool_calls":'), null);
+});
+
+test('spawn argv carries --append-system-prompt with the tool envelope when metadata is present', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('what is the weather?', {
+      system: 'You are concise.',
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'auto',
+    }),
+    emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()?.args ?? [];
+  // The flag occurs at least once (operator can pass additional ones via
+  // extraArgs; identity-injecting variant may also fire). The openai-compat
+  // value is identified by the tool-envelope contract phrase.
+  const idx = args.findIndex(
+    (a, i) =>
+      args[i - 1] === '--append-system-prompt' &&
+      typeof a === 'string' &&
+      a.includes('"tool_calls":[{"id":"call_<unique>"'),
+  );
+  assert.ok(idx >= 0, 'expected --append-system-prompt carrying the tool envelope');
+  // User system precedes the envelope contract in that same value.
+  assert.match(args[idx] as string, /You are concise\./);
+  assert.match(args[idx] as string, /"name": "get_weather"/);
+});
+
+test('absent metadata → no openai-compat --append-system-prompt is injected', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const args = fake.lastChild()?.args ?? [];
+  // No tool-envelope contract anywhere in argv when the caller didn't ask
+  // for the extension.
+  const hasEnvelope = args.some(
+    (a) => typeof a === 'string' && a.includes('"tool_calls":[{"id":"call_<unique>"'),
+  );
+  assert.equal(hasEnvelope, false);
+});
+
+test('assistant {"tool_calls":[...]} reply becomes a data-part artifact when extension is active', async () => {
+  const envelope = {
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  };
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: JSON.stringify(envelope) }],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: JSON.stringify(envelope) }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('what is the weather in Seoul?', { tools: SAMPLE_TOOLS }),
+    emit,
+    NEVER,
+  );
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  const part = artifacts[0].artifact.parts[0];
+  assert.equal(part.kind, 'data');
+  if (part.kind !== 'data') throw new Error('expected data part');
+  assert.deepEqual(part.data, envelope);
+  // Artifact carries the extension URI so downstream filters can route on it.
+  assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+});
+
+test('non-envelope assistant text still streams as a text artifact under the extension', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'No tool needed; the answer is 42.' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'No tool needed; the answer is 42.',
+      }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }),
+    emit,
+    NEVER,
+  );
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  assert.equal(textOf(artifacts[0]), 'No tool needed; the answer is 42.');
+  // Plain-text path leaves the artifact untagged — no extension URI claim
+  // that doesn't apply to this turn.
+  assert.equal(artifacts[0].artifact.extensions, undefined);
+});
+
+test('extension off: a coincidental {"tool_calls":[...]} text stays a text artifact', async () => {
+  // Without the extension we don't claim any envelope contract is in
+  // force, so this defends against false-positive routing if the model
+  // happens to emit a JSON-shaped reply for unrelated reasons.
+  const envelope = JSON.stringify({ tool_calls: [] });
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: envelope }] },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: envelope }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  assert.equal(artifacts[0].artifact.parts[0].kind, 'text');
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -352,6 +352,26 @@ function traceabilityRequested(task: {
   );
 }
 
+// One entry of `tool_call_history` — either an `assistant` turn echoing the
+// model's prior tool_calls envelope, or a `tool` turn carrying the function
+// return that the gateway executed externally. Mirrors OpenAI Chat
+// Completions message shape for these two roles.
+export interface OpenAICompatHistoryAssistant {
+  role: 'assistant';
+  tool_calls: unknown[];
+}
+export interface OpenAICompatHistoryTool {
+  role: 'tool';
+  tool_call_id: string;
+  name?: string;
+  // OpenAI permits string-or-content-parts; on the wire we require string so
+  // gateways own the normalisation. Bridges treat it as opaque text.
+  content: string;
+}
+export type OpenAICompatHistoryEntry =
+  | OpenAICompatHistoryAssistant
+  | OpenAICompatHistoryTool;
+
 // Payload of the openai-compat A2A extension as carried under
 // `Message.metadata[OPENAI_COMPAT_EXTENSION_URI]`. Each field is optional and
 // is forwarded verbatim from the OpenAI-shaped originating request.
@@ -359,10 +379,50 @@ export interface OpenAICompatMetadata {
   system?: string;
   tools?: unknown[];
   tool_choice?: unknown;
+  tool_call_history?: OpenAICompatHistoryEntry[];
+}
+
+// Whole-array validator for `tool_call_history`. Returns null (caller drops
+// the field) on ANY malformed entry rather than skipping it — order and
+// id-pairings between `assistant.tool_calls` and `role:"tool"` results
+// matter, so dropping a middle entry would silently break the model's view
+// of the prior round. Strict-or-nothing is safer than forgiving-with-holes.
+function parseToolCallHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
+  if (raw.length === 0) return null;
+  const out: OpenAICompatHistoryEntry[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+    const e = entry as Record<string, unknown>;
+    if (
+      e.role === 'assistant' &&
+      Array.isArray(e.tool_calls) &&
+      e.tool_calls.length > 0
+    ) {
+      out.push({ role: 'assistant', tool_calls: e.tool_calls });
+      continue;
+    }
+    if (
+      e.role === 'tool' &&
+      typeof e.tool_call_id === 'string' &&
+      e.tool_call_id.length > 0 &&
+      typeof e.content === 'string'
+    ) {
+      const toolEntry: OpenAICompatHistoryTool = {
+        role: 'tool',
+        tool_call_id: e.tool_call_id,
+        content: e.content,
+      };
+      if (typeof e.name === 'string' && e.name.length > 0) toolEntry.name = e.name;
+      out.push(toolEntry);
+      continue;
+    }
+    return null;
+  }
+  return out;
 }
 
 // Extract and shape-check the openai-compat metadata key. Returns null when
-// the metadata key is absent, malformed, or actionably empty (all three
+// the metadata key is absent, malformed, or actionably empty (all four
 // fields missing or trivial) so the caller can fall back to its non-extension
 // path without conditional null-checks on every read.
 export function parseOpenAICompatMetadata(
@@ -376,7 +436,16 @@ export function parseOpenAICompatMetadata(
   if (typeof r.system === 'string' && r.system.length > 0) out.system = r.system;
   if (Array.isArray(r.tools) && r.tools.length > 0) out.tools = r.tools;
   if (r.tool_choice !== undefined && r.tool_choice !== null) out.tool_choice = r.tool_choice;
-  if (out.system === undefined && out.tools === undefined && out.tool_choice === undefined) {
+  if (Array.isArray(r.tool_call_history)) {
+    const history = parseToolCallHistory(r.tool_call_history);
+    if (history) out.tool_call_history = history;
+  }
+  if (
+    out.system === undefined &&
+    out.tools === undefined &&
+    out.tool_choice === undefined &&
+    out.tool_call_history === undefined
+  ) {
     return null;
   }
   return out;
@@ -437,6 +506,14 @@ export function buildOpenAICompatSystemPrompt(meta: OpenAICompatMetadata): strin
         '- Do not execute the function yourself; just emit the call.',
         '- If no function should be called, answer normally in natural language.',
         '',
+        // History-block contract: aligned with `formatToolCallHistory`'s
+        // rendering. The model needs to know how to read the block AND that
+        // already-resolved calls must not be repeated, otherwise it'll loop.
+        'On follow-up turns the user message may begin with a <tool_call_history>...</tool_call_history> block containing a JSON array of prior round-trips. Each entry is one of:',
+        '  - {"role":"assistant","tool_calls":[...]} — calls you previously emitted on an earlier turn.',
+        '  - {"role":"tool","tool_call_id":"call_…","name":"…","content":"…"} — the authoritative return value for one of those calls.',
+        'Treat the history as the source of truth for what has happened so far. Do NOT repeat a call whose tool_call_id already appears in the history. Either emit a NEW tool_calls envelope (to chain another call) or compose a natural-language answer using the prior results.',
+        '',
         'Available functions:',
         JSON.stringify(meta.tools, null, 2),
       ].join('\n'),
@@ -450,6 +527,21 @@ export function buildOpenAICompatSystemPrompt(meta: OpenAICompatMetadata): strin
   }
 
   return sections.join('\n\n');
+}
+
+// Render a `tool_call_history` payload as a `<tool_call_history>`-wrapped
+// JSON block. Goes at the front of the user content on follow-up turns so
+// the model reads the prior round before the new instruction; the wrapper
+// tag makes the boundary unambiguous against the user's own text. The
+// inner array is the parsed history verbatim — same shape as on the wire,
+// so the model only has to learn one structure (also taught in the
+// SYSTEM_INSTRUCTION above).
+export function formatToolCallHistory(history: OpenAICompatHistoryEntry[]): string {
+  return [
+    '<tool_call_history>',
+    JSON.stringify(history, null, 2),
+    '</tool_call_history>',
+  ].join('\n');
 }
 
 // Attempt to interpret an assistant message as the OpenAI tool-call envelope
@@ -776,6 +868,19 @@ export function createClaudeBackend(
       const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
 
       const mapped = await mapPartsToContentBlocks(task.message.parts, opts.fetchUriPolicy, signal);
+      if (mapped.ok && openaiCompat?.tool_call_history) {
+        // Spec contract: bridges MUST replay the entire `tool_call_history`
+        // in order. We render it as a text block and prepend it to the user
+        // content so the model reads the prior round BEFORE the current
+        // user turn. Any internal optimisation (e.g. claude `--resume`
+        // already holds the prior `assistant.tool_calls` in session
+        // memory) is invisible to the wire and does not change replay
+        // semantics — the redundancy is the price of cross-bridge interop.
+        mapped.blocks.unshift({
+          type: 'text',
+          text: formatToolCallHistory(openaiCompat.tool_call_history),
+        });
+      }
       if (!mapped.ok) {
         emit({
           type: 'task.fail',

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1,6 +1,10 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import { TRACEABILITY_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  TRACEABILITY_EXTENSION_URI,
+  type Part,
+} from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
 import { formatAcct, formatMention, type AgentIdentity } from '../identity.js';
 import {
@@ -348,6 +352,129 @@ function traceabilityRequested(task: {
   );
 }
 
+// Payload of the openai-compat A2A extension as carried under
+// `Message.metadata[OPENAI_COMPAT_EXTENSION_URI]`. Each field is optional and
+// is forwarded verbatim from the OpenAI-shaped originating request.
+export interface OpenAICompatMetadata {
+  system?: string;
+  tools?: unknown[];
+  tool_choice?: unknown;
+}
+
+// Extract and shape-check the openai-compat metadata key. Returns null when
+// the metadata key is absent, malformed, or actionably empty (all three
+// fields missing or trivial) so the caller can fall back to its non-extension
+// path without conditional null-checks on every read.
+export function parseOpenAICompatMetadata(
+  metadata: Record<string, unknown> | undefined,
+): OpenAICompatMetadata | null {
+  if (!metadata) return null;
+  const raw = metadata[OPENAI_COMPAT_EXTENSION_URI];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  const out: OpenAICompatMetadata = {};
+  if (typeof r.system === 'string' && r.system.length > 0) out.system = r.system;
+  if (Array.isArray(r.tools) && r.tools.length > 0) out.tools = r.tools;
+  if (r.tool_choice !== undefined && r.tool_choice !== null) out.tool_choice = r.tool_choice;
+  if (out.system === undefined && out.tools === undefined && out.tool_choice === undefined) {
+    return null;
+  }
+  return out;
+}
+
+function describeToolChoice(toolChoice: unknown): string | null {
+  if (toolChoice === undefined || toolChoice === null) return null;
+  if (toolChoice === 'auto') {
+    return 'tool_choice="auto": call a function only if appropriate; otherwise answer in natural language.';
+  }
+  if (toolChoice === 'required') {
+    return 'tool_choice="required": you MUST emit a tool_calls envelope — answering in natural language is not allowed for this turn.';
+  }
+  if (typeof toolChoice === 'object' && !Array.isArray(toolChoice)) {
+    const c = toolChoice as { type?: unknown; function?: unknown };
+    if (c.type === 'function' && c.function && typeof c.function === 'object') {
+      const fn = c.function as { name?: unknown };
+      if (typeof fn.name === 'string' && fn.name.length > 0) {
+        return `tool_choice: you MUST emit a tool_calls envelope that calls the function named "${fn.name}".`;
+      }
+    }
+  }
+  return null;
+}
+
+// Build the system-prompt text injected via `--append-system-prompt` when the
+// openai-compat extension is active. Composition rules:
+//
+//   - User-supplied `system` (if any) is included verbatim, first.
+//   - The tool-envelope contract block is included only when `tools` were
+//     provided and `tool_choice` is not "none" — without tools the envelope
+//     would be a contract the model can't satisfy. With tool_choice="none"
+//     we instead emit a short "do not use the envelope" directive so the
+//     gateway's intent is preserved.
+//   - A tool_choice descriptor line is appended when the value is one of
+//     the recognised shapes (`"auto"` / `"required"` / `{type:"function",
+//     function:{name}}`); unrecognised values are silently dropped because
+//     the model can't act on a shape it doesn't understand.
+export function buildOpenAICompatSystemPrompt(meta: OpenAICompatMetadata): string {
+  const sections: string[] = [];
+  if (meta.system) sections.push(meta.system);
+
+  const toolChoiceIsNone = meta.tool_choice === 'none';
+  const hasTools = meta.tools !== undefined && !toolChoiceIsNone;
+
+  if (hasTools) {
+    sections.push(
+      [
+        'You are routed through an OpenAI-compatible gateway and have access to the following callable functions.',
+        '',
+        'When you decide a function should be called, respond with ONLY a single JSON object (no prose, no code fences, no markdown) of the exact shape:',
+        '',
+        '{"tool_calls":[{"id":"call_<unique>","function":{"name":"<fn name>","arguments":{<args as JSON object>}}}]}',
+        '',
+        '- "id" must be a unique string starting with "call_".',
+        '- "arguments" must be a JSON object matching the function\'s parameters schema.',
+        '- Emit nothing outside the JSON object.',
+        '- Do not execute the function yourself; just emit the call.',
+        '- If no function should be called, answer normally in natural language.',
+        '',
+        'Available functions:',
+        JSON.stringify(meta.tools, null, 2),
+      ].join('\n'),
+    );
+    const tcDesc = describeToolChoice(meta.tool_choice);
+    if (tcDesc) sections.push(tcDesc);
+  } else if (toolChoiceIsNone) {
+    sections.push(
+      'A list of OpenAI-style tools was supplied with tool_choice="none". Do not emit a tool_calls envelope; always answer in natural language.',
+    );
+  }
+
+  return sections.join('\n\n');
+}
+
+// Attempt to interpret an assistant message as the OpenAI tool-call envelope
+// the SYSTEM_INSTRUCTION above teaches the model to emit. Returns the parsed
+// envelope verbatim (preserving unknown keys) when the trimmed text parses as
+// a JSON object carrying a `tool_calls` array; otherwise null so the caller
+// falls back to a text artifact. Strict: a leading non-`{` character (prose
+// preamble, code fence, etc.) short-circuits without paying the JSON.parse.
+export function tryParseToolCallsEnvelope(
+  text: string,
+): (Record<string, unknown> & { tool_calls: unknown[] }) | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (!Array.isArray(obj.tool_calls)) return null;
+  return obj as Record<string, unknown> & { tool_calls: unknown[] };
+}
+
 // Pull `tool_use` blocks out of an `assistant`-role message's content
 // array. Each one becomes one `claude-tool-call` artifact upstream, with
 // a head-truncated `<tool>: <input>` summary plus a `data` part carrying
@@ -641,6 +768,13 @@ export function createClaudeBackend(
         return;
       }
 
+      // Detect the openai-compat extension payload once per task so the
+      // result feeds both the spawn argv (--append-system-prompt) and the
+      // assistant artifact path (tool_calls JSON → data part). Absent or
+      // malformed metadata leaves the run on the original non-extension code
+      // path with no envelope-detection cost.
+      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+
       const mapped = await mapPartsToContentBlocks(task.message.parts, opts.fetchUriPolicy, signal);
       if (!mapped.ok) {
         emit({
@@ -682,6 +816,16 @@ export function createClaudeBackend(
         }
       }
 
+      // Per-task `--append-system-prompt` carrying the openai-compat
+      // extension's system / tools / tool_choice. Placed AFTER identityArgs
+      // (so the self-identity directive is the model's first read) but
+      // BEFORE extraArgs (so an operator-supplied append still wins by
+      // appending last — claude concatenates each --append-system-prompt
+      // occurrence in argv order).
+      const openaiCompatArgs: readonly string[] = openaiCompat
+        ? ['--append-system-prompt', buildOpenAICompatSystemPrompt(openaiCompat)]
+        : [];
+
       const args: string[] = [
         '-p',
         '--input-format',
@@ -703,6 +847,7 @@ export function createClaudeBackend(
             ]
           : []),
         ...identityArgs,
+        ...openaiCompatArgs,
         ...settingsArgs,
         ...extraArgs,
       ];
@@ -819,6 +964,32 @@ export function createClaudeBackend(
 
       const emitAssistantArtifact = (text: string): void => {
         if (!text) return;
+        // When the openai-compat extension is active for this task, the
+        // model was instructed to emit `{"tool_calls":[...]}` JSON for tool
+        // turns. Detect that shape and surface it as an A2A `data` part so
+        // the upstream gateway can forward it as `tool_calls` on the
+        // OpenAI response without re-parsing model prose. Non-envelope text
+        // (natural-language answers, or any turn from a task that didn't
+        // request the extension) falls through to the text artifact path
+        // unchanged.
+        if (openaiCompat) {
+          const envelope = tryParseToolCallsEnvelope(text);
+          if (envelope) {
+            emit({
+              type: 'task.artifact',
+              taskId: task.taskId,
+              artifact: {
+                artifactId: randomUUID(),
+                name: 'claude-message',
+                parts: [{ kind: 'data', data: envelope }],
+                extensions: [OPENAI_COMPAT_EXTENSION_URI],
+              },
+              lastChunk: true,
+            });
+            emittedAnyArtifact = true;
+            return;
+          }
+        }
         emit({
           type: 'task.artifact',
           taskId: task.taskId,

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,6 +5,8 @@ export const TRACEABILITY_EXTENSION_URI =
   'https://github.com/a2aproject/a2a-samples/extensions/traceability/v1';
 export const SIWE_BEARER_AUTH_EXTENSION_URI =
   'https://github.com/planetarium/a2a-x402-wallet/tree/main/docs/siwe-bearer-auth/v0.1';
+export const OPENAI_COMPAT_EXTENSION_URI =
+  'https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1';
 
 export const TextPart = z.object({
   kind: z.literal('text'),


### PR DESCRIPTION
## Summary

Implements the [A2A openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `claude` backend so cooperating OpenAI-compatible gateways (e.g. `planetarium/oai2a2a`) can route `system` / `tools` / `tool_choice` and `tool_call_history` through A2A `Message.metadata` without text-injecting them into user-role content — the failure mode that motivated the upstream spec (security-trained models flag the inlined instructions as prompt injection at non-deterministic rates).

The bridge does **not** actually call tools. It folds the metadata into a per-task `--append-system-prompt` that teaches the spawned `claude` to emit a `{"tool_calls":[…]}` envelope on function-call turns. Envelope replies are surfaced as A2A `data` part artifacts. On follow-up turns, the multi-turn history payload is prepended as a `<tool_call_history>` JSON block so the model can pick up where it left off.

Two logical commits:

- **`b5b14af`** — turn 1: metadata reading, prompt assembly, envelope detection.
- **`4e3193c`** — multi-turn `tool_call_history` per the [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30) consensus (option A, `tool_call_history` field, MUST replay, stateless gateway).

## What's in the change

- **`@vicoop-bridge/protocol`** — new `OPENAI_COMPAT_EXTENSION_URI` constant.
- **`packages/client/cards/claude.json`** — advertises the extension URI under `capabilities.extensions[]` so cooperating gateways discover the capability from a card fetch.
- **`packages/client/src/backends/claude.ts`**:
  - `parseOpenAICompatMetadata` reads / shape-checks `Message.metadata[URI]` — handles `system`, `tools`, `tool_choice`, and `tool_call_history` (whole-array strict-or-nothing validation since `tool_call_id` pairings depend on order).
  - `buildOpenAICompatSystemPrompt` assembles the per-task system prompt. `tool_choice: "none"` suppresses the envelope contract; `"auto"` / `"required"` / `{type:"function", function:{name}}` map to soft / hard / forced-function directives. When tools are present, a paragraph explains the `<tool_call_history>` block format and pins an anti-loop directive — calls whose `tool_call_id` already appears in the history MUST NOT be re-emitted.
  - `formatToolCallHistory` renders the history as a `<tool_call_history>`-wrapped pretty JSON block.
  - In `handle()`, the metadata feeds both the spawn argv (`--append-system-prompt`) and the assistant-message detector. The history block is prepended to the user content on every turn — bridge MUST replay regardless of internal session reuse (claude `--resume`).
  - `tryParseToolCallsEnvelope` strict-parses each assistant message; matches become `data` part artifacts (`extensions: [URI]`); non-matches stream as text artifacts unchanged.
- **`packages/client/src/backends/claude.test.ts`** — 24 new tests covering metadata shape handling (incl. multi-turn validation edge cases), prompt composition under each `tool_choice` variant, history paragraph presence, strict envelope parsing, spawn argv injection, data-part conversion E2E, history block injection E2E, and the absent-metadata pass-through path.

No server-side changes required: `executor.ts` already forwards non-`_`-prefixed metadata over WS, and `agent-card.ts` passes through `wire.capabilities.extensions` verbatim.

## Out of scope (per spec)

- `response_format` (JSON Schema structured output).
- MCP overlap.
- Codex backend — codex's system-prompt seam isn't as clean as `claude --append-system-prompt`; tracked as a follow-up.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `pnpm --filter @vicoop-bridge/client test` → 358/358 (24 new).
- [x] `pnpm --filter @vicoop-bridge/server test` → unchanged.
- [x] **E2E turn 1**: ran the daemon from this branch against the production bridge as a fresh `claude-oai-test-*` agent; `oai2a2a` gateway sent a `get_weather` tool request via `metadata[URI]`; the model emitted the envelope JSON; the bridge surfaced it as a `kind: "data"` artifact with `extensions: ["…/openai-compat/v1"]`. ✓
- [x] **E2E multi-turn**: same contextId follow-up with `tool_call_history` carrying the prior `assistant.tool_calls` + `role:"tool"` result; the model read the history block, used the prior `get_weather` return value, and answered in natural language without re-emitting the envelope (anti-loop directive verified). ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)