### PR TITLE
feat(client): A2A openai-compat extension on openclaw backend (turn 1 + multi-turn)

### DIFF
--- a/.changeset/openai-compat-extension-openclaw.md
+++ b/.changeset/openai-compat-extension-openclaw.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Implement the A2A [openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `openclaw` backend, mirroring the contract added for `claude` in #152 and `codex` in #159. Because OpenClaw's `chat.send` RPC has no `system` field — the entire writable channel into the model is the user `message` text — the contract is folded into the user content as tagged XML blocks: `<system_instructions>` carrying the envelope contract + tools + tool_choice, then `<user_message>` carrying the caller's actual prompt. Envelope detection runs on every assistant transcript entry (and on the terminal `chat` event for the non-streaming fallback path) and surfaces matches as A2A `data` part artifacts tagged with `OPENAI_COMPAT_EXTENSION_URI`.
+
+The `openclaw` agent card now advertises the extension URI under `capabilities.extensions[]` so cooperating gateways can discover it from a card fetch. The card description explicitly flags the contract as **best-effort**: because OpenClaw's wire has no system-prompt seam, reliability depends on the gateway's host model honoring the text-injected instructions. Verified on Anthropic `claude-sonnet-4-6` in repeated probes (5/5 envelope-on-tool-turn, 5/5 anti-loop-on-history-turn); OSS-hosted gateways may require per-model measurement, and tasks against a non-cooperating host model fall through cleanly to the existing text-artifact path with no extension URI tag.

--- a/.changeset/openai-compat-multi-turn-openclaw.md
+++ b/.changeset/openai-compat-multi-turn-openclaw.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Extend the [openai-compat/v1 A2A extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) handling on the `openclaw` backend with multi-turn `tool_call_history` support (per the [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30) consensus), mirroring the claude-side behaviour shipped in #152 and the codex-side behaviour shipped in #159. When the metadata payload carries a `tool_call_history` array, the bridge renders it as a `<tool_call_history>...</tool_call_history>` JSON block and inserts it between the `<system_instructions>` and `<user_message>` wrappers in `chat.send.message`, so the model reads the prior round before the current user turn.
+
+The bridge replays the history unconditionally on every turn (stateless-gateway contract): even though `chat.send` against the same `sessionKey` resumes a session whose memory may already include the prior turn, the wire history is the source of truth. The shared anti-loop directive from `buildOpenAICompatSystemPrompt` keeps the model from re-emitting a call whose `tool_call_id` already appears in the history.

--- a/.changeset/openai-compat-openclaw-secondary-agent.md
+++ b/.changeset/openai-compat-openclaw-secondary-agent.md
@@ -1,0 +1,9 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Add an opt-in `openaiCompatAgent` / `backends.openclaw.openai_compat_agent` / `OPENCLAW_OAI_COMPAT_AGENT` option that routes tasks carrying the openai-compat extension metadata to a secondary OpenClaw agent name (encoded in the `chat.send.sessionKey` `agent:<name>:<contextId>` prefix), instead of the default `agent`. The operator pairs this with an `agents.list` entry in the OpenClaw gateway config whose `tools.deny=["*"]` disables the host model's native tools (Bash, browser, weather skills, etc.) so the model has no in-host alternative to the envelope contract.
+
+Motivation: the text-injected envelope contract competes with whatever native tools the host agent advertises in its own system prompt. When both are present, the model frequently satisfies the request with a native skill (Bash + wttr.in, browser, etc.) and ignores the envelope-emit directive. Pilot measurement on anthropic `claude-sonnet-4-6` (`N=10` per arm) on a tool-call-prone weather prompt: envelope compliance was 5/10 with the default `main` agent (full tools), 10/10 when the same request was routed to an `oai` agent configured with `tools.profile=minimal` + `tools.deny=["*"]`. Non-extension tasks continue to flow through the default `agent`, so the split is invisible to callers that don't request the extension.
+
+When the option is unset (default), all tasks — extension or not — use the single configured `agent`, preserving today's behavior.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -244,6 +244,7 @@ omit what you don't need) is:
       "gateway_url": "ws://127.0.0.1:18789",
       "gateway_token": "<gateway-token-if-required>",
       "agent": "main",
+      "openai_compat_agent": "oai",
       "task_timeout_ms": 600000
     }
   }
@@ -267,8 +268,8 @@ or CI overrides). `setup` only ever touches `server_url`, `server_token`, and
 > (`CLAUDE_CWD`, `CLAUDE_SETTINGS_JSON`, `CODEX_CWD`,
 > `CODEX_SANDBOX_MODE`, `OPENCLAW_GATEWAY_URL` /
 > `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_AGENT` /
-> `OPENCLAW_TASK_TIMEOUT_MS`) still override the corresponding config
-> values.
+> `OPENCLAW_OAI_COMPAT_AGENT` / `OPENCLAW_TASK_TIMEOUT_MS`) still
+> override the corresponding config values.
 
 If you omit `--caller`, `setup` succeeds but prints a warning that the
 agent will be public until you restrict callers:
@@ -424,7 +425,38 @@ second WS. Override if yours isn't on the default:
 | `OPENCLAW_GATEWAY_URL` | `ws://127.0.0.1:18789` | Local gateway endpoint |
 | `OPENCLAW_GATEWAY_TOKEN` | *(none)* | If your gateway requires auth |
 | `OPENCLAW_AGENT` | `main` | Agent name inside OpenClaw |
+| `OPENCLAW_OAI_COMPAT_AGENT` | *(unset, single-agent mode)* | Optional secondary OpenClaw agent name dedicated to tasks carrying the A2A openai-compat extension metadata. When set, the bridge routes those tasks via `agent:<this>:<contextId>` sessionKeys; non-extension tasks keep using `OPENCLAW_AGENT`. Pairs with a `tools.deny=["*"]` `agents.list` entry on the OpenClaw side — see the box below. |
 | `OPENCLAW_TASK_TIMEOUT_MS` | backend default | Per-task timeout |
+
+> **Recommended dual-agent setup for the openai-compat extension.**
+> If you advertise the `…/openai-compat/v1` extension on the OpenClaw
+> card (it ships advertised by default) and expect OpenAI-shaped
+> callers to actually hit it, configure two OpenClaw agents instead
+> of one. The default `main` agent keeps its full toolset for normal
+> natural-language traffic; a secondary `oai` agent runs with native
+> tools disabled so the host model can't satisfy a tool-call prompt
+> with its own Bash / browser / weather skill and ignore the
+> envelope contract the bridge text-injects into the user message.
+>
+> Add this to the OpenClaw gateway config (`~/.openclaw/openclaw.json`
+> on the host running OpenClaw):
+> ```json
+> {
+>   "agents": {
+>     "list": [
+>       { "id": "main" },
+>       { "id": "oai", "tools": { "profile": "minimal", "deny": ["*"] } }
+>     ]
+>   }
+> }
+> ```
+> Then set `OPENCLAW_OAI_COMPAT_AGENT=oai` (or
+> `backends.openclaw.openai_compat_agent: "oai"` in `config.json`)
+> on the vicoop-client side. Pilot measurement on
+> `anthropic/claude-sonnet-4-6` saw envelope-contract compliance
+> rise from 5/10 (single-agent baseline, full tools) to 10/10 with
+> this split. Leave `OPENCLAW_OAI_COMPAT_AGENT` unset and you get
+> today's single-agent behavior on every task.
 
 ### Claude-specific env
 

--- a/docs/openclaw-e2e.md
+++ b/docs/openclaw-e2e.md
@@ -386,6 +386,137 @@ Notes:
   enabled simultaneously as a fallback for callers that don't register
   the MCP server.
 
