### PR TITLE
ci: add client workflow and run server tests on PR

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -1,21 +1,19 @@
-name: Server CI
+name: Client CI
 
 on:
   pull_request:
     paths:
-      - '.github/workflows/server-ci.yml'
-      - 'packages/server/**'
+      - '.github/workflows/client-ci.yml'
+      - 'packages/client/**'
       - 'packages/protocol/**'
-      - 'packages/admin-ui/**'
       - 'pnpm-lock.yaml'
       - 'package.json'
   push:
     branches: [main]
     paths:
-      - '.github/workflows/server-ci.yml'
-      - 'packages/server/**'
+      - '.github/workflows/client-ci.yml'
+      - 'packages/client/**'
       - 'packages/protocol/**'
-      - 'packages/admin-ui/**'
       - 'pnpm-lock.yaml'
       - 'package.json'
 
@@ -44,15 +42,11 @@ jobs:
       - name: Build protocol
         run: pnpm --filter @vicoop-bridge/protocol build
 
-      - name: Typecheck server
-        run: pnpm --filter @vicoop-bridge/server typecheck
+      - name: Typecheck client
+        run: pnpm --filter @vicoop-bridge/client typecheck
 
-      - name: Test server
-        run: pnpm --filter @vicoop-bridge/server test
+      - name: Test client
+        run: pnpm --filter @vicoop-bridge/client test
 
-      - name: Build server
-        run: pnpm --filter @vicoop-bridge/server build
-
-      - name: Smoke test A2X SDK import
-        working-directory: packages/server
-        run: node --input-type=module -e "await import('@a2x/sdk'); console.log('a2x-sdk-import-ok')"
+      - name: Build client
+        run: pnpm --filter @vicoop-bridge/client build

--- a/packages/client/src/login.test.ts
+++ b/packages/client/src/login.test.ts
@@ -27,11 +27,25 @@ test('login saves owner-session bearer without registering a client', async (t) 
   const calls: Array<{ url: string; body: string }> = [];
   t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
 
+  // Pin `resolveConfigDir()` to `${tmpHome}/.vicoop` regardless of host env
+  // by setting `VICOOP_HOME` directly (its precedence is "explicit override
+  // wins"). Without this, a CI runner with `XDG_CONFIG_HOME` already exported
+  // would route the owner-session write to `$XDG_CONFIG_HOME/vicoop/...`
+  // instead of `${tmpHome}/.vicoop/...`, and the later `readFileSync`
+  // assertion would `ENOENT`. Restore every touched env on teardown.
   const previousHome = process.env.HOME;
+  const previousVicoop = process.env.VICOOP_HOME;
+  const previousXdg = process.env.XDG_CONFIG_HOME;
   process.env.HOME = tmpHome;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  delete process.env.XDG_CONFIG_HOME;
   t.after(() => {
     if (previousHome === undefined) delete process.env.HOME;
     else process.env.HOME = previousHome;
+    if (previousVicoop === undefined) delete process.env.VICOOP_HOME;
+    else process.env.VICOOP_HOME = previousVicoop;
+    if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousXdg;
   });
 
   const originalFetch = globalThis.fetch;

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -305,15 +305,30 @@ test('setup prompts for login when no owner-session is available', async (t) => 
   const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-setup-no-auth-'));
   t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
 
+  // Pin `resolveConfigDir()` to a known empty tmpdir via VICOOP_HOME so the
+  // "no owner-session on disk" path is exercised even on CI hosts that have
+  // an exported `XDG_CONFIG_HOME` (Linux runners). Without this, the resolver
+  // would route loadOwnerSession() at a populated XDG dir and skip the
+  // login-prompt branch we're asserting on; the test would then fall through
+  // to a real device-flow `fetch`, fail the network call, and surface
+  // "fetch failed" on stderr instead of the prompt.
   const previousHome = process.env.HOME;
+  const previousVicoop = process.env.VICOOP_HOME;
+  const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousToken = process.env.VICOOP_OWNER_TOKEN;
   const previousBridge = process.env.VICOOP_BRIDGE;
   process.env.HOME = tmpHome;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  delete process.env.XDG_CONFIG_HOME;
   delete process.env.VICOOP_OWNER_TOKEN;
   delete process.env.VICOOP_BRIDGE;
   t.after(() => {
     if (previousHome === undefined) delete process.env.HOME;
     else process.env.HOME = previousHome;
+    if (previousVicoop === undefined) delete process.env.VICOOP_HOME;
+    else process.env.VICOOP_HOME = previousVicoop;
+    if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = previousXdg;
     if (previousToken === undefined) delete process.env.VICOOP_OWNER_TOKEN;
     else process.env.VICOOP_OWNER_TOKEN = previousToken;
     if (previousBridge === undefined) delete process.env.VICOOP_BRIDGE;


### PR DESCRIPTION
## Summary

- New `.github/workflows/client-ci.yml` mirroring Server CI: typecheck → test → build for `@vicoop-bridge/client` and `@vicoop-bridge/protocol`. Path filter scoped to `packages/{client,protocol}/**` so unrelated server-only PRs skip it.
- `server-ci.yml`: add `pnpm --filter @vicoop-bridge/server test` between typecheck and build. Tests existed already; they just never ran in CI.

## Why

Spotted while reviewing #172: that PR was mostly client code, but only Server CI ran on it — none of the client typecheck/test caught anything automatically. Same for the server-side card-resolver test added in the same PR — CI's typecheck and build covered it incidentally, but the `pnpm test` step that exercises `card-resolver.test.ts` wasn't part of the workflow.

This PR closes both gaps so future regressions in either package surface on the PR rather than at merge time.

## Test plan

- [x] Locally ran each step the new workflows execute, against this branch's main+CI commits:
  - `pnpm --filter @vicoop-bridge/protocol build` — clean
  - `pnpm --filter @vicoop-bridge/client typecheck` — clean
  - `pnpm --filter @vicoop-bridge/client test` — 404/404 pass
  - `pnpm --filter @vicoop-bridge/client build` — clean
  - `pnpm --filter @vicoop-bridge/server typecheck` — clean
  - `pnpm --filter @vicoop-bridge/server test` — 181/181 pass
  - `pnpm --filter @vicoop-bridge/server build` — clean
- [ ] Confirm both workflows trigger on this PR (Client CI from the workflow-file path filter; Server CI from `server-ci.yml` itself being in the changed-files set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)