### PR TITLE
feat(server): canonical agent card for codex-app-server backend

### DIFF
--- a/packages/server/src/card-resolver.test.ts
+++ b/packages/server/src/card-resolver.test.ts
@@ -35,6 +35,24 @@ test('resolves canonical codex server card from backendKind', () => {
   assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
 });
 
+test('resolves canonical codex-app-server card from backendKind', () => {
+  // The new backend shares the codex capability surface (one Codex agent
+  // either way; only the transport differs), so the canonical card mirrors
+  // the codex one for input/output modes — callers fetching the
+  // well-known agent-card.json shouldn't see a different contract just
+  // because the operator opted into the persistent-process backend.
+  const result = resolveHelloAgentCard(frame({ backendKind: 'codex-app-server' }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok && result.source, 'canonical');
+  assert.equal(result.ok && result.agentCard.name, 'codex-app-server');
+  assert.deepEqual(
+    result.ok && result.agentCard.defaultInputModes,
+    ['text/plain', 'image/png', 'image/jpeg', 'image/gif', 'image/webp', 'application/json'],
+  );
+  assert.deepEqual(result.ok && result.agentCard.defaultOutputModes, ['text/plain']);
+});
+
 test('inline card overrides backendKind', () => {
   const inline = {
     name: 'operator-custom',
@@ -89,7 +107,7 @@ test('rejects unknown backendKind when no inline card is provided', () => {
 // decide whether to send the openai-compat metadata payload will assume
 // the bridge can't honor it and silently fall back to text injection or
 // refuse the call. So pin it here.
-for (const kind of ['claude', 'codex', 'openclaw'] as const) {
+for (const kind of ['claude', 'codex', 'codex-app-server', 'openclaw'] as const) {
   test(`canonical ${kind} card advertises the openai-compat extension URI`, () => {
     const result = resolveHelloAgentCard(frame({ backendKind: kind }));
     assert.equal(result.ok, true);

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -14,6 +14,7 @@ const canonicalCards = new Map<string, AgentCardType>(
   Object.entries({
     claude: readCanonicalCard('claude'),
     codex: readCanonicalCard('codex'),
+    'codex-app-server': readCanonicalCard('codex-app-server'),
     echo: readCanonicalCard('echo'),
     openclaw: readCanonicalCard('openclaw'),
   }),

--- a/packages/server/src/cards/codex-app-server.json
+++ b/packages/server/src/cards/codex-app-server.json
@@ -1,0 +1,40 @@
+{
+  "name": "codex-app-server",
+  "description": "OpenAI Codex agent driven via `codex app-server` (persistent stdio JSON-RPC). One long-lived codex process serves all turns; drop-in capability surface for the `codex` backend. Accepts text, inline image, and JSON data part inputs.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": true,
+    "extensions": [
+      {
+        "uri": "https://github.com/a2aproject/a2a-samples/extensions/traceability/v1",
+        "description": "Opt-in execution trace stream for Codex command executions.",
+        "required": false
+      },
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the Codex agent responds with text. Include image (image/{png,jpeg,gif,webp}) parts as inline `file.bytes`. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks.",
+      "tags": ["chat", "assistant", "codex"]
+    }
+  ]
+}


### PR DESCRIPTION
Companion to #172. Adds the `codex-app-server` entry to the canonical card map (`card-resolver.ts`) and a `cards/codex-app-server.json` mirroring the existing `codex` card's capability surface (input/output modes, openai-compat URI, traceability URI).

## Why

Clients that opt into the new backend (#172) **without** supplying an inline `--card` override would otherwise hit `4013 unknown backend kind` at hello. Operators using inline cards today are unaffected.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/server typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/server test` — 181/181 pass (179 prior + 2 new)
- New tests: canonical card resolution for `codex-app-server`, and pinning of the openai-compat URI on it (consistent with the existing pin loop for claude/codex/openclaw).

## Notes

- Independent of #172 — can merge in either order.
- Inline cards keep priority; the inline path doesn't reach this map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)