### PR TITLE
feat(client): add codex-app-server backend (persistent JSON-RPC over stdio)

### DIFF
--- a/.changeset/codex-app-server-backend.md
+++ b/.changeset/codex-app-server-backend.md
@@ -1,0 +1,20 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add `codex-app-server` backend that drives one persistent `codex app-server`
+subprocess over stdio JSON-RPC for the lifetime of the client, instead of
+spawning `codex exec` per task. Same A2A surface as the existing `codex`
+backend (drop-in replacement: openai-compat extension, tool_call_history,
+image FileParts, traceability artifacts, sandbox modes). Operators opt in
+via `--backend codex-app-server`, `BACKEND=codex-app-server`, or
+`config.backend = "codex-app-server"`; the existing `codex` backend is
+unchanged so rollback is one flag away.
+
+Measured baseline (prompt: `Reply OK`, same contextId, 2 turns):
+- `codex` (current, per-task spawn): turn 1 ~10s, turn 2 ~10s
+- `codex-app-server` (new): turn 1 ~6–9s, turn 2 ~1.3–1.6s
+
+The win is on follow-up turns — the prior backend paid `codex exec resume`
+startup on every turn; the new one keeps the agent warm in a single
+process. See #169 for the full design and measurement notes.

--- a/packages/client/src/backends/codex-app-server-rpc.ts
+++ b/packages/client/src/backends/codex-app-server-rpc.ts
@@ -1,0 +1,441 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { Logger } from '../logger.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// child handle / spawn — same shape as codex.ts so tests can inject the same
+// way. The runtime adds an `on('exit'|'error', …)` surface large enough for
+// the dispatcher's lifecycle hooks; everything else (`once`, `removeListener`)
+// is intentionally omitted to keep the test fake minimal.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AppServerChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
+  readonly stdout: NodeJS.ReadableStream | null;
+  readonly stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface AppServerSpawnOptions {
+  cwd?: string;
+}
+
+export type AppServerSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: AppServerSpawnOptions,
+) => AppServerChildHandle;
+
+// Default spawn — node:child_process.spawn cast to our minimal surface.
+export const defaultAppServerSpawn: AppServerSpawnFn = (command, args, options) =>
+  nodeSpawn(command, args, { cwd: options.cwd, stdio: ['pipe', 'pipe', 'pipe'] }) as unknown as AppServerChildHandle;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Narrow typed views of the app-server protocol. We do NOT pull in the 81
+// types `codex app-server generate-ts` produces — instead we model only what
+// our backend reads/writes, so schema drift in unrelated v2 methods cannot
+// break our build. The trade-off is that field additions on the methods we
+// DO use must be picked up here manually; the dispatcher passes unknown
+// fields through unchanged via `params: unknown`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
+
+export interface InitializeParams {
+  clientInfo: { name: string; title: string; version: string };
+}
+
+export interface InitializeResult {
+  userAgent?: string;
+  codexHome?: string;
+  platformFamily?: string;
+  platformOs?: string;
+}
+
+export interface ThreadStartParams {
+  cwd?: string | null;
+  sandbox?: SandboxMode | null;
+  developerInstructions?: string | null;
+  baseInstructions?: string | null;
+}
+
+export interface ThreadResumeParams {
+  threadId: string;
+  cwd?: string | null;
+  sandbox?: SandboxMode | null;
+}
+
+export interface ThreadStartOrResumeResult {
+  thread: { id: string };
+}
+
+export type UserInputItem =
+  | { type: 'text'; text: string; text_elements: never[] }
+  | { type: 'localImage'; path: string };
+
+export interface TurnStartParams {
+  threadId: string;
+  input: UserInputItem[];
+}
+
+export interface TurnStartResult {
+  turn: { id: string; status: string };
+}
+
+export interface TurnInterruptParams {
+  threadId: string;
+  turnId: string;
+}
+
+export interface ApprovalResponse {
+  decision: 'accept' | 'acceptForSession' | 'decline';
+}
+
+// Subset of `ThreadItem` we observe — others fall through to `{ type: string }`.
+export type ThreadItem =
+  | { type: 'agentMessage'; id: string; text: string }
+  | { type: 'commandExecution'; id: string; command?: string; status?: string; exitCode?: number | null }
+  | { type: string; [key: string]: unknown };
+
+// ─────────────────────────────────────────────────────────────────────────────
+// JSON-RPC wire types. Codex uses a "JSON-RPC 2.0 lite" — the `"jsonrpc": "2.0"`
+// header is omitted on the wire. We tolerate either form on input.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface JsonRpcResponse {
+  id: number | string;
+  result?: unknown;
+  error?: { code?: number; message?: string };
+}
+
+interface JsonRpcRequest {
+  id: number | string;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcNotification {
+  method: string;
+  params?: unknown;
+}
+
+type IncomingMessage = JsonRpcResponse | JsonRpcRequest | JsonRpcNotification;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type NotificationHandler = (method: string, params: unknown) => void;
+export type ServerRequestHandler = (id: number | string, method: string, params: unknown) => Promise<unknown> | unknown;
+
+export interface AppServerRpcClientOptions {
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly cwd?: string;
+  readonly spawn?: AppServerSpawnFn;
+  readonly logger?: Logger;
+  // Cap stderr we retain for crash diagnostics. Default 8KB — same scale as
+  // the stderr cap in the existing codex/claude backends.
+  readonly stderrCaptureBytes?: number;
+}
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+  method: string;
+}
+
+// Reasons a pending request can be rejected without a server response.
+// `transport_closed` covers any path where the child went away
+// (close / error / kill) — the surface is uniform so callers don't have
+// to discriminate between SIGPIPE-vs-exit-vs-crash.
+export const TRANSPORT_CLOSED = 'transport_closed';
+
+export class AppServerRpcError extends Error {
+  constructor(
+    message: string,
+    readonly code?: number,
+    readonly rpcMethod?: string,
+  ) {
+    super(message);
+    this.name = 'AppServerRpcError';
+  }
+}
+
+// Drives one `codex app-server` subprocess. The class is intentionally
+// agnostic to backend semantics (threads, turns, approvals) — those live
+// in `codex-app-server.ts` and consume `request` / `notify` /
+// `onNotification` / `onServerRequest` here.
+export class AppServerRpcClient {
+  private readonly command: string;
+  private readonly args: readonly string[];
+  private readonly cwd?: string;
+  private readonly spawnFn: AppServerSpawnFn;
+  private readonly logger?: Logger;
+  private readonly stderrCaptureBytes: number;
+
+  private child: AppServerChildHandle | null = null;
+  private stdoutBuf = '';
+  private stderrTail = '';
+  private nextId = 0;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly notificationHandlers = new Set<NotificationHandler>();
+  private serverRequestHandler: ServerRequestHandler | null = null;
+  private closed = false;
+  private closeReason: { code?: number | null; signal?: NodeJS.Signals | null; error?: unknown } | null = null;
+  private readonly closeWaiters = new Set<(reason: { code?: number | null; signal?: NodeJS.Signals | null; error?: unknown }) => void>();
+
+  constructor(opts: AppServerRpcClientOptions = {}) {
+    this.command = opts.command ?? 'codex';
+    this.args = opts.args ?? ['app-server'];
+    this.cwd = opts.cwd;
+    this.spawnFn = opts.spawn ?? defaultAppServerSpawn;
+    this.logger = opts.logger;
+    this.stderrCaptureBytes = opts.stderrCaptureBytes ?? 8192;
+  }
+
+  // Spawn the child and wire stdio. Throws synchronously on `spawn(2)`
+  // failure — callers handle that as the first-task `task.fail` path so
+  // operators see `code=app_server_unavailable` rather than a swallowed
+  // crash on the very first turn.
+  start(): void {
+    if (this.child) throw new Error('AppServerRpcClient.start called twice');
+    if (this.closed) throw new Error('AppServerRpcClient.start called after close');
+    const child = this.spawnFn(this.command, this.args, { cwd: this.cwd });
+    this.child = child;
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      this.stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      this.drainStdout();
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      this.stderrTail += s;
+      if (this.stderrTail.length > this.stderrCaptureBytes) {
+        this.stderrTail = this.stderrTail.slice(-this.stderrCaptureBytes);
+      }
+    });
+    child.on('error', (err) => this.handleTransportEnd({ error: err }));
+    child.on('close', (code, signal) => this.handleTransportEnd({ code, signal }));
+  }
+
+  // Test-only convenience: surface the buffered stderr so failures can
+  // include the child's last words. Production paths log it on close.
+  getStderrTail(): string {
+    return this.stderrTail;
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  // Resolves when the child has exited (close/error). Used by the backend
+  // to detect crashes without polling.
+  waitForClose(): Promise<{ code?: number | null; signal?: NodeJS.Signals | null; error?: unknown }> {
+    if (this.closed) return Promise.resolve(this.closeReason ?? {});
+    return new Promise((resolve) => {
+      this.closeWaiters.add(resolve);
+    });
+  }
+
+  // Send a JSON-RPC request and resolve with the `result` field. Rejects
+  // with `AppServerRpcError` on protocol error or `Error("transport_closed")`
+  // if the child exits before responding.
+  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    if (this.closed) {
+      return Promise.reject(new Error(TRANSPORT_CLOSED));
+    }
+    if (!this.child?.stdin) {
+      return Promise.reject(new Error('AppServerRpcClient.request before start (no stdin)'));
+    }
+    const id = this.nextId++;
+    const msg: Record<string, unknown> = { method, id };
+    if (params !== undefined) msg.params = params;
+    const line = JSON.stringify(msg) + '\n';
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        method,
+      });
+      try {
+        this.child!.stdin!.write(line);
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  // Fire-and-forget notification (no `id`). Used for `initialized` and
+  // any future client-side notifications. Silently no-ops after close —
+  // the lifecycle log already covered why the transport went away.
+  notify(method: string, params?: unknown): void {
+    if (this.closed || !this.child?.stdin) return;
+    const msg: Record<string, unknown> = { method };
+    if (params !== undefined) msg.params = params;
+    try {
+      this.child.stdin.write(JSON.stringify(msg) + '\n');
+    } catch {
+      // best effort — pending requests will surface the real error
+    }
+  }
+
+  // Respond to a server-initiated request (e.g. approval prompts).
+  // The dispatcher routes server requests to the registered handler;
+  // the handler's return value flows back here as the `result`. Errors
+  // (sync throw or promise rejection) become JSON-RPC errors.
+  private respond(id: number | string, result: unknown): void {
+    if (this.closed || !this.child?.stdin) return;
+    try {
+      this.child.stdin.write(JSON.stringify({ id, result }) + '\n');
+    } catch {
+      // best effort
+    }
+  }
+
+  private respondError(id: number | string, message: string): void {
+    if (this.closed || !this.child?.stdin) return;
+    try {
+      this.child.stdin.write(JSON.stringify({ id, error: { message } }) + '\n');
+    } catch {
+      // best effort
+    }
+  }
+
+  onNotification(handler: NotificationHandler): () => void {
+    this.notificationHandlers.add(handler);
+    return () => this.notificationHandlers.delete(handler);
+  }
+
+  setServerRequestHandler(handler: ServerRequestHandler | null): void {
+    this.serverRequestHandler = handler;
+  }
+
+  // SIGTERM the child. Pending requests are rejected via the close
+  // handler, so callers don't need a separate teardown step.
+  kill(signal: NodeJS.Signals = 'SIGTERM'): void {
+    if (!this.child || this.closed) return;
+    try {
+      this.child.kill(signal);
+    } catch {
+      // best effort
+    }
+  }
+
+  // ─── internals ─────────────────────────────────────────────────────────
+
+  private drainStdout(): void {
+    let nl: number;
+    while ((nl = this.stdoutBuf.indexOf('\n')) !== -1) {
+      const line = this.stdoutBuf.slice(0, nl).trim();
+      this.stdoutBuf = this.stdoutBuf.slice(nl + 1);
+      if (!line) continue;
+      let msg: IncomingMessage;
+      try {
+        msg = JSON.parse(line) as IncomingMessage;
+      } catch {
+        this.logger?.warn(`[codex-app-server] bad json line: ${line.slice(0, 200)}`);
+        continue;
+      }
+      this.dispatch(msg);
+    }
+  }
+
+  private dispatch(msg: IncomingMessage): void {
+    // Response to a client-initiated request.
+    if (
+      'id' in msg &&
+      msg.id !== undefined &&
+      !('method' in msg)
+    ) {
+      const resp = msg as JsonRpcResponse;
+      const id = typeof resp.id === 'number' ? resp.id : Number(resp.id);
+      const p = this.pending.get(id);
+      if (!p) return;
+      this.pending.delete(id);
+      if (resp.error) {
+        p.reject(
+          new AppServerRpcError(
+            resp.error.message ?? `rpc error (${resp.error.code ?? 'unknown'})`,
+            resp.error.code,
+            p.method,
+          ),
+        );
+      } else {
+        p.resolve(resp.result);
+      }
+      return;
+    }
+    // Server-initiated request — has both `id` and `method`. Route to
+    // the handler, then ship the response back.
+    if ('id' in msg && msg.id !== undefined && 'method' in msg) {
+      const req = msg as JsonRpcRequest;
+      const handler = this.serverRequestHandler;
+      if (!handler) {
+        // No handler means we have no opinion — but silence here would
+        // hang the agent's turn (codex blocks on approval requests).
+        // Decline by default so a misconfigured backend fails closed
+        // rather than hanging.
+        this.logger?.warn(
+          `[codex-app-server] no handler for server request ${req.method}; declining`,
+        );
+        this.respond(req.id, { decision: 'decline' });
+        return;
+      }
+      Promise.resolve()
+        .then(() => handler(req.id, req.method, req.params))
+        .then(
+          (result) => this.respond(req.id, result),
+          (err) => {
+            this.logger?.warn(
+              `[codex-app-server] server request handler failed for ${req.method}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            this.respondError(req.id, err instanceof Error ? err.message : String(err));
+          },
+        );
+      return;
+    }
+    // Notification.
+    if ('method' in msg) {
+      const note = msg as JsonRpcNotification;
+      for (const h of this.notificationHandlers) {
+        try {
+          h(note.method, note.params);
+        } catch (err) {
+          this.logger?.warn(
+            `[codex-app-server] notification handler threw on ${note.method}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  private handleTransportEnd(reason: { code?: number | null; signal?: NodeJS.Signals | null; error?: unknown }): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeReason = reason;
+    // Reject every pending request with a uniform sentinel so callers
+    // can branch on `err.message === TRANSPORT_CLOSED` rather than
+    // inspecting child exit details.
+    const detail = reason.error
+      ? `: ${reason.error instanceof Error ? reason.error.message : String(reason.error)}`
+      : reason.signal
+        ? ` (signal ${reason.signal})`
+        : reason.code != null
+          ? ` (code ${reason.code})`
+          : '';
+    for (const [, p] of this.pending) {
+      p.reject(new Error(`${TRANSPORT_CLOSED}${detail}`));
+    }
+    this.pending.clear();
+    for (const w of this.closeWaiters) {
+      try {
+        w(reason);
+      } catch {
+        // best effort
+      }
+    }
+    this.closeWaiters.clear();
+  }
+}

--- a/packages/client/src/backends/codex-app-server.test.ts
+++ b/packages/client/src/backends/codex-app-server.test.ts
@@ -1,0 +1,943 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createCodexAppServerBackend } from './codex-app-server.js';
+import type {
+  AppServerChildHandle,
+  AppServerSpawnFn,
+  AppServerSpawnOptions,
+} from './codex-app-server-rpc.js';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  TRACEABILITY_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fake stdio child — same shape as codex.test.ts so the test surface stays
+// familiar. Tests script behaviour by registering an `onStdinLine` callback
+// per child; whenever the backend writes a newline-terminated JSON-RPC frame
+// to stdin the helper parses it, hands the parsed object to the scenario,
+// and lets the scenario emit responses/notifications back on stdout.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FakeChild extends AppServerChildHandle {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd?: string;
+  killed: boolean;
+  killSignal: NodeJS.Signals | null;
+  /** All stdin chunks concatenated (newline-delimited JSON-RPC frames). */
+  readonly stdinPayload: () => string;
+  /** Parse every complete line written so far. */
+  readonly stdinFrames: () => unknown[];
+  /** Push one JSON-RPC line to the backend's stdout. */
+  emitStdout(obj: unknown): void;
+  /** Push raw text (non-JSON line, partial buffer, etc.). */
+  emitStdoutRaw(text: string): void;
+  /** Push stderr bytes — mostly for transport-failure tests. */
+  emitStderr(text: string): void;
+  /** Synthesise a process exit. */
+  finish(code: number | null, sig?: NodeJS.Signals | null): void;
+}
+
+interface FakeSpawn {
+  spawn: AppServerSpawnFn;
+  children: FakeChild[];
+  lastChild: () => FakeChild;
+}
+
+interface ChildScenario {
+  /** Called per inbound JSON-RPC line from the backend. */
+  onLine?: (line: Record<string, unknown>, child: FakeChild, index: number) => void;
+}
+
+function makeFakeSpawn(
+  configure: (child: FakeChild, index: number) => ChildScenario | void,
+): FakeSpawn {
+  const children: FakeChild[] = [];
+  const spawn: AppServerSpawnFn = (
+    command,
+    args,
+    options: AppServerSpawnOptions,
+  ) => {
+    const stdoutEmitter = new EventEmitter();
+    const stderrEmitter = new EventEmitter();
+    const closeListeners: Array<
+      (code: number | null, sig: NodeJS.Signals | null) => void
+    > = [];
+    let closed = false;
+
+    const mkReadable = (em: EventEmitter): NodeJS.ReadableStream =>
+      ({
+        on(event: string, cb: (...a: unknown[]) => void) {
+          em.on(event, cb);
+        },
+      }) as unknown as NodeJS.ReadableStream;
+
+    const stdinChunks: string[] = [];
+    let stdinBuf = '';
+    let onLine: ChildScenario['onLine'] | undefined;
+
+    const handleLine = (line: string): void => {
+      if (!onLine) return;
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+      onLine(parsed, child, children.length - 1);
+    };
+
+    const writeBytes = (chunk: unknown): void => {
+      const s =
+        typeof chunk === 'string'
+          ? chunk
+          : Buffer.from(chunk as Buffer).toString('utf8');
+      stdinChunks.push(s);
+      stdinBuf += s;
+      let nl: number;
+      while ((nl = stdinBuf.indexOf('\n')) !== -1) {
+        const line = stdinBuf.slice(0, nl).trim();
+        stdinBuf = stdinBuf.slice(nl + 1);
+        if (line) handleLine(line);
+      }
+    };
+    const stdin: NodeJS.WritableStream = {
+      write(chunk: unknown): boolean {
+        writeBytes(chunk);
+        return true;
+      },
+      end(chunk?: unknown) {
+        if (chunk !== undefined) writeBytes(chunk);
+        return stdin;
+      },
+      on() {
+        return stdin;
+      },
+      once() {
+        return stdin;
+      },
+      emit() {
+        return false;
+      },
+    } as unknown as NodeJS.WritableStream;
+
+    const child: FakeChild = {
+      command,
+      args,
+      cwd: options.cwd,
+      stdin,
+      stdout: mkReadable(stdoutEmitter),
+      stderr: mkReadable(stderrEmitter),
+      killed: false,
+      killSignal: null,
+      stdinPayload: () => stdinChunks.join(''),
+      stdinFrames: () => {
+        const out: unknown[] = [];
+        for (const line of stdinChunks.join('').split('\n')) {
+          const t = line.trim();
+          if (!t) continue;
+          try {
+            out.push(JSON.parse(t));
+          } catch {
+            // ignore — tests assert on framed content
+          }
+        }
+        return out;
+      },
+      emitStdout(obj) {
+        stdoutEmitter.emit('data', Buffer.from(JSON.stringify(obj) + '\n', 'utf8'));
+      },
+      emitStdoutRaw(text) {
+        stdoutEmitter.emit('data', Buffer.from(text, 'utf8'));
+      },
+      emitStderr(text) {
+        stderrEmitter.emit('data', Buffer.from(text, 'utf8'));
+      },
+      kill(sig?: NodeJS.Signals) {
+        this.killed = true;
+        this.killSignal = sig ?? 'SIGTERM';
+        queueMicrotask(() => {
+          if (closed) return;
+          closed = true;
+          for (const l of closeListeners) l(null, this.killSignal);
+        });
+        return true;
+      },
+      on(
+        event: 'close' | 'error',
+        listener:
+          | ((code: number | null, signal: NodeJS.Signals | null) => void)
+          | ((err: Error) => void),
+      ) {
+        if (event === 'close') {
+          closeListeners.push(
+            listener as (c: number | null, s: NodeJS.Signals | null) => void,
+          );
+        }
+      },
+      finish(code, sig = null) {
+        if (closed) return;
+        closed = true;
+        for (const l of closeListeners) l(code, sig);
+      },
+    };
+
+    children.push(child);
+    const scenario = configure(child, children.length - 1);
+    if (scenario?.onLine) onLine = scenario.onLine;
+    return child;
+  };
+  return {
+    spawn,
+    children,
+    lastChild: () => {
+      const c = children.at(-1);
+      if (!c) throw new Error('no spawned child yet');
+      return c;
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scenario helpers — encode the canonical app-server happy-path response
+// pattern (initialize → thread/start|resume → turn/start → notifications →
+// turn/completed) once so the per-test code stays focused on the bit under
+// test.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface HappyPathOptions {
+  agentMessageText?: string;
+  threadId?: string;
+  turnId?: string;
+  /**
+   * After how many `turn/start` requests we should pretend the agent
+   * emitted a `commandExecution` item before completing. Default 0.
+   */
+  emitCommandExecutionTurns?: number[];
+  /** Optional override of the initialize result payload. */
+  initializeResult?: Record<string, unknown>;
+}
+
+function happyPath(opts: HappyPathOptions = {}): ChildScenario {
+  const agentMessageText = opts.agentMessageText ?? 'OK';
+  const threadId = opts.threadId ?? 'thr-1';
+  const turnId = opts.turnId ?? 'turn-1';
+  const commandTurns = new Set(opts.emitCommandExecutionTurns ?? []);
+  let turnCounter = 0;
+  let activeThreadId = threadId;
+  return {
+    onLine(frame, child) {
+      const id = (frame as { id?: number | string }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({
+          id,
+          result:
+            opts.initializeResult ?? {
+              userAgent: 'fake-codex/0.130.0',
+              codexHome: '/tmp',
+              platformFamily: 'unix',
+              platformOs: 'macos',
+            },
+        });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        activeThreadId = threadId;
+        child.emitStdout({ id, result: { thread: { id: activeThreadId } } });
+        return;
+      }
+      if (method === 'thread/resume' && id !== undefined) {
+        const p = (frame as { params?: { threadId?: string } }).params;
+        activeThreadId = p?.threadId ?? threadId;
+        child.emitStdout({ id, result: { thread: { id: activeThreadId } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        turnCounter += 1;
+        const localTurnId = `${turnId}-${turnCounter}`;
+        child.emitStdout({
+          id,
+          result: { turn: { id: localTurnId, status: 'inProgress' } },
+        });
+        // Schedule the notifications on a microtask so the backend's
+        // turn/start promise resolves and `activeTurnId` is recorded
+        // before the first notification arrives.
+        queueMicrotask(() => {
+          child.emitStdout({
+            method: 'item/agentMessage/delta',
+            params: { itemId: 'item-1', delta: agentMessageText, turnId: localTurnId },
+          });
+          if (commandTurns.has(turnCounter)) {
+            child.emitStdout({
+              method: 'item/completed',
+              params: {
+                turnId: localTurnId,
+                threadId: activeThreadId,
+                item: {
+                  type: 'commandExecution',
+                  id: 'cmd-1',
+                  command: 'ls -la',
+                  status: 'success',
+                  exitCode: 0,
+                  aggregatedOutput: 'foo\nbar\n',
+                },
+              },
+            });
+          }
+          child.emitStdout({
+            method: 'item/completed',
+            params: {
+              turnId: localTurnId,
+              threadId: activeThreadId,
+              item: { type: 'agentMessage', id: 'item-1', text: agentMessageText },
+            },
+          });
+          child.emitStdout({
+            method: 'turn/completed',
+            params: {
+              turn: { id: localTurnId, status: 'completed', items: [], error: null },
+            },
+          });
+        });
+        return;
+      }
+    },
+  };
+}
+
+function assign(
+  text: string,
+  contextId = 'ctx-1',
+  overrides: Partial<TaskAssignFrame> = {},
+): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId: `task-${Math.random().toString(36).slice(2, 10)}`,
+    contextId,
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'text', text }],
+    },
+    ...overrides,
+  };
+}
+
+function collect(): { emit: (f: UpFrame) => void; frames: UpFrame[] } {
+  const frames: UpFrame[] = [];
+  return { emit: (f) => frames.push(f), frames };
+}
+
+function findRequest(frames: unknown[], method: string): Record<string, unknown> | null {
+  for (const f of frames) {
+    if (f === null || typeof f !== 'object') continue;
+    const o = f as { method?: unknown; id?: unknown };
+    if (o.method === method && 'id' in o && o.id !== undefined) {
+      return f as Record<string, unknown>;
+    }
+  }
+  return null;
+}
+
+const NEVER: AbortSignal = new AbortController().signal;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('first task runs initialize + thread/start + turn/start and emits agent artifact', async () => {
+  const fake = makeFakeSpawn(() => happyPath({ agentMessageText: 'OK' }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn, cwd: '/repo' });
+
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  // Only ONE child should have been spawned (singleton app-server).
+  assert.equal(fake.children.length, 1);
+  const child = fake.lastChild();
+  assert.equal(child.command, 'codex');
+  assert.deepEqual(child.args, ['app-server']);
+  assert.equal(child.cwd, '/repo');
+
+  // Sent frames must include initialize → initialized (notif) → thread/start → turn/start.
+  const sent = child.stdinFrames();
+  assert.ok(findRequest(sent, 'initialize'), 'initialize sent');
+  const init = sent.find((f) => (f as { method?: string }).method === 'initialized') as
+    | Record<string, unknown>
+    | undefined;
+  assert.ok(init && !('id' in init), 'initialized is a notification (no id)');
+  const threadStart = findRequest(sent, 'thread/start');
+  assert.ok(threadStart, 'thread/start sent');
+  const turnStart = findRequest(sent, 'turn/start');
+  assert.ok(turnStart, 'turn/start sent');
+
+  // thread/start carries sandbox=read-only and cwd.
+  const tsParams = (threadStart as { params?: { sandbox?: string; cwd?: string } }).params;
+  assert.equal(tsParams?.sandbox, 'read-only');
+  assert.equal(tsParams?.cwd, '/repo');
+
+  // turn/start carries the text input plus an empty `text_elements`.
+  const tParams = (turnStart as {
+    params?: { threadId?: string; input?: Array<{ type: string; text?: string; text_elements?: unknown[] }> };
+  }).params;
+  assert.equal(tParams?.threadId, 'thr-1');
+  assert.deepEqual(tParams?.input, [
+    { type: 'text', text: 'hello', text_elements: [] },
+  ]);
+
+  // The backend emits working → artifact → complete with completed state.
+  assert.equal(frames[0]?.type, 'task.status');
+  assert.equal(frames[1]?.type, 'task.artifact');
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.complete');
+  assert.equal(last?.type === 'task.complete' && last.status.state, 'completed');
+});
+
+test('follow-up task with same contextId uses thread/resume not thread/start', async () => {
+  const fake = makeFakeSpawn(() => happyPath({ threadId: 'thr-1' }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+
+  const a = collect();
+  await backend.handle(assign('first', 'ctx-A'), a.emit, NEVER);
+  const b = collect();
+  await backend.handle(assign('second', 'ctx-A'), b.emit, NEVER);
+
+  // Still one child.
+  assert.equal(fake.children.length, 1);
+  const frames = fake.lastChild().stdinFrames();
+  const startCount = frames.filter((f) => (f as { method?: string }).method === 'thread/start').length;
+  const resumeCount = frames.filter((f) => (f as { method?: string }).method === 'thread/resume').length;
+  const turnStarts = frames.filter((f) => (f as { method?: string }).method === 'turn/start').length;
+
+  assert.equal(startCount, 1, 'only one thread/start over two tasks');
+  assert.equal(resumeCount, 1, 'second task resumes the thread');
+  assert.equal(turnStarts, 2, 'one turn per task');
+
+  assert.equal(a.frames.at(-1)?.type, 'task.complete');
+  assert.equal(b.frames.at(-1)?.type, 'task.complete');
+});
+
+test('distinct contextIds get distinct threads on a single app-server', async () => {
+  const fake = makeFakeSpawn((_child, _idx) => {
+    // Both contexts share the same fake server, so use a counter for threadId.
+    let threadCounter = 0;
+    let turnCounter = 0;
+    return {
+      onLine(frame, child) {
+        const id = (frame as { id?: number | string }).id;
+        const method = (frame as { method?: string }).method;
+        if (method === 'initialize' && id !== undefined) {
+          child.emitStdout({ id, result: { userAgent: 'fake' } });
+          return;
+        }
+        if (method === 'thread/start' && id !== undefined) {
+          threadCounter += 1;
+          const tid = `thr-${threadCounter}`;
+          child.emitStdout({ id, result: { thread: { id: tid } } });
+          return;
+        }
+        if (method === 'thread/resume' && id !== undefined) {
+          const p = (frame as { params?: { threadId?: string } }).params;
+          child.emitStdout({ id, result: { thread: { id: p?.threadId ?? 'thr-?' } } });
+          return;
+        }
+        if (method === 'turn/start' && id !== undefined) {
+          turnCounter += 1;
+          const localTurnId = `turn-${turnCounter}`;
+          const params = (frame as { params?: { threadId?: string } }).params;
+          const threadId = params?.threadId ?? 'thr-?';
+          child.emitStdout({
+            id,
+            result: { turn: { id: localTurnId, status: 'inProgress' } },
+          });
+          queueMicrotask(() => {
+            child.emitStdout({
+              method: 'item/completed',
+              params: {
+                turnId: localTurnId,
+                threadId,
+                item: { type: 'agentMessage', id: 'i', text: `reply-${turnCounter}` },
+              },
+            });
+            child.emitStdout({
+              method: 'turn/completed',
+              params: { turn: { id: localTurnId, status: 'completed' } },
+            });
+          });
+        }
+      },
+    };
+  });
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+
+  const a = collect();
+  await backend.handle(assign('hi A', 'ctx-A'), a.emit, NEVER);
+  const b = collect();
+  await backend.handle(assign('hi B', 'ctx-B'), b.emit, NEVER);
+
+  assert.equal(fake.children.length, 1);
+  const frames = fake.lastChild().stdinFrames();
+  const starts = frames.filter((f) => (f as { method?: string }).method === 'thread/start');
+  assert.equal(starts.length, 2, 'one thread/start per context');
+});
+
+test('abort sends turn/interrupt and emits canceled', async () => {
+  // Scenario: respond to initialize, thread/start, turn/start, but never
+  // emit a turn/completed unless an interrupt arrives.
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: unknown }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({ id, result: { userAgent: 'fake' } });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({ id, result: { turn: { id: 'turn-x', status: 'inProgress' } } });
+        return;
+      }
+      if (method === 'turn/interrupt' && id !== undefined) {
+        child.emitStdout({ id, result: {} });
+        // After ack, emit a turn/completed status=interrupted.
+        queueMicrotask(() => {
+          child.emitStdout({
+            method: 'turn/completed',
+            params: { turn: { id: 'turn-x', status: 'interrupted' } },
+          });
+        });
+      }
+    },
+  }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+
+  const ctrl = new AbortController();
+  const { emit, frames } = collect();
+  const handlePromise = backend.handle(assign('hang'), emit, ctrl.signal);
+  // Give the backend time to send turn/start before aborting.
+  await new Promise((r) => setTimeout(r, 20));
+  ctrl.abort();
+  await handlePromise;
+
+  const sent = fake.lastChild().stdinFrames();
+  const interrupt = findRequest(sent, 'turn/interrupt');
+  assert.ok(interrupt, 'turn/interrupt sent on abort');
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.complete');
+  assert.equal(last?.type === 'task.complete' && last.status.state, 'canceled');
+});
+
+test('approval server-request gets auto-decline by default', async () => {
+  let lastApprovalResponse: unknown = null;
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: unknown }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({ id, result: { userAgent: 'fake' } });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({ id, result: { turn: { id: 't', status: 'inProgress' } } });
+        // Send a server-initiated approval request to the client.
+        queueMicrotask(() => {
+          child.emitStdout({
+            id: 9999,
+            method: 'execCommandApproval',
+            params: { command: 'rm -rf /' },
+          });
+        });
+        return;
+      }
+      // The auto-decline response comes back from the client with `id: 9999`.
+      if (id === 9999) {
+        lastApprovalResponse = frame;
+        // After approval is declined, conclude the turn.
+        queueMicrotask(() => {
+          child.emitStdout({
+            method: 'item/completed',
+            params: {
+              turnId: 't',
+              item: { type: 'agentMessage', id: 'a', text: 'declined' },
+            },
+          });
+          child.emitStdout({
+            method: 'turn/completed',
+            params: { turn: { id: 't', status: 'completed' } },
+          });
+        });
+      }
+    },
+  }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('do dangerous thing'), emit, NEVER);
+
+  const approvalFrame = lastApprovalResponse as { id?: number; result?: { decision?: string } } | null;
+  assert.equal(approvalFrame?.id, 9999);
+  assert.equal(approvalFrame?.result?.decision, 'decline');
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('app-server spawn failure surfaces app_server_unavailable', async () => {
+  const failingSpawn: AppServerSpawnFn = () => {
+    throw new Error('ENOENT');
+  };
+  const backend = createCodexAppServerBackend({ spawn: failingSpawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.fail');
+  assert.equal(
+    last?.type === 'task.fail' && last.error.code,
+    'app_server_unavailable',
+  );
+});
+
+test('transport closing mid-turn emits task.fail', async () => {
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: unknown }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({ id, result: { userAgent: 'fake' } });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({ id, result: { turn: { id: 't', status: 'inProgress' } } });
+        // Kill the child mid-turn.
+        queueMicrotask(() => child.finish(1));
+      }
+    },
+  }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('crash me'), emit, NEVER);
+
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.fail');
+  assert.equal(last?.type === 'task.fail' && last.error.code, 'turn_failed');
+});
+
+test('traceability extension surfaces commandExecution item as a trace artifact', async () => {
+  const fake = makeFakeSpawn(() =>
+    happyPath({ agentMessageText: 'done', emitCommandExecutionTurns: [1] }),
+  );
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assign('run ls', 'ctx-trace', {
+      requestedExtensions: [TRACEABILITY_EXTENSION_URI],
+    }),
+    emit,
+    NEVER,
+  );
+
+  const traceArtifact = frames.find(
+    (f) =>
+      f.type === 'task.artifact' && f.artifact.extensions?.includes(TRACEABILITY_EXTENSION_URI),
+  );
+  assert.ok(traceArtifact, 'trace artifact emitted');
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('image FilePart is materialised under a temp dir and passed as localImage UserInput', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const written: Array<{ file: string; size: number }> = [];
+  const backend = createCodexAppServerBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/test-codex-as',
+    writeFile: async (file, data) => {
+      written.push({ file, size: data.length });
+    },
+    rm: async () => undefined,
+  });
+
+  const tiny = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString('base64');
+  const { emit, frames } = collect();
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 'task-img',
+      contextId: 'ctx-img',
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [
+          { kind: 'text', text: 'what is this' },
+          { kind: 'file', file: { mimeType: 'image/png', bytes: tiny } },
+        ],
+      },
+    },
+    emit,
+    NEVER,
+  );
+
+  assert.equal(written.length, 1);
+  assert.match(written[0].file, /^\/tmp\/test-codex-as\/image-1\.png$/);
+
+  const turnStart = findRequest(fake.lastChild().stdinFrames(), 'turn/start');
+  const params = (turnStart as {
+    params?: { input?: Array<{ type: string; path?: string }> };
+  }).params;
+  const imageItem = params?.input?.find((it) => it.type === 'localImage');
+  assert.ok(imageItem, 'localImage UserInput present');
+  assert.equal(imageItem?.path, '/tmp/test-codex-as/image-1.png');
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('openai-compat tool_call_history is replayed as a prefix on the user text', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assign('next', 'ctx-hist', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'next' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tool_call_history: [
+              {
+                role: 'assistant',
+                tool_calls: [
+                  { id: 'tc1', function: { name: 'lookup', arguments: '{}' } },
+                ],
+              },
+              { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
+            ],
+          },
+        },
+      },
+    }),
+    emit,
+    NEVER,
+  );
+
+  const turnStart = findRequest(fake.lastChild().stdinFrames(), 'turn/start');
+  const params = (turnStart as {
+    params?: { input?: Array<{ type: string; text?: string }> };
+  }).params;
+  const textItem = params?.input?.find((it) => it.type === 'text');
+  assert.ok(textItem?.text?.includes('next'));
+  assert.ok(
+    textItem?.text?.includes('tool_call_history') ||
+      textItem?.text?.includes('lookup'),
+    'tool call history is replayed in the prompt',
+  );
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('expired session falls back to thread/start instead of thread/resume', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  let clock = 1_000_000;
+  const backend = createCodexAppServerBackend({
+    spawn: fake.spawn,
+    sessionTtlMs: 1_000,
+    now: () => clock,
+  });
+
+  await backend.handle(assign('first', 'ctx-ttl'), collect().emit, NEVER);
+  clock += 60_000; // jump well past the TTL
+  await backend.handle(assign('second', 'ctx-ttl'), collect().emit, NEVER);
+
+  const frames = fake.lastChild().stdinFrames();
+  const starts = frames.filter((f) => (f as { method?: string }).method === 'thread/start').length;
+  const resumes = frames.filter((f) => (f as { method?: string }).method === 'thread/resume').length;
+  assert.equal(starts, 2, 'expired session re-runs thread/start');
+  assert.equal(resumes, 0, 'no thread/resume across the TTL boundary');
+});
+
+test('two concurrent tasks on the same contextId run sequentially through the mutex', async () => {
+  // Make the fake server delay turn/completed so we can observe the ordering.
+  const fake = makeFakeSpawn(() => {
+    let turnCounter = 0;
+    const pendingTurns: Array<{ id: number | string; localId: string }> = [];
+    return {
+      onLine(frame, child) {
+        const id = (frame as { id?: number | string }).id;
+        const method = (frame as { method?: string }).method;
+        if (method === 'initialize' && id !== undefined) {
+          child.emitStdout({ id, result: { userAgent: 'fake' } });
+          return;
+        }
+        if ((method === 'thread/start' || method === 'thread/resume') && id !== undefined) {
+          child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+          return;
+        }
+        if (method === 'turn/start' && id !== undefined) {
+          turnCounter += 1;
+          const localTurnId = `turn-${turnCounter}`;
+          child.emitStdout({ id, result: { turn: { id: localTurnId, status: 'inProgress' } } });
+          pendingTurns.push({ id, localId: localTurnId });
+          // Drive turns to completion on the next macrotask; the second
+          // turn must not race the first.
+          setTimeout(() => {
+            const t = pendingTurns.shift();
+            if (!t) return;
+            child.emitStdout({
+              method: 'item/completed',
+              params: {
+                turnId: t.localId,
+                item: { type: 'agentMessage', id: 'a', text: `r-${t.localId}` },
+              },
+            });
+            child.emitStdout({
+              method: 'turn/completed',
+              params: { turn: { id: t.localId, status: 'completed' } },
+            });
+          }, 10);
+        }
+      },
+    };
+  });
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+
+  const a = collect();
+  const b = collect();
+  const t0 = Date.now();
+  const promiseA = backend.handle(assign('first', 'ctx-conc'), a.emit, NEVER);
+  const promiseB = backend.handle(assign('second', 'ctx-conc'), b.emit, NEVER);
+  await Promise.all([promiseA, promiseB]);
+  const elapsed = Date.now() - t0;
+
+  // Both tasks completed.
+  assert.equal(a.frames.at(-1)?.type, 'task.complete');
+  assert.equal(b.frames.at(-1)?.type, 'task.complete');
+  // Each fake turn carries a 10ms delay; serial execution should land
+  // around 20ms+ rather than ~10ms parallel.
+  assert.ok(elapsed >= 18, `concurrent same-context should serialise (elapsed=${elapsed}ms)`);
+
+  // Sanity: only ONE turn was on the wire at any moment — the second
+  // turn/start would have been queued, so they arrived in order.
+  const frames = fake.lastChild().stdinFrames();
+  const turnStarts = frames.filter((f) => (f as { method?: string }).method === 'turn/start');
+  assert.equal(turnStarts.length, 2);
+});
+
+test('backend tolerates a malformed (non-JSON) stdout line without breaking the turn', async () => {
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: unknown }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        // Garbage line first — must NOT crash the dispatcher.
+        child.emitStdoutRaw('this is not json\n');
+        child.emitStdout({ id, result: { userAgent: 'fake' } });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({ id, result: { turn: { id: 't', status: 'inProgress' } } });
+        queueMicrotask(() => {
+          child.emitStdout({
+            method: 'item/completed',
+            params: { turnId: 't', item: { type: 'agentMessage', id: 'a', text: 'ok' } },
+          });
+          child.emitStdout({
+            method: 'turn/completed',
+            params: { turn: { id: 't', status: 'completed' } },
+          });
+        });
+      }
+    },
+  }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('turn/start RPC error surfaces task.fail with turn_failed', async () => {
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: unknown }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({ id, result: { userAgent: 'fake' } });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr' } } });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({
+          id,
+          error: { code: -32001, message: 'overloaded' },
+        });
+      }
+    },
+  }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('x'), emit, NEVER);
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.fail');
+  assert.equal(last?.type === 'task.fail' && last.error.code, 'turn_failed');
+});
+
+test('openai-compat envelope agent message is emitted as a data part', async () => {
+  const envelope = JSON.stringify({
+    tool_calls: [{ id: '1', function: { name: 'fetch', arguments: '{}' } }],
+  });
+  const fake = makeFakeSpawn(() => happyPath({ agentMessageText: envelope }));
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assign('what tools?', 'ctx-oai', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'what tools?' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            system: 'be terse',
+            tools: [{ type: 'function', function: { name: 'fetch', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    emit,
+    NEVER,
+  );
+
+  // The envelope-shaped agent message must be a `data` part.
+  const artifact = frames.find((f) => f.type === 'task.artifact');
+  assert.ok(artifact);
+  if (artifact?.type === 'task.artifact') {
+    const p = artifact.artifact.parts[0];
+    assert.equal(p.kind, 'data');
+    assert.ok(artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+  }
+
+  // developerInstructions must have been included in thread/start.
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { developerInstructions?: string } }).params;
+  assert.ok(
+    typeof params?.developerInstructions === 'string' &&
+      params.developerInstructions.length > 0,
+    'developerInstructions sent on thread/start',
+  );
+});

--- a/packages/client/src/backends/codex-app-server.ts
+++ b/packages/client/src/backends/codex-app-server.ts
@@ -1,0 +1,816 @@
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  TRACEABILITY_EXTENSION_URI,
+  type Part,
+} from '@vicoop-bridge/protocol';
+import type { Backend, Emit, TaskAssign } from '../backend.js';
+import { createLogger, type Logger } from '../logger.js';
+import { mapPartsToCodexInput } from './codex.js';
+import {
+  buildOpenAICompatSystemPrompt,
+  formatToolCallHistory,
+  parseOpenAICompatMetadata,
+  tryParseToolCallsEnvelope,
+} from './claude.js';
+import { createTimingRecorder } from './timing.js';
+import {
+  AppServerRpcClient,
+  defaultAppServerSpawn,
+  TRANSPORT_CLOSED,
+  type AppServerSpawnFn,
+  type InitializeResult,
+  type SandboxMode,
+  type ThreadItem,
+  type UserInputItem,
+} from './codex-app-server-rpc.js';
+
+// Public re-export so operators can refer to the same sandbox-mode type
+// surface as the existing `codex` backend without crossing files.
+export type CodexAppServerSandboxMode = SandboxMode;
+export type ApprovalDecision = 'accept' | 'acceptForSession' | 'decline';
+
+export interface CodexAppServerBackendOptions {
+  command?: string;
+  appServerArgs?: readonly string[];
+  cwd?: string;
+  sandboxMode?: SandboxMode;
+  // What to answer when codex sends a server-initiated approval request
+  // (execCommandApproval / applyPatchApproval). Default `decline` — safe
+  // even under workspace-write; operators that explicitly want auto-accept
+  // opt in via config.
+  approvalDecision?: ApprovalDecision;
+  spawn?: AppServerSpawnFn;
+  stderrCaptureBytes?: number;
+  // How long an idle `(contextId → threadId)` mapping survives without use.
+  // Default 1 hour. `0` disables session reuse — every task does
+  // `thread/start` from scratch.
+  sessionTtlMs?: number;
+  // Test seam: deterministic clock for TTL eviction and timing.
+  now?: () => number;
+  // Idle-silence heartbeat — same semantics as `codex` / `claude`.
+  heartbeatMs?: number;
+  setIntervalFn?: (fn: () => void, ms: number) => unknown;
+  clearIntervalFn?: (handle: unknown) => void;
+  mkdtemp?: (prefix: string) => Promise<string>;
+  writeFile?: (file: string, data: Buffer) => Promise<void>;
+  rm?: (file: string, options: { recursive: boolean; force: boolean }) => Promise<void>;
+  logger?: Logger;
+  // Wait this long for `initialize` to complete on the first task before
+  // surfacing `app_server_unavailable`. Subsequent tasks reuse the client
+  // and skip this wait. Default 10s.
+  initializeTimeoutMs?: number;
+  // Wait this long for `turn/completed` after `turn/start`. Default 0
+  // (no client-side timeout — the server is authoritative). Set to a
+  // positive value to fail-fast against a hung agent.
+  turnTimeoutMs?: number;
+}
+
+interface SessionEntry {
+  threadId: string;
+  lastUsedAt: number;
+  writeId: number;
+}
+
+const DEFAULT_HEARTBEAT_MS = 30_000;
+const COMMAND_TRACE_MAX_CHARS = 2_000;
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+function traceabilityRequested(task: {
+  message?: { extensions?: readonly string[] };
+  requestedExtensions?: readonly string[];
+}): boolean {
+  return (
+    task.requestedExtensions?.includes(TRACEABILITY_EXTENSION_URI) === true ||
+    task.message?.extensions?.includes(TRACEABILITY_EXTENSION_URI) === true
+  );
+}
+
+function clipTo(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+// app-server `commandExecution` item summary — same shape as the codex.ts
+// helper but reading camelCase fields from the new schema rather than
+// the snake_case JSON-event shape.
+function commandExecutionSummary(item: Extract<ThreadItem, { type: 'commandExecution' }>): string {
+  const command = typeof item.command === 'string' ? item.command : '<unknown command>';
+  const status = typeof item.status === 'string' ? item.status : 'unknown';
+  const exit = typeof item.exitCode === 'number' ? item.exitCode : null;
+  const rawOutput = (item as { aggregatedOutput?: unknown }).aggregatedOutput;
+  const output = typeof rawOutput === 'string' ? rawOutput.trim() : '';
+  const head = exit === null ? `${command} (${status})` : `${command} (${status}, exit ${exit})`;
+  return clipTo(output ? `${head}\n${output}` : head, COMMAND_TRACE_MAX_CHARS);
+}
+
+interface PreparedInput {
+  input: UserInputItem[];
+  tempDir: string | null;
+  instructions: string | null;
+}
+
+// Convert mapped prompt + image files to the app-server `UserInput[]` shape.
+// Order: any tool_call_history prefix → user text → images appended.
+function buildUserInput(
+  prompt: string,
+  imageFiles: string[],
+  toolCallHistoryPrefix: string | null,
+): UserInputItem[] {
+  const items: UserInputItem[] = [];
+  const textBody = toolCallHistoryPrefix
+    ? prompt
+      ? `${toolCallHistoryPrefix}\n\n${prompt}`
+      : toolCallHistoryPrefix
+    : prompt;
+  if (textBody) {
+    items.push({ type: 'text', text: textBody, text_elements: [] });
+  }
+  for (const p of imageFiles) {
+    items.push({ type: 'localImage', path: p });
+  }
+  return items;
+}
+
+// Per-task in-progress notification subscription — listens for
+// `item/agentMessage/delta`, `item/completed`, and `turn/completed`
+// scoped to the active turn, then resolves with the final state.
+interface TurnRunOutcome {
+  status: 'completed' | 'failed' | 'interrupted' | 'aborted';
+  error?: { message: string };
+  finalText: string | null;
+}
+
+export function createCodexAppServerBackend(
+  opts: CodexAppServerBackendOptions = {},
+): Backend {
+  const command = opts.command ?? 'codex';
+  const appServerArgs = opts.appServerArgs ?? ['app-server'];
+  const cwd = opts.cwd;
+  const sandboxMode: SandboxMode = opts.sandboxMode ?? 'read-only';
+  const approvalDecision: ApprovalDecision = opts.approvalDecision ?? 'decline';
+  const spawnFn = opts.spawn ?? defaultAppServerSpawn;
+  const stderrCap = opts.stderrCaptureBytes ?? 8192;
+  const sessionTtlMs = opts.sessionTtlMs ?? 60 * 60 * 1000;
+  const now = opts.now ?? Date.now;
+  const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const setIntervalImpl =
+    opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
+  const clearIntervalImpl =
+    opts.clearIntervalFn ??
+    ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+  const mkdtemp = opts.mkdtemp ?? fs.mkdtemp;
+  const writeFile = opts.writeFile ?? fs.writeFile;
+  const rm = opts.rm ?? fs.rm;
+  const logger = opts.logger ?? createLogger();
+  const initializeTimeoutMs = opts.initializeTimeoutMs ?? 10_000;
+  const turnTimeoutMs = opts.turnTimeoutMs ?? 0;
+
+  // contextId → (threadId, lastUsedAt) — same shape as codex.ts so the
+  // resume / TTL / writeId-protected rollback logic carries straight
+  // across. The only difference is the "session" identifier (threadId
+  // here vs codex CLI thread_id) and the absence of a per-task subprocess
+  // (one app-server serves all threads).
+  const sessions = new Map<string, SessionEntry>();
+  let writeCounter = 0;
+
+  function evictExpired(cutoff: number): void {
+    for (const [key, entry] of sessions) {
+      if (entry.lastUsedAt < cutoff) sessions.delete(key);
+    }
+  }
+
+  // contextId mutex — codex app-server requires turns within a thread to
+  // be serialised (a second `turn/start` while another is active is
+  // rejected). The old `codex` backend never hit this race because each
+  // task spawned a new process. We funnel concurrent same-contextId
+  // tasks through a per-context chain.
+  const contextLocks = new Map<string, Promise<void>>();
+
+  async function acquireContextLock(contextId: string): Promise<() => void> {
+    const prev = contextLocks.get(contextId) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // Chain off the prior holder; the next holder waits on `prev` and
+    // installs `next` as the new tail. When `release()` fires the chain
+    // moves forward. The tail is only cleared if no one else queued behind
+    // us, to keep the map free of stale entries on idle contexts.
+    contextLocks.set(
+      contextId,
+      prev.then(() => next),
+    );
+    await prev;
+    return () => {
+      release();
+      // If we are still the tail, drop the entry so the map doesn't grow
+      // unbounded with idle contexts.
+      if (contextLocks.get(contextId) === next) {
+        contextLocks.delete(contextId);
+      }
+    };
+  }
+
+  let rpcClient: AppServerRpcClient | null = null;
+  let initInFlight: Promise<AppServerRpcClient> | null = null;
+  let serverInfo: InitializeResult | null = null;
+
+  // Spawn the app-server, do the handshake, register handlers. Subsequent
+  // tasks reuse the same client until it dies; a dead client is replaced
+  // on the next `ensureClient()` call.
+  async function ensureClient(): Promise<AppServerRpcClient> {
+    if (rpcClient && !rpcClient.isClosed()) return rpcClient;
+    if (initInFlight) return initInFlight;
+    initInFlight = (async () => {
+      const c = new AppServerRpcClient({
+        command,
+        args: appServerArgs,
+        cwd,
+        spawn: spawnFn,
+        logger,
+        stderrCaptureBytes: stderrCap,
+      });
+      c.setServerRequestHandler((_id, _method) => ({ decision: approvalDecision }));
+      try {
+        c.start();
+      } catch (err) {
+        initInFlight = null;
+        throw err;
+      }
+      // Clear singleton on crash so the next task respawns.
+      void c.waitForClose().then(() => {
+        if (rpcClient === c) {
+          rpcClient = null;
+          serverInfo = null;
+        }
+      });
+      try {
+        const initParams = {
+          clientInfo: {
+            name: 'vicoop-bridge',
+            title: 'vicoop-bridge client',
+            version: '1',
+          },
+        };
+        const result = await withTimeout(
+          c.request<InitializeResult>('initialize', initParams),
+          initializeTimeoutMs,
+          'initialize timed out',
+        );
+        c.notify('initialized');
+        serverInfo = result;
+        rpcClient = c;
+        return c;
+      } catch (err) {
+        try {
+          c.kill();
+        } catch {
+          // best effort
+        }
+        throw err;
+      } finally {
+        initInFlight = null;
+      }
+    })();
+    return initInFlight;
+  }
+
+  return {
+    name: 'codex-app-server',
+
+    async handle(task, rawEmit, signal) {
+      let lastEmitAt = now();
+      const recorder = createTimingRecorder({
+        logger,
+        backend: 'codex-app-server',
+        taskId: task.taskId,
+        contextId: task.contextId,
+        now,
+      });
+      const emit: typeof rawEmit = (frame) => {
+        lastEmitAt = now();
+        const terminal = frame.type === 'task.complete' || frame.type === 'task.fail';
+        if (terminal) recorder.mark('emit');
+        rawEmit(frame);
+        if (terminal) {
+          const state =
+            frame.type === 'task.fail'
+              ? 'failed'
+              : frame.status?.state ?? 'completed';
+          const code = frame.type === 'task.fail' ? frame.error?.code : undefined;
+          recorder.finish({ state, code });
+        }
+      };
+
+      if (signal.aborted) {
+        emit({
+          type: 'task.complete',
+          taskId: task.taskId,
+          status: { state: 'canceled', timestamp: new Date().toISOString() },
+        });
+        return;
+      }
+
+      // Funnel concurrent same-contextId tasks. The existing `codex`
+      // backend dodged this race by spawning per-task; app-server serialises
+      // turns per thread, so we enforce that here rather than letting the
+      // server reject the second `turn/start`.
+      const releaseLock = await acquireContextLock(task.contextId);
+      try {
+        if (signal.aborted) {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+
+        // Detect the openai-compat extension once. The system-prompt text
+        // feeds `developerInstructions` on the next thread/start; the
+        // tool_call_history is replayed as a user-prompt prefix (same
+        // contract the `codex` backend enforces).
+        const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+        const systemPrompt =
+          openaiCompat ? buildOpenAICompatSystemPrompt(openaiCompat) : '';
+        const toolCallHistoryPrefix = openaiCompat?.tool_call_history
+          ? formatToolCallHistory(openaiCompat.tool_call_history)
+          : null;
+
+        const mapped = await mapPartsToCodexInput(task.message.parts, {
+          mkdtemp,
+          writeFile,
+          rm,
+        });
+        recorder.mark('map');
+        if (!mapped.ok) {
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: { code: mapped.code, message: mapped.message },
+          });
+          return;
+        }
+
+        try {
+          const userInput = buildUserInput(
+            mapped.prompt,
+            mapped.imageFiles,
+            toolCallHistoryPrefix,
+          );
+
+          let client: AppServerRpcClient;
+          try {
+            client = await ensureClient();
+            recorder.mark('initialized');
+          } catch (err) {
+            emit({
+              type: 'task.fail',
+              taskId: task.taskId,
+              error: {
+                code: 'app_server_unavailable',
+                message: `codex app-server failed to start: ${errorMessage(err)}`,
+              },
+            });
+            return;
+          }
+
+          // Session-reuse map: same writeId-protected pattern as codex.ts
+          // so a concurrent task on the same contextId doesn't get its
+          // session entry rolled back from under it.
+          const tNow = now();
+          if (sessionTtlMs > 0) evictExpired(tNow - sessionTtlMs);
+          const existing = sessionTtlMs > 0 ? sessions.get(task.contextId) : undefined;
+          let writeId = 0;
+          if (sessionTtlMs > 0) {
+            writeId = ++writeCounter;
+            if (existing) {
+              sessions.set(task.contextId, {
+                threadId: existing.threadId,
+                lastUsedAt: tNow,
+                writeId,
+              });
+            }
+          }
+          const isResume = existing !== undefined;
+          let observedThreadId: string | null = null;
+
+          const rollbackResumeRefresh = (): void => {
+            if (!isResume || sessionTtlMs <= 0) return;
+            const cur = sessions.get(task.contextId);
+            if (cur?.threadId === existing.threadId && cur.writeId === writeId) {
+              sessions.set(task.contextId, {
+                threadId: existing.threadId,
+                lastUsedAt: existing.lastUsedAt,
+                writeId: ++writeCounter,
+              });
+            }
+          };
+          const rollbackFreshThread = (): void => {
+            if (isResume || sessionTtlMs <= 0 || !observedThreadId) return;
+            const cur = sessions.get(task.contextId);
+            if (cur?.threadId === observedThreadId && cur.writeId === writeId) {
+              sessions.delete(task.contextId);
+            }
+          };
+
+          emit({
+            type: 'task.status',
+            taskId: task.taskId,
+            status: { state: 'working', timestamp: new Date().toISOString() },
+          });
+
+          // For resumes we only re-attach to the existing thread without
+          // overriding config — initial `thread/start` already set sandbox
+          // and developerInstructions. Fresh threads pass both.
+          let threadId: string;
+          try {
+            if (isResume) {
+              const resumeResult = await client.request<{ thread: { id: string } }>(
+                'thread/resume',
+                {
+                  threadId: existing.threadId,
+                  cwd,
+                  sandbox: sandboxMode,
+                },
+              );
+              threadId = resumeResult.thread.id;
+            } else {
+              const startResult = await client.request<{ thread: { id: string } }>(
+                'thread/start',
+                {
+                  cwd,
+                  sandbox: sandboxMode,
+                  ...(systemPrompt ? { developerInstructions: systemPrompt } : {}),
+                },
+              );
+              threadId = startResult.thread.id;
+              observedThreadId = threadId;
+              if (sessionTtlMs > 0) {
+                sessions.set(task.contextId, {
+                  threadId,
+                  lastUsedAt: now(),
+                  writeId,
+                });
+              }
+            }
+            recorder.mark('threadReady');
+          } catch (err) {
+            rollbackResumeRefresh();
+            // Transport closed mid-handshake: report as crash so operator
+            // sees the same code as a startup-time failure; the next task
+            // will re-spawn the client.
+            if (err instanceof Error && err.message.startsWith(TRANSPORT_CLOSED)) {
+              emit({
+                type: 'task.fail',
+                taskId: task.taskId,
+                error: {
+                  code: 'app_server_crashed',
+                  message: `codex app-server transport closed during ${isResume ? 'thread/resume' : 'thread/start'}: ${err.message}`,
+                },
+              });
+              return;
+            }
+            emit({
+              type: 'task.fail',
+              taskId: task.taskId,
+              error: {
+                code: isResume ? 'thread_resume_failed' : 'thread_start_failed',
+                message: errorMessage(err),
+              },
+            });
+            return;
+          }
+
+          // Subscribe to notifications scoped to our turn. The turnId is
+          // not known until `turn/start` returns; we capture it then
+          // filter incoming notifications by it. Prior to capture we
+          // ignore turn-level events (no turn of ours is yet on the wire).
+          let activeTurnId: string | null = null;
+          let finalText: string | null = null;
+          let emittedAnyArtifact = false;
+          const emitTraceArtifacts = traceabilityRequested(task);
+
+          const emitAgentArtifact = (text: string): void => {
+            if (!text) return;
+            // openai-compat envelope detection — same contract the codex
+            // backend uses, so callers see identical `data` parts.
+            if (openaiCompat) {
+              const envelope = tryParseToolCallsEnvelope(text);
+              if (envelope) {
+                emit({
+                  type: 'task.artifact',
+                  taskId: task.taskId,
+                  artifact: {
+                    artifactId: randomUUID(),
+                    name: 'codex-message',
+                    parts: [{ kind: 'data', data: envelope }],
+                    extensions: [OPENAI_COMPAT_EXTENSION_URI],
+                  },
+                  lastChunk: true,
+                });
+                emittedAnyArtifact = true;
+                return;
+              }
+            }
+            emit({
+              type: 'task.artifact',
+              taskId: task.taskId,
+              artifact: {
+                artifactId: randomUUID(),
+                name: 'codex-message',
+                parts: [{ kind: 'text', text }],
+              },
+              lastChunk: true,
+            });
+            emittedAnyArtifact = true;
+          };
+
+          const emitCommandTrace = (
+            item: Extract<ThreadItem, { type: 'commandExecution' }>,
+          ): void => {
+            if (!emitTraceArtifacts) return;
+            emit({
+              type: 'task.artifact',
+              taskId: task.taskId,
+              artifact: {
+                artifactId: randomUUID(),
+                name: 'codex-command-execution',
+                parts: [
+                  { kind: 'text', text: commandExecutionSummary(item) },
+                  {
+                    kind: 'data',
+                    data: {
+                      command: typeof item.command === 'string' ? item.command : undefined,
+                      status: typeof item.status === 'string' ? item.status : undefined,
+                      exitCode: typeof item.exitCode === 'number' ? item.exitCode : undefined,
+                    },
+                  },
+                ],
+                extensions: [TRACEABILITY_EXTENSION_URI],
+                metadata: { traceType: 'command-execution' },
+              },
+              lastChunk: true,
+            });
+            emittedAnyArtifact = true;
+          };
+
+          // Drive the turn to completion. The notification subscription
+          // captures the agent's final message text and command-execution
+          // traces; the loop resolves on `turn/completed` or `turn/failed`.
+          const outcome: TurnRunOutcome = await new Promise((resolve) => {
+            let settled = false;
+            const finish = (o: TurnRunOutcome): void => {
+              if (settled) return;
+              settled = true;
+              cleanupNotifications();
+              if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
+              signal.removeEventListener('abort', onAbort);
+              resolve(o);
+            };
+
+            const cleanupNotifications = client.onNotification((method, params) => {
+              if (method === 'item/completed') {
+                const p = params as { item?: ThreadItem; turnId?: string } | undefined;
+                if (activeTurnId && p?.turnId !== activeTurnId) return;
+                const item = p?.item;
+                if (!item) return;
+                if (item.type === 'agentMessage' && typeof item.text === 'string') {
+                  recorder.mark('firstFinal');
+                  finalText = item.text;
+                  emitAgentArtifact(item.text);
+                  return;
+                }
+                if (item.type === 'commandExecution') {
+                  emitCommandTrace(item as Extract<ThreadItem, { type: 'commandExecution' }>);
+                }
+                return;
+              }
+              if (method === 'item/agentMessage/delta') {
+                const p = params as { turnId?: string } | undefined;
+                if (activeTurnId && p?.turnId !== activeTurnId) return;
+                recorder.mark('firstDelta');
+                return;
+              }
+              if (method === 'turn/completed') {
+                const p = params as
+                  | {
+                      turn?: { id?: string; status?: string; error?: { message?: string } | null };
+                    }
+                  | undefined;
+                const t = p?.turn;
+                if (activeTurnId && t?.id !== activeTurnId) return;
+                if (t?.status === 'completed') {
+                  finish({ status: 'completed', finalText });
+                } else if (t?.status === 'interrupted') {
+                  finish({ status: 'interrupted', finalText });
+                } else {
+                  finish({
+                    status: 'failed',
+                    error: { message: t?.error?.message ?? `turn ended with status ${t?.status ?? 'unknown'}` },
+                    finalText,
+                  });
+                }
+              }
+            });
+
+            const onAbort = (): void => {
+              // Best-effort `turn/interrupt`; the resolution will land on
+              // turn/completed status:'interrupted'. If the rpc client is
+              // dead we still resolve as aborted.
+              if (activeTurnId) {
+                client.request('turn/interrupt', { threadId, turnId: activeTurnId }).catch(() => {});
+              }
+              // Don't `finish` immediately — wait for the server's terminal
+              // event to land so we don't race with a `turn/completed`
+              // arriving during the round-trip.
+              setTimeoutCheckAbort();
+            };
+            // If turn/completed never arrives after abort (e.g. server
+            // ignored interrupt because turn was already settling),
+            // we still resolve to canceled after a short grace period.
+            let abortGracePending = false;
+            const setTimeoutCheckAbort = (): void => {
+              if (abortGracePending) return;
+              abortGracePending = true;
+              setTimeout(() => {
+                if (!settled) {
+                  finish({ status: 'aborted', finalText });
+                }
+              }, 2_000);
+            };
+            signal.addEventListener('abort', onAbort);
+
+            // Idle-silence heartbeat — same shape as codex.ts.
+            let heartbeatHandle: unknown = null;
+            if (heartbeatMs > 0) {
+              heartbeatHandle = setIntervalImpl(() => {
+                if (settled) return;
+                if (now() - lastEmitAt < heartbeatMs) return;
+                emit({
+                  type: 'task.status',
+                  taskId: task.taskId,
+                  status: { state: 'working', timestamp: new Date().toISOString() },
+                });
+              }, heartbeatMs);
+            }
+
+            // Wire client-side timeout if configured. The default 0 means
+            // wait for the server.
+            if (turnTimeoutMs > 0) {
+              setTimeout(() => {
+                if (!settled) {
+                  finish({
+                    status: 'failed',
+                    error: { message: `turn timed out after ${turnTimeoutMs}ms` },
+                    finalText,
+                  });
+                }
+              }, turnTimeoutMs);
+            }
+
+            // Detect a transport closure mid-turn — the rpc client rejects
+            // pending requests on close, but our turn-result loop is
+            // notification-driven. Race the close future against the rest.
+            void client.waitForClose().then(() => {
+              if (!settled) {
+                finish({
+                  status: 'failed',
+                  error: { message: 'codex app-server transport closed during turn' },
+                  finalText,
+                });
+              }
+            });
+
+            // Fire turn/start. The response carries our turnId so we can
+            // filter notifications.
+            client
+              .request<{ turn: { id: string } }>('turn/start', {
+                threadId,
+                input: userInput,
+              })
+              .then(
+                (res) => {
+                  activeTurnId = res.turn.id;
+                  recorder.mark('turnStarted');
+                },
+                (err) => {
+                  finish({
+                    status: 'failed',
+                    error: { message: `turn/start failed: ${errorMessage(err)}` },
+                    finalText,
+                  });
+                },
+              );
+          });
+
+          // Map turn outcome to A2A lifecycle.
+          if (outcome.status === 'interrupted' || outcome.status === 'aborted') {
+            rollbackFreshThread();
+            rollbackResumeRefresh();
+            emit({
+              type: 'task.complete',
+              taskId: task.taskId,
+              status: { state: 'canceled', timestamp: new Date().toISOString() },
+            });
+            return;
+          }
+
+          if (outcome.status === 'failed') {
+            rollbackFreshThread();
+            rollbackResumeRefresh();
+            emit({
+              type: 'task.fail',
+              taskId: task.taskId,
+              error: {
+                code: 'turn_failed',
+                message: outcome.error?.message ?? 'turn failed',
+              },
+            });
+            return;
+          }
+
+          // Refresh the resumed binding on success so TTL extends.
+          if (isResume && sessionTtlMs > 0) {
+            const cur = sessions.get(task.contextId);
+            if (cur?.threadId === existing.threadId && cur.writeId === writeId) {
+              sessions.set(task.contextId, {
+                threadId: existing.threadId,
+                lastUsedAt: now(),
+                writeId,
+              });
+            }
+          }
+
+          const completeText = outcome.finalText ?? '';
+          const parts: Part[] = completeText
+            ? [{ kind: 'text', text: completeText }]
+            : [];
+          if (!emittedAnyArtifact && completeText) {
+            emit({
+              type: 'task.artifact',
+              taskId: task.taskId,
+              artifact: {
+                artifactId: randomUUID(),
+                name: 'codex-result',
+                parts,
+              },
+              lastChunk: true,
+            });
+          }
+
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: {
+              state: 'completed',
+              timestamp: new Date().toISOString(),
+              ...(parts.length
+                ? {
+                    message: {
+                      role: 'agent',
+                      messageId: randomUUID(),
+                      parts,
+                    },
+                  }
+                : {}),
+            },
+          });
+        } finally {
+          if (mapped.tempDir) {
+            try {
+              await rm(mapped.tempDir, { recursive: true, force: true });
+            } catch {
+              // best-effort cleanup
+            }
+          }
+        }
+      } finally {
+        releaseLock();
+      }
+    },
+  };
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  if (ms <= 0) return p;
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(label)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (err) => {
+        clearTimeout(t);
+        reject(err);
+      },
+    );
+  });
+}

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -87,7 +87,11 @@ interface CodexEvent {
   };
 }
 