+## openai-compat envelope verification
+
+A sixth exercise at
+`packages/client/scripts/probe-openclaw-openai-compat.mjs` measures
+whether the OpenClaw host model honors the text-injected
+`{"tool_calls":[…]}` envelope contract for the
+[A2A openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1).
+Unlike the previous exercises, this one's reliability depends on
+the gateway's host model — OpenClaw's `chat.send` RPC has no
+system-prompt seam, so the bridge folds the contract into the user
+message as tagged XML blocks. A paranoid host model can refuse to
+follow user-injected pseudo-system instructions; a tool-rich host
+can satisfy the prompt with its own skill (Bash + wttr.in, etc.)
+and ignore the envelope directive. The probe quantifies both
+behaviors against your actual deployment.
+
+The script runs two turns:
+
+1. **Turn 1** — sends a `<system_instructions>` block carrying the
+   envelope contract + a `get_weather` tool definition, then a
+   `<user_message>` asking for the weather. Reports whether the
+   assistant emitted the `{"tool_calls":[...]}` envelope verbatim
+   or answered in natural language.
+2. **Turn 2** — same `sessionKey` follow-up with a
+   `<tool_call_history>` block carrying a synthesized prior
+   `assistant.tool_calls` + a `role:"tool"` result. Reports
+   whether the model re-emitted the envelope (anti-loop directive
+   violated) or composed a natural-language answer using the prior
+   result (anti-loop honored).
+
+### Single-agent run (baseline)
+
+Reuses the `oc-e2e-anthropic` image from the attach-outputs section
+(`auth.mode=none` + Anthropic API key + claude-sonnet-4-6):
+
+```bash
+docker run -d --name openclaw-e2e \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  oc-e2e-anthropic \
+  node openclaw.mjs gateway --allow-unconfigured --bind loopback
+
+# wait for "[gateway] ready"
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  node:20 \
+  node ./scripts/probe-openclaw-openai-compat.mjs
+```
+
+Expected verdict tail (one possible outcome — the result is
+stochastic on this configuration):
+
+```
+=== VERDICT ===
+turn1 envelope detected: true {"tool_calls":[{"id":"call_seoul_weather",…}]}
+turn2 envelope detected: false (text: "Right now in Seoul, it's…")
+```
+
+On pilot probes against `claude-sonnet-4-6` the single-agent
+configuration delivered turn-1 envelope compliance ~5/10 — the
+host model frequently satisfied the prompt with its own native
+weather skill and skipped the envelope. To measure your own
+deployment's rate, wrap the probe in a small loop and count
+`turn1 envelope detected: true` lines across N runs.
+
+### Dual-agent run (recommended for openai-compat traffic)
+
+Define a secondary OpenClaw agent with native tools disabled, then
+point the bridge at it for openai-compat tasks via
+`OPENCLAW_OAI_COMPAT_AGENT`. Non-extension tasks continue to flow
+through the default `main` agent with its full toolset, so this
+split is invisible to natural-language callers.
+
+```bash
+mkdir -p /tmp/oc-build-multiagent
+cat > /tmp/oc-build-multiagent/Dockerfile << 'EOF'
+FROM ghcr.io/openclaw/openclaw:latest
+USER root
+RUN mkdir -p /home/node/.openclaw && \
+    printf '%s' '{"gateway":{"auth":{"mode":"none"}},"agents":{"defaults":{"model":{"primary":"anthropic/claude-sonnet-4-6"}},"list":[{"id":"main"},{"id":"oai","tools":{"profile":"minimal","deny":["*"]}}]}}' \
+      > /home/node/.openclaw/openclaw.json && \
+    chown -R node:node /home/node/.openclaw
+USER node
+EOF
+docker build -t oc-e2e-multiagent /tmp/oc-build-multiagent
+
+docker run -d --name openclaw-e2e \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  oc-e2e-multiagent \
+  node openclaw.mjs gateway --allow-unconfigured --bind loopback
+
+# wait for "[gateway] ready"
+
+docker run --rm \
+  --network container:openclaw-e2e \
+  -v "$PWD":/w -w /w/packages/client \
+  -e OPENCLAW_OAI_COMPAT_AGENT=oai \
+  node:20 \
+  node ./scripts/probe-openclaw-openai-compat.mjs
+```
+
+Expected verdict tail:
+
+```
+=== VERDICT ===
+turn1 envelope detected: true {"tool_calls":[{"id":"call_seoul_weather",…}]}
+turn2 envelope detected: false (text: "It's currently clear in Seoul and about 7°C.")
+```
+
+Both turns now produce the expected shape deterministically:
+turn 1 emits the envelope (the `oai` agent has no native tool to
+fall back on), turn 2 reads the synthesized `tool_call_history`
+and answers in natural language with the prior tool result
+(anti-loop directive honored). Pilot N=10 measurement on the same
+prompt: 10/10 envelope on turn 1, 10/10 anti-loop on turn 2.
+
+### Verifying the routing split
+
+To confirm the bridge is actually routing extension and
+non-extension tasks to different agents, watch the OpenClaw
+gateway log while the probe runs:
+
+```bash
+docker exec openclaw-e2e sh -c 'cat /tmp/openclaw/openclaw-*.log' | grep sessionKey
+```
+
+The extension-bearing task should reach
+`agent:oai:<contextId>`, the plain follow-up (if you run a separate
+natural-language `chat.send`) should reach `agent:main:<contextId>`.
+
 ## Teardown
 
 ```bash

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -8,7 +8,7 @@
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part. Best-effort: contract is text-injected into user content because the OpenClaw `chat.send` wire has no system-prompt seam, so reliability depends on the gateway's host model honoring the embedded instructions (verified on anthropic claude-sonnet-4-6 in repeated probes; OSS-hosted gateways may require per-model measurement).",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part. Best-effort: contract is text-injected into user content because the OpenClaw `chat.send` wire has no system-prompt seam, so reliability depends on the gateway's host model honoring the embedded instructions. Pilot measurement on anthropic claude-sonnet-4-6 (N=10 per arm): with the host agent's native tools enabled, envelope compliance is ~50%; with a dedicated tools-disabled agent (gateway `agents.list[].tools.deny=[\"*\"]`) routed via `backends.openclaw.openai_compat_agent` / `OPENCLAW_OAI_COMPAT_AGENT`, compliance rose to 100%. The split is opt-in; operators who don't configure the secondary agent get the single-agent baseline behavior.",
         "required": false
       }
     ]

