### PR TITLE
fix(client): stop unref'ing the reconnect timer so the daemon survives disconnect (#156)

### DIFF
--- a/.changeset/client-reconnect-timer-stays-refed.md
+++ b/.changeset/client-reconnect-timer-stays-refed.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Fix `vicoop-client` daemon exiting on the first WebSocket disconnect instead of reconnecting (#156). `scheduleReconnect()` previously called `.unref()` on the reconnect timer, which left the daemon process with no refed handles after the `close` handler cleared the heartbeat and reconnect-reset timers — Node would drain the event loop and exit before the first reconnect attempt fired, killing the entire exponential-backoff/jitter path. The other `.unref()` calls in the file are kept: the heartbeat and reconnect-reset timers only matter while the WS is open (the WS itself refs the loop then), and the probe-deadline timer is cleared on the fast path. `stop()` still cleans up the now-refed reconnect timer explicitly via `clearReconnectTimer()`, so intentional shutdown remains prompt.
+
+Production daemons running under a supervisor (systemd `Restart=`, etc.) masked the bug behind automatic restarts; dev / sidecar daemons without a supervisor died on the first network blip.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -283,7 +283,7 @@ test('Client reconnect timer is refed so a disconnected daemon stays alive (#156
   // reconnect timer. With the WS dropped and the heartbeat / reset timers
   // already cleared, that left the daemon process with no refed handles
   // and Node exited before the first reconnect attempt fired. The existing
-  // "reconnects after WebSocket close" test below passes regardless of the
+  // "reconnects after WebSocket close" test above passes regardless of the
   // unref because the test process has the mock WebSocketServer and http
   // server keeping the loop alive on their own. We assert directly on the
   // refed-ness of the scheduled timer instead, so the regression is caught

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -393,26 +393,43 @@ test('Client daemon (subprocess) survives WS disconnect and reconnects (#156)', 
   // Wait for the child to print `daemon-ready` so we know the Client has
   // been constructed and `start()` has been called. Without this we could
   // race the child's startup and observe `helloCount === 0` purely because
-  // the fixture hasn't connected yet.
+  // the fixture hasn't connected yet. The three terminal paths are unified
+  // through a single `cleanup` so an early `exit` rejects the promise (it
+  // used to merely clear the timeout, which left the promise pending
+  // forever on startup failures), the readiness signal can resolve once,
+  // and the 5s timeout still fires if the child neither readies nor exits.
   await new Promise<void>((resolve, reject) => {
     let buf = '';
+    const cleanup = (): void => {
+      child.stdout.off('data', onData);
+      child.off('exit', onExit);
+      clearTimeout(timeout);
+    };
     const onData = (b: Buffer): void => {
       buf += b.toString('utf8');
       if (buf.includes('daemon-ready')) {
-        child.stdout.off('data', onData);
+        cleanup();
         resolve();
       }
     };
-    child.stdout.on('data', onData);
+    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
+      reject(
+        new Error(
+          `daemon fixture exited before becoming ready (code=${code} signal=${signal}). stderr: ${stderr.join('')}`,
+        ),
+      );
+    };
     const timeout = setTimeout(() => {
-      child.stdout.off('data', onData);
+      cleanup();
       reject(
         new Error(
           `daemon fixture did not become ready within 5s. stderr: ${stderr.join('')}`,
         ),
       );
     }, 5000);
-    child.on('exit', () => clearTimeout(timeout));
+    child.stdout.on('data', onData);
+    child.on('exit', onExit);
   });
 
   try {

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,7 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import { fileURLToPath } from 'node:url';
 import { WebSocketServer, type WebSocket } from 'ws';
 import {
   parseUpFrame,
@@ -271,6 +273,166 @@ test('Client reconnects after WebSocket close and sends hello again', async () =
     }
   } finally {
     client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('Client reconnect timer is refed so a disconnected daemon stays alive (#156)', async () => {
+  // Regression: scheduleReconnect() previously called `.unref()` on the
+  // reconnect timer. With the WS dropped and the heartbeat / reset timers
+  // already cleared, that left the daemon process with no refed handles
+  // and Node exited before the first reconnect attempt fired. The existing
+  // "reconnects after WebSocket close" test below passes regardless of the
+  // unref because the test process has the mock WebSocketServer and http
+  // server keeping the loop alive on their own. We assert directly on the
+  // refed-ness of the scheduled timer instead, so the regression is caught
+  // even in-process.
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', () => helloCount++);
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks */
+    }),
+    // Keep the reconnect delay long enough that the timer is still pending
+    // when we inspect it below. Without this we'd race the reconnect itself.
+    reconnectDelayMs: 5000,
+    reconnectMaxDelayMs: 5000,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+  });
+
+  // Private-field access for the regression check. The reconnect timer is
+  // an implementation detail, but the invariant ("must keep the event loop
+  // alive while disconnected") is part of the daemon contract — and the
+  // only way to assert that in-process without a subprocess is to look at
+  // the timer's `hasRef()`. Kept narrow so a refactor renaming the field
+  // will fail loudly here.
+  interface Internals {
+    reconnectTimer: { hasRef(): boolean } | null;
+  }
+  const internals = client as unknown as Internals;
+
+  try {
+    client.start();
+    await waitFor(() => helloCount === 1, 'expected initial hello');
+    // Forcibly drop the connection on the server side. `terminate()` skips
+    // the close-frame handshake so the client observes a 1006 abnormal
+    // closure — matching the production repro in the issue and avoiding
+    // the "1006 is not a transmissible code" error that `close(1006, ...)`
+    // would throw on the server-side socket.
+    connections[0]!.terminate();
+    await waitFor(
+      () => internals.reconnectTimer !== null,
+      'expected reconnect timer to be scheduled after disconnect',
+    );
+    assert.equal(
+      internals.reconnectTimer!.hasRef(),
+      true,
+      'reconnect timer must keep the event loop alive — without this the daemon exits on first disconnect (#156)',
+    );
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('Client daemon (subprocess) survives WS disconnect and reconnects (#156)', async () => {
+  // End-to-end regression: spawn a real Node child that runs only the
+  // Client (no other refed handles), force-close its WS, and assert that
+  // the child stays alive long enough to reconnect. This is the scenario
+  // the in-process tests can't reproduce — there the WebSocketServer and
+  // http.Server keep the loop alive regardless of how the reconnect timer
+  // is refed.
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    ws.on('message', () => {
+      helloCount++;
+      // Drop the connection on the first hello so the child has to recover
+      // via its reconnect path. 1006 is delivered as an abnormal closure on
+      // the client side, matching the production reproduction in the issue.
+      if (helloCount === 1) ws.terminate();
+    });
+  });
+
+  const fixturePath = fileURLToPath(
+    new URL('./reconnect-daemon-fixture.ts', import.meta.url),
+  );
+  // We're already running under tsx (per the package's test script), so
+  // the same `--import tsx` flag is available to the child. Pinning to
+  // `process.execPath` keeps us off PATH and out of sync with whatever
+  // node is in `node_modules/.bin`.
+  const child = spawn(
+    process.execPath,
+    ['--import', 'tsx', fixturePath, serverUrl],
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  let exited = false;
+  let exitInfo: { code: number | null; signal: NodeJS.Signals | null } | null = null;
+  child.on('exit', (code, signal) => {
+    exited = true;
+    exitInfo = { code, signal };
+  });
+  const stderr: string[] = [];
+  child.stderr.on('data', (b: Buffer) => stderr.push(b.toString('utf8')));
+  // Wait for the child to print `daemon-ready` so we know the Client has
+  // been constructed and `start()` has been called. Without this we could
+  // race the child's startup and observe `helloCount === 0` purely because
+  // the fixture hasn't connected yet.
+  await new Promise<void>((resolve, reject) => {
+    let buf = '';
+    const onData = (b: Buffer): void => {
+      buf += b.toString('utf8');
+      if (buf.includes('daemon-ready')) {
+        child.stdout.off('data', onData);
+        resolve();
+      }
+    };
+    child.stdout.on('data', onData);
+    const timeout = setTimeout(() => {
+      child.stdout.off('data', onData);
+      reject(
+        new Error(
+          `daemon fixture did not become ready within 5s. stderr: ${stderr.join('')}`,
+        ),
+      );
+    }, 5000);
+    child.on('exit', () => clearTimeout(timeout));
+  });
+
+  try {
+    await waitFor(() => helloCount === 1, 'expected initial hello from child', 3000);
+    // The server terminated the socket after the first hello. If the
+    // daemon is healthy it reconnects after reconnectDelayMs (100ms in
+    // the fixture) and sends a second hello. If the unref regression is
+    // back, the child exits before the reconnect fires.
+    await waitFor(
+      () => helloCount === 2,
+      `expected reconnect hello from daemon — child exited=${exited} info=${JSON.stringify(exitInfo)} stderr=${stderr.join('')}`,
+      3000,
+    );
+    assert.equal(
+      exited,
+      false,
+      `daemon must survive the disconnect; exited with ${JSON.stringify(exitInfo)} stderr=${stderr.join('')}`,
+    );
+  } finally {
+    if (!exited) child.kill('SIGTERM');
     await closeServer(server, wss);
   }
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
+import { createRequire } from 'node:module';
 import type { AddressInfo } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { WebSocketServer, type WebSocket } from 'ws';
@@ -373,13 +374,20 @@ test('Client daemon (subprocess) survives WS disconnect and reconnects (#156)', 
   const fixturePath = fileURLToPath(
     new URL('./reconnect-daemon-fixture.ts', import.meta.url),
   );
-  // We're already running under tsx (per the package's test script), so
-  // the same `--import tsx` flag is available to the child. Pinning to
-  // `process.execPath` keeps us off PATH and out of sync with whatever
-  // node is in `node_modules/.bin`.
+  // Invoke tsx's CLI script directly instead of `node --import tsx ...`.
+  // `--import` was added in Node 20.6.0, but the repo's `engines.node` only
+  // requires `>=20`, so 20.0–20.5 must also work; tsx 4.x's own CLI
+  // registers its loader internally and is portable across every Node 20+
+  // minor. Pinning to `process.execPath` keeps us off PATH so the child
+  // runs under the same node binary as the parent test process.
+  // `tsx/cli` is tsx 4.x's exported entry point that maps to its CLI
+  // script (see the package's `exports` field). `tsx/dist/cli.mjs`
+  // isn't a publicly exported path and throws ERR_PACKAGE_PATH_NOT_EXPORTED
+  // under Node's exports-field enforcement.
+  const tsxCli = createRequire(import.meta.url).resolve('tsx/cli');
   const child = spawn(
     process.execPath,
-    ['--import', 'tsx', fixturePath, serverUrl],
+    [tsxCli, fixturePath, serverUrl],
     { stdio: ['ignore', 'pipe', 'pipe'] },
   );
   let exited = false;
@@ -390,49 +398,56 @@ test('Client daemon (subprocess) survives WS disconnect and reconnects (#156)', 
   });
   const stderr: string[] = [];
   child.stderr.on('data', (b: Buffer) => stderr.push(b.toString('utf8')));
-  // Wait for the child to print `daemon-ready` so we know the Client has
-  // been constructed and `start()` has been called. Without this we could
-  // race the child's startup and observe `helloCount === 0` purely because
-  // the fixture hasn't connected yet. The three terminal paths are unified
-  // through a single `cleanup` so an early `exit` rejects the promise (it
-  // used to merely clear the timeout, which left the promise pending
-  // forever on startup failures), the readiness signal can resolve once,
-  // and the 5s timeout still fires if the child neither readies nor exits.
-  await new Promise<void>((resolve, reject) => {
-    let buf = '';
-    const cleanup = (): void => {
-      child.stdout.off('data', onData);
-      child.off('exit', onExit);
-      clearTimeout(timeout);
-    };
-    const onData = (b: Buffer): void => {
-      buf += b.toString('utf8');
-      if (buf.includes('daemon-ready')) {
-        cleanup();
-        resolve();
-      }
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
-      cleanup();
-      reject(
-        new Error(
-          `daemon fixture exited before becoming ready (code=${code} signal=${signal}). stderr: ${stderr.join('')}`,
-        ),
-      );
-    };
-    const timeout = setTimeout(() => {
-      cleanup();
-      reject(
-        new Error(
-          `daemon fixture did not become ready within 5s. stderr: ${stderr.join('')}`,
-        ),
-      );
-    }, 5000);
-    child.stdout.on('data', onData);
-    child.on('exit', onExit);
-  });
-
+  // The single try/finally below wraps the readiness wait *and* the
+  // assertions so the child + mock server are cleaned up even when the
+  // readiness path itself rejects (timeout or early exit). An earlier
+  // shape put the readiness wait outside the try and would leak the child
+  // and leave the WebSocketServer / http.Server open on those failure
+  // modes, flaking the rest of the suite.
   try {
+    // Wait for the child to print `daemon-ready` so we know the Client has
+    // been constructed and `start()` has been called. Without this we could
+    // race the child's startup and observe `helloCount === 0` purely
+    // because the fixture hasn't connected yet. The three terminal paths
+    // are unified through a single `cleanup` so an early `exit` rejects
+    // the promise (it used to merely clear the timeout, which left the
+    // promise pending forever on startup failures), the readiness signal
+    // can resolve once, and the 5s timeout still fires if the child
+    // neither readies nor exits.
+    await new Promise<void>((resolve, reject) => {
+      let buf = '';
+      const cleanup = (): void => {
+        child.stdout.off('data', onData);
+        child.off('exit', onExit);
+        clearTimeout(timeout);
+      };
+      const onData = (b: Buffer): void => {
+        buf += b.toString('utf8');
+        if (buf.includes('daemon-ready')) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+        cleanup();
+        reject(
+          new Error(
+            `daemon fixture exited before becoming ready (code=${code} signal=${signal}). stderr: ${stderr.join('')}`,
+          ),
+        );
+      };
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `daemon fixture did not become ready within 5s. stderr: ${stderr.join('')}`,
+          ),
+        );
+      }, 5000);
+      child.stdout.on('data', onData);
+      child.on('exit', onExit);
+    });
+
     await waitFor(() => helloCount === 1, 'expected initial hello from child', 3000);
     // The server terminated the socket after the first hello. If the
     // daemon is healthy it reconnects after reconnectDelayMs (100ms in

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -394,12 +394,19 @@ export class Client {
     const attempt = this.reconnectAttempt++;
     const delay = this.nextReconnectDelay(attempt);
     this.logger.info(`reconnecting in ${delay}ms attempt=${attempt + 1}`);
+    // Intentionally NOT unref'd. By the time we get here the WS is gone and
+    // the heartbeat / reconnect-reset timers have been cleared, so this timer
+    // is the only handle keeping a disconnected daemon up until reconnect
+    // fires — signal listeners alone don't ref the event loop. Unref'ing it
+    // (a previous revision did) caused the process to exit on the first
+    // disconnect, killing the entire reconnect/backoff path. `stop()` clears
+    // this timer explicitly via `clearReconnectTimer()`, so intentional
+    // shutdown still exits cleanly. See issue #156.
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.logger.info(`reconnect attempt=${attempt + 1}`);
       this.connect();
     }, delay);
