### PR TITLE
feat(client): A2A openai-compat extension on codex backend (turn 1 + multi-turn)

### DIFF
--- a/.changeset/openai-compat-extension-codex.md
+++ b/.changeset/openai-compat-extension-codex.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Implement the A2A [openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `codex` backend, mirroring the contract added for `claude` in #152. When an inbound `Message.metadata` carries the extension key, the client lifts `system` / `tools` / `tool_choice` out of the payload and materialises them to a per-task instructions file pointed at by `-c model_instructions_file="<path>"` (codex 0.130+; `experimental_instructions_file` is deprecated). The file teaches the spawned `codex` to emit a `{"tool_calls":[{"id":"call_…","function":{"name":"…","arguments":{…}}}]}` envelope when it decides to call a function. Envelope replies are detected on every `agent_message` and surfaced as an A2A `data` part artifact (`extensions: ["…/openai-compat/v1"]`) so the upstream OpenAI-compatible gateway can forward them verbatim as `tool_calls`; non-envelope turns continue to stream as text artifacts.
+
+The instructions file co-locates with the existing per-task image temp dir when one is present, or a freshly-minted one otherwise — a single cleanup path drains both. Write failures emit `task.fail` with code `input_file_write_failed`. The `codex` agent card now advertises the extension URI under `capabilities.extensions[]`, so cooperating gateways can discover the capability from a card fetch. Tasks that do not carry the extension metadata key are unchanged — no instructions file, no envelope detection, no argv injection.

--- a/.changeset/openai-compat-multi-turn-codex.md
+++ b/.changeset/openai-compat-multi-turn-codex.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Extend the [openai-compat/v1 A2A extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) handling on the `codex` backend with multi-turn `tool_call_history` support (per the consensus on [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30)), mirroring the claude-side behaviour shipped in #152. When the metadata payload carries a `tool_call_history` array — an OpenAI-shaped record of prior `assistant.tool_calls` and `role:"tool"` returns — the bridge renders it as a `<tool_call_history>...</tool_call_history>` JSON block and prepends it to the user prompt sent to `codex` on stdin, so the model can pick up the conversation where it left off after the gateway executed a tool externally.
+
+The bridge replays the history unconditionally on every turn (stateless-gateway contract): even when `codex exec resume` brings the model's own prior turn into thread memory, the wire history is the source of truth and gets injected. The shared system-prompt paragraph (from `claude.ts`) pins the anti-loop directive — the model must NOT repeat any call whose `tool_call_id` already appears in the history. A history-only payload (no `system` / `tools` / `tool_choice`) skips the instructions file entirely but still triggers the prompt prepend.

--- a/packages/client/cards/codex.json
+++ b/packages/client/cards/codex.json
@@ -10,6 +10,11 @@
         "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
         "description": "Opt-in execution trace stream for Codex command executions.",
         "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
       }
     ]
   },

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -8,6 +8,7 @@ import {
 } from './codex.js';
 import type { Logger } from '../logger.js';
 import {
+  OPENAI_COMPAT_EXTENSION_URI,
   TRACEABILITY_EXTENSION_URI,
   type TaskAssignFrame,
   type UpFrame,
@@ -811,4 +812,359 @@ test('image materialization failure emits task.fail and cleans temp dir before s
   assert.equal(fail.type, 'task.fail');
   assert.equal(fail.error.code, 'input_file_write_failed');
   assert.match(fail.error.message, /disk full/);
+});
+
+// ---------------------------------------------------------------------------
+// openai-compat extension
+//
+// The pure helpers (parseOpenAICompatMetadata, buildOpenAICompatSystemPrompt,
+// formatToolCallHistory, tryParseToolCallsEnvelope) live in claude.ts and are
+// covered by claude.test.ts — codex.ts imports them verbatim, so we only test
+// the codex-specific wiring here: argv injection of the `-c
+// model_instructions_file=...` seam, file write/cleanup lifecycle, history
+// prepend on the stdin prompt, and envelope→data-part artifact conversion.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get the current weather for a city.',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+function assignWithOpenAICompat(
+  text: string,
+  payload: Record<string, unknown>,
+  contextId = 'ctx-1',
+): TaskAssignFrame {
+  const base = assign(text, contextId);
+  return {
+    ...base,
+    message: {
+      ...base.message,
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: payload },
+    },
+  };
+}
+
+test('argv carries `-c model_instructions_file=...` and the file contains the envelope contract', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const written: Array<{ path: string; data: Buffer }> = [];
+  const removed: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-instr',
+    writeFile: async (filePath, data) => {
+      written.push({ path: String(filePath), data: Buffer.from(data as Buffer) });
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('what is the weather?', {
+      system: 'You are concise.',
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'auto',
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  // Exactly one instructions file written under the freshly-minted temp dir.
+  assert.equal(written.length, 1);
+  assert.equal(written[0].path, '/tmp/vicoop-codex-instr/instructions.md');
+  const body = written[0].data.toString('utf8');
+  // The user system precedes the envelope contract in the rendered file.
+  assert.match(body, /^You are concise\./);
+  assert.match(body, /"tool_calls":\[\{"id":"call_<unique>"/);
+  assert.match(body, /"name": "get_weather"/);
+  assert.match(body, /tool_choice="auto"/);
+
+  // The argv carries the `-c model_instructions_file="..."` pair; the value
+  // is TOML-quoted (so paths with spaces / unicode survive). Position is
+  // after the sandbox `-c` block and `--skip-git-repo-check`, before any
+  // operator extras — pin it precisely.
+  assert.deepEqual(fake.lastChild()!.args, [
+    'exec',
+    '--json',
+    '-c',
+    'sandbox_mode="read-only"',
+    '--skip-git-repo-check',
+    '-c',
+    'model_instructions_file="/tmp/vicoop-codex-instr/instructions.md"',
+    '-',
+  ]);
+
+  // Cleanup ran on the instructions temp dir.
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-instr']);
+});
+
+test('absent metadata → no instructions file is written and no `model_instructions_file` arg appears', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  let mkdtempCalls = 0;
+  const written: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => {
+      mkdtempCalls++;
+      return '/tmp/vicoop-codex-instr';
+    },
+    writeFile: async (filePath) => {
+      written.push(String(filePath));
+    },
+    rm: async () => {},
+  });
+
+  await backend.handle(assign('hello'), collect().emit, NEVER);
+
+  // No openai-compat metadata → no temp dir, no instructions file.
+  assert.equal(mkdtempCalls, 0);
+  assert.deepEqual(written, []);
+  const args = fake.lastChild()!.args;
+  assert.equal(
+    args.some((a) => typeof a === 'string' && a.startsWith('model_instructions_file=')),
+    false,
+  );
+});
+
+test('instructions file is co-located with the image temp dir when both are present (single cleanup)', async () => {
+  // When the task also carries images, mapPartsToCodexInput already minted
+  // a temp dir for them. The instructions file MUST land in that same dir
+  // so a single `rm -r` cleans both, and no second mkdtemp is issued.
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  let mkdtempCalls = 0;
+  const written: Array<{ path: string; data: Buffer }> = [];
+  const removed: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => {
+      mkdtempCalls++;
+      return '/tmp/vicoop-codex-mix';
+    },
+    writeFile: async (filePath, data) => {
+      written.push({ path: String(filePath), data: Buffer.from(data as Buffer) });
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+
+  const taskWithImage: TaskAssignFrame = {
+    ...assignWithOpenAICompat('what is this?', {
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'auto',
+    }),
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [
+        { kind: 'text', text: 'what is this?' },
+        { kind: 'file', file: { mimeType: 'image/png', bytes: Buffer.from('png').toString('base64') } },
+      ],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          tools: SAMPLE_TOOLS,
+          tool_choice: 'auto',
+        },
+      },
+    },
+  };
+
+  await backend.handle(taskWithImage, collect().emit, NEVER);
+
+  // mkdtemp ran exactly once (the image path); the instructions file
+  // landed in the same dir so cleanup is a single rm.
+  assert.equal(mkdtempCalls, 1);
+  const paths = written.map((w) => w.path);
+  assert.ok(paths.includes('/tmp/vicoop-codex-mix/image-1.png'));
+  assert.ok(paths.includes('/tmp/vicoop-codex-mix/instructions.md'));
+  // Only one rm — for the shared dir.
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-mix']);
+});
+
+test('instructions write failure emits task.fail and cleans the freshly-minted temp dir', async () => {
+  // Mirror the image write-failure path: the file the operator could see
+  // referenced in the failure message is the system prompt one. The
+  // instructions temp dir was minted just for this run, so it must be
+  // cleaned even though the child never spawned.
+  let spawned = 0;
+  const removed: string[] = [];
+  const backend = createCodexBackend({
+    spawn: () => {
+      spawned++;
+      throw new Error('should not spawn');
+    },
+    mkdtemp: async () => '/tmp/vicoop-codex-instr-fail',
+    writeFile: async () => {
+      throw new Error('disk full');
+    },
+    rm: async (filePath) => {
+      removed.push(String(filePath));
+    },
+  });
+
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('go', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }),
+    emit,
+    NEVER,
+  );
+
+  assert.equal(spawned, 0);
+  assert.deepEqual(removed, ['/tmp/vicoop-codex-instr-fail']);
+  const fail = frames[0] as Extract<UpFrame, { type: 'task.fail' }>;
+  assert.equal(fail.type, 'task.fail');
+  assert.equal(fail.error.code, 'input_file_write_failed');
+  assert.match(fail.error.message, /failed to materialize codex instructions/);
+  assert.match(fail.error.message, /disk full/);
+});
+
+test('agent_message envelope JSON becomes a data-part artifact tagged with the extension URI', async () => {
+  const envelope = {
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  };
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: JSON.stringify(envelope) },
+      }),
+    ],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-env',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('what is the weather in Seoul?', { tools: SAMPLE_TOOLS }),
+    emit,
+    NEVER,
+  );
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  const part = artifacts[0].artifact.parts[0];
+  assert.equal(part.kind, 'data');
+  if (part.kind !== 'data') throw new Error('expected data part');
+  assert.deepEqual(part.data, envelope);
+  // Tagged so downstream gateways can route on the extension.
+  assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+});
+
+test('extension off: a coincidental {"tool_calls":[...]} agent_message stays a text artifact', async () => {
+  // No metadata → no envelope contract is in force, so a model emitting
+  // JSON-shaped text by coincidence MUST NOT be routed as a tool call.
+  // Guards against false positives polluting natural-language tasks.
+  const coincidental = JSON.stringify({ tool_calls: [] });
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: coincidental },
+      }),
+    ],
+  ]);
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  assert.equal(artifacts[0].artifact.parts[0].kind, 'text');
+  assert.equal(textOf(artifacts[0]), coincidental);
+  assert.equal(artifacts[0].artifact.extensions, undefined);
+});
+
+test('extension on but the model answered in prose → text artifact, no extension tag', async () => {
+  // The extension being active does not mean every turn is a tool turn:
+  // tool_choice="auto" lets the model answer naturally. Non-envelope text
+  // must still flow through as a text artifact and must NOT carry the
+  // extension URI tag, which would mis-claim a data-part contract.
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({
+        type: 'item.completed',
+        item: { type: 'agent_message', text: 'No tool needed; the answer is 42.' },
+      }),
+    ],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-prose',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }),
+    emit,
+    NEVER,
+  );
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 1);
+  assert.equal(textOf(artifacts[0]), 'No tool needed; the answer is 42.');
+  assert.equal(artifacts[0].artifact.extensions, undefined);
+});
+
+test('tool_choice="none" writes a no-envelope directive to the instructions file', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const written: Array<{ path: string; data: Buffer }> = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-none',
+    writeFile: async (filePath, data) => {
+      written.push({ path: String(filePath), data: Buffer.from(data as Buffer) });
+    },
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('hi', {
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'none',
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  assert.equal(written.length, 1);
+  const body = written[0].data.toString('utf8');
+  // The envelope contract block is suppressed under tool_choice="none";
+  // an explicit "do not emit" directive replaces it so the gateway's
+  // intent (no tool calls this turn) is preserved.
+  assert.doesNotMatch(body, /"tool_calls":\[\{"id":"call_<unique>"/);
+  assert.match(body, /tool_choice="none"/);
 });

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -841,6 +841,21 @@ const SAMPLE_TOOLS = [
   },
 ];
 
+const SAMPLE_HISTORY: ReadonlyArray<Record<string, unknown>> = [
+  {
+    role: 'assistant',
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  },
+  {
+    role: 'tool',
+    tool_call_id: 'call_abc',
+    name: 'get_weather',
+    content: '{"temp":15,"cond":"sunny"}',
+  },
+];
+
 function assignWithOpenAICompat(
   text: string,
   payload: Record<string, unknown>,
@@ -942,6 +957,48 @@ test('absent metadata → no instructions file is written and no `model_instruct
   );
 });
 
+test('history-only payload writes no instructions file (build prompt is empty) but still prepends the history block', async () => {
+  // Cooperating gateway sent only the multi-turn history — no tools, no
+  // system, no tool_choice. `buildOpenAICompatSystemPrompt` returns "" in
+  // that case, so we MUST NOT mkdtemp / write an empty instructions file.
+  // The history is still required by spec to be replayed in user content.
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  let mkdtempCalls = 0;
+  const written: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => {
+      mkdtempCalls++;
+      return '/tmp/vicoop-codex-instr';
+    },
+    writeFile: async (filePath) => {
+      written.push(String(filePath));
+    },
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('continue', { tool_call_history: SAMPLE_HISTORY }),
+    collect().emit,
+    NEVER,
+  );
+
+  assert.equal(mkdtempCalls, 0);
+  assert.deepEqual(written, []);
+  const args = fake.lastChild()!.args;
+  assert.equal(
+    args.some((a) => typeof a === 'string' && a.startsWith('model_instructions_file=')),
+    false,
+  );
+
+  // History still prepended to user content.
+  const stdin = fake.lastChild()!.stdinPayload;
+  assert.match(stdin, /^<tool_call_history>\n/);
+  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue$/);
+});
+
 test('instructions file is co-located with the image temp dir when both are present (single cleanup)', async () => {
   // When the task also carries images, mapPartsToCodexInput already minted
   // a temp dir for them. The instructions file MUST land in that same dir
@@ -1034,6 +1091,57 @@ test('instructions write failure emits task.fail and cleans the freshly-minted t
   assert.equal(fail.error.code, 'input_file_write_failed');
   assert.match(fail.error.message, /failed to materialize codex instructions/);
   assert.match(fail.error.message, /disk full/);
+});
+
+test('multi-turn: history block is prepended to the user prompt on stdin', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-mt',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('continue, please', {
+      tools: SAMPLE_TOOLS,
+      tool_call_history: SAMPLE_HISTORY,
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const stdin = fake.lastChild()!.stdinPayload;
+  // History block precedes the user prompt, separated by a blank line so
+  // the model sees the boundary clearly.
+  assert.match(stdin, /^<tool_call_history>\n/);
+  assert.match(stdin, /"role": "assistant"/);
+  assert.match(stdin, /"tool_call_id": "call_abc"/);
+  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue, please$/);
+});
+
+test('multi-turn: absent tool_call_history leaves the stdin prompt untouched', async () => {
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-mt-none',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('hi', { tools: SAMPLE_TOOLS }),
+    collect().emit,
+    NEVER,
+  );
+
+  // No <tool_call_history> wrapper leaks onto a first-turn task.
+  const stdin = fake.lastChild()!.stdinPayload;
+  assert.equal(stdin, 'hi');
 });
 
 test('agent_message envelope JSON becomes a data-part artifact tagged with the extension URI', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -11,6 +11,7 @@ import {
 import type { Backend } from '../backend.js';
 import {
   buildOpenAICompatSystemPrompt,
+  formatToolCallHistory,
   parseOpenAICompatMetadata,
   tryParseToolCallsEnvelope,
 } from './claude.js';
@@ -497,8 +498,20 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
         child.stdin.on('error', (err: unknown) => {
           if (!stdinError) stdinError = err;
         });
+        // Spec contract: bridges MUST replay the entire `tool_call_history`
+        // in order on every follow-up turn. Render it as a `<tool_call_history>`
+        // JSON block and prepend it to the user prompt so the model reads
+        // the prior round BEFORE the current user turn. Any internal session
+        // reuse (codex `exec resume`) is invisible to the wire and does not
+        // change replay semantics — the redundancy is the price of
+        // cross-bridge interop.
+        const promptToWrite = openaiCompat?.tool_call_history
+          ? (mapped.prompt
+              ? `${formatToolCallHistory(openaiCompat.tool_call_history)}\n\n${mapped.prompt}`
+              : formatToolCallHistory(openaiCompat.tool_call_history))
+          : mapped.prompt;
         try {
-          child.stdin.end(mapped.prompt);
+          child.stdin.end(promptToWrite);
         } catch (err) {
           stdinError = err;
         }

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -3,8 +3,17 @@ import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { TRACEABILITY_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  TRACEABILITY_EXTENSION_URI,
+  type Part,
+} from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import {
+  buildOpenAICompatSystemPrompt,
+  parseOpenAICompatMetadata,
+  tryParseToolCallsEnvelope,
+} from './claude.js';
 import { createLogger, escapeLineSeparators, safeToken, type Logger } from '../logger.js';
 import { INPUT_FILE_MAX_BYTES, INPUT_IMAGE_MIME } from './fetch-uri-file.js';
 
@@ -312,6 +321,21 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
         return;
       }
 
+      // Detect the openai-compat extension payload once per task so the
+      // result feeds three places: (a) the instructions file we materialise
+      // for `-c model_instructions_file=...`, (b) the assistant artifact
+      // path (envelope JSON → data part), and (c) the user prompt prefix
+      // for multi-turn `tool_call_history`. Absent or malformed metadata
+      // leaves the run on the original non-extension code path with no
+      // envelope-detection cost.
+      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+
+      // A separately-rooted temp dir created only when openai-compat is
+      // active AND no image temp dir already exists. Tracked here (outside
+      // the try/finally) so the finally block can clean it independently
+      // of `mapped.tempDir`.
+      let instructionsTempDir: string | null = null;
+
       try {
         if (signal.aborted) {
           emit({
@@ -320,6 +344,42 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
             status: { state: 'canceled', timestamp: new Date().toISOString() },
           });
           return;
+        }
+
+        // Materialise the openai-compat system prompt to a file we point
+        // codex at via `-c model_instructions_file="..."`. codex 0.130+
+        // exposes this as the seam for caller-supplied instructions;
+        // `experimental_instructions_file` is deprecated and silently
+        // ignored. Skip when the built prompt is empty (e.g. metadata only
+        // carried `tool_call_history`, which is replayed in user content
+        // instead — no system-level contract needed).
+        let instructionsFile: string | null = null;
+        if (openaiCompat) {
+          const systemPromptText = buildOpenAICompatSystemPrompt(openaiCompat);
+          if (systemPromptText) {
+            try {
+              let dir: string;
+              if (mapped.tempDir) {
+                dir = mapped.tempDir;
+              } else {
+                instructionsTempDir = await mkdtemp(path.join(os.tmpdir(), 'vicoop-codex-'));
+                dir = instructionsTempDir;
+              }
+              const file = path.join(dir, 'instructions.md');
+              await writeFile(file, Buffer.from(systemPromptText, 'utf8'));
+              instructionsFile = file;
+            } catch (err) {
+              emit({
+                type: 'task.fail',
+                taskId: task.taskId,
+                error: {
+                  code: 'input_file_write_failed',
+                  message: `failed to materialize codex instructions: ${errorMessage(err)}`,
+                },
+              });
+              return;
+            }
+          }
         }
 
         const tNow = now();
@@ -344,11 +404,20 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
         const skipGitRepoCheck = extraArgs.includes(SKIP_GIT_REPO_CHECK_FLAG)
           ? []
           : [SKIP_GIT_REPO_CHECK_FLAG];
+        // `-c key=val` expects val to parse as TOML; for a string value
+        // that means wrapped in TOML's basic-string double quotes. Lean on
+        // JSON.stringify since TOML's basic-string escape set matches
+        // JSON's (\", \\, \n, \t, etc.) so the value survives spaces /
+        // unicode / quotes in the path verbatim.
+        const instructionsArgs = instructionsFile
+          ? ['-c', `model_instructions_file=${JSON.stringify(instructionsFile)}`]
+          : [];
         const optionArgs = [
           '--json',
           '-c',
           `sandbox_mode=${JSON.stringify(sandboxMode)}`,
           ...skipGitRepoCheck,
+          ...instructionsArgs,
           ...mapped.imageFiles.flatMap((filePath) => ['--image', filePath]),
           ...extraArgs,
         ];
@@ -443,6 +512,32 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
 
         const emitAgentArtifact = (text: string): void => {
           if (!text) return;
+          // When the openai-compat extension is active for this task, the
+          // model was instructed to emit `{"tool_calls":[...]}` JSON for
+          // tool turns. Detect that shape and surface it as an A2A `data`
+          // part so the upstream gateway can forward it as `tool_calls` on
+          // the OpenAI response without re-parsing model prose. Non-envelope
+          // text (natural-language answers, or any turn from a task that
+          // didn't request the extension) falls through to the text artifact
+          // path unchanged.
+          if (openaiCompat) {
+            const envelope = tryParseToolCallsEnvelope(text);
+            if (envelope) {
+              emit({
+                type: 'task.artifact',
+                taskId: task.taskId,
+                artifact: {
+                  artifactId: randomUUID(),
+                  name: 'codex-message',
+                  parts: [{ kind: 'data', data: envelope }],
+                  extensions: [OPENAI_COMPAT_EXTENSION_URI],
+                },
+                lastChunk: true,
+              });
+              emittedAnyArtifact = true;
+              return;
+            }
+          }
           emit({
             type: 'task.artifact',
             taskId: task.taskId,
@@ -665,6 +760,15 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
             await rm(mapped.tempDir, { recursive: true, force: true });
           } catch {
             // Best-effort cleanup; task result should not fail after the child settled.
+          }
+        }
+        // Separately clean the openai-compat instructions dir when it was
+        // not co-located with `mapped.tempDir` (i.e. there were no images).
+        if (instructionsTempDir && instructionsTempDir !== mapped.tempDir) {
+          try {
+            await rm(instructionsTempDir, { recursive: true, force: true });
+          } catch {
+            // Best-effort cleanup; see above.
           }
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #152 — implements the [A2A openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `codex` backend so cooperating OpenAI-compatible gateways (e.g. `planetarium/oai2a2a`) can route `system` / `tools` / `tool_choice` and `tool_call_history` through A2A `Message.metadata` without text-injecting them into user-role content.

Closes #153.

The codex CLI lacks a clean `--append-system-prompt` seam (#153's chief unknown), so the per-task system prompt is materialised to a file and pointed at via `-c model_instructions_file="<path>"` (codex 0.130+; `experimental_instructions_file` is deprecated and silently ignored). The instructions file co-locates with the existing per-task image temp dir when one is present, or a freshly-minted one otherwise — a single cleanup path drains both.

Two logical commits:

- **`97f5607`** — turn 1: metadata reading, instructions file write, argv injection, envelope detection.
- **`7a79fee`** — multi-turn `tool_call_history` per the [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30) consensus (option A, `tool_call_history` field, MUST replay, stateless gateway).

## What's in the change

- **`packages/client/cards/codex.json`** — advertises the extension URI under `capabilities.extensions[]` so cooperating gateways discover the capability from a card fetch.
- **`packages/client/src/backends/codex.ts`**:
  - Imports `parseOpenAICompatMetadata`, `buildOpenAICompatSystemPrompt`, `formatToolCallHistory`, and `tryParseToolCallsEnvelope` verbatim from `claude.ts` — the contract is the same on both backends, so the helpers stay in one place.
  - In `handle()`, the parsed metadata feeds three places: (a) a per-task instructions file written via `writeFile` and pointed at by `-c model_instructions_file="..."`, (b) the assistant artifact path (envelope JSON → data part with `extensions: [OPENAI_COMPAT_EXTENSION_URI]`), and (c) the user-prompt prefix on stdin for multi-turn replay.
  - When `buildOpenAICompatSystemPrompt` returns empty (history-only payload), no instructions file is written and no `model_instructions_file` arg is added — but the history block is still prepended.
  - Instructions write failures emit `task.fail` with code `input_file_write_failed` and clean any freshly-minted temp dir before returning.
  - `emitAgentArtifact` runs the envelope check only when the extension was requested for this task, so non-extension tasks pay zero cost on every assistant message.
- **`packages/client/src/backends/codex.test.ts`** — 11 new tests covering argv injection (with and without metadata), instructions file content under each `tool_choice` variant, co-location with the image temp dir, write-failure rollback, multi-turn history prepend on stdin (and the absent-history pass-through), envelope-to-data-part conversion, the false-positive defence on coincidental JSON-shaped prose when the extension is off, and the prose-under-extension-on text fallback.

## codex CLI behaviour confirmed (gpt-5 / codex 0.130.0)

Verified directly before implementation:

1. **`model_instructions_file`** is honoured as the system-prompt seam. `experimental_instructions_file` is deprecated and emits a deprecation warning to stderr.
2. **Envelope emission**: given a `buildOpenAICompatSystemPrompt`-shaped instructions file, gpt-5 emits the `{"tool_calls":[…]}` envelope verbatim on tool turns (no prose / fences). Surfaces in JSONL as `item.completed` with `item.type === "agent_message"`.
3. **Multi-turn anti-loop**: with a `<tool_call_history>` block prepended (carrying the prior `assistant.tool_calls` + `role:"tool"` result), the model does NOT re-emit the envelope; it composes a natural-language answer using the prior tool result. The anti-loop directive in the shared system prompt is sufficient.

## Out of scope (per the issue)

- `openclaw` backend — separate ticket.
- `response_format` (JSON Schema structured output) — same as #152.
- MCP overlap — same as #152.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `pnpm --filter @vicoop-bridge/client test` → 372/372 (11 new).
- [x] `pnpm --filter @vicoop-bridge/server test` → unchanged (174 pass, 26 skipped).
- [x] Codex CLI seam + envelope + multi-turn anti-loop verified directly against `codex exec --json` on gpt-5 (see "codex CLI behaviour confirmed" above).
- [x] **E2E live**: registered fresh `codex-e2e-*` agent via `registerClient` on `https://vicoop-bridge-server.fly.dev`, ran a daemon from this branch (`--backend codex --card cards/codex.json`) against the prod WS endpoint. Confirmed:
  - `GET /agents/<id>/.well-known/agent-card.json` includes the openai-compat URI under `capabilities.extensions[]`.
  - **Turn 1** (`tools` + `tool_choice:"auto"`, no history): the model emitted the envelope JSON; the bridge surfaced it as a `kind:"data"` artifact carrying `tool_calls[0].function.name === "get_weather"` with arguments `{location:"Seoul", unit:"c"}`, tagged `extensions: ["…/openai-compat/v1"]`.
  - **Multi-turn** (same `contextId`, `tool_call_history` carrying the prior `assistant.tool_calls` + a stubbed `role:"tool"` result `{"tempC":7,"condition":"clear"}`): the model read the history block, did NOT re-emit the envelope, and answered in natural language ("It's currently clear in Seoul and about 7°C.") as an untagged text artifact — anti-loop verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)