--- a/packages/client/cards/openclaw.json
+++ b/packages/client/cards/openclaw.json
@@ -3,7 +3,16 @@
   "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; when the operator enables outbound file delivery, can also return file artifacts spanning images, PDFs, structured data (JSON/XML/CSV/HTML/Markdown), archives, audio, video, and other binary types.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": true },
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part. Best-effort: contract is text-injected into user content because the OpenClaw `chat.send` wire has no system-prompt seam, so reliability depends on the gateway's host model honoring the embedded instructions (verified on anthropic claude-sonnet-4-6 in repeated probes; OSS-hosted gateways may require per-model measurement).",
+        "required": false
+      }
+    ]
+  },
   "defaultInputModes": [
     "text/plain",
     "image/png",

--- a/packages/client/scripts/probe-openclaw-openai-compat.mjs
+++ b/packages/client/scripts/probe-openclaw-openai-compat.mjs
@@ -1,0 +1,199 @@
+// Probe whether OpenClaw (Anthropic claude-sonnet-4-6) honors a
+// text-injected openai-compat envelope contract on the user-content channel.
+//
+// Approach mirrors the candidate-A design from the codex/claude analysis: the
+// bridge has no `system` field on `chat.send`, so the entire contract
+// (system instructions, available tools, optional tool_call_history) is
+// folded into the user message wrapped in tagged XML blocks. If the host
+// model treats the wrapper as instructions, it emits the
+// `{"tool_calls":[...]}` envelope; if its prompt-injection training rejects
+// the user-role-as-system framing, it answers in natural language and the
+// gateway-style contract is moot.
+//
+// Run inside a sidecar that shares the gateway container's net namespace:
+//   docker run --rm --network container:openclaw-e2e \
+//     -v "$PWD":/w -w /w/packages/client \
+//     -e DEBUG=1 \
+//     node:20 \
+//     node ./scripts/probe-openclaw-openai-compat.mjs
+
+import { createOpenclawBackend } from '../dist/backends/openclaw.js';
+
+// Whatever shape claude.ts ships verbatim for the openai-compat contract.
+// Inlined here so the probe is self-contained (no internal-only imports).
+const SYSTEM_INSTRUCTIONS = `You are routed through an OpenAI-compatible gateway and have access to the following callable functions.
+
+When you decide a function should be called, respond with ONLY a single JSON object (no prose, no code fences, no markdown) of the exact shape:
+
+{"tool_calls":[{"id":"call_<unique>","function":{"name":"<fn name>","arguments":{<args as JSON object>}}}]}
+
+- "id" must be a unique string starting with "call_".
+- "arguments" must be a JSON object matching the function's parameters schema.
+- Emit nothing outside the JSON object.
+- Do not execute the function yourself; just emit the call.
+- If no function should be called, answer normally in natural language.
+
+On follow-up turns the user message may begin with a <tool_call_history>...</tool_call_history> block containing a JSON array of prior round-trips. Each entry is one of:
+  - {"role":"assistant","tool_calls":[...]} — calls you previously emitted on an earlier turn.
+  - {"role":"tool","tool_call_id":"call_…","name":"…","content":"…"} — the authoritative return value for one of those calls.
+Treat the history as the source of truth for what has happened so far. Do NOT repeat a call whose tool_call_id already appears in the history. Either emit a NEW tool_calls envelope (to chain another call) or compose a natural-language answer using the prior results.
+
+Available functions:
+[
+  {
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "description": "Get current weather for a city.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": { "type": "string" },
+          "unit":     { "type": "string", "enum": ["c", "f"] }
+        },
+        "required": ["location"]
+      }
+    }
+  }
+]
+
+tool_choice="auto": call a function only if appropriate; otherwise answer in natural language.`;
+
+function buildTurn1Message(userText) {
+  return [
+    '<system_instructions>',
+    SYSTEM_INSTRUCTIONS,
+    '</system_instructions>',
+    '',
+    '<user_message>',
+    userText,
+    '</user_message>',
+  ].join('\n');
+}
+
+function buildTurn2Message(userText, history) {
+  return [
+    '<system_instructions>',
+    SYSTEM_INSTRUCTIONS,
+    '</system_instructions>',
+    '',
+    '<tool_call_history>',
+    JSON.stringify(history, null, 2),
+    '</tool_call_history>',
+    '',
+    '<user_message>',
+    userText,
+    '</user_message>',
+  ].join('\n');
+}
+
+async function runOne(label, message, contextId) {
+  const backend = createOpenclawBackend({
+    url: 'ws://127.0.0.1:18789',
+    token: '',                  // auth.mode=none in the test gateway
+    debug: process.env.DEBUG === '1',
+    taskTimeoutMs: 120_000,
+  });
+
+  const frames = [];
+  const taskId = `probe-${label}-${Date.now()}`;
+  const task = {
+    type: 'task.assign',
+    taskId,
+    contextId,
+    message: {
+      role: 'user',
+      messageId: `msg-${taskId}`,
+      parts: [{ kind: 'text', text: message }],
+    },
+  };
+
+  const t0 = Date.now();
+  await backend.handle(task, (f) => {
+    frames.push(f);
+    if (f.type === 'task.artifact') {
+      const ps = f.artifact?.parts ?? [];
+      for (const p of ps) {
+        if (p.kind === 'text') console.log(`[${label}] artifact.text:`, JSON.stringify(p.text));
+        else if (p.kind === 'data') console.log(`[${label}] artifact.data:`, JSON.stringify(p.data));
+        else console.log(`[${label}] artifact.${p.kind}`);
+      }
+    } else if (f.type === 'task.fail') {
+      console.log(`[${label}] task.fail:`, f.error);
+    } else if (f.type === 'task.complete') {
+      console.log(`[${label}] task.complete state=${f.status?.state}`);
+    }
+  }, new AbortController().signal);
+  const dt = Date.now() - t0;
+
+  // Pull terminal frame for summary.
+  const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+  const artifacts = frames.filter((f) => f.type === 'task.artifact');
+  console.log(`[${label}] elapsed=${dt}ms terminal=${terminal?.type} state=${terminal?.status?.state ?? terminal?.error?.code} artifacts=${artifacts.length}`);
+
+  return { terminal, artifacts, frames };
+}
+
+const CONTEXT_ID = `probe-ctx-${Date.now()}`;
+
+console.log('=== TURN 1 ===');
+const turn1 = await runOne(
+  'turn1',
+  buildTurn1Message("What's the weather in Seoul right now?"),
+  CONTEXT_ID,
+);
+
+console.log('');
+console.log('=== TURN 2 (multi-turn) ===');
+const history = [
+  {
+    role: 'assistant',
+    tool_calls: [
+      { id: 'call_get_weather_seoul', function: { name: 'get_weather', arguments: { location: 'Seoul', unit: 'c' } } },
+    ],
+  },
+  {
+    role: 'tool',
+    tool_call_id: 'call_get_weather_seoul',
+    name: 'get_weather',
+    content: JSON.stringify({ tempC: 7, condition: 'clear' }),
+  },
+];
+const turn2 = await runOne(
+  'turn2',
+  buildTurn2Message('Now please answer in natural language.', history),
+  CONTEXT_ID,
+);
+
+// Lightweight conclusion: try to detect the envelope shape on the final
+// assistant text part of each turn.
+function tryEnvelope(text) {
+  if (!text) return null;
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return null;
+  try {
+    const obj = JSON.parse(trimmed);
+    if (obj && typeof obj === 'object' && Array.isArray(obj.tool_calls)) return obj;
+  } catch {}
+  return null;
+}
+
+function lastAssistantText(frames) {
+  const arts = frames.filter((f) => f.type === 'task.artifact');
+  for (let i = arts.length - 1; i >= 0; i--) {
+    const ps = arts[i].artifact?.parts ?? [];
+    for (const p of ps) if (p.kind === 'text' && p.text) return p.text;
+  }
+  return '';
+}
+
+console.log('');
+console.log('=== VERDICT ===');
+const t1text = lastAssistantText(turn1.frames);
+const t2text = lastAssistantText(turn2.frames);
+const t1env = tryEnvelope(t1text);
+const t2env = tryEnvelope(t2text);
+console.log('turn1 envelope detected:', !!t1env, t1env ? JSON.stringify(t1env) : `(text: ${JSON.stringify(t1text.slice(0, 300))})`);
+console.log('turn2 envelope detected:', !!t2env, t2env ? JSON.stringify(t2env) : `(text: ${JSON.stringify(t2text.slice(0, 300))})`);
+
+process.exit(0);

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -3255,4 +3255,132 @@ test('multi-turn: tool_call_history block is prepended to chat.send.message on f
   }
 });
 
