### PR TITLE
feat(client): list-clients / revoke-client CLI for owner-side cleanup

### DIFF
--- a/.changeset/list-revoke-client-cli.md
+++ b/.changeset/list-revoke-client-cli.md
@@ -14,11 +14,11 @@ Add `vicoop-client list-clients` and `vicoop-client revoke-client` subcommands s
 **Server surface**
 
 - `GET /admin-api/clients` and `DELETE /admin-api/clients/:target` under the same owner-session bearer guard as the existing `/admin-api/agents/*` routes. RLS filters list/delete to the operator's own rows; reads of another principal's rows return 404 (no existence leak), name-resolution ambiguity returns 409.
-- `Registry.disconnectClient(clientId)` closes every live WebSocket bound to a revoked client with new close code **4012 "client revoked"**. (4010 was already taken by the agent-id-owned-by-different-principal path in `ws.ts`.)
+- `Registry.disconnectClient(clientId)` closes every live WebSocket bound to a revoked client with new close code **4014 "client revoked"**. (4010 was already taken by the agent-id-owned-by-different-principal path in `ws.ts`.)
 
 **Daemon behavior**
 
-- The client daemon's reconnect loop now branches on close code 4012: log `client revoked by owner; exiting`, abort inflight tasks, and exit non-zero without reconnecting. Without this branch the daemon would loop forever against a permanently-failing auth.
+- The client daemon's reconnect loop now branches on close code 4014: log `client revoked by owner; exiting`, abort inflight tasks, and exit non-zero without reconnecting. Without this branch the daemon would loop forever against a permanently-failing auth.
 
 **Revocation propagation**
 

--- a/.changeset/list-revoke-client-cli.md
+++ b/.changeset/list-revoke-client-cli.md
@@ -18,11 +18,11 @@ Add `vicoop-client list-clients` and `vicoop-client revoke-client` subcommands s
 
 **Daemon behavior**
 
-- The client daemon's reconnect loop now branches on close code 4014: log `client revoked by owner; exiting`, abort inflight tasks, and exit non-zero without reconnecting. Without this branch the daemon would loop forever against a permanently-failing auth.
+- The client daemon's reconnect loop now treats two close codes as terminal: 4014 "client revoked" (the live-disconnect path) and 4005 "bad token" (the relaunch path — a daemon restarted with the same revoked token, or launched with a wrong token in the first place). Both fire `onFatal` and exit non-zero instead of reconnect-looping against a permanently-failing auth. All other close codes still go through the normal exponential-backoff reconnect path.
 
 **Revocation propagation**
 
-- Client-token verification in `ws.ts` queries `clients` directly on every WS register (no LRU cache, unlike the 60s `callers` cache documented in `local-testing.md`), so revocation is effectively synchronous from the next auth attempt — a daemon relaunched with the same token after revoke fails with close code 4005 "bad token". No cache-invalidation work needed on the server side.
+- Client-token verification in `ws.ts` queries `clients` directly on every WS register (no LRU cache, unlike the 60s `callers` cache documented in `local-testing.md`), so revocation is effectively synchronous from the next auth attempt — and combined with the 4005-terminal client behavior above, a daemon relaunched with the same token after revoke exits at first hello instead of looping. No cache-invalidation work needed on the server side.
 
 **Schema**
 

--- a/.changeset/list-revoke-client-cli.md
+++ b/.changeset/list-revoke-client-cli.md
@@ -1,0 +1,31 @@
+---
+"@vicoop-bridge/client": minor
+"@vicoop-bridge/server": minor
+---
+
+Add `vicoop-client list-clients` and `vicoop-client revoke-client` subcommands so an owner can inspect and clean up their own `clients` rows from the CLI without dropping into admin GraphQL or psql (issue #166).
+
+**Client surface**
+
+- `vicoop-client list-clients [--bridge URL] [--json]` lists every `clients` row owned by the operator. Output columns are `client_id`, `client_name`, `allowed_agent_ids`, `revoked`, `connected`, `created_at`. `connected` reflects in-memory registry state so orphans left behind by an aborted setup or an exited daemon show up with `connected: false`.
+- `vicoop-client revoke-client <client-id-or-name> [--bridge URL]` resolves either a UUID `client_id` or a unique `client_name` and sets `revoked = true` on the row. An ambiguous name exits non-zero with a list of candidate ids so the operator can retry with the id.
+- Both subcommands authenticate with the existing `vicoop-client login` owner-session bearer — same flow as `add-caller` / `remove-caller`.
+
+**Server surface**
+
+- `GET /admin-api/clients` and `DELETE /admin-api/clients/:target` under the same owner-session bearer guard as the existing `/admin-api/agents/*` routes. RLS filters list/delete to the operator's own rows; reads of another principal's rows return 404 (no existence leak), name-resolution ambiguity returns 409.
+- `Registry.disconnectClient(clientId)` closes every live WebSocket bound to a revoked client with new close code **4012 "client revoked"**. (4010 was already taken by the agent-id-owned-by-different-principal path in `ws.ts`.)
+
+**Daemon behavior**
+
+- The client daemon's reconnect loop now branches on close code 4012: log `client revoked by owner; exiting`, abort inflight tasks, and exit non-zero without reconnecting. Without this branch the daemon would loop forever against a permanently-failing auth.
+
+**Revocation propagation**
+
+- Client-token verification in `ws.ts` queries `clients` directly on every WS register (no LRU cache, unlike the 60s `callers` cache documented in `local-testing.md`), so revocation is effectively synchronous from the next auth attempt — a daemon relaunched with the same token after revoke fails with close code 4005 "bad token". No cache-invalidation work needed on the server side.
+
+**Schema**
+
+- No schema migration. The existing `clients.revoked BOOLEAN` column and `revoke_client(TEXT)` PL/pgSQL function are reused as-is. Promoting the column to a `revoked_at TIMESTAMPTZ` for audit-trail purposes is filed as a follow-up — it's orthogonal to the CLI surface this change ships and would have a much larger blast radius (the `client_with_token` TYPE, the admin agent's LLM prompt, and all `SELECT … WHERE revoked = false` predicates would need touching).
+
+Documentation: a new "Inspecting and revoking your clients" section in `docs/install-client.md` replaces the previous "use the admin agent's CRUD mutations" hand-wave for the cleanup case.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -786,10 +786,14 @@ vicoop-client revoke-client <client-id-or-name>
   with a list of matching `client_id`s so you can retry with the id.
 - If the daemon is alive at the moment of revocation, its WebSocket is
   closed with code **4014 "client revoked"** and the daemon exits
-  non-zero without reconnecting. The bridge's WS auth path also rejects
-  the token on the next register attempt, so a daemon launched again with
-  the same token will fail with **close code 4005 "bad token"** rather
-  than reconnect-loop indefinitely.
+  non-zero without reconnecting.
+- If the daemon is **relaunched** with the same token after revocation
+  (rather than already being live), the bridge's WS auth path rejects
+  the hello with **close code 4005 "bad token"** — the daemon treats
+  4005 as terminal too (same `onFatal` path as 4014), so it exits
+  non-zero on the first reconnect attempt rather than reconnect-loop
+  indefinitely against a permanently-rejected token. The same 4005
+  branch catches plain mis-typed / wrong tokens at first launch.
 - Propagation is **synchronous from the next auth attempt**: client-token
   verification queries `clients` directly on every WS register with no
   cache, so there is no equivalent of the 60s `callers` LRU window.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -785,7 +785,7 @@ vicoop-client revoke-client <client-id-or-name>
 - A unique name resolves automatically; an ambiguous name exits non-zero
   with a list of matching `client_id`s so you can retry with the id.
 - If the daemon is alive at the moment of revocation, its WebSocket is