-type MappedInput =
+// Shared with the `codex-app-server` backend: the input-mapping result
+// shape is identical (prompt text + materialised image temp paths +
+// tempDir for finally-cleanup); only the downstream wire framing differs
+// (argv `--image` vs. `UserInput {type:"localImage", path}`).
+export type MappedInput =
   | { ok: true; prompt: string; imageFiles: string[]; tempDir: string | null }
   | { ok: false; code: string; message: string };
 
@@ -162,7 +166,7 @@ function commandSummary(item: NonNullable<CodexEvent['item']>): string {
   return clipTo(output ? `${head}\n${output}` : head, COMMAND_TRACE_MAX_CHARS);
 }
 
-async function mapPartsToCodexInput(
+export async function mapPartsToCodexInput(
   parts: readonly Part[],
   io: {
     mkdtemp: (prefix: string) => Promise<string>;

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -6,6 +6,11 @@ import { echoBackend } from './backends/echo.js';
 import { createOpenclawBackend } from './backends/openclaw.js';
 import { createClaudeBackend } from './backends/claude.js';
 import { createCodexBackend, type CodexSandboxMode } from './backends/codex.js';
+import {
+  createCodexAppServerBackend,
+  type ApprovalDecision,
+  type CodexAppServerSandboxMode,
+} from './backends/codex-app-server.js';
 import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
@@ -231,8 +236,31 @@ function pickBackend(name: string, args: Args): Backend {
           ),
         extraArgs: backends.codex?.extra_args,
       });
+    case 'codex-app-server': {
+      const cas = backends['codex-app-server'];
+      // Reuses the `codex` sandbox-mode parser since the enum is identical
+      // (the SandboxMode type re-exported from codex-app-server.ts is the
+      // same string union). Env-var precedence mirrors the `codex` case
+      // so operators can share a single `CODEX_SANDBOX_MODE` / `CODEX_CWD`
+      // across both backends and swap by changing only `--backend`.
+      return createCodexAppServerBackend({
+        cwd:
+          process.env.CODEX_CWD?.trim() ||
+          cas?.cwd ||
+          undefined,
+        sandboxMode:
+          (parseCodexSandboxMode(process.env.CODEX_SANDBOX_MODE) as CodexAppServerSandboxMode | undefined) ??
+          (parseCodexSandboxMode(
+            cas?.sandbox_mode,
+            'backends.codex-app-server.sandbox_mode (config.json)',
+          ) as CodexAppServerSandboxMode | undefined),
+        approvalDecision: cas?.approval_decision as ApprovalDecision | undefined,
+      });
+    }
     default:
-      throw new Error(`unknown backend: ${name} (supported: echo, openclaw, claude, codex)`);
+      throw new Error(
+        `unknown backend: ${name} (supported: echo, openclaw, claude, codex, codex-app-server)`,
+      );
   }
 }
 

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -374,6 +374,60 @@ test('normalizeConfig drops unknown backend and unknown codex.sandbox_mode', (t)
   });
 });
 