+test('openaiCompatAgent: chat.send.sessionKey routes openai-compat tasks to the configured secondary agent', async () => {
+  // Tasks WITH the extension metadata use `agent:oai:...`; tasks WITHOUT it
+  // keep using the default `agent:main:...`. The operator pairs this with
+  // an OpenClaw config that puts `tools.deny=["*"]` on the `oai` agent so
+  // the host model can't fall back to its own skills (Bash, browser,
+  // weather, etc.) and the envelope contract becomes deterministic.
+  const sentKeys: string[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const params = req.params as { sessionKey: string };
+        sentKeys.push(params.sessionKey);
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: `run-${sentKeys.length}`, status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: `run-${sentKeys.length}`,
+            sessionKey: params.sessionKey,
+            seq: 1,
+            state: 'final',
+            message: { text: 'ok' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url, openaiCompatAgent: 'oai' });
+    // Extension-bearing task → routed to `oai`.
+    await backend.handle(
+      makeOpenAICompatTask('t-route-oai', 'what is the weather?', { tools: OAI_SAMPLE_TOOLS }, 'ctx-route-oai'),
+      () => {},
+      NEVER,
+    );
+    // Plain task → keeps the default `main`.
+    await backend.handle(makeTask('t-route-main', 'hello'), () => {}, NEVER);
+
+    assert.equal(sentKeys.length, 2);
+    assert.equal(sentKeys[0], 'agent:oai:ctx-route-oai');
+    assert.equal(sentKeys[1], 'agent:main:ctx-t-route-main');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('openaiCompatAgent: when unset, openai-compat tasks still use the default agent name', async () => {
+  // Default behavior pre-#161 / when the operator hasn't opted into the
+  // split: every task — extension or not — goes to the single configured
+  // `agent`. Guards against the routing override leaking onto every
+  // operator who hasn't set the new option.
+  const sentKeys: string[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const params = req.params as { sessionKey: string };
+        sentKeys.push(params.sessionKey);
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: `run-${sentKeys.length}`, status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: `run-${sentKeys.length}`,
+            sessionKey: params.sessionKey,
+            seq: 1,
+            state: 'final',
+            message: { text: 'ok' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    // No openaiCompatAgent here — both tasks should reach `agent:main:...`.
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-noroute-oai', 'hi', { tools: OAI_SAMPLE_TOOLS }, 'ctx-noroute-oai'),
+      () => {},
+      NEVER,
+    );
+    await backend.handle(makeTask('t-noroute-plain', 'hi'), () => {}, NEVER);
+
+    assert.equal(sentKeys.length, 2);
+    assert.equal(sentKeys[0], 'agent:main:ctx-noroute-oai');
+    assert.equal(sentKeys[1], 'agent:main:ctx-t-noroute-plain');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('openaiCompatAgent: blank string (e.g. empty env template) does not override the default agent', async () => {
+  // Mirrors the daemon-level "trim + treat-empty-as-unset" pattern other
+  // openclaw options follow so an install.sh env template with the key
+  // present-but-blank doesn't accidentally activate the split.
+  const sentKeys: string[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        const params = req.params as { sessionKey: string };
+        sentKeys.push(params.sessionKey);
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'run-blank', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: 'run-blank',
+            sessionKey: params.sessionKey,
+            seq: 1,
+            state: 'final',
+            message: { text: 'ok' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url, openaiCompatAgent: '   ' });
+    await backend.handle(
+      makeOpenAICompatTask('t-blank', 'hi', { tools: OAI_SAMPLE_TOOLS }, 'ctx-blank'),
+      () => {},
+      NEVER,
+    );
+    assert.equal(sentKeys[0], 'agent:main:ctx-blank');
+  } finally {
+    await fake.close();
+  }
+});
+
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -42,6 +42,7 @@ import {
   parseLsofListeningPorts,
   redactUrl,
 } from './openclaw.js';
+import type { OpenAICompatHistoryEntry } from './claude.js';
 import {
   OPENAI_COMPAT_EXTENSION_URI,
   type TaskAssignFrame,
@@ -2840,6 +2841,21 @@ const OAI_SAMPLE_TOOLS = [
   },
 ];
 
+const OAI_SAMPLE_HISTORY: OpenAICompatHistoryEntry[] = [
+  {
+    role: 'assistant',
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  },
+  {
+    role: 'tool',
+    tool_call_id: 'call_abc',
+    name: 'get_weather',
+    content: '{"temp":15,"cond":"sunny"}',
+  },
+];
+
 function makeOpenAICompatTask(
   taskId: string,
   text: string,
@@ -2877,6 +2893,24 @@ test('composeOpenAICompatUserMessage: wraps system_instructions + user_message w
   assert.match(out, /<\/system_instructions>\n\n<user_message>/);
   // User content sits inside user_message verbatim, no extra wrapping.
   assert.match(out, /<user_message>\nwhat is the weather\?\n<\/user_message>$/);
+});
+
+test('composeOpenAICompatUserMessage: history-only payload omits system_instructions but still wraps user content + history', () => {
+  // No tools / no system / no tool_choice → buildOpenAICompatSystemPrompt
+  // returns "". We MUST NOT emit an empty <system_instructions></system_instructions>
+  // shell (the block-presence-vs-absence signal is part of the contract).
+  const out = composeOpenAICompatUserMessage(
+    { tool_call_history: OAI_SAMPLE_HISTORY },
+    'continue, please',
+  );
+  assert.doesNotMatch(out, /<system_instructions>/);
+  // History block is still injected — spec contract requires per-turn replay.
+  assert.match(out, /^<tool_call_history>\n/);
+  assert.match(out, /"role": "assistant"/);
+  assert.match(out, /"tool_call_id": "call_abc"/);
+  assert.match(out, /\n<\/tool_call_history>\n\n<user_message>/);
+  // User content follows.
+  assert.match(out, /<user_message>\ncontinue, please\n<\/user_message>$/);
 });
 
 test('composeOpenAICompatUserMessage: tool_choice="none" suppresses envelope contract but keeps no-envelope directive', () => {
@@ -3175,5 +3209,50 @@ test('extension on but model answered in prose → text artifact, no extension t
   }
 });
 
+test('multi-turn: tool_call_history block is prepended to chat.send.message on follow-up turn', async () => {
+  let sentMessage: string | null = null;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sentMessage = (req.params as { message: string }).message;
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-mt', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: 'r-mt',
+            sessionKey: 'agent:main:ctx-t-mt',
+            seq: 1,
+            state: 'final',
+            message: { text: '7°C and clear in Seoul.' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-mt', 'natural language please', {
+        tools: OAI_SAMPLE_TOOLS,
+        tool_call_history: OAI_SAMPLE_HISTORY,
+      }),
+      () => {},
+      NEVER,
+    );
+    assert.ok(sentMessage);
+    // System instructions block precedes the history block.
+    assert.match(sentMessage!, /^<system_instructions>/);
+    // History block is present, in order, between system_instructions and user_message.
+    assert.match(sentMessage!, /<\/system_instructions>\n\n<tool_call_history>\n/);
+    assert.match(sentMessage!, /"role": "assistant"/);
+    assert.match(sentMessage!, /"tool_call_id": "call_abc"/);
+    assert.match(sentMessage!, /\n<\/tool_call_history>\n\n<user_message>/);
+    // User content closes the message.
+    assert.match(sentMessage!, /<user_message>\nnatural language please\n<\/user_message>$/);
+  } finally {
+    await fake.close();
+  }
+});
 
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -35,13 +35,18 @@ async function pickUnusedLoopbackPort(): Promise<number> {
   });
 }
 import {
+  composeOpenAICompatUserMessage,
   createOpenclawBackend,
   listenersToGatewayUrls,
   mapPartsToChatInput,
   parseLsofListeningPorts,
   redactUrl,
 } from './openclaw.js';