-    this.reconnectTimer.unref?.();
   }
 
   private nextReconnectDelay(attempt: number): number {

--- a/packages/client/src/reconnect-daemon-fixture.ts
+++ b/packages/client/src/reconnect-daemon-fixture.ts
@@ -1,0 +1,55 @@
+// Daemon fixture used by client.test.ts to verify a real Node process running
+// the bridge client survives an unintentional WebSocket disconnect — i.e. the
+// reconnect timer keeps the event loop alive on its own. The in-process unit
+// tests can't catch that regression because the test process has the mock
+// WebSocketServer / http.Server keeping the loop alive regardless of how the
+// reconnect timer is refed. See issue #156.
+//
+// Spawned as: `node --import tsx reconnect-daemon-fixture.ts <serverUrl>`.
+// Lifecycle: starts the Client, reports liveness on stdout so the parent test
+// can observe it's still running across the disconnect, and exits on SIGTERM
+// from the parent at end-of-test.
+import { Client } from './client.js';
+
+const serverUrl = process.argv[2];
+if (!serverUrl) {
+  console.error('reconnect-daemon-fixture: missing serverUrl argv');
+  process.exit(2);
+}
+
+const client = new Client({
+  serverUrl,
+  token: 'fixture-token',
+  agentId: 'fixture-agent',
+  backendKind: 'echo',
+  backend: {
+    name: 'fixture',
+    handle: async () => {
+      /* no tasks */
+    },
+  },
+  reconnectDelayMs: 100,
+  reconnectMaxDelayMs: 100,
+  reconnectJitterRatio: 0,
+  reconnectStableMs: 0,
+  heartbeatIntervalMs: 0,
+  // Quiet by default — the parent test only needs to know we're alive, not
+  // the per-frame log volume.
+  logLevel: 'warn',
+});
+
+client.start();
+
+// One-shot ready signal so the parent test knows it can stop waiting for
+// child startup. Crucially, this fixture installs no other refed handles
+// (no setInterval, no http listener) — the entire point of this fixture is
+// that *only* the Client's internal timers/sockets keep the event loop
+// alive. If the reconnect timer is unref'd (regression of #156), the
+// process exits on the first disconnect and the parent test sees the
+// child's `exit` event before observing a reconnect-driven hello.
+process.stdout.write('daemon-ready\n');
+
+process.on('SIGTERM', () => {
+  client.stop();
+  process.exit(0);
+});

--- a/packages/client/src/reconnect-daemon-fixture.ts
+++ b/packages/client/src/reconnect-daemon-fixture.ts
@@ -5,10 +5,14 @@
 // WebSocketServer / http.Server keeping the loop alive regardless of how the
 // reconnect timer is refed. See issue #156.
 //
-// Spawned as: `node --import tsx reconnect-daemon-fixture.ts <serverUrl>`.
-// Lifecycle: starts the Client, reports liveness on stdout so the parent test
-// can observe it's still running across the disconnect, and exits on SIGTERM
-// from the parent at end-of-test.
+// Invoked by the test as:
+//   `<node> <tsx/cli> reconnect-daemon-fixture.ts <serverUrl>`
+// where `<tsx/cli>` is the script path resolved from the `tsx/cli` package
+// export. The test deliberately avoids `node --import tsx ...` so the
+// subprocess runs on every Node 20+ minor (the `--import` flag was only
+// added in Node 20.6.0). Lifecycle: starts the Client, prints `daemon-ready`
+// on stdout so the parent knows startup completed, then waits silently
+// until SIGTERM from the parent at end-of-test.
 import { Client } from './client.js';
 
 const serverUrl = process.argv[2];

--- a/packages/client/tsconfig.build.json
+++ b/packages/client/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts"]
+  "exclude": ["src/**/*.test.ts", "src/**/*-fixture.ts"]
 }


