### PR TITLE
feat(server): advertise openai-compat URI on canonical agent cards

### DIFF
--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import type { HelloFrame } from '@vicoop-bridge/protocol';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  type HelloFrame,
+} from '@vicoop-bridge/protocol';
 import { resolveHelloAgentCard } from './card-resolver.js';
 
 function frame(overrides: Partial<HelloFrame>): Pick<HelloFrame, 'agentCard' | 'backendKind'> {
@@ -72,3 +75,30 @@ test('rejects unknown backendKind when no inline card is provided', () => {
     backendKind: 'custom',
   });
 });
+
+// Pin the openai-compat advertisement on canonical cards: this is the
+// surface external A2A callers fetch via `/agents/<id>/.well-known/agent-card.json`
+// when an operator hasn't supplied an inline card override. The card-side
+// advertisement and the client-side metadata-honoring code were shipped in
+// PRs #152 / #159 / #161, but the original PRs touched only the
+// client-bundled `packages/client/cards/*.json` files; without these
+// canonical-card entries the URI silently disappears for every operator on
+// the default `setup` path (which doesn't pass `--card`).
+//
+// If a future card edit drops the URI, callers that rely on the card to
+// decide whether to send the openai-compat metadata payload will assume
+// the bridge can't honor it and silently fall back to text injection or
+// refuse the call. So pin it here.
+for (const kind of ['claude', 'codex', 'openclaw'] as const) {
+  test(`canonical ${kind} card advertises the openai-compat extension URI`, () => {
+    const result = resolveHelloAgentCard(frame({ backendKind: kind }));
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const uris =
+      result.agentCard.capabilities?.extensions?.map((e) => e.uri) ?? [];
+    assert.ok(
+      uris.includes(OPENAI_COMPAT_EXTENSION_URI),
+      `expected canonical ${kind} card to advertise ${OPENAI_COMPAT_EXTENSION_URI}, got: ${JSON.stringify(uris)}`,
+    );
+  });
+}

--- a/packages/server/src/cards/claude.json
+++ b/packages/server/src/cards/claude.json
@@ -10,6 +10,11 @@
         "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
         "description": "Opt-in execution trace stream for Claude Code tool calls and tool-result media.",
         "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
       }
     ]
   },

--- a/packages/server/src/cards/codex.json
+++ b/packages/server/src/cards/codex.json
@@ -10,6 +10,11 @@
         "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
         "description": "Opt-in execution trace stream for Codex command executions.",
         "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
       }
     ]
   },

--- a/packages/server/src/cards/openclaw.json
+++ b/packages/server/src/cards/openclaw.json
@@ -3,7 +3,16 @@
   "description": "General-purpose AI assistant. Can answer questions, browse the web, run shell commands, manage files, and operate tools its operator has granted. Accepts text, image, and PDF inputs; when the operator enables outbound file delivery, can also return file artifacts spanning images, PDFs, structured data (JSON/XML/CSV/HTML/Markdown), archives, audio, video, and other binary types.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
-  "capabilities": { "streaming": true },
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part. Best-effort: contract is text-injected into user content because the OpenClaw `chat.send` wire has no system-prompt seam, so reliability depends on the gateway's host model honoring the embedded instructions (verified on anthropic claude-sonnet-4-6 in repeated probes; OSS-hosted gateways may require per-model measurement).",
+        "required": false
+      }
+    ]
+  },
   "defaultInputModes": [
     "text/plain",
     "image/png",


### PR DESCRIPTION
## Summary

PRs #152 (claude), #159 (codex), and #161 (openclaw) all added the
[openai-compat/v1](https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1)
extension to the **client-bundled** cards under `packages/client/cards/`.
But after #103 (which closed #97) the canonical AgentCard for an agent
connecting on the default `setup` path — i.e. without an explicit
`--card` operator override — comes from this directory:
`packages/server/src/cards/`. Not from the client tarball.

So every operator on the default path is currently advertising the
**pre-extension** card despite running a 0.14.0 client that honors the
metadata. External A2A callers fetching
`/agents/<id>/.well-known/agent-card.json` can't discover the
capability and either fall back to text-injection or refuse the call.

This patch adds the URI to the three canonical cards. `echo` is left
untouched (no model, no point).

## What's in the change

- **`packages/server/src/cards/claude.json`** — appends the URI to
  `capabilities.extensions[]`. Description mirrors the client card.
- **`packages/server/src/cards/codex.json`** — same.
- **`packages/server/src/cards/openclaw.json`** — adds the URI under a
  fresh `capabilities.extensions[]` block. Description carries the
  best-effort caveat shipped in #161 (text-injection because OpenClaw's
  `chat.send` wire has no system-prompt seam; reliability depends on
  the host model honoring the embedded instructions).
- **`packages/server/src/card-resolver.test.ts`** — pins the URI on
  each canonical card so a future card edit can't silently drop it.
  The assertion runs through `resolveHelloAgentCard` so we cover the
  exact code path callers hit, not just file contents.

No client changes needed — the client-side advertise was already
correct in 0.14.0; this PR brings the server-resolved canonical cards
into line with it.

## Why now

`codex-5875aaf3` (and any other agent on default install) on
`https://vicoop-bridge-server.fly.dev` currently surfaces a card
without the openai-compat URI:

```bash
$ curl -s https://vicoop-bridge-server.fly.dev/agents/codex-5875aaf3/.well-known/agent-card.json \
    | jq '.capabilities.extensions[].uri'
"https://github.com/a2aproject/a2a-samples/extensions/traceability/v1"
```

After this PR is deployed (one `fly deploy`), the same fetch will
include the openai-compat URI — and all other default-path agents
get it for free, no client restart, no inline-card override.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `pnpm --filter @vicoop-bridge/server test` → 203/203 (3 new
      canonical-card assertions, others unchanged).
- [ ] After merge, deploy to fly.dev and re-fetch
      `/agents/codex-5875aaf3/.well-known/agent-card.json` to confirm
      the URI shows up without the client redeploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)