-import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
 
 // Most tests don't exercise cancellation. Reusing one unaborted signal keeps
 // those call sites noise-free; cancel-specific tests build their own
@@ -2806,5 +2811,369 @@ test('heartbeat: suppressed after signal.abort so canceled tasks do not look lik
     await fake.close();
   }
 });
+
+// ---------------------------------------------------------------------------
+// openai-compat extension
+//
+// The pure helpers (parseOpenAICompatMetadata, buildOpenAICompatSystemPrompt,
+// formatToolCallHistory, tryParseToolCallsEnvelope) live in claude.ts and are
+// covered by claude.test.ts — openclaw.ts imports them verbatim, so we only
+// test the openclaw-specific wiring here: chat.send.message composition with
+// the XML-wrapped contract blocks, envelope→data-part on session.message,
+// non-streaming envelope on the terminal chat event, and the false-positive
+// defence when the extension is off.
+// ---------------------------------------------------------------------------
+
+const OAI_SAMPLE_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get the current weather for a city.',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string' } },
+        required: ['city'],
+        additionalProperties: false,
+      },
+    },
+  },
+];
+
+function makeOpenAICompatTask(
+  taskId: string,
+  text: string,
+  payload: Record<string, unknown>,
+  contextId = `ctx-${taskId}`,
+): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId,
+    contextId,
+    message: {
+      role: 'user',
+      messageId: `msg-${taskId}`,
+      parts: [{ kind: 'text', text }],
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: payload },
+    },
+  };
+}
+
+test('composeOpenAICompatUserMessage: wraps system_instructions + user_message with tools+tool_choice present', () => {
+  const out = composeOpenAICompatUserMessage(
+    { tools: OAI_SAMPLE_TOOLS, tool_choice: 'auto', system: 'Be terse.' },
+    'what is the weather?',
+  );
+  // User system precedes the envelope contract inside the system_instructions block.
+  assert.match(out, /^<system_instructions>\nBe terse\./);
+  // Envelope contract wording (the precise text the LLM is being trained
+  // against at runtime — pinned to detect accidental rewordings).
+  assert.match(out, /"tool_calls":\[\{"id":"call_<unique>"/);
+  // tools JSON inlined inside the block.
+  assert.match(out, /"name": "get_weather"/);
+  // tool_choice descriptor present in the same block.
+  assert.match(out, /tool_choice="auto"/);
+  // system_instructions block closes before user_message opens.
+  assert.match(out, /<\/system_instructions>\n\n<user_message>/);
+  // User content sits inside user_message verbatim, no extra wrapping.
+  assert.match(out, /<user_message>\nwhat is the weather\?\n<\/user_message>$/);
+});
+
+test('composeOpenAICompatUserMessage: tool_choice="none" suppresses envelope contract but keeps no-envelope directive', () => {
+  const out = composeOpenAICompatUserMessage(
+    { tools: OAI_SAMPLE_TOOLS, tool_choice: 'none' },
+    'hi',
+  );
+  // The envelope contract block is gone under tool_choice="none".
+  assert.doesNotMatch(out, /"tool_calls":\[\{"id":"call_<unique>"/);
+  // The explicit "do not use the envelope" directive replaces it.
+  assert.match(out, /tool_choice="none"/);
+});
+
+test('chat.send.message carries the XML-wrapped envelope contract when metadata is present', async () => {
+  let sentMessage: string | null = null;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sentMessage = (req.params as { message: string }).message;
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-oai', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: 'r-oai',
+            sessionKey: 'agent:main:ctx-t-oai-argv',
+            seq: 1,
+            state: 'final',
+            // Reply with the envelope so we don't trip the natural-language path.
+            message: { text: '{"tool_calls":[{"id":"call_1","function":{"name":"get_weather","arguments":{"city":"Seoul"}}}]}' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-oai-argv', 'what is the weather?', {
+        tools: OAI_SAMPLE_TOOLS,
+        tool_choice: 'auto',
+      }),
+      () => {},
+      NEVER,
+    );
+    assert.ok(sentMessage, 'expected chat.send to fire');
+    // The user content was wrapped by the helper before reaching chat.send.
+    assert.match(sentMessage!, /^<system_instructions>/);
+    assert.match(sentMessage!, /"tool_calls":\[\{"id":"call_<unique>"/);
+    assert.match(sentMessage!, /<user_message>\nwhat is the weather\?\n<\/user_message>$/);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('absent metadata → chat.send.message is the raw user text (no XML wrapper leaks)', async () => {
+  // Guards against the XML wrapping accidentally activating on non-extension
+  // tasks (e.g. if metadata parsing started returning a non-null sentinel
+  // for shapes that should really be treated as absent).
+  let sentMessage: string | null = null;
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sentMessage = (req.params as { message: string }).message;
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-plain', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId: 'r-plain',
+            sessionKey: 'agent:main:ctx-t-plain',
+            seq: 1,
+            state: 'final',
+            message: { text: 'ok' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t-plain', 'just a plain hello'), () => {}, NEVER);
+    assert.equal(sentMessage, 'just a plain hello');
+  } finally {
+    await fake.close();
+  }
+});
+
+test('envelope JSON on session.message becomes a data-part artifact tagged with the extension URI', async () => {
+  const frames: UpFrame[] = [];
+  const envelope = {
+    tool_calls: [
+      { id: 'call_abc', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  };
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-env', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitSessionMessage(sock, {
+            sessionKey: 'agent:main:ctx-t-env',
+            messageId: 'mid-1',
+            message: { role: 'assistant', text: JSON.stringify(envelope) },
+          });
+          setImmediate(() => {
+            fake.emitChat(sock, {
+              runId: 'r-env',
+              sessionKey: 'agent:main:ctx-t-env',
+              seq: 1,
+              state: 'final',
+              message: { text: JSON.stringify(envelope) },
+            });
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-env', 'what is the weather in Seoul?', { tools: OAI_SAMPLE_TOOLS }),
+      (f) => frames.push(f),
+      NEVER,
+    );
+    const artifacts = frames.filter(
+      (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+    );
+    assert.equal(artifacts.length, 1);
+    const part = artifacts[0].artifact.parts[0];
+    assert.equal(part.kind, 'data');
+    if (part.kind !== 'data') throw new Error('expected data part');
+    assert.deepEqual(part.data, envelope);
+    assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('envelope JSON arriving only on the terminal chat event (no session.message) still becomes a data-part artifact', async () => {
+  // Non-streaming fallback: the gateway never broadcasts session.message
+  // (older image, or this task lost streaming ownership to a concurrent
+  // peer). The bridge MUST still surface the envelope via the terminal
+  // chat 'final' event so the cooperating gateway sees `tool_calls`.
+  const frames: UpFrame[] = [];
+  const envelope = {
+    tool_calls: [
+      { id: 'call_xyz', function: { name: 'get_weather', arguments: { city: 'Seoul' } } },
+    ],
+  };
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-env-nostream', status: 'started' } }),
+        );
+        setImmediate(() => {
+          // NO session.message emit — go straight to terminal.
+          fake.emitChat(sock, {
+            runId: 'r-env-nostream',
+            sessionKey: 'agent:main:ctx-t-env-nostream',
+            seq: 1,
+            state: 'final',
+            message: { text: JSON.stringify(envelope) },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-env-nostream', 'what is the weather?', { tools: OAI_SAMPLE_TOOLS }),
+      (f) => frames.push(f),
+      NEVER,
+    );
+    const artifacts = frames.filter(
+      (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+    );
+    assert.equal(artifacts.length, 1);
+    const part = artifacts[0].artifact.parts[0];
+    assert.equal(part.kind, 'data');
+    if (part.kind !== 'data') throw new Error('expected data part');
+    assert.deepEqual(part.data, envelope);
+    assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+    // task.complete still carries the envelope JSON as text in status.message
+    // (mirrors claude/codex: data-part is the primary surface, text in the
+    // terminal slot is the conventional A2A mirror).
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete && complete.type === 'task.complete');
+    const stamped = complete.status.message?.parts[0];
+    assert.equal(stamped?.kind, 'text');
+    if (stamped?.kind === 'text') assert.equal(stamped.text, JSON.stringify(envelope));
+  } finally {
+    await fake.close();
+  }
+});
+
+test('extension off: a coincidental {"tool_calls":[...]} reply stays a text artifact', async () => {
+  // Without the extension we don't claim any envelope contract is in force,
+  // so a JSON-shaped reply from a non-cooperating task MUST NOT be routed
+  // as a tool call. Guards against false-positive routing.
+  const frames: UpFrame[] = [];
+  const coincidental = JSON.stringify({ tool_calls: [] });
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-coincidental', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitSessionMessage(sock, {
+            sessionKey: 'agent:main:ctx-t-coincidental',
+            messageId: 'mid-c',
+            message: { role: 'assistant', text: coincidental },
+          });
+          setImmediate(() => {
+            fake.emitChat(sock, {
+              runId: 'r-coincidental',
+              sessionKey: 'agent:main:ctx-t-coincidental',
+              seq: 1,
+              state: 'final',
+              message: { text: coincidental },
+            });
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t-coincidental', 'hi'), (f) => frames.push(f), NEVER);
+    const artifacts = frames.filter(
+      (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+    );
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].artifact.parts[0].kind, 'text');
+    assert.equal(artifacts[0].artifact.extensions, undefined);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('extension on but model answered in prose → text artifact, no extension tag', async () => {
+  // The extension being active does not mean every turn is a tool turn:
+  // a tool_choice="auto" model is free to answer in natural language, and
+  // a non-cooperating host model may refuse the envelope contract entirely.
+  // Either way, non-envelope text must flow through as a text artifact
+  // without the extension URI tag — mis-claiming the contract was honored
+  // would mislead the upstream gateway.
+  const frames: UpFrame[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method === 'chat.send') {
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId: 'r-prose', status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitSessionMessage(sock, {
+            sessionKey: 'agent:main:ctx-t-prose',
+            messageId: 'mid-p',
+            message: { role: 'assistant', text: 'No tool needed; the answer is 42.' },
+          });
+          setImmediate(() => {
+            fake.emitChat(sock, {
+              runId: 'r-prose',
+              sessionKey: 'agent:main:ctx-t-prose',
+              seq: 1,
+              state: 'final',
+              message: { text: 'No tool needed; the answer is 42.' },
+            });
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(
+      makeOpenAICompatTask('t-prose', 'hi', { tools: OAI_SAMPLE_TOOLS, tool_choice: 'auto' }),
+      (f) => frames.push(f),
+      NEVER,
+    );
+    const artifacts = frames.filter(
+      (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+    );
+    assert.equal(artifacts.length, 1);
+    const part = artifacts[0].artifact.parts[0];
+    assert.equal(part.kind, 'text');
+    if (part.kind === 'text') assert.equal(part.text, 'No tool needed; the answer is 42.');
+    assert.equal(artifacts[0].artifact.extensions, undefined);
+  } finally {
+    await fake.close();
+  }
+});
+
 
 export { createFakeGateway, makeTask };

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -3,8 +3,14 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import WebSocket from 'ws';
-import type { Part } from '@vicoop-bridge/protocol';
+import { OPENAI_COMPAT_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import {
+  buildOpenAICompatSystemPrompt,
+  parseOpenAICompatMetadata,
+  tryParseToolCallsEnvelope,
+  type OpenAICompatMetadata,
+} from './claude.js';
 import {
   createBoundedFileReader,
   inferMimeFromPath,
@@ -485,6 +491,40 @@ export async function mapPartsToChatInput(
       attachments,
     },
   };
+}
+
+// Compose the user-content payload for `chat.send.message` when the
+// openai-compat extension is active. OpenClaw has no system-prompt wire
+// seam — the only writable channel into the model is the user message
+// itself — so the contract is folded in as tagged XML blocks:
+//
+//   <system_instructions>…envelope contract + tools + tool_choice…</system_instructions>
+//   <tool_call_history>…JSON array of prior round-trips…</tool_call_history>  // optional
+//   <user_message>…the caller's actual text…</user_message>
+//
+// The wrapper tags exist so a host model that respects user-injected
+// pseudo-system framing has a clear boundary; non-cooperating models will
+// see the block as opaque user content and may answer in natural
+// language, in which case the bridge falls through to the existing text
+// artifact path (no envelope tag) without claiming the extension was
+// honored.
+//
+// `system_instructions` is omitted when `buildOpenAICompatSystemPrompt`
+// returns empty (e.g. a history-only payload with no tools / system /
+// tool_choice). `tool_call_history` is omitted when absent. The user-message
+// wrapper is always present so the model's mental model of where its
+// instructions end and the user's prompt begins is stable across turns.
+export function composeOpenAICompatUserMessage(
+  meta: OpenAICompatMetadata,
+  userText: string,
+): string {
+  const blocks: string[] = [];
+  const sys = buildOpenAICompatSystemPrompt(meta);
+  if (sys) {
+    blocks.push(`<system_instructions>\n${sys}\n</system_instructions>`);
+  }
+  blocks.push(`<user_message>\n${userText}\n</user_message>`);
+  return blocks.join('\n\n');
 }
 
 function extractFinalText(message: unknown): string {
@@ -1258,6 +1298,21 @@ export function createOpenclawBackend(
         return;
       }
 
+      // Detect the openai-compat extension payload once per task so the
+      // result feeds both the chat.send.message composition (system /
+      // tools / tool_choice / tool_call_history → tagged XML blocks
+      // prepended to the user content, since OpenClaw has no system-prompt
+      // wire seam) and the assistant artifact path (envelope JSON → data
+      // part). Absent / malformed metadata leaves the run on the original
+      // non-extension code path with no envelope-detection cost.
+      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+      if (openaiCompat) {
+        mapped.input.message = composeOpenAICompatUserMessage(
+          openaiCompat,
+          mapped.input.message,
+        );
+      }
+
       let gw: GatewayClient;
       try {
         gw = await ensureConnected();
@@ -1385,6 +1440,34 @@ export function createOpenclawBackend(
             // sync check above and our turn on the queue (e.g. terminal
             // chat event drained ahead of us).
             if (sessionMessageSettled) return;
+            // When the openai-compat extension is active for this task,
+            // the model was instructed to emit `{"tool_calls":[...]}` JSON
+            // for tool turns. Detect that shape and surface it as an A2A
+            // `data` part tagged with the extension URI so the upstream
+            // gateway can forward it verbatim as `tool_calls`. The
+            // envelope is the complete payload — no attachOutputs
+            // processing, no text part. Non-envelope text (natural-
+            // language answers, internal tool transcript, or any turn
+            // from a task that didn't request the extension) falls
+            // through to the existing text artifact path unchanged.
+            if (openaiCompat) {
+              const envelope = tryParseToolCallsEnvelope(artifactText);
+              if (envelope) {
+                emit({
+                  type: 'task.artifact',
+                  taskId: task.taskId,
+                  artifact: {
+                    artifactId: randomUUID(),
+                    name: 'openclaw-message',
+                    parts: [{ kind: 'data', data: envelope }],
+                    extensions: [OPENAI_COMPAT_EXTENSION_URI],
+                  },
+                  lastChunk: true,
+                });
+                emittedAnyArtifact = true;
+                return;
+              }
+            }
             const { parts } = await processAssistantText(artifactText);
             if (parts.length === 0) return;
             emit({
@@ -1614,6 +1697,52 @@ export function createOpenclawBackend(
         }
 
         const text2 = extractFinalText(result.message);
+
+        // Non-streaming fallback path for the envelope: when no streaming
+        // subscription delivered a session.message artifact (e.g. the
+        // concurrent-task case forfeited streaming ownership, or the
+        // gateway is older than v2026.3.22 and never broadcasts
+        // session.message at all), the only way to surface the envelope
+        // is here. Mirrors the streaming-path detection in
+        // onSessionMessage: match → single data-part artifact tagged with
+        // the extension URI; non-match → fall through to the existing
+        // text-artifact path with full processAssistantText handling.
+        if (openaiCompat) {
+          const envelope = tryParseToolCallsEnvelope(text2);
+          if (envelope) {
+            if (!emittedAnyArtifact) {
+              emit({
+                type: 'task.artifact',
+                taskId: task.taskId,
+                artifact: {
+                  artifactId: randomUUID(),
+                  name: 'openclaw-result',
+                  parts: [{ kind: 'data', data: envelope }],
+                  extensions: [OPENAI_COMPAT_EXTENSION_URI],
+                },
+                lastChunk: true,
+              });
+            }
+            emit({
+              type: 'task.complete',
+              taskId: task.taskId,
+              status: {
+                state: 'completed',
+                timestamp: new Date().toISOString(),
+                message: {
+                  role: 'agent',
+                  messageId: randomUUID(),
+                  // text2 is the raw envelope JSON string; stamp it on
+                  // status.message for callers that pull terminal content
+                  // from the conventional A2A slot. Mirrors claude/codex.
+                  parts: [{ kind: 'text', text: text2 }],
+                },
+              },
+            });
+            return;
+          }
+        }
+
         const { parts: finalArtifactParts, cleanedText } = await processAssistantText(text2);
         // Only emit the final-result artifact when streaming produced
         // nothing — otherwise each assistant message already went out as its

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -7,6 +7,7 @@ import { OPENAI_COMPAT_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol'
 import type { Backend } from '../backend.js';
 import {
   buildOpenAICompatSystemPrompt,
+  formatToolCallHistory,
   parseOpenAICompatMetadata,
   tryParseToolCallsEnvelope,
   type OpenAICompatMetadata,
@@ -522,6 +523,9 @@ export function composeOpenAICompatUserMessage(
   const sys = buildOpenAICompatSystemPrompt(meta);
   if (sys) {
     blocks.push(`<system_instructions>\n${sys}\n</system_instructions>`);
+  }
+  if (meta.tool_call_history) {
+    blocks.push(formatToolCallHistory(meta.tool_call_history));
   }
   blocks.push(`<user_message>\n${userText}\n</user_message>`);
   return blocks.join('\n\n');

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -575,6 +575,39 @@ export interface OpenclawBackendOptions {
   url?: string;
   token?: string;
   agent?: string;
+  /**
+   * Optional secondary agent name to route tasks carrying the openai-compat
+   * extension metadata to, instead of the default `agent`. Intended for
+   * operators who want to dedicate a tools-disabled agent profile to
+   * envelope-contract requests so the host model isn't tempted to satisfy
+   * the question with its own native skills (Bash, browser, weather, etc.)
+   * — which is the main source of stochastic envelope-contract refusals.
+   *
+   * The operator pairs this with a matching `agents.list` entry in the
+   * OpenClaw gateway config:
+   *
+   *   {
+   *     "agents": {
+   *       "list": [
+   *         { "id": "main" },
+   *         { "id": "oai", "tools": { "profile": "minimal", "deny": ["*"] } }
+   *       ]
+   *     }
+   *   }
+   *
+   * Then sets `openaiCompatAgent: "oai"` here so tasks whose
+   * `Message.metadata` carries the openai-compat URI are routed through
+   * `agent:oai:<contextId>` sessionKeys instead of the default
+   * `agent:main:<contextId>`. Non-extension tasks still use the default
+   * agent's full toolset.
+   *
+   * Pilot measurement on `anthropic/claude-sonnet-4-6`: envelope-contract
+   * compliance rose from 5/10 (default `main` agent with full tools) to
+   * 10/10 (`oai` agent with tools disabled) on a tool-call-prone prompt.
+   *
+   * Leave undefined to disable the split — every task uses `agent`.
+   */
+  openaiCompatAgent?: string;
   thinking?: string;
   sessionKeyPrefix?: string;
   debug?: boolean;
@@ -858,6 +891,19 @@ export function createOpenclawBackend(
   const url = opts.url ?? process.env.OPENCLAW_GATEWAY_URL ?? 'ws://127.0.0.1:18789';
   const token = opts.token ?? process.env.OPENCLAW_GATEWAY_TOKEN;
   const agent = opts.agent ?? process.env.OPENCLAW_AGENT ?? 'main';
+  // Optional secondary agent name dedicated to openai-compat tasks. See the
+  // doc comment on `OpenclawBackendOptions.openaiCompatAgent` for the
+  // operator-side OpenClaw config (agents.list + tools.deny=["*"]) this
+  // pairs with. Trim + treat-empty-as-unset across env / opts so an
+  // install.sh-style env template with the key present-but-blank doesn't
+  // shadow a populated config.json. When unresolved, all tasks route to
+  // `agent`.
+  const openaiCompatAgentRaw =
+    opts.openaiCompatAgent ?? process.env.OPENCLAW_OAI_COMPAT_AGENT;
+  const openaiCompatAgent =
+    typeof openaiCompatAgentRaw === 'string' && openaiCompatAgentRaw.trim().length > 0
+      ? openaiCompatAgentRaw.trim()
+      : undefined;
   const thinking = opts.thinking ?? process.env.OPENCLAW_THINKING;
   const sessionPrefix = opts.sessionKeyPrefix ?? 'agent';
   const debug = opts.debug ?? process.env.OPENCLAW_DEBUG === '1';
@@ -1328,7 +1374,17 @@ export function createOpenclawBackend(
         });
         return;
       }
-      const sessionKey = `${sessionPrefix}:${agent}:${task.contextId}`;
+      // When the openai-compat extension is active on this task AND the
+      // operator has configured a secondary agent name for it, route via
+      // that agent's session-key namespace. That secondary agent is expected
+      // to have `tools.deny=["*"]` so the host model has no native tools,
+      // eliminating the system-vs-user-instruction conflict that
+      // significantly reduces envelope-contract compliance (see the doc
+      // comment on `OpenclawBackendOptions.openaiCompatAgent`). Tasks
+      // without the extension metadata always use the default `agent`,
+      // so this split is invisible to non-compat callers.
+      const effectiveAgent = openaiCompat && openaiCompatAgent ? openaiCompatAgent : agent;
+      const sessionKey = `${sessionPrefix}:${effectiveAgent}:${task.contextId}`;
       const { message: text, attachments } = mapped.input;
 
       emit({

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -201,6 +201,8 @@ function pickBackend(name: string, args: Args): Backend {
         url: process.env.OPENCLAW_GATEWAY_URL?.trim() || oc?.gateway_url,
         token: process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || oc?.gateway_token,
         agent: process.env.OPENCLAW_AGENT?.trim() || oc?.agent,
+        openaiCompatAgent:
+          process.env.OPENCLAW_OAI_COMPAT_AGENT?.trim() || oc?.openai_compat_agent,
         taskTimeoutMs: envTimeoutMs === 'valid' ? undefined : oc?.task_timeout_ms,
       });
     }

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -121,6 +121,14 @@ export interface OpenclawBackendConfig {
   gateway_url?: string;
   gateway_token?: string;
   agent?: string;
+  /**
+   * Optional secondary agent name dedicated to tasks carrying the
+   * openai-compat extension metadata. See
+   * `OpenclawBackendOptions.openaiCompatAgent` for the operator-side
+   * pairing (OpenClaw `agents.list` entry with `tools.deny=["*"]`).
+   * Leave unset to route every task through `agent`.
+   */
+  openai_compat_agent?: string;
   task_timeout_ms?: number;
 }
 
@@ -235,12 +243,14 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
       const url = asString(ocRaw.gateway_url);
       const tok = asString(ocRaw.gateway_token);
       const ag = asString(ocRaw.agent);
+      const oai = asString(ocRaw.openai_compat_agent);
       const tto = asNumber(ocRaw.task_timeout_ms);
-      if (url || tok || ag || tto !== undefined) {
+      if (url || tok || ag || oai || tto !== undefined) {
         out.openclaw = {};
         if (url) out.openclaw.gateway_url = url;
         if (tok) out.openclaw.gateway_token = tok;
         if (ag) out.openclaw.agent = ag;
+        if (oai) out.openclaw.openai_compat_agent = oai;
         if (tto !== undefined) out.openclaw.task_timeout_ms = tto;
       }
     }


### PR DESCRIPTION
## Summary

Follow-up to #152 (`claude`) and #159 (`codex`) — implements the [A2A openai-compat/v1 extension](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1) on the `openclaw` backend.

This closes the third and final backend in the trio.

### What's different from claude/codex

`openclaw` is fundamentally different: it doesn't spawn a local CLI, it talks to an external WS gateway. OpenClaw's `chat.send` RPC has **no `system` field on the wire** — the only writable channel into the model is the user `message` text — so the contract has to be folded into user content directly, wrapped in tagged XML blocks:

```
<system_instructions>…envelope contract + tools + tool_choice…</system_instructions>
<tool_call_history>…JSON array of prior round-trips (follow-up turns only)…</tool_call_history>
<user_message>…the caller's actual text…</user_message>
```

The four pure helpers (`parseOpenAICompatMetadata`, `buildOpenAICompatSystemPrompt`, `formatToolCallHistory`, `tryParseToolCallsEnvelope`) are imported verbatim from `claude.ts`. A new `composeOpenAICompatUserMessage` does the openclaw-specific block synthesis.

### Best-effort caveat AND the tools-disabled-agent recipe that recovers it

Because the contract lives in user-role content rather than a true system seam, a model whose prompt-injection training is paranoid may treat the `<system_instructions>` block as untrusted text and refuse the envelope contract. But there's a second, larger failure mode that emerged in field measurement: when the host OpenClaw agent has its own tools enabled (Bash, browser, weather skills, etc.), the model frequently satisfies tool-call prompts with the native skill instead of emitting the envelope.

Measurement on anthropic `claude-sonnet-4-6` (N=10 per arm, same tool-call-prone weather prompt, same gateway):

| Configuration | Envelope compliance |
|---|---|
| Default `main` agent, full tools | **5/10** |
| Global `tools.profile=minimal` + `tools.deny=["*"]` | **10/10** |
| Dedicated `oai` agent with tools disabled, routed only for openai-compat tasks | **10/10** |

The third row is the operator recipe shipped in this PR:

1. In the OpenClaw gateway config, define a secondary agent with native tools disabled:
   ```json
   {
     "agents": {
       "list": [
         { "id": "main" },
         { "id": "oai", "tools": { "profile": "minimal", "deny": ["*"] } }
       ]
     }
   }
   ```
2. Tell the bridge to route openai-compat tasks to that agent:
   - `OPENCLAW_OAI_COMPAT_AGENT=oai`, or
   - `backends.openclaw.openai_compat_agent: "oai"` in config.json, or
   - `OpenclawBackendOptions.openaiCompatAgent: "oai"` in code.
3. Non-extension tasks continue to flow through `main` with its full toolset.

When the option is unset, every task — extension or not — uses the single configured `agent`, preserving today's baseline.

### Four logical commits

- **`a9f4594`** — turn 1: metadata reading, `composeOpenAICompatUserMessage`, envelope detection in `onSessionMessage` + terminal `chat.final` path, card advertise.
- **`f591c57`** — multi-turn `tool_call_history` per the [planetarium/oai2a2a#30](https://github.com/planetarium/oai2a2a/issues/30) consensus.
- **`17efbf1`** — `packages/client/scripts/probe-openclaw-openai-compat.mjs`: reproducible per-host-model measurement script.
- **`cf8100d`** — opt-in `openaiCompatAgent` secondary-agent routing for the tools-disabled recipe above.

## What's in the change

- **`packages/client/cards/openclaw.json`** — advertises the URI under `capabilities.extensions[]`; description now carries the full measurement table and the operator-side recipe so cooperating gateways can discover both from a card fetch.
- **`packages/client/src/backends/openclaw.ts`**:
  - Imports the four shared helpers from `claude.ts`.
  - `composeOpenAICompatUserMessage` synthesizes the XML-wrapped user content.
  - `handle()` parses metadata once; replaces `mapped.input.message` before `chat.send`.
  - When `openaiCompatAgent` is set, sessionKey routes openai-compat tasks to that secondary agent name; everything else uses the default `agent`.
  - `onSessionMessage` + terminal `chat.final` paths run `tryParseToolCallsEnvelope`. Match → `data` part artifact tagged with `OPENAI_COMPAT_EXTENSION_URI`; non-match → existing text-artifact path including `attachOutputs` processing.
- **`packages/client/src/config.ts`** + **`packages/client/src/cli.ts`** — `backends.openclaw.openai_compat_agent` config field plus the `OPENCLAW_OAI_COMPAT_AGENT` env, following the same env-wins-over-config precedence the other openclaw options use.
- **`packages/client/src/backends/openclaw.test.ts`** — 13 new tests covering composer output under each metadata shape, argv-equivalent `chat.send.message` injection, the absent-metadata regression, envelope→data-part on session.message and on terminal final, false-positive defence with the extension off, the prose-under-extension-on text fallback, and the new sessionKey routing in all three states (set / unset / blank).
- **`packages/client/scripts/probe-openclaw-openai-compat.mjs`** — sidecar reliability probe used to produce the measurement table above.

## Out of scope

- Changes to the OpenClaw gateway itself.
- `response_format` (JSON Schema structured output) — same as #152 / #159.
- MCP overlap — same as #152 / #159.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `pnpm --filter @vicoop-bridge/client test` → 387/387 (13 new openclaw tests).
- [x] `pnpm --filter @vicoop-bridge/server test` → unchanged.
- [x] **Reliability probe** on `ghcr.io/openclaw/openclaw:latest` + `anthropic/claude-sonnet-4-6`:
  - `N=10` baseline (full tools, default `main` agent): 5/10 envelope, 5/10 text fallback.
  - `N=10` with `tools.deny=["*"]` applied globally: 10/10 envelope.
  - `N=10` with the dual-agent setup + `openaiCompatAgent="oai"` (this PR's recipe), openai-compat task → `oai` agent: 10/10 envelope.
  - Plain (non-extension) task → still routes to `main` and the model uses its native tools (verified the response cites wttr.in-shaped numbers, not envelope JSON).
- [ ] OSS-hosted OpenClaw gateway probe — out of scope for this PR; operators on those deployments should run the probe script themselves and decide whether the dual-agent recipe is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)