+test('normalizeConfig accepts backends.codex-app-server with sandbox_mode and approval_decision', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-cas-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      server_url: 'wss://b',
+      backend: 'codex-app-server',
+      backends: {
+        'codex-app-server': {
+          cwd: '/srv',
+          sandbox_mode: 'workspace-write',
+          approval_decision: 'acceptForSession',
+        },
+      },
+    }),
+  );
+  assert.deepEqual(readConfig(path), {
+    server_url: 'wss://b',
+    backend: 'codex-app-server',
+    backends: {
+      'codex-app-server': {
+        cwd: '/srv',
+        sandbox_mode: 'workspace-write',
+        approval_decision: 'acceptForSession',
+      },
+    },
+  });
+});
+
+test('normalizeConfig drops invalid codex-app-server approval_decision and sandbox_mode', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-cas-bad-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      backends: {
+        'codex-app-server': {
+          cwd: '/work',
+          sandbox_mode: 'workspace_write', // typo — dropped
+          approval_decision: 'yes', // not in enum — dropped
+        },
+      },
+    }),
+  );
+  assert.deepEqual(readConfig(path), {
+    backends: {
+      'codex-app-server': { cwd: '/work' },
+    },
+  });
+});
+
 test('readConfig drops malformed fields and keeps the rest', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-bad-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -117,6 +117,18 @@ export interface CodexBackendConfig {
   extra_args?: string[];
 }
 
+// Operator-side defaults for the `codex-app-server` backend. The wire
+// surface intentionally avoids `extra_args` — the JSON-RPC client does not
+// take CLI flags the way `codex exec` does, and any future override goes
+// through the protocol's `developerInstructions` / per-turn config knobs
+// instead.
+export interface CodexAppServerBackendConfig {
+  cwd?: string;
+  sandbox_mode?: string;
+  /** What to answer when codex requests user approval. Default `decline`. */
+  approval_decision?: 'accept' | 'acceptForSession' | 'decline';
+}
+
 export interface OpenclawBackendConfig {
   gateway_url?: string;
   gateway_token?: string;
@@ -135,6 +147,7 @@ export interface OpenclawBackendConfig {
 export interface BackendConfigs {
   claude?: ClaudeBackendConfig;
   codex?: CodexBackendConfig;
+  'codex-app-server'?: CodexAppServerBackendConfig;
   openclaw?: OpenclawBackendConfig;
 }
 
@@ -175,7 +188,18 @@ function asRecord(v: unknown): Record<string, unknown> | undefined {
 // reach a downstream parser that does `process.exit(1)`. Anything outside
 // these sets is treated like any other malformed field — dropped, the rest
 // of the file kept usable.
-const KNOWN_BACKENDS = new Set(['echo', 'openclaw', 'claude', 'codex']);
+const KNOWN_BACKENDS = new Set([
+  'echo',
+  'openclaw',
+  'claude',
+  'codex',
+  'codex-app-server',
+]);
+const KNOWN_APPROVAL_DECISIONS = new Set([
+  'accept',
+  'acceptForSession',
+  'decline',
+]);
 const KNOWN_CODEX_SANDBOX_MODES = new Set([
   'read-only',
   'workspace-write',
@@ -236,6 +260,24 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
         if (cwd) out.codex.cwd = cwd;
         if (validSandbox) out.codex.sandbox_mode = validSandbox;
         if (extraArgs && extraArgs.length > 0) out.codex.extra_args = extraArgs;
+      }
+    }
+    const casRaw = asRecord(backends['codex-app-server']);
+    if (casRaw) {
+      const cwd = asString(casRaw.cwd);
+      const sandbox = asString(casRaw.sandbox_mode);
+      const validSandbox =
+        sandbox && KNOWN_CODEX_SANDBOX_MODES.has(sandbox) ? sandbox : undefined;
+      const approvalRaw = asString(casRaw.approval_decision);
+      const validApproval =
+        approvalRaw && KNOWN_APPROVAL_DECISIONS.has(approvalRaw)
+          ? (approvalRaw as 'accept' | 'acceptForSession' | 'decline')
+          : undefined;
+      if (cwd || validSandbox || validApproval) {
+        out['codex-app-server'] = {};
+        if (cwd) out['codex-app-server']!.cwd = cwd;
+        if (validSandbox) out['codex-app-server']!.sandbox_mode = validSandbox;
+        if (validApproval) out['codex-app-server']!.approval_decision = validApproval;
       }
     }
     const ocRaw = asRecord(backends.openclaw);

--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -35,6 +35,24 @@ test('resolves canonical codex server card from backendKind', () => {
   assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
 });
 
+test('resolves canonical codex-app-server card from backendKind', () => {
+  // The new backend shares the codex capability surface (one Codex agent
+  // either way; only the transport differs), so the canonical card mirrors
+  // the codex one for input/output modes — callers fetching the
+  // well-known agent-card.json shouldn't see a different contract just
+  // because the operator opted into the persistent-process backend.
+  const result = resolveHelloAgentCard(frame({ backendKind: 'codex-app-server' }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.source, 'canonical');
+  assert.equal(result.ok && result.agentCard.name, 'codex-app-server');
+  assert.deepEqual(
+    result.ok && result.agentCard.defaultInputModes,
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/json'],
+  );
+  assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
+});
+
 test('inline card overrides backendKind', () => {
   const inline = {
     name: 'operator-custom',
@@ -89,7 +107,7 @@ test('rejects unknown backendKind when no inline card is provided', () => {
 // decide whether to send the openai-compat metadata payload will assume
 // the bridge can't honor it and silently fall back to text injection or
 // refuse the call. So pin it here.
-for (const kind of ['claude', 'codex', 'openclaw'] as const) {
+for (const kind of ['claude', 'codex', 'codex-app-server', 'openclaw'] as const) {
   test(`canonical ${kind} card advertises the openai-compat extension URI`, () => {
     const result = resolveHelloAgentCard(frame({ backendKind: kind }));
     assert.equal(result.ok, true);

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -14,6 +14,7 @@ const canonicalCards = new Map<string, AgentCardType>(
   Object.entries({
     claude: readCanonicalCard('claude'),
     codex: readCanonicalCard('codex'),
+    'codex-app-server': readCanonicalCard('codex-app-server'),
     echo: readCanonicalCard('echo'),
     openclaw: readCanonicalCard('openclaw'),
   }),

--- a/packages/server/src/cards/codex-app-server.json
+++ b/packages/server/src/cards/codex-app-server.json
@@ -1,0 +1,40 @@
+{
+  "name": "codex-app-server",
+  "description": "OpenAI Codex agent driven via `codex app-server` (persistent stdio JSON-RPC). One long-lived codex process serves all turns; drop-in capability surface for the `codex` backend. Accepts text, inline image, and JSON data part inputs.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Codex command executions.",
+        "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the Codex agent responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks.",
+      "tags": ["chat", "assistant", "codex"]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #169.

## Summary

New backend `codex-app-server` that drives a single `codex app-server` subprocess for the lifetime of the client and routes every task through JSON-RPC over stdio:

- `initialize` once per client lifetime (paid on first task only)
- `thread/start` (fresh contextId) or `thread/resume` (known contextId) per task
- `turn/start` with the user input, notifications streamed back as A2A artifacts

**Drop-in replacement** for the existing `codex` backend — openai-compat extension, `tool_call_history` replay, image FileParts (via `localImage` UserInput), traceability artifacts, sandbox modes all carry over with the same semantics. Opt in via `--backend codex-app-server`, `BACKEND=codex-app-server`, or `config.backend = "codex-app-server"`. The existing `codex` backend is unchanged so rollback is one flag away.

This PR includes the matching **server-side canonical agent card** so clients opting in without `--card` aren't rejected with `4013 unknown backend kind`.

## Measured impact

Same prompt (`Reply with exactly the word: OK`), same contextId, two turns, on the new backend driven against real `codex` 0.130:

```
[client] timing backend=codex-app-server turn=1 initializedMs=167 threadReadyMs=1149 turnStartedMs=1150 firstFinalMs=9100 totalMs=9108 state=completed
[client] timing backend=codex-app-server turn=2 initializedMs=0   threadReadyMs=4    turnStartedMs=5    firstFinalMs=1566 totalMs=1594 state=completed
```

| Turn | `codex` (current) | `codex-app-server` (new) | Δ |
|---|---:|---:|---:|
| 1 (fresh thread) | ~10 s | ~9.1 s | −1 s |
| **2 (same contextId)** | **~10 s** | **~1.6 s** | **−8.4 s** |

The win is on follow-up turns — the current backend pays `codex exec resume` startup on every turn; the new one keeps the agent warm in a single process. See #169 for the full measurement set and design notes.

## Implementation

### Client

- `backends/codex-app-server-rpc.ts` (~310 lines) — JSON-RPC stdio client. `request` / `notify` / `onNotification` / `setServerRequestHandler`, readline dispatch, id matching, `waitForClose()` for crash detection. Narrow typed views of `InitializeParams`, `ThreadStartParams`, `TurnStartParams`, `UserInputItem`, `ThreadItem` (subset) — we deliberately **don't** import the 81-file `codex app-server generate-ts` output so unrelated v2 schema drift can't break our build.

- `backends/codex-app-server.ts` (~520 lines) — `createCodexAppServerBackend`. Lazy spawn + initialize singleton; `contextId → threadId` map with TTL eviction (same pattern as `codex.ts`, writeId-protected rollback); per-`contextId` mutex (codex serialises turns within a thread, so a second concurrent task on the same context queues rather than racing the server); abort → `turn/interrupt`; transport-crash recovery (next task respawns + resume); idle-silence heartbeat parity with codex/claude; reuses `mapPartsToCodexInput` from `codex.ts` so input-staging (temp dir, image write, mime/size guards) is identical.

- `backends/codex-app-server.test.ts` (~700 lines) — 15 spawn-mock scenarios covering: initialize/thread/turn happy path, follow-up turn → resume, multi-context (one process, multiple threads), abort → turn/interrupt, approval auto-decline, spawn failure → `app_server_unavailable`, transport crash mid-turn, traceability artifacts, image FilePart → localImage, tool_call_history prefix, openai-compat envelope → data part, TTL expiry, same-contextId mutex serialisation, malformed stdout line tolerance, `turn/start` RPC error.

- `cli.ts` / `config.ts` — `case 'codex-app-server'` in `pickBackend` mirroring the `codex` case; `backends['codex-app-server']` zod schema in normalize step accepting `cwd`, `sandbox_mode`, `approval_decision`.

- `codex.ts` — exports `mapPartsToCodexInput` and `MappedInput` so the new backend reuses the exact input-mapping behaviour rather than reimplementing it.

### Server

- `cards/codex-app-server.json` — canonical agent card mirroring the existing `codex` card's capability surface (same Codex agent, only the transport differs). Input/output modes, openai-compat URI, and traceability URI all carry over.
- `card-resolver.ts` — `'codex-app-server'` registered in the canonical card map.
- `card-resolver.test.ts` — canonical card resolution test for the new backend, plus inclusion in the openai-compat-URI pin loop.

Inline cards (`--card <path>`) still take priority — the server-side change only unblocks operators relying on canonical lookup.

## Approval policy

Server-initiated `execCommandApproval` / `applyPatchApproval` **auto-decline by default** (safe under any sandbox). Operators that explicitly run `workspace-write` or `danger-full-access` can opt into `accept` / `acceptForSession` via:

```json
{
  "backends": {
    "codex-app-server": {
      "sandbox_mode": "workspace-write",
      "approval_decision": "acceptForSession"
    }
  }
}
```

## Risks & guards

- **codex CLI version drift**: we model only the small subset of methods we use (`initialize`, `thread/start`, `thread/resume`, `turn/start`, `turn/interrupt`) with narrow inline interfaces, so additions to unrelated v2 methods don't affect us. The `initialize` response is logged; field renames on the methods we DO use would surface as test failures.
- **Process crash mid-turn**: handled — pending RPC requests are rejected with `transport_closed`, the singleton is reset, and the next task respawns + resumes the prior thread via the persisted `threadId`.
- **Same-contextId race**: handled by a per-contextId mutex (`acquireContextLock`). Tested under `two concurrent tasks on the same contextId run sequentially through the mutex`.
- **No upstream npm package**: types are local inline.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/server typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 404/404 pass (387 prior + 15 new backend + 2 new config)
- [x] `pnpm --filter @vicoop-bridge/server test` — 181/181 pass (179 prior + 2 new card-resolver)
- [x] End-to-end with real `codex` 0.130: two-turn run, second turn ~1.6 s (was ~10 s on the old backend)
- [x] Staging agent on the production server: spawned the new backend behind `acct:codex-as-test@vicoop-bridge-server.fly.dev` and confirmed lifecycle + timing log shape against live traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)