### PR DESCRIPTION
## Summary

Closes #156. `scheduleReconnect()` was calling `.unref()` on the reconnect timer at `packages/client/src/client.ts:402`. After a WS drop the `close` handler clears the heartbeat and reconnect-reset timers, leaving the unref'd reconnect timer as the only candidate handle to keep the daemon alive — but an unref'd timer doesn't ref the event loop, and signal listeners (`SIGINT`/`SIGTERM`) don't either. Node would drain the loop and exit before the first reconnect attempt fired, so the entire backoff/jitter path was effectively dead code on a non-supervised daemon.

Production daemons running under `systemd Restart=` and similar masked the bug behind automatic restarts; dev / sidecar daemons died on the first network blip. Reproduced twice during #152 E2E verification (one 4009 slot-takeover, one 1006 abnormal closure) — see the issue for log excerpts.

The other `.unref()` calls in the file stay as-is. They're all keepalive / maintenance / fast-path timers that only need to fire while a refed handle (the WS itself, or — for the probe — its own `finally` clearTimeout) is already pinning the loop. The reconnect timer is the only one whose entire purpose is to keep a disconnected daemon alive.

`stop()` continues to clear this timer explicitly via `clearReconnectTimer()`, so intentional SIGINT/SIGTERM shutdown still exits promptly with the timer now refed.