-  closed with code **4012 "client revoked"** and the daemon exits
+  closed with code **4014 "client revoked"** and the daemon exits
   non-zero without reconnecting. The bridge's WS auth path also rejects
   the token on the next register attempt, so a daemon launched again with
   the same token will fail with **close code 4005 "bad token"** rather

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -753,8 +753,49 @@ section of `docs/local-testing.md` for the same note.
   the existing `clients` row and invalidates the old hash, so your
   `allowedAgentIds` and `agent_policies` carry over. Re-run Step 4 only if
   you intentionally want a new client identity; in that case the old
-  `clients` row (and cascading `agent_policies`) can be cleaned up via
-  the admin agent's CRUD mutations (#29).
+  `clients` row can be revoked from the CLI — see
+  [Inspecting and revoking your clients](#inspecting-and-revoking-your-clients).
+
+## Inspecting and revoking your clients
+
+`vicoop-client list-agents` only shows *currently connected* agents. To see
+every `clients` row registered under your owner principal — including
+orphans left behind by an aborted `setup`, an exited daemon, or a leaked
+`CLIENT_TOKEN` — use:
+
+```bash
+vicoop-client list-clients
+```
+
+Columns are `client_id`, `client_name`, `allowed_agent_ids`, `revoked`,
+`connected`, `created_at`. The `connected` flag reflects in-memory
+registry state, so a row with `connected: false` is exactly the kind of
+orphan you want to clean up.
+
+To revoke a client — and disconnect its live WebSocket if one is bound —
+use either the UUID `client_id` or a unique `client_name`:
+
+```bash
+vicoop-client revoke-client <client-id-or-name>
+```
+
+- A revoked client's row is kept (`revoked = true`) so audit history
+  survives; existing `agent_policies` cascade-deleted only when the
+  underlying row is later hard-deleted.
+- A unique name resolves automatically; an ambiguous name exits non-zero
+  with a list of matching `client_id`s so you can retry with the id.
+- If the daemon is alive at the moment of revocation, its WebSocket is
+  closed with code **4012 "client revoked"** and the daemon exits
+  non-zero without reconnecting. The bridge's WS auth path also rejects
+  the token on the next register attempt, so a daemon launched again with
+  the same token will fail with **close code 4005 "bad token"** rather
+  than reconnect-loop indefinitely.
+- Propagation is **synchronous from the next auth attempt**: client-token
+  verification queries `clients` directly on every WS register with no
+  cache, so there is no equivalent of the 60s `callers` LRU window.
+
+Both subcommands use the same owner-session bearer as `add-caller` /
+`remove-caller`; no SIWE re-sign required.
 
 ## What's next
 

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -7,7 +7,9 @@ import {
   runAddCaller,
   runListAgents,
   runListCallers,
+  runListClients,
   runRemoveCaller,
+  runRevokeClient,
 } from './admin-cli.js';
 
 interface Captured {
@@ -246,6 +248,105 @@ test('subcommand surfaces network errors as a clean exit-1 instead of crashing',
   const code = await runListAgents([]);
   assert.equal(code, 1);
   assert.match(stderr.read(), /network error.*fetch failed/);
+});
+
+test('list-clients calls GET /admin-api/clients and renders rows with connected flag', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: {
+      clients: [
+        {
+          client_id: 'cid-1',
+          client_name: 'usage-test-1',
+          owner_principal: 'eth:0xabc',
+          allowed_agent_ids: ['agent-a'],
+          revoked: false,
+          connected: false,
+          created_at: '2026-05-07T00:00:00.000Z',
+        },
+      ],
+    },
+  });
+
+  const code = await runListClients([]);
+  assert.equal(code, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients`);
+  assert.equal(calls[0].headers.authorization, `Bearer ${TOKEN}`);
+  const out = stdout.read();
+  assert.match(out, /client_id:\s+cid-1/);
+  assert.match(out, /connected:\s+false/);
+});
+
+test('list-clients --json prints raw JSON', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, { body: { clients: [] } });
+
+  const code = await runListClients(['--json']);
+  assert.equal(code, 0);
+  const parsed = JSON.parse(stdout.read()) as { clients: unknown[] };
+  assert.deepEqual(parsed, { clients: [] });
+});
+
+test('revoke-client DELETEs /admin-api/clients/<target>', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: {
+      client_id: 'cid-1',
+      client_name: 'usage-test-1',
+      revoked: true,
+      closed_connections: 0,
+    },
+  });
+
+  const code = await runRevokeClient(['usage-test-1']);
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'DELETE');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients/usage-test-1`);
+});
+
+test('revoke-client URL-encodes the target (so names with /, : survive)', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const target = 'weird/name:with-colon';
+  const { calls } = installFetch(t, {
+    body: { client_id: 'cid', client_name: target, revoked: true, closed_connections: 0 },
+  });
+  const code = await runRevokeClient([target]);
+  assert.equal(code, 0);
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients/${encodeURIComponent(target)}`);
+});
+
+test('revoke-client surfaces 409 ambiguous-name error as exit 1', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stderr = captureStderr(t);
+  installFetch(t, {
+    status: 409,
+    body: { error: 'Ambiguous client name "dup" matches multiple clients (a, b). Specify client_id instead.' },
+  });
+
+  const code = await runRevokeClient(['dup']);
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /409.*Ambiguous client name/);
+});
+
+test('revoke-client requires exactly one positional', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stderr = captureStderr(t);
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error('fetch should not be called when args are invalid');
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = original;
+  });
+  const code = await runRevokeClient([]);
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /usage: vicoop-client revoke-client/);
 });
 
 test('subcommand surfaces server error on non-2xx response', async (t) => {

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -10,7 +10,13 @@
 
 import { resolveOwnerSession } from './owner-session.js';
 
-type Subcommand = 'add-caller' | 'remove-caller' | 'list-callers' | 'list-agents';
+type Subcommand =
+  | 'add-caller'
+  | 'remove-caller'
+  | 'list-callers'
+  | 'list-agents'
+  | 'list-clients'
+  | 'revoke-client';
 
 interface ParsedArgs {
   positional: string[];
@@ -58,6 +64,10 @@ function usage(sub: Subcommand): string {
       return 'usage: vicoop-client list-callers <agent_id> [--bridge URL] [--token TOKEN] [--json]';
     case 'list-agents':
       return 'usage: vicoop-client list-agents [--bridge URL] [--token TOKEN] [--json]';
+    case 'list-clients':
+      return 'usage: vicoop-client list-clients [--bridge URL] [--token TOKEN] [--json]';
+    case 'revoke-client':
+      return 'usage: vicoop-client revoke-client <client-id-or-name> [--bridge URL] [--token TOKEN] [--json]';
   }
 }
 
@@ -180,6 +190,41 @@ function renderCallerList(body: unknown): string {
   ].join('\n');
 }
 
+function renderClientList(body: unknown): string {
+  if (!body || typeof body !== 'object' || !('clients' in body)) return String(body);
+  const clients = (body as { clients: Array<Record<string, unknown>> }).clients;
+  if (clients.length === 0) return '(no clients registered)';
+  return clients
+    .map((c) => {
+      const agents = (c.allowed_agent_ids as string[] | undefined)?.join(', ') ?? '';
+      return [
+        `client_id:         ${c.client_id}`,
+        `client_name:       ${c.client_name}`,
+        `allowed_agent_ids: ${agents}`,
+        `revoked:           ${c.revoked}`,
+        `connected:         ${c.connected}`,
+        `created_at:        ${c.created_at}`,
+      ].join('\n');
+    })
+    .join('\n---\n');
+}
+
+function renderRevokeResult(body: unknown): string {
+  if (!body || typeof body !== 'object') return String(body);
+  const b = body as {
+    client_id?: string;
+    client_name?: string;
+    revoked?: boolean;
+    closed_connections?: number;
+  };
+  return [
+    `client_id:          ${b.client_id}`,
+    `client_name:        ${b.client_name}`,
+    `revoked:            ${b.revoked}`,
+    `closed_connections: ${b.closed_connections}`,
+  ].join('\n');
+}
+
 function renderAgentList(body: unknown): string {
   if (!body || typeof body !== 'object' || !('agents' in body)) return String(body);
   const agents = (body as { agents: Array<Record<string, unknown>> }).agents;
@@ -282,6 +327,61 @@ export async function runListCallers(args: string[]): Promise<number> {
     path: `/admin-api/agents/${encodeURIComponent(agentId)}/callers`,
   });
   return emit(result, parsed.json, renderCallerList);
+}
+
+export async function runListClients(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('list-clients')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('list-clients')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 0) {
+    process.stderr.write(`${usage('list-clients')}\n`);
+    return 1;
+  }
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: '/admin-api/clients',
+  });
+  return emit(result, parsed.json, renderClientList);
+}
+
+export async function runRevokeClient(args: string[]): Promise<number> {
+  const parsed = parseArgs(args);
+  if ('error' in parsed) {
+    process.stderr.write(`${parsed.error}\n${usage('revoke-client')}\n`);
+    return 1;
+  }
+  if (parsed.help) {
+    process.stdout.write(`${usage('revoke-client')}\n`);
+    return 0;
+  }
+  if (parsed.positional.length !== 1) {
+    process.stderr.write(`${usage('revoke-client')}\n`);
+    return 1;
+  }
+  const [target] = parsed.positional;
+  const session = resolveSession(parsed);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'DELETE',
+    path: `/admin-api/clients/${encodeURIComponent(target)}`,
+  });
+  return emit(result, parsed.json, renderRevokeResult);
 }
 
 export async function runListAgents(args: string[]): Promise<number> {

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -15,7 +15,9 @@ import {
   runAddCaller,
   runListAgents,
   runListCallers,
+  runListClients,
   runRemoveCaller,
+  runRevokeClient,
 } from './admin-cli.js';
 import { runWhoami } from './whoami.js';
 import { deriveIdentity } from './identity.js';
@@ -30,7 +32,7 @@ import { mergeClientArgs, parseFlags, type DaemonArgs as Args } from './cli-args
 const DAEMON_USAGE =
   'vicoop-client --server <ws://...> --token <t> --agentId <id> --backend <echo|openclaw|claude|codex> [--card <path>] [--config <path>]';
 const SUBCOMMAND_LIST =
-  'subcommands: login, setup, upgrade, list-agents, list-callers, add-caller, remove-caller, whoami (run any with --help)';
+  'subcommands: login, setup, upgrade, list-agents, list-callers, add-caller, remove-caller, list-clients, revoke-client, whoami (run any with --help)';
 const CODEX_SANDBOX_MODES = new Set<CodexSandboxMode>([
   'read-only',
   'workspace-write',
@@ -340,6 +342,14 @@ async function main(): Promise<void> {
 
   if (argv[0] === 'list-agents') {
     process.exit(await runListAgents(argv.slice(1)));
+  }
+
+  if (argv[0] === 'list-clients') {
+    process.exit(await runListClients(argv.slice(1)));
+  }
+
+  if (argv[0] === 'revoke-client') {
+    process.exit(await runRevokeClient(argv.slice(1)));
   }
 
   if (argv[0] === 'whoami') {

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -251,6 +251,13 @@ function runClient(argv: string[]): void {
     agentCard,
     backendKind: args.backend,
     backend: pickBackend(args.backend, args),
+    // Daemon entrypoint: a fatal terminal close (currently 4014 "client
+    // revoked") should drop the process with a non-zero exit so
+    // systemd / a parent supervisor sees the revocation as a hard
+    // failure instead of masking it as a transient disconnect. The
+    // Client class deliberately does not call process.exit itself —
+    // tests and future in-process embedders pass a non-exiting callback.
+    onFatal: () => process.exit(1),
   });
 
   client.start();

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -340,11 +340,58 @@ test('Client stops on 4014 "client revoked", invokes onFatal, and does NOT recon
   }
 });
 
-test('Client treats non-4014 closes as reconnectable and does NOT call onFatal', async () => {
-  // Companion to the 4014 test: any other close code (here 1012 service
-  // restart, the same code the reconnect-happy-path test uses) must
-  // fall through to the normal reconnect path and never trigger the
-  // fatal callback.
+test('Client stops on 4005 "bad token" too (revoke-then-relaunch case, #166)', async () => {
+  // 4005 is what ws.ts emits when the token lookup returns no row —
+  // either the operator pasted the wrong secret, or the daemon was
+  // relaunched after revocation without rotating. Both are permanent
+  // auth failures, so the daemon must surface onFatal instead of
+  // looping reconnects against an unreachable row.
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', () => helloCount++);
+  });
+
+  const fatalCalls: Array<{ code: number; reason: string }> = [];
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks */
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+    onFatal: (info) => fatalCalls.push(info),
+  });
+
+  try {
+    client.start();
+    await waitFor(() => helloCount === 1, 'expected initial hello');
+    connections[0]!.close(4005, 'bad token');
+    await waitFor(() => fatalCalls.length === 1, 'expected onFatal to fire on 4005');
+    assert.equal(fatalCalls[0]!.code, 4005);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(helloCount, 1, 'must not reconnect after 4005');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('Client treats reconnectable closes (1012) as non-terminal and does NOT call onFatal', async () => {
+  // Companion to the 4014/4005 tests: a transient close code (here 1012
+  // service restart, the same code the reconnect-happy-path test uses)
+  // must fall through to the normal reconnect path and never trigger
+  // the fatal callback.
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });
   const serverUrl = await listen(server);

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -278,6 +278,112 @@ test('Client reconnects after WebSocket close and sends hello again', async () =
   }
 });
 
+test('Client stops on 4014 "client revoked", invokes onFatal, and does NOT reconnect (#166)', async () => {
+  // When the bridge revokes the client mid-flight, the daemon must:
+  //   1. surface the fatal close via `onFatal` so the entrypoint can
+  //      drive process exit (the Client itself never calls process.exit),
+  //   2. mark itself stopped and clear the reconnect timer so it does
+  //      not loop forever against a permanently-failing auth.
+  //
+  // Asserting both: the recording onFatal must fire exactly once with
+  // code 4014, and no second `hello` ever lands on the server.
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', () => helloCount++);
+  });
+
+  const fatalCalls: Array<{ code: number; reason: string }> = [];
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks */
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+    onFatal: (info) => fatalCalls.push(info),
+  });
+
+  interface Internals {
+    stopped: boolean;
+    reconnectTimer: unknown;
+  }
+  const internals = client as unknown as Internals;
+
+  try {
+    client.start();
+    await waitFor(() => helloCount === 1, 'expected initial hello');
+    connections[0]!.close(4014, 'client revoked');
+    await waitFor(() => fatalCalls.length === 1, 'expected onFatal to fire');
+    assert.equal(fatalCalls[0]!.code, 4014);
+    assert.equal(fatalCalls[0]!.reason, 'client revoked');
+    assert.equal(internals.stopped, true, 'client must mark itself stopped');
+    assert.equal(internals.reconnectTimer, null, 'reconnect must not be scheduled');
+    // Give the (would-be) reconnect plenty of headroom to misfire — if
+    // the 4014 branch fell through to scheduleReconnect we'd see a
+    // second hello within ~50ms (delay=10ms + a few ms of slack).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(helloCount, 1, 'must not reconnect after 4014');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('Client treats non-4014 closes as reconnectable and does NOT call onFatal', async () => {
+  // Companion to the 4014 test: any other close code (here 1012 service
+  // restart, the same code the reconnect-happy-path test uses) must
+  // fall through to the normal reconnect path and never trigger the
+  // fatal callback.
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', () => helloCount++);
+  });
+
+  const fatalCalls: Array<{ code: number; reason: string }> = [];
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks */
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+    onFatal: (info) => fatalCalls.push(info),
+  });
+
+  try {
+    client.start();
+    await waitFor(() => helloCount === 1, 'expected initial hello');
+    connections[0]!.close(1012, 'service restart');
+    await waitFor(() => helloCount === 2, 'expected reconnect after non-fatal close');
+    assert.deepEqual(fatalCalls, [], 'onFatal must not fire on reconnectable closes');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('Client reconnect timer is refed so a disconnected daemon stays alive (#156)', async () => {
   // Regression: scheduleReconnect() previously called `.unref()` on the
   // reconnect timer. With the WS dropped and the heartbeat / reset timers

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -330,7 +330,9 @@ export class Client {
       // Terminal auth failures the daemon cannot recover from by waiting:
       //
       //   - **4014 "client revoked"** (issue #166). The DB row was just
-      //     soft-deleted by an owner-side `vicoop-client revoke-client`.
+      //     flagged `revoked = true` by an owner-side `vicoop-client
+      //     revoke-client` (the row stays — soft revocation, not
+      //     deletion — but ws.ts's `revoked = false` filter excludes it).
       //     Future hellos will be rejected with 4005 anyway, so we exit
       //     immediately rather than wait one more reconnect cycle.
       //

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -312,10 +312,23 @@ export class Client {
       // close frame; sanitize before logging so a server can't inject a
       // fake `[client] …` line via newlines.
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
-      if (current) {
-        this.ws = null;
-        this.scheduleReconnect();
+      if (!current) return;
+      this.ws = null;
+      // 4012 is the server's "client revoked" signal (issue #166). The DB
+      // row was just soft-deleted by an owner-side `vicoop-client
+      // revoke-client`, and ws.ts will reject every future hello with the
+      // same token. Looping forever would just spam reconnects against a
+      // permanently-failing auth; stop the daemon with a non-zero exit so
+      // systemd / a parent supervisor surfaces the revocation instead of
+      // masking it as a transient network hiccup.
+      if (code === 4012) {
+        this.logger.error('client revoked by owner; exiting');
+        this.stopped = true;
+        this.clearReconnectTimer();
+        for (const controller of this.inflight.values()) controller.abort();
+        process.exit(1);
       }
+      this.scheduleReconnect();
     });
 
     ws.on('error', (err) => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -61,16 +61,17 @@ export interface ClientOptions {
   // this unset and logs land on `console.log` / `.warn` / `.error`.
   logSink?: ConsoleSink;
   // Invoked when the daemon hits a non-recoverable terminal close code
-  // (currently only 4014 "client revoked"). The Client itself only
-  // tears down its own state — `stopped = true`, reconnect timer
-  // cleared, inflight tasks aborted — and delegates the
-  // process-lifecycle decision (e.g. process.exit(1)) to the caller via
-  // this callback. Two reasons we don't call process.exit here: tests
-  // that construct a Client can't recover from a forced exit, and
-  // future embedders (a long-running parent process hosting multiple
-  // clients) need to keep running after one client is revoked. The
-  // production entrypoint (`cli.ts runClient`) wires this to
-  // `process.exit(1)`; tests pass a capturing callback.
+  // (currently 4014 "client revoked" and 4005 "bad token" — see the
+  // close-handler in `connect()` for the rationale on each). The Client
+  // itself only tears down its own state — `stopped = true`, reconnect
+  // timer cleared, inflight tasks aborted — and delegates the
+  // process-lifecycle decision (e.g. process.exit(1)) to the caller
+  // via this callback. Two reasons we don't call process.exit here:
+  // tests that construct a Client can't recover from a forced exit,
+  // and future embedders (a long-running parent process hosting
+  // multiple clients) need to keep running after one client is
+  // revoked. The production entrypoint (`cli.ts runClient`) wires this
+  // to `process.exit(1)`; tests pass a capturing callback.
   onFatal?: (info: { code: number; reason: string }) => void;
 }
 
@@ -326,17 +327,33 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
-      // 4014 is the server's "client revoked" signal (issue #166). The
-      // DB row was just soft-deleted by an owner-side `vicoop-client
-      // revoke-client`, and ws.ts will reject every future hello with
-      // the same token. Looping forever would just spam reconnects
-      // against a permanently-failing auth; tear down our own reconnect
-      // state and delegate the process-lifecycle decision to `onFatal`
-      // (the production entrypoint exits non-zero so systemd / a parent
-      // supervisor surfaces the revocation instead of masking it as a
-      // transient network hiccup).
-      if (code === 4014) {
-        this.logger.error('client revoked by owner; stopping');
+      // Terminal auth failures the daemon cannot recover from by waiting:
+      //
+      //   - **4014 "client revoked"** (issue #166). The DB row was just
+      //     soft-deleted by an owner-side `vicoop-client revoke-client`.
+      //     Future hellos will be rejected with 4005 anyway, so we exit
+      //     immediately rather than wait one more reconnect cycle.
+      //
+      //   - **4005 "bad token"**. ws.ts only emits 4005 after a
+      //     `SELECT … WHERE token_hash = $1 AND revoked = false` returns
+      //     no row — either the token is wrong (operator copy/paste, or
+      //     daemon was relaunched after revocation without rotating) or
+      //     the row is revoked but the daemon missed the live 4014 close.
+      //     In both cases the failure is permanent: no amount of backoff
+      //     produces a row that matches. Looping just spams the bridge.
+      //
+      // Other close codes (4001-4004 / 4006-4013) might be transient or
+      // bug-shaped but are out of scope for this PR — they continue to
+      // hit scheduleReconnect.
+      //
+      // We tear down our own reconnect state and delegate the
+      // process-lifecycle decision to `onFatal`. The production
+      // entrypoint exits non-zero so systemd / a parent supervisor
+      // surfaces the failure instead of masking it as a transient
+      // network hiccup.
+      if (code === 4014 || code === 4005) {
+        const label = code === 4014 ? 'client revoked by owner' : 'bridge rejected token';
+        this.logger.error(`${label}; stopping (code=${code})`);
         this.stopped = true;
         this.clearReconnectTimer();
         for (const controller of this.inflight.values()) controller.abort();

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -60,6 +60,18 @@ export interface ClientOptions {
   // Test seam: override the default console sink. Production callers leave
   // this unset and logs land on `console.log` / `.warn` / `.error`.
   logSink?: ConsoleSink;
+  // Invoked when the daemon hits a non-recoverable terminal close code
+  // (currently only 4014 "client revoked"). The Client itself only
+  // tears down its own state — `stopped = true`, reconnect timer
+  // cleared, inflight tasks aborted — and delegates the
+  // process-lifecycle decision (e.g. process.exit(1)) to the caller via
+  // this callback. Two reasons we don't call process.exit here: tests
+  // that construct a Client can't recover from a forced exit, and
+  // future embedders (a long-running parent process hosting multiple
+  // clients) need to keep running after one client is revoked. The
+  // production entrypoint (`cli.ts runClient`) wires this to
+  // `process.exit(1)`; tests pass a capturing callback.
+  onFatal?: (info: { code: number; reason: string }) => void;
 }
 
 const DEFAULT_PROBE_DEADLINE_MS = 3000;
@@ -314,19 +326,22 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
-      // 4012 is the server's "client revoked" signal (issue #166). The DB
-      // row was just soft-deleted by an owner-side `vicoop-client
-      // revoke-client`, and ws.ts will reject every future hello with the
-      // same token. Looping forever would just spam reconnects against a
-      // permanently-failing auth; stop the daemon with a non-zero exit so
-      // systemd / a parent supervisor surfaces the revocation instead of
-      // masking it as a transient network hiccup.
-      if (code === 4012) {
-        this.logger.error('client revoked by owner; exiting');
+      // 4014 is the server's "client revoked" signal (issue #166). The
+      // DB row was just soft-deleted by an owner-side `vicoop-client
+      // revoke-client`, and ws.ts will reject every future hello with
+      // the same token. Looping forever would just spam reconnects
+      // against a permanently-failing auth; tear down our own reconnect
+      // state and delegate the process-lifecycle decision to `onFatal`
+      // (the production entrypoint exits non-zero so systemd / a parent
+      // supervisor surfaces the revocation instead of masking it as a
+      // transient network hiccup).
+      if (code === 4014) {
+        this.logger.error('client revoked by owner; stopping');
         this.stopped = true;
         this.clearReconnectTimer();
         for (const controller of this.inflight.values()) controller.abort();
-        process.exit(1);
+        this.opts.onFatal?.({ code, reason: reason.toString() });
+        return;
       }
       this.scheduleReconnect();
     });

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -335,3 +335,282 @@ test(
     }
   },
 );
+
+// ── /admin-api/clients (issue #166) ──────────────────────────────
+
+test(
+  'GET /admin-api/clients returns only the operator’s own clients with connected flag',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const ownerA = `eth:0x${'3'.repeat(40)}`;
+    const ownerB = `eth:0x${'4'.repeat(40)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, ownerA);
+      setupB = await setupOwner(sql, ownerB);
+
+      const registry = new Registry();
+      // Only setupA is "connected" — setupB has a clients row but no live WS.
+      registry.registerAgent(fakeConnection({
+        agentId: setupA.agentId,
+        clientId: setupA.clientId,
+        ownerPrincipal: ownerA,
+      }));
+
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request('/admin-api/clients', {
+        headers: authHeaders(setupA.ownerToken),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        clients: Array<{ client_id: string; connected: boolean; revoked: boolean }>;
+      };
+      const setupAClientId = setupA.clientId;
+      const ids = body.clients.map((c) => c.client_id);
+      assert.ok(ids.includes(setupAClientId), 'should see own client');
+      assert.ok(!ids.includes(setupB.clientId), 'should not see other owner’s client');
+      const a = body.clients.find((c) => c.client_id === setupAClientId)!;
+      assert.equal(a.connected, true);
+      assert.equal(a.revoked, false);
+    } finally {
+      if (setupA) await teardown(sql, ownerA, setupA.clientId);
+      if (setupB) await teardown(sql, ownerB, setupB.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'GET /admin-api/clients shows persisted orphans (clients with no live WS) as connected:false',
+  { skip: !hasDb },
+  async () => {
+    // Repros the issue's concrete trigger: two test clients were registered,
+    // their daemons exited, and `list-agents` showed them as gone — but the
+    // `clients` rows persisted. /admin-api/clients must surface those rows
+    // with connected=false so the operator can spot them.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'5'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry(); // no agents registered → all clients orphaned
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request('/admin-api/clients', {
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { clients: Array<{ client_id: string; connected: boolean }> };
+      const row = body.clients.find((c) => c.client_id === setup!.clientId);
+      assert.ok(row, 'orphan client should be listed');
+      assert.equal(row.connected, false);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/clients/:target sets revoked=true and closes the live WS with 4012',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'6'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+
+      // Recording WS so we can assert the close code propagated.
+      const closeArgs: Array<{ code: number; reason: string }> = [];
+      const ws = {
+        close(code: number, reason: string) {
+          closeArgs.push({ code, reason });
+        },
+      } as unknown as WebSocket;
+
+      const registry = new Registry();
+      registry.registerAgent({
+        ...fakeConnection({
+          agentId: setup.agentId,
+          clientId: setup.clientId,
+          ownerPrincipal: owner,
+        }),
+        ws,
+      });
+
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(
+        `/admin-api/clients/${encodeURIComponent(setup.clientId)}`,
+        { method: 'DELETE', headers: authHeaders(setup.ownerToken) },
+      );
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as {
+        client_id: string;
+        revoked: boolean;
+        closed_connections: number;
+      };
+      assert.equal(body.client_id, setup.clientId);
+      assert.equal(body.revoked, true);
+      assert.equal(body.closed_connections, 1);
+      assert.deepEqual(closeArgs, [{ code: 4012, reason: 'client revoked' }]);
+
+      // DB row reflects the revocation.
+      const rows = await sql<{ revoked: boolean }[]>`
+        SELECT revoked FROM clients WHERE id = ${setup.clientId}
+      `;
+      assert.equal(rows[0]?.revoked, true);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/clients/:name resolves a unique client_name',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'7'.repeat(40)}`;
+    const uniqueName = `revoke-test-name-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      // Rename the just-created row so we can target it by name.
+      await sql`UPDATE clients SET client_name = ${uniqueName} WHERE id = ${setup.clientId}`;
+
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(
+        `/admin-api/clients/${encodeURIComponent(uniqueName)}`,
+        { method: 'DELETE', headers: authHeaders(setup.ownerToken) },
+      );
+      assert.equal(res.status, 200);
+      const body = (await res.json()) as { client_id: string; client_name: string };
+      assert.equal(body.client_id, setup.clientId);
+      assert.equal(body.client_name, uniqueName);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/clients/:name returns 409 when the name is ambiguous',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'8'.repeat(40)}`;
+    const dupName = `ambiguous-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, owner);
+      setupB = await setupOwner(sql, owner);
+      // Both rows are owned by the same principal and share the same name.
+      await sql`UPDATE clients SET client_name = ${dupName} WHERE id IN (${setupA.clientId}, ${setupB.clientId})`;
+
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(
+        `/admin-api/clients/${encodeURIComponent(dupName)}`,
+        { method: 'DELETE', headers: authHeaders(setupA.ownerToken) },
+      );
+      assert.equal(res.status, 409);
+      const body = (await res.json()) as { error: string };
+      assert.match(body.error, /Ambiguous client name/);
+      assert.match(body.error, /Specify client_id/);
+
+      // Neither client should be revoked — the ambiguous lookup must abort
+      // before any state change.
+      const rows = await sql<{ id: string; revoked: boolean }[]>`
+        SELECT id, revoked FROM clients WHERE id IN (${setupA.clientId}, ${setupB.clientId})
+      `;
+      for (const r of rows) assert.equal(r.revoked, false);
+    } finally {
+      if (setupA) await teardown(sql, owner, setupA.clientId);
+      if (setupB) await teardown(sql, owner, setupB.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/clients/:target returns 404 when nothing matches',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'9'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(
+        '/admin-api/clients/no-such-id-or-name',
+        { method: 'DELETE', headers: authHeaders(setup.ownerToken) },
+      );
+      assert.equal(res.status, 404);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/clients/:id returns 404 for another owner’s client (RLS)',
+  { skip: !hasDb },
+  async () => {
+    // RLS hides B's row from A's principal, so resolveClient yields no match
+    // and we surface 404 — same shape as "no such client" so we don't leak
+    // existence of rows owned by a different principal.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const ownerA = `eth:0x${'a'.repeat(40)}`;
+    const ownerB = `eth:0x${'b'.repeat(40)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, ownerA);
+      setupB = await setupOwner(sql, ownerB);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const res = await app.request(
+        `/admin-api/clients/${encodeURIComponent(setupB.clientId)}`,
+        { method: 'DELETE', headers: authHeaders(setupA.ownerToken) },
+      );
+      assert.equal(res.status, 404);
+
+      // ownerB's row remains intact.
+      const rows = await sql<{ revoked: boolean }[]>`
+        SELECT revoked FROM clients WHERE id = ${setupB.clientId}
+      `;
+      assert.equal(rows[0]?.revoked, false);
+    } finally {
+      if (setupA) await teardown(sql, ownerA, setupA.clientId);
+      if (setupB) await teardown(sql, ownerB, setupB.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  '/admin-api/clients endpoints reject missing owner-session bearer',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+      const list = await app.request('/admin-api/clients');
+      assert.equal(list.status, 401);
+      const revoke = await app.request('/admin-api/clients/anything', { method: 'DELETE' });
+      assert.equal(revoke.status, 401);
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -413,7 +413,7 @@ test(
 );
 
 test(
-  'DELETE /admin-api/clients/:target sets revoked=true and closes the live WS with 4012',
+  'DELETE /admin-api/clients/:target sets revoked=true and closes the live WS with 4014',
   { skip: !hasDb },
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
@@ -454,7 +454,7 @@ test(
       assert.equal(body.client_id, setup.clientId);
       assert.equal(body.revoked, true);
       assert.equal(body.closed_connections, 1);
-      assert.deepEqual(closeArgs, [{ code: 4012, reason: 'client revoked' }]);
+      assert.deepEqual(closeArgs, [{ code: 4014, reason: 'client revoked' }]);
 
       // DB row reflects the revocation.
       const rows = await sql<{ revoked: boolean }[]>`

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -369,7 +369,7 @@ export async function revokeClientForOwner(
   });
 
   // Close every live WebSocket session bound to this client. The daemon
-  // sees close code 4012 and exits without reconnecting (see client.ts).
+  // sees close code 4014 and exits without reconnecting (see client.ts).
   const closedConnections = registry.disconnectClient(resolved.id);
 
   return {

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -249,3 +249,133 @@ export function listActiveAgents(
       connected_at: new Date(a.connectedAt).toISOString(),
     }));
 }
+
+export interface ClientListItem {
+  client_id: string;
+  client_name: string;
+  owner_principal: string;
+  allowed_agent_ids: string[];
+  revoked: boolean;
+  created_at: string;
+  /**
+   * True iff at least one agent owned by this client is currently registered
+   * in the in-memory WebSocket registry. Distinguishes orphaned `clients`
+   * rows (daemon never started, or has since exited) from rows whose daemon
+   * is alive — the original motivation for the issue.
+   */
+  connected: boolean;
+}
+
+export async function listClientsForOwner(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+): Promise<ClientListItem[]> {
+  const rows = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      SELECT id, owner_principal, client_name, allowed_agent_ids, revoked, created_at
+      FROM clients
+      ORDER BY created_at DESC
+    `;
+  });
+
+  // Build the set of client_ids whose agents are currently connected.
+  // listAgents() returns the registry's in-memory view; deduplicating by
+  // clientId keeps the set small even if a client has many agents bound.
+  const connectedClientIds = new Set<string>();
+  for (const conn of registry.listAgents()) {
+    connectedClientIds.add(conn.clientId);
+  }
+
+  return rows.map((r) => ({
+    client_id: r.id as string,
+    client_name: r.client_name as string,
+    owner_principal: r.owner_principal as string,
+    allowed_agent_ids: (r.allowed_agent_ids as string[]) ?? [],
+    revoked: r.revoked as boolean,
+    created_at:
+      r.created_at instanceof Date
+        ? r.created_at.toISOString()
+        : (r.created_at as string),
+    connected: connectedClientIds.has(r.id as string),
+  }));
+}
+
+export interface RevokeClientResult {
+  client_id: string;
+  client_name: string;
+  revoked: boolean;
+  /** Number of live WebSocket connections closed as part of this revoke. */
+  closed_connections: number;
+}
+
+// Resolve a CLI argument (either a UUID `client_id` or a `client_name`) to a
+// unique client row owned by `principalId`. Returns 404 when nothing matches
+// and a distinct 409 when a name is ambiguous, so the CLI can tell the user
+// to retry with the id.
+async function resolveClient(
+  db: Sql,
+  principalId: string,
+  target: string,
+): Promise<{ id: string; client_name: string }> {
+  // Try id-match first — if `target` is a valid id and resolves to a row,
+  // we're done. If it doesn't, fall through to name lookup. We deliberately
+  // do NOT pre-filter on UUID shape: ids are TEXT in this schema (the table
+  // happens to default-generate UUIDs, but the column is `TEXT PRIMARY KEY`),
+  // so any string can in principle be an id.
+  const byId = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`SELECT id, client_name FROM clients WHERE id = ${target}`;
+  });
+  if (byId.length === 1) {
+    return { id: byId[0].id as string, client_name: byId[0].client_name as string };
+  }
+
+  const byName = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`SELECT id, client_name FROM clients WHERE client_name = ${target}`;
+  });
+  if (byName.length === 0) {
+    throw new AdminApiError(`No client found matching "${target}".`, 404);
+  }
+  if (byName.length > 1) {
+    const ids = byName.map((r) => r.id as string).join(', ');
+    throw new AdminApiError(
+      `Ambiguous client name "${target}" matches multiple clients (${ids}). ` +
+        'Specify client_id instead.',
+      409,
+    );
+  }
+  return { id: byName[0].id as string, client_name: byName[0].client_name as string };
+}
+
+export async function revokeClientForOwner(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+  target: string,
+): Promise<RevokeClientResult> {
+  const resolved = await resolveClient(db, principalId, target);
+
+  await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    // revoke_client() is SECURITY INVOKER and re-checks RLS; resolveClient()
+    // already verified the row is visible to this principal so the UPDATE
+    // inside will succeed (or NOT FOUND if a concurrent delete happened, in
+    // which case the function raises — we let that propagate as 500 because
+    // it's a genuinely unexpected race, not a user-facing error condition).
+    await tx`SELECT revoke_client(${resolved.id})`;
+  });
+
+  // Close every live WebSocket session bound to this client. The daemon
+  // sees close code 4012 and exits without reconnecting (see client.ts).
+  const closedConnections = registry.disconnectClient(resolved.id);
+
+  return {
+    client_id: resolved.id,
+    client_name: resolved.client_name,
+    revoked: true,
+    closed_connections: closedConnections,
+  };
+}

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -374,11 +374,13 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
 
   function adminApiErrorResponse(c: Context, err: unknown): Response {
     if (err instanceof AdminApiError) {
-      // Cast to a Hono-acceptable status union; AdminApiError uses standard
-      // HTTP codes (400/403/404/409) that Hono accepts for c.json's second
-      // arg. 409 is the ambiguous-client-name signal from
-      // revokeClientForOwner — the operator passed a name that matches
-      // multiple rows and needs to retry with the id.
+      // Cast to a Hono-acceptable status union. AdminApiError uses standard
+      // HTTP codes that Hono accepts for c.json's second arg: 400 invalid
+      // input, 401 auth (currently emitted only by adminApiUnauthorized,
+      // not through this path, but kept in the union so a future
+      // AdminApiError with status 401 still typechecks), 403 forbidden,
+      // 404 not-found / RLS-hidden, 409 ambiguous-client-name from
+      // revokeClientForOwner.
       return c.json({ error: err.message }, err.status as 400 | 401 | 403 | 404 | 409);
     }
     logEvent('admin_api_error', { error: String(err) });
@@ -450,7 +452,8 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // and may be a UUID `client_id` or a `client_name`; the server resolves
   // the ambiguity (404 if neither matches, 409 with the candidate ids if a
   // name matches multiple rows). On success, sets `revoked = true` and
-  // closes every live WS bound to the client with code 4012.
+  // closes every live WS bound to the client with code 4014 — see the
+  // close-code rationale in Registry.disconnectClient.
   app.delete('/admin-api/clients/:target', async (c) => {
     const auth = await authOwnerSession(c);
     if (!auth.ok) return adminApiUnauthorized(c, auth);

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -18,7 +18,9 @@ import {
   addCaller,
   listActiveAgents,
   listCallers,
+  listClientsForOwner,
   removeCaller,
+  revokeClientForOwner,
 } from './admin-api.js';
 import { agentAuthMiddleware, getAgentConn, getCaller } from './agent-auth.js';
 import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
@@ -373,8 +375,11 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   function adminApiErrorResponse(c: Context, err: unknown): Response {
     if (err instanceof AdminApiError) {
       // Cast to a Hono-acceptable status union; AdminApiError uses standard
-      // HTTP codes (400/403/404) that Hono accepts for c.json's second arg.
-      return c.json({ error: err.message }, err.status as 400 | 401 | 403 | 404);
+      // HTTP codes (400/403/404/409) that Hono accepts for c.json's second
+      // arg. 409 is the ambiguous-client-name signal from
+      // revokeClientForOwner — the operator passed a name that matches
+      // multiple rows and needs to retry with the id.
+      return c.json({ error: err.message }, err.status as 400 | 401 | 403 | 404 | 409);
     }
     logEvent('admin_api_error', { error: String(err) });
     return c.json({ error: 'Internal error' }, 500);
@@ -418,6 +423,43 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         auth.principalId,
         c.req.param('id'),
         principal,
+      );
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  // List the owner's `clients` rows so operators can see persisted state
+  // (including orphans from aborted setup / exited daemons) without
+  // dropping to admin GraphQL or psql. RLS filters to the principal's own
+  // rows. `connected` is the in-memory registry view so callers can spot
+  // orphans at a glance — see issue #166.
+  app.get('/admin-api/clients', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
+    try {
+      const clients = await listClientsForOwner(opts.db, opts.registry, auth.principalId);
+      return c.json({ clients });
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  // Revoke a client by id or unique name. The target travels in the URL path
+  // and may be a UUID `client_id` or a `client_name`; the server resolves
+  // the ambiguity (404 if neither matches, 409 with the candidate ids if a
+  // name matches multiple rows). On success, sets `revoked = true` and
+  // closes every live WS bound to the client with code 4012.
+  app.delete('/admin-api/clients/:target', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
+    try {
+      const result = await revokeClientForOwner(
+        opts.db,
+        opts.registry,
+        auth.principalId,
+        c.req.param('target'),
       );
       return c.json(result);
     } catch (err) {

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -251,10 +251,10 @@ test('notifyAgentChange log cannot be hijacked by newline injection via agentId'
   );
 });
 
-test('disconnectClient closes every ws bound to the client_id with code 4012', () => {
+test('disconnectClient closes every ws bound to the client_id with code 4014', () => {
   // Two agents owned by the revoked client + one agent owned by an unrelated
   // client. After disconnectClient('c1'), only the first two sockets see a
-  // close, and they see code 4012 with the "client revoked" reason. The
+  // close, and they see code 4014 with the "client revoked" reason. The
   // unrelated socket is untouched.
   const registry = new Registry();
   const ws1 = makeRecordingWs();
@@ -272,8 +272,8 @@ test('disconnectClient closes every ws bound to the client_id with code 4012', (
 
   const closed = registry.disconnectClient('c1');
   assert.equal(closed, 2);
-  assert.deepEqual(ws1.closeArgs, [{ code: 4012, reason: 'client revoked' }]);
-  assert.deepEqual(ws2.closeArgs, [{ code: 4012, reason: 'client revoked' }]);
+  assert.deepEqual(ws1.closeArgs, [{ code: 4014, reason: 'client revoked' }]);
+  assert.deepEqual(ws2.closeArgs, [{ code: 4014, reason: 'client revoked' }]);
   assert.deepEqual(ws3.closeArgs, []);
 });
 

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -11,6 +11,21 @@ function makeWs(): WebSocket {
   return { close: () => undefined } as unknown as WebSocket;
 }
 
+interface RecordingWs extends WebSocket {
+  closeArgs: Array<{ code: number; reason: string }>;
+}
+
+function makeRecordingWs(): RecordingWs {
+  const closeArgs: Array<{ code: number; reason: string }> = [];
+  const ws = {
+    closeArgs,
+    close(code: number, reason: string) {
+      closeArgs.push({ code, reason });
+    },
+  } as unknown as RecordingWs;
+  return ws;
+}
+
 function makeCard(streaming: boolean): AgentCard {
   return {
     name: 'test',
@@ -234,4 +249,44 @@ test('notifyAgentChange log cannot be hijacked by newline injection via agentId'
     undefined,
     'attacker payload must not surface as a top-level JSON field',
   );
+});
+
+test('disconnectClient closes every ws bound to the client_id with code 4012', () => {
+  // Two agents owned by the revoked client + one agent owned by an unrelated
+  // client. After disconnectClient('c1'), only the first two sockets see a
+  // close, and they see code 4012 with the "client revoked" reason. The
+  // unrelated socket is untouched.
+  const registry = new Registry();
+  const ws1 = makeRecordingWs();
+  const ws2 = makeRecordingWs();
+  const ws3 = makeRecordingWs();
+  const base = {
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    connectedAt: 0,
+  };
+  registry.registerAgent({ ...base, agentId: 'a1', clientId: 'c1', ws: ws1 });
+  registry.registerAgent({ ...base, agentId: 'a2', clientId: 'c1', ws: ws2 });
+  registry.registerAgent({ ...base, agentId: 'a3', clientId: 'c2', ws: ws3 });
+
+  const closed = registry.disconnectClient('c1');
+  assert.equal(closed, 2);
+  assert.deepEqual(ws1.closeArgs, [{ code: 4012, reason: 'client revoked' }]);
+  assert.deepEqual(ws2.closeArgs, [{ code: 4012, reason: 'client revoked' }]);
+  assert.deepEqual(ws3.closeArgs, []);
+});
+
+test('disconnectClient returns 0 when no agents are bound to the client', () => {
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws: makeWs(),
+    connectedAt: 0,
+  });
+  assert.equal(registry.disconnectClient('orphan-client'), 0);
 });

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -81,13 +81,16 @@ export class Registry {
   // live daemon was revoked.
   //
   // 4014 is the next unused slot in the bridge's WS close-code range:
-  // 4001-4011 are claimed by ws.ts (hello timeout / frame parse /
-  // protocol-version / token / agent allowlist / registry collision /
-  // duplicate hello / reserved agent id / cross-principal policy), and
-  // 4012-4013 by card-resolver.ts (missing card-or-backend / unknown
-  // backend). Reusing any of those would make the daemon misclassify
-  // unrelated handshake failures as revocation and exit instead of
-  // backing off.
+  //   - 4001-4008 ws.ts (hello timeout, invalid frame, expected hello,
+  //     protocol-version mismatch, bad token, registry registration
+  //     failed, duplicate hello, agent id not in client allowlist)
+  //   - 4009 registry.ts (this file: `replaced by new connection`)
+  //   - 4010-4011 ws.ts (agent id owned by a different principal,
+  //     reserved agent id)
+  //   - 4012-4013 card-resolver.ts (missing card-or-backend, unknown
+  //     backend kind)
+  // Reusing any of those would make the daemon misclassify unrelated
+  // handshake failures as revocation and exit instead of backing off.
   //
   // The close itself fires this WS's own `close` handler asynchronously,
   // which in turn calls unregisterAgent and removes the entry from the

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -75,10 +75,19 @@ export class Registry {
 
   // Close every live WebSocket whose ClientConnection.clientId matches.
   // Used by the admin-api revoke-client path so a daemon whose client row
-  // was just revoked sees a distinct close code (4012) and exits without
+  // was just revoked sees a distinct close code (4014) and exits without
   // reconnecting. Returns the number of connections closed; callers
   // surface that to the operator as confirmation that an orphan vs a
   // live daemon was revoked.
+  //
+  // 4014 is the next unused slot in the bridge's WS close-code range:
+  // 4001-4011 are claimed by ws.ts (hello timeout / frame parse /
+  // protocol-version / token / agent allowlist / registry collision /
+  // duplicate hello / reserved agent id / cross-principal policy), and
+  // 4012-4013 by card-resolver.ts (missing card-or-backend / unknown
+  // backend). Reusing any of those would make the daemon misclassify
+  // unrelated handshake failures as revocation and exit instead of
+  // backing off.
   //
   // The close itself fires this WS's own `close` handler asynchronously,
   // which in turn calls unregisterAgent and removes the entry from the
@@ -89,7 +98,7 @@ export class Registry {
     let closed = 0;
     for (const conn of this.agents.values()) {
       if (conn.clientId !== clientId) continue;
-      conn.ws.close(4012, 'client revoked');
+      conn.ws.close(4014, 'client revoked');
       closed++;
     }
     return closed;

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -73,6 +73,28 @@ export class Registry {
     return { ok: true };
   }
 
+  // Close every live WebSocket whose ClientConnection.clientId matches.
+  // Used by the admin-api revoke-client path so a daemon whose client row
+  // was just revoked sees a distinct close code (4012) and exits without
+  // reconnecting. Returns the number of connections closed; callers
+  // surface that to the operator as confirmation that an orphan vs a
+  // live daemon was revoked.
+  //
+  // The close itself fires this WS's own `close` handler asynchronously,
+  // which in turn calls unregisterAgent and removes the entry from the
+  // `agents` map and flushes any bound tasks via the usual disconnect
+  // path. We don't pre-delete from `agents` here — letting the close
+  // handler do it keeps the in-memory state machine single-sourced.
+  disconnectClient(clientId: string): number {
+    let closed = 0;
+    for (const conn of this.agents.values()) {
+      if (conn.clientId !== clientId) continue;
+      conn.ws.close(4012, 'client revoked');
+      closed++;
+    }
+    return closed;
+  }
+
   unregisterAgent(agentId: string, ws: WebSocket): void {
     const existing = this.agents.get(agentId);
     if (!existing || existing.ws !== ws) return;


### PR DESCRIPTION
Closes #166.

## Summary

- `vicoop-client list-clients` — lists every `clients` row owned by the operator with a `connected` flag so orphans left behind by an aborted setup or an exited daemon are visible from the CLI.
- `vicoop-client revoke-client <id-or-name>` — sets `revoked = true` on the row, closes any live WS bound to that client, and tells the daemon to exit. Resolves UUID `client_id` or unique `client_name`; ambiguous names return 409 with candidate ids.
- New WS close code **4014 "client revoked"** + daemon-side branch that exits non-zero without reconnecting.

## Design notes

- **No schema migration.** `clients.revoked BOOLEAN` and `revoke_client(TEXT)` already exist in `schema.sql`. Promoting to `revoked_at TIMESTAMPTZ` is filed as a follow-up — orthogonal to the CLI surface this PR ships and has a much larger blast radius (`client_with_token` TYPE, admin LLM prompt, every `WHERE revoked = false` predicate).
- **Close code 4014.** Audited the bridge's WS close-code range before picking: 4001-4008 ws.ts, 4009 registry.ts, 4010-4011 ws.ts, 4012-4013 card-resolver.ts. 4014 is the next free slot; the rationale lives in `Registry.disconnectClient` so future close-code choices stay collision-free. (Earlier revisions of this PR tried 4010 — collided with `agent id owned by a different principal` — and then 4012 — collided with `missing agent card or backend kind`. Both were caught and fixed in review.)
- **`process.exit` lifted out of the Client class.** The daemon's fatal close handler now invokes a new `ClientOptions.onFatal` callback; the Client only tears down its own state (`stopped = true`, reconnect timer cleared, inflight tasks aborted). The production entrypoint in `cli.ts` wires `onFatal: () => process.exit(1)`; tests pass capturing callbacks. This keeps the class testable and friendly to future in-process embedders.
- **No cache invalidation needed.** `ws.ts:27` already queries `clients` directly on every WS register — there is no equivalent of the 60s `callers` LRU cache on client tokens, so revocation is synchronous from the next auth attempt. Documented as such in `install-client.md`.
- **RLS gives the 404 / 409 / cross-owner story for free.** `listClientsForOwner` and `revokeClientForOwner` go through `setRlsContext()` like every other admin-api function. A name that resolves uniquely under the operator's RLS view is unambiguous; one that matches multiple rows triggers a deliberate 409 with the candidate ids so the operator can retry with the id.

## Files

- `packages/server/src/admin-api.ts` — `listClientsForOwner`, `revokeClientForOwner`, `resolveClient` (handles id vs unique-name vs ambiguous-name).
- `packages/server/src/registry.ts` — `disconnectClient(clientId): number`, closes every matching ws with 4014; includes the full close-code audit comment.
- `packages/server/src/http.tsx` — `GET /admin-api/clients`, `DELETE /admin-api/clients/:target`, with 409 added to the AdminApiError status union.
- `packages/client/src/admin-cli.ts` — `runListClients`, `runRevokeClient`, plus renderers.
- `packages/client/src/cli.ts` — subcommand wiring + updated `SUBCOMMAND_LIST` + `onFatal: () => process.exit(1)` for the daemon path.
- `packages/client/src/client.ts` — 4014 branch in the WS close handler, calls `opts.onFatal` instead of `process.exit`.
- `packages/client/src/client.test.ts` — two new regressions: 4014 → onFatal + no reconnect, 1012 → reconnect + no onFatal.
- `docs/install-client.md` — new "Inspecting and revoking your clients" section.
- `.changeset/list-revoke-client-cli.md` — `@vicoop-bridge/client` + `@vicoop-bridge/server` minor.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `packages/client/src/admin-cli.test.ts` — 14 / 14 pass (6 new for list/revoke)
- [x] `packages/client/src/client.test.ts` — 43 / 43 pass (2 new for 4014 / onFatal)
- [x] `packages/server/src/admin-api.test.ts` — 14 / 14 pass (8 new: RLS / 4014 / ambiguous name / orphan listing / unauthorized)
- [x] `packages/server/src/registry.test.ts` — 9 / 9 pass (2 new for `disconnectClient`)
- [x] Full server suite: 208 / 210 pass. The 2 failures are pre-existing in `src/auth/siwe-exchange.test.ts` (audience-mismatch, reproduced on clean main); unrelated to this change.
- [ ] Manual: `vicoop-client list-clients` + `revoke-client` against a local bridge with a live daemon to eyeball the human renderer and confirm the daemon exits on 4014.

## Out of scope (per the issue)

- Cross-owner revocation (admin-only; covered by admin GraphQL)
- Caller token revocation (different table, different flow)
- In-place token rotation (`rotate-client` — already exists at the GraphQL layer)
- `revoked_at TIMESTAMPTZ` audit-trail upgrade (separate follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