## Tests

Two new tests cover the regression at different layers:

1. **`Client reconnect timer is refed so a disconnected daemon stays alive (#156)`** — in-process. Forces a disconnect, waits for the reconnect timer to schedule, and asserts `hasRef() === true` on it. The existing `Client reconnects after WebSocket close and sends hello again` test passes regardless of the bug because the test process has the mock `WebSocketServer` and `http.Server` keeping the loop alive on their own — `hasRef()` is the only way to catch the broken invariant in-process.
2. **`Client daemon (subprocess) survives WS disconnect and reconnects (#156)`** — out-of-process. Spawns a Node child (`node --import tsx packages/client/src/reconnect-daemon-fixture.ts <serverUrl>`) running only the `Client` (no `setInterval`, no http server — the fixture's only refed handle is whatever the Client itself installs). The parent's mock server force-`terminate()`s the connection on the first hello, and the test asserts the child stays alive and re-hellos. This reproduces the production scenario the in-process tests cannot.

Both tests fail when `.unref()` is restored on the reconnect timer (verified locally before committing).

The fixture file is excluded from the build via a new `tsconfig.build.json` entry so it doesn't ship in `dist/`.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client test` — 363 pass (was 361 + 2 new)
- [x] `pnpm --filter @vicoop-bridge/client typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/client build` — clean; `dist/` does not contain the fixture
- [x] Restored `.unref?.()` locally and re-ran tests — both new tests fail as expected (hasRef in ~12ms, subprocess after the 3s wait window)
- [ ] Smoke: run a real `vicoop-client` daemon against a bridge that drops the WS (e.g. server restart or 4009 slot takeover) and confirm the daemon reconnects without supervisor restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)