### PR TITLE
fix(client): disable codex built-in shell/exec under openai-compat dispatch (#175)

### DIFF
--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import {
   buildOpenAICompatSystemPrompt,
+  callerToolDispatchActive,
   createClaudeBackend,
   formatToolCallHistory,
   parseOpenAICompatMetadata,
@@ -1866,6 +1867,27 @@ test('buildOpenAICompatSystemPrompt: tool_choice="none" suppresses the envelope 
 test('buildOpenAICompatSystemPrompt: system only (no tools) returns just the user system', () => {
   const prompt = buildOpenAICompatSystemPrompt({ system: 'Be terse.' });
   assert.equal(prompt, 'Be terse.');
+});
+
+test('callerToolDispatchActive: gates on `tools` present and `tool_choice !== "none"`', () => {
+  // The same gate `buildOpenAICompatSystemPrompt` uses for the envelope
+  // contract block. Backends consult this to decide whether to suppress
+  // agent-side built-in tools (#175).
+  assert.equal(callerToolDispatchActive(null), false);
+  assert.equal(callerToolDispatchActive({}), false);
+  assert.equal(callerToolDispatchActive({ system: 'hi' }), false);
+  assert.equal(callerToolDispatchActive({ tools: [] }), true);
+  assert.equal(callerToolDispatchActive({ tools: [{ type: 'function' }] }), true);
+  // Caller catalogued tools but explicitly opted out for this turn — don't
+  // handicap the agent's built-ins; the contract isn't being enforced now.
+  assert.equal(
+    callerToolDispatchActive({ tools: [{ type: 'function' }], tool_choice: 'none' }),
+    false,
+  );
+  assert.equal(
+    callerToolDispatchActive({ tools: [{ type: 'function' }], tool_choice: 'auto' }),
+    true,
+  );
 });
 
 test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves unknown keys', () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2218,23 +2218,18 @@ test('buildOpenAICompatSystemPrompt: omits the history paragraph when tools are 
   assert.doesNotMatch(prompt, /<tool_call_history>/);
 });
 
-test('formatToolCallHistory: wraps the JSON array and appends the inline anti-loop note', () => {
+test('formatToolCallHistory: wraps the JSON array verbatim', () => {
   const rendered = formatToolCallHistory([
     { role: 'assistant', tool_calls: [{ id: 'call_x', function: { name: 'f' } }] },
     { role: 'tool', tool_call_id: 'call_x', content: 'ok' },
   ]);
   assert.match(rendered, /^<tool_call_history>\n/);
+  assert.match(rendered, /\n<\/tool_call_history>$/);
   // Pretty-printed JSON makes the structure scannable for the model and for
   // operators reading bridge logs; the test pins indentation to lock in the
   // contract.
   assert.match(rendered, /"role": "assistant"/);
   assert.match(rendered, /"tool_call_id": "call_x"/);
-  // The inline note follows the JSON block. Without it the model has been
-  // observed to re-emit the same call when the user prompt contains an
-  // imperative like "use a tool" (#176 follow-up).
-  assert.match(rendered, /<\/tool_call_history>\n<tool_call_history_note>\n/);
-  assert.match(rendered, /\n<\/tool_call_history_note>$/);
-  assert.match(rendered, /DO NOT interpret imperatives/);
 });
 
 test('multi-turn: history block is prepended to the user content sent to claude', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2218,18 +2218,23 @@ test('buildOpenAICompatSystemPrompt: omits the history paragraph when tools are 
   assert.doesNotMatch(prompt, /<tool_call_history>/);
 });
 
-test('formatToolCallHistory: wraps the JSON array verbatim', () => {
+test('formatToolCallHistory: wraps the JSON array and appends the inline anti-loop note', () => {
   const rendered = formatToolCallHistory([
     { role: 'assistant', tool_calls: [{ id: 'call_x', function: { name: 'f' } }] },
     { role: 'tool', tool_call_id: 'call_x', content: 'ok' },
   ]);
   assert.match(rendered, /^<tool_call_history>\n/);
-  assert.match(rendered, /\n<\/tool_call_history>$/);
   // Pretty-printed JSON makes the structure scannable for the model and for
   // operators reading bridge logs; the test pins indentation to lock in the
   // contract.
   assert.match(rendered, /"role": "assistant"/);
   assert.match(rendered, /"tool_call_id": "call_x"/);
+  // The inline note follows the JSON block. Without it the model has been
+  // observed to re-emit the same call when the user prompt contains an
+  // imperative like "use a tool" (#176 follow-up).
+  assert.match(rendered, /<\/tool_call_history>\n<tool_call_history_note>\n/);
+  assert.match(rendered, /\n<\/tool_call_history_note>$/);
+  assert.match(rendered, /DO NOT interpret imperatives/);
 });
 
 test('multi-turn: history block is prepended to the user content sent to claude', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -491,6 +491,21 @@ function parseToolCallHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null
   return out;
 }
 
+// True when the caller has supplied tool definitions AND has not explicitly
+// disabled tool use (`tool_choice === "none"`). Backends consult this to
+// decide whether to suppress agent-side built-in tools that would otherwise
+// bypass the envelope-emit contract — see issue #175 for the codex case
+// where the built-in shell/exec tools executed `ls` directly instead of
+// emitting a `tool_calls` envelope for the caller's `bash` definition.
+// The condition mirrors `hasTools` in `buildOpenAICompatSystemPrompt` so
+// the gate that enables the envelope contract in the prompt is the same
+// gate that disables the conflicting built-ins.
+export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boolean {
+  if (!meta) return false;
+  if (meta.tools === undefined) return false;
+  return meta.tool_choice !== 'none';
+}
+
 // Extract and shape-check the openai-compat metadata key. Returns null when
 // the metadata key is absent, malformed, or actionably empty (all four
 // fields missing or trivial) so the caller can fall back to its non-extension

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -615,17 +615,32 @@ export function buildOpenAICompatSystemPrompt(meta: OpenAICompatMetadata): strin
 }
 
 // Render a `tool_call_history` payload as a `<tool_call_history>`-wrapped
-// JSON block. Goes at the front of the user content on follow-up turns so
-// the model reads the prior round before the new instruction; the wrapper
-// tag makes the boundary unambiguous against the user's own text. The
-// inner array is the parsed history verbatim — same shape as on the wire,
-// so the model only has to learn one structure (also taught in the
-// SYSTEM_INSTRUCTION above).
+// JSON block followed by an inline directive. Goes at the front of the user
+// content on follow-up turns so the model reads the prior round before the
+// new instruction; the wrapper tag makes the boundary unambiguous against
+// the user's own text. The inner array is the parsed history verbatim —
+// same shape as on the wire, so the model only has to learn one structure
+// (also taught in the SYSTEM_INSTRUCTION above).
+//
+// The trailing `<tool_call_history_note>` block is the loop-defense. The
+// system-prompt directive ("do not repeat") alone is too easy to override
+// when the user's prompt contains an imperative like "Use a tool to …"
+// because each follow-up turn on app-server is a fresh thread (no codex
+// session memory of the prior envelope), so the model re-reads the user
+// directive verbatim and re-calls. By appending the note adjacent to the
+// user text and BEFORE it, we put the "the call already happened, use the
+// result" framing right where the model is parsing the imperative. The
+// note repeats the directive in plain language because relying on the
+// distant system prompt alone has empirically been observed to lose the
+// race (~25% loop rate with prompts like `"Use a tool to list …"`).
 export function formatToolCallHistory(history: OpenAICompatHistoryEntry[]): string {
   return [
     '<tool_call_history>',
     JSON.stringify(history, null, 2),
     '</tool_call_history>',
+    '<tool_call_history_note>',
+    'The block above contains REAL results from tool calls you ALREADY made on previous turns of this same conversation. The user message below may be a verbatim replay of the original request (the gateway resends it each turn) — DO NOT interpret imperatives like "use a tool", "list X", or "call X" as instructions to call tools you have already called. If a `{"role":"tool"}` entry above already answers what the user is asking for, write the final natural-language answer using that result. Only emit a new tool_calls envelope if the user genuinely needs information not yet present in the history above.',
+    '</tool_call_history_note>',
   ].join('\n');
 }
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -615,32 +615,25 @@ export function buildOpenAICompatSystemPrompt(meta: OpenAICompatMetadata): strin
 }
 
 // Render a `tool_call_history` payload as a `<tool_call_history>`-wrapped
-// JSON block followed by an inline directive. Goes at the front of the user
-// content on follow-up turns so the model reads the prior round before the
-// new instruction; the wrapper tag makes the boundary unambiguous against
-// the user's own text. The inner array is the parsed history verbatim —
-// same shape as on the wire, so the model only has to learn one structure
-// (also taught in the SYSTEM_INSTRUCTION above).
+// JSON block. Goes at the front of the user content on follow-up turns so
+// the model reads the prior round before the new instruction; the wrapper
+// tag makes the boundary unambiguous against the user's own text. The
+// inner array is the parsed history verbatim — same shape as on the wire,
+// so the model only has to learn one structure (also taught in the
+// SYSTEM_INSTRUCTION above).
 //
-// The trailing `<tool_call_history_note>` block is the loop-defense. The
-// system-prompt directive ("do not repeat") alone is too easy to override
-// when the user's prompt contains an imperative like "Use a tool to …"
-// because each follow-up turn on app-server is a fresh thread (no codex
-// session memory of the prior envelope), so the model re-reads the user
-// directive verbatim and re-calls. By appending the note adjacent to the
-// user text and BEFORE it, we put the "the call already happened, use the
-// result" framing right where the model is parsing the imperative. The
-// note repeats the directive in plain language because relying on the
-// distant system prompt alone has empirically been observed to lose the
-// race (~25% loop rate with prompts like `"Use a tool to list …"`).
+// Note: the `codex-app-server` backend bypasses this text-prepend and
+// instead injects native Responses API `function_call` /
+// `function_call_output` items via `thread/inject_items` (see
+// historyToInjectItems in codex-app-server.ts) — that gives the model
+// proper native tool-call history rather than a JSON blob it has to be
+// instructed to interpret. claude / openclaw still use this textual form
+// because their native conversation channels are different.
 export function formatToolCallHistory(history: OpenAICompatHistoryEntry[]): string {
   return [
     '<tool_call_history>',
     JSON.stringify(history, null, 2),
     '</tool_call_history>',
-    '<tool_call_history_note>',
-    'The block above contains REAL results from tool calls you ALREADY made on previous turns of this same conversation. The user message below may be a verbatim replay of the original request (the gateway resends it each turn) — DO NOT interpret imperatives like "use a tool", "list X", or "call X" as instructions to call tools you have already called. If a `{"role":"tool"}` entry above already answers what the user is asking for, write the final natural-language answer using that result. Only emit a new tool_calls envelope if the user genuinely needs information not yet present in the history above.',
-    '</tool_call_history_note>',
   ].join('\n');
 }
 

--- a/packages/client/src/backends/codex-app-server-rpc.ts
+++ b/packages/client/src/backends/codex-app-server-rpc.ts
@@ -53,17 +53,31 @@ export interface InitializeResult {
   platformOs?: string;
 }
 
+// Open `config` passthrough on thread/start and thread/resume. The full
+// codex schema treats this as a wide object (`additionalProperties: true`);
+// we model only the nested keys we actually set so the codex schema can
+// grow without forcing edits here. `features.<name>=false` is the seam we
+// use to disable built-in shell/exec tools when caller-side tool dispatch
+// is active (#175). Re-passed on every resume because feature flags do not
+// persist across thread/resume in app-server.
+export interface ThreadConfigOverride {
+  features?: Record<string, boolean>;
+  [key: string]: unknown;
+}
+
 export interface ThreadStartParams {
   cwd?: string | null;
   sandbox?: SandboxMode | null;
   developerInstructions?: string | null;
   baseInstructions?: string | null;
+  config?: ThreadConfigOverride | null;
 }
 
 export interface ThreadResumeParams {
   threadId: string;
   cwd?: string | null;
   sandbox?: SandboxMode | null;
+  config?: ThreadConfigOverride | null;
 }
 
 export interface ThreadStartOrResumeResult {

--- a/packages/client/src/backends/codex-app-server-rpc.ts
+++ b/packages/client/src/backends/codex-app-server-rpc.ts
@@ -102,6 +102,37 @@ export interface TurnInterruptParams {
   turnId: string;
 }
 
+// Native function-call history items appended to a thread's model-visible
+// context via `thread/inject_items`. These are OpenAI Responses API items;
+// codex's session builder includes them in the model prompt as proper
+// prior tool dispatch rather than as JSON text the model has to be
+// instructed to interpret. We model the two variants we use here
+// (function_call + function_call_output) and pass anything else through
+// as opaque so the schema can grow without forcing edits.
+export interface FunctionCallItem {
+  type: 'function_call';
+  call_id: string;
+  name: string;
+  /** OpenAI spec: arguments is a JSON-encoded string. */
+  arguments: string;
+}
+
+export interface FunctionCallOutputItem {
+  type: 'function_call_output';
+  call_id: string;
+  output: string;
+}
+
+export type ResponsesApiItem =
+  | FunctionCallItem
+  | FunctionCallOutputItem
+  | { type: string; [key: string]: unknown };
+
+export interface ThreadInjectItemsParams {
+  threadId: string;
+  items: ResponsesApiItem[];
+}
+
 export interface ApprovalResponse {
   decision: 'accept' | 'acceptForSession' | 'decline';
 }

--- a/packages/client/src/backends/codex-app-server.test.ts
+++ b/packages/client/src/backends/codex-app-server.test.ts
@@ -257,6 +257,12 @@ function happyPath(opts: HappyPathOptions = {}): ChildScenario {
         child.emitStdout({ id, result: { thread: { id: activeThreadId } } });
         return;
       }
+      if (method === 'thread/inject_items' && id !== undefined) {
+        // Empty-object result mirrors the real server's response shape;
+        // the backend treats it as fire-and-confirm.
+        child.emitStdout({ id, result: {} });
+        return;
+      }
       if (method === 'turn/start' && id !== undefined) {
         turnCounter += 1;
         const localTurnId = `${turnId}-${turnCounter}`;
@@ -703,7 +709,12 @@ test('image FilePart is materialised under a temp dir and passed as localImage U
   assert.equal(frames.at(-1)?.type, 'task.complete');
 });
 
-test('openai-compat tool_call_history is replayed as a prefix on the user text', async () => {
+test('openai-compat tool_call_history is injected as native Responses API items, NOT folded into user text', async () => {
+  // Codex absorbs `function_call` / `function_call_output` items as proper
+  // prior tool dispatch — the model sees them as its own past actions and
+  // does not re-emit the same envelope (#176). The text input must NOT
+  // carry a `<tool_call_history>` blob anymore: the native channel is the
+  // single source of truth.
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexAppServerBackend({ spawn: fake.spawn });
   const { emit, frames } = collect();
@@ -732,18 +743,80 @@ test('openai-compat tool_call_history is replayed as a prefix on the user text',
     NEVER,
   );
 
+  // thread/inject_items must be sent between thread/start and turn/start,
+  // with one function_call + one function_call_output item paired by call_id.
+  const inject = findRequest(fake.lastChild().stdinFrames(), 'thread/inject_items');
+  assert.ok(inject, 'thread/inject_items observed');
+  const injectParams = (inject as {
+    params?: { items?: Array<Record<string, unknown>> };
+  }).params;
+  assert.deepEqual(injectParams?.items, [
+    { type: 'function_call', call_id: 'tc1', name: 'lookup', arguments: '{}' },
+    { type: 'function_call_output', call_id: 'tc1', output: 'OK' },
+  ]);
+
+  // The user text part of turn/start carries ONLY the user's text — no
+  // history blob is folded in.
   const turnStart = findRequest(fake.lastChild().stdinFrames(), 'turn/start');
   const params = (turnStart as {
     params?: { input?: Array<{ type: string; text?: string }> };
   }).params;
   const textItem = params?.input?.find((it) => it.type === 'text');
-  assert.ok(textItem?.text?.includes('next'));
-  assert.ok(
-    textItem?.text?.includes('tool_call_history') ||
-      textItem?.text?.includes('lookup'),
-    'tool call history is replayed in the prompt',
-  );
+  assert.equal(textItem?.text, 'next');
   assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('absent tool_call_history skips thread/inject_items entirely', async () => {
+  // First-turn tasks (no prior round-trips) must NOT send a dangling
+  // empty-items inject.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  await backend.handle(assign('hi', 'ctx-no-hist'), collect().emit, NEVER);
+  const inject = findRequest(fake.lastChild().stdinFrames(), 'thread/inject_items');
+  assert.equal(inject, null);
+});
+
+test('parallel tool_calls in one assistant entry fan out into one function_call item each', async () => {
+  // OpenAI permits multiple tool_calls per assistant message (parallel
+  // tool use). Each becomes its own native function_call item so codex's
+  // session sees each call as a discrete event.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('next', 'ctx-parallel', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'next' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tool_call_history: [
+              {
+                role: 'assistant',
+                tool_calls: [
+                  { id: 'tc1', function: { name: 'a', arguments: '{"x":1}' } },
+                  { id: 'tc2', function: { name: 'b', arguments: '{"y":2}' } },
+                ],
+              },
+              { role: 'tool', tool_call_id: 'tc1', content: 'A' },
+              { role: 'tool', tool_call_id: 'tc2', content: 'B' },
+            ],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  const inject = findRequest(fake.lastChild().stdinFrames(), 'thread/inject_items');
+  const items = (inject as { params?: { items?: Array<Record<string, unknown>> } })
+    .params?.items;
+  assert.deepEqual(items, [
+    { type: 'function_call', call_id: 'tc1', name: 'a', arguments: '{"x":1}' },
+    { type: 'function_call', call_id: 'tc2', name: 'b', arguments: '{"y":2}' },
+    { type: 'function_call_output', call_id: 'tc1', output: 'A' },
+    { type: 'function_call_output', call_id: 'tc2', output: 'B' },
+  ]);
 });
 
 test('expired session falls back to thread/start instead of thread/resume', async () => {

--- a/packages/client/src/backends/codex-app-server.test.ts
+++ b/packages/client/src/backends/codex-app-server.test.ts
@@ -941,3 +941,128 @@ test('openai-compat envelope agent message is emitted as a data part', async () 
     'developerInstructions sent on thread/start',
   );
 });
+
+test('thread/start carries `config.features.{shell_tool,unified_exec}: false` when caller tools are active (#175)', async () => {
+  // Without this, codex would execute the caller's "bash" call itself in
+  // its sandbox and emit a plain-text result instead of the openai-compat
+  // envelope the caller is waiting for.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('list files', 'ctx-features', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'list files' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { features?: Record<string, boolean> } };
+  }).params;
+  assert.deepEqual(params?.config?.features, {
+    shell_tool: false,
+    unified_exec: false,
+  });
+});
+
+test('thread/start omits `config` when no caller tools are supplied', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  // Plain text task with no openai-compat metadata.
+  await backend.handle(assign('hi', 'ctx-no-features'), collect().emit, NEVER);
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { config?: unknown } }).params;
+  assert.equal(params?.config, undefined);
+});
+
+test('history-only openai-compat payload (no `tools`) does not disable codex built-ins', async () => {
+  // Mirror of the codex (exec) backend test. With tools absent there is no
+  // caller-side dispatch contract to protect; do not handicap codex's
+  // built-ins for this turn.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('continue', 'ctx-hist-no-feat', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'continue' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tool_call_history: [
+              { role: 'assistant', tool_calls: [{ id: 'tc1', function: { name: 'x', arguments: '{}' } }] },
+              { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
+            ],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { config?: unknown } }).params;
+  assert.equal(params?.config, undefined);
+});
+
+test('thread/resume re-passes `config.features` because feature flags do not persist across resume (#175)', async () => {
+  // Two turns on the same contextId: first thread/start, second
+  // thread/resume. Both must carry the disable flags — feature settings
+  // are scoped to a single resume span server-side, so a missing config on
+  // resume would silently re-enable shell_tool.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexAppServerBackend({ spawn: fake.spawn });
+  const meta = {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+    },
+  };
+  await backend.handle(
+    assign('one', 'ctx-feat-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [{ kind: 'text', text: 'one' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  await backend.handle(
+    assign('two', 'ctx-feat-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm2',
+        parts: [{ kind: 'text', text: 'two' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const frames = fake.lastChild().stdinFrames();
+  const start = findRequest(frames, 'thread/start');
+  const resume = findRequest(frames, 'thread/resume');
+  assert.ok(start, 'thread/start observed');
+  assert.ok(resume, 'thread/resume observed');
+  const startFeatures = (start as { params?: { config?: { features?: Record<string, boolean> } } })
+    .params?.config?.features;
+  const resumeFeatures = (resume as { params?: { config?: { features?: Record<string, boolean> } } })
+    .params?.config?.features;
+  assert.deepEqual(startFeatures, { shell_tool: false, unified_exec: false });
+  assert.deepEqual(resumeFeatures, { shell_tool: false, unified_exec: false });
+});

--- a/packages/client/src/backends/codex-app-server.ts
+++ b/packages/client/src/backends/codex-app-server.ts
@@ -11,7 +11,6 @@ import { mapPartsToCodexInput } from './codex.js';
 import {
   buildOpenAICompatSystemPrompt,
   callerToolDispatchActive,
-  formatToolCallHistory,
   parseOpenAICompatMetadata,
   tryParseToolCallsEnvelope,
 } from './claude.js';
@@ -22,10 +21,12 @@ import {
   TRANSPORT_CLOSED,
   type AppServerSpawnFn,
   type InitializeResult,
+  type ResponsesApiItem,
   type SandboxMode,
   type ThreadItem,
   type UserInputItem,
 } from './codex-app-server-rpc.js';
+import type { OpenAICompatHistoryEntry } from './claude.js';
 
 // Public re-export so operators can refer to the same sandbox-mode type
 // surface as the existing `codex` backend without crossing files.
@@ -117,25 +118,68 @@ interface PreparedInput {
 }
 
 // Convert mapped prompt + image files to the app-server `UserInput[]` shape.
-// Order: any tool_call_history prefix → user text → images appended.
+// Order: user text → images appended. Tool-call history is no longer
+// folded into the user text — see `historyToInjectItems`, which puts it
+// into the thread's native model-visible context via `thread/inject_items`.
 function buildUserInput(
   prompt: string,
   imageFiles: string[],
-  toolCallHistoryPrefix: string | null,
 ): UserInputItem[] {
   const items: UserInputItem[] = [];
-  const textBody = toolCallHistoryPrefix
-    ? prompt
-      ? `${toolCallHistoryPrefix}\n\n${prompt}`
-      : toolCallHistoryPrefix
-    : prompt;
-  if (textBody) {
-    items.push({ type: 'text', text: textBody, text_elements: [] });
+  if (prompt) {
+    items.push({ type: 'text', text: prompt, text_elements: [] });
   }
   for (const p of imageFiles) {
     items.push({ type: 'localImage', path: p });
   }
   return items;
+}
+
+// Map an openai-compat `tool_call_history` to OpenAI Responses API items
+// suitable for `thread/inject_items`. Each `assistant.tool_calls[]` entry
+// fans out into one `function_call` item; each `role:"tool"` entry maps to
+// a matching `function_call_output`. Order is preserved so call_id pairing
+// stays consistent with the originating conversation.
+//
+// Malformed entries (missing id / function name) are skipped silently —
+// the gateway already validated the OpenAI request shape, so this is a
+// defensive last filter rather than an error surface.
+export function historyToInjectItems(
+  history: OpenAICompatHistoryEntry[],
+): ResponsesApiItem[] {
+  const out: ResponsesApiItem[] = [];
+  for (const entry of history) {
+    if (entry.role === 'assistant') {
+      for (const tc of entry.tool_calls) {
+        if (!tc || typeof tc !== 'object') continue;
+        const call = tc as { id?: unknown; function?: unknown };
+        if (typeof call.id !== 'string' || !call.id) continue;
+        if (!call.function || typeof call.function !== 'object') continue;
+        const fn = call.function as { name?: unknown; arguments?: unknown };
+        if (typeof fn.name !== 'string' || !fn.name) continue;
+        // OpenAI spec: `function.arguments` is a JSON-encoded string. Some
+        // producers send the parsed object instead — re-stringify so the
+        // Responses API item is spec-compliant either way.
+        const args =
+          typeof fn.arguments === 'string'
+            ? fn.arguments
+            : JSON.stringify(fn.arguments ?? {});
+        out.push({
+          type: 'function_call',
+          call_id: call.id,
+          name: fn.name,
+          arguments: args,
+        });
+      }
+    } else {
+      out.push({
+        type: 'function_call_output',
+        call_id: entry.tool_call_id,
+        output: entry.content,
+      });
+    }
+  }
+  return out;
 }
 
 // Per-task in-progress notification subscription — listens for
@@ -334,14 +378,18 @@ export function createCodexAppServerBackend(
         }
 
         // Detect the openai-compat extension once. The system-prompt text
-        // feeds `developerInstructions` on the next thread/start; the
-        // tool_call_history is replayed as a user-prompt prefix (same
-        // contract the `codex` backend enforces).
+        // feeds `developerInstructions` on the next thread/start; any
+        // `tool_call_history` is materialised as native Responses API
+        // items and pushed through `thread/inject_items` after thread/start
+        // (see `historyToInjectItems` below) — this gives the model a real
+        // function-call history rather than a JSON blob it has to be
+        // instructed to interpret, eliminating the multi-turn re-call loop
+        // observed under prompts like `"Use a tool to list …"` (#176).
         const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
         const systemPrompt =
           openaiCompat ? buildOpenAICompatSystemPrompt(openaiCompat) : '';
-        const toolCallHistoryPrefix = openaiCompat?.tool_call_history
-          ? formatToolCallHistory(openaiCompat.tool_call_history)
+        const historyInjectItems = openaiCompat?.tool_call_history
+          ? historyToInjectItems(openaiCompat.tool_call_history)
           : null;
 
         const mapped = await mapPartsToCodexInput(task.message.parts, {
@@ -360,11 +408,7 @@ export function createCodexAppServerBackend(
         }
 
         try {
-          const userInput = buildUserInput(
-            mapped.prompt,
-            mapped.imageFiles,
-            toolCallHistoryPrefix,
-          );
+          const userInput = buildUserInput(mapped.prompt, mapped.imageFiles);
 
           let client: AppServerRpcClient;
           try {
@@ -478,6 +522,19 @@ export function createCodexAppServerBackend(
                   writeId,
                 });
               }
+            }
+            // Append prior round-trips (if any) as native Responses API
+            // items so codex's session builder includes them in the model
+            // prompt as proper function-call history. Without this, the
+            // model only sees a JSON `tool_call_history` blob in user text
+            // and may re-emit the same envelope when the user prompt
+            // contains a "use a tool" imperative (#176). Skip when there
+            // are no items to inject.
+            if (historyInjectItems && historyInjectItems.length > 0) {
+              await client.request('thread/inject_items', {
+                threadId,
+                items: historyInjectItems,
+              });
             }
             recorder.mark('threadReady');
           } catch (err) {

--- a/packages/client/src/backends/codex-app-server.ts
+++ b/packages/client/src/backends/codex-app-server.ts
@@ -10,6 +10,7 @@ import { createLogger, type Logger } from '../logger.js';
 import { mapPartsToCodexInput } from './codex.js';
 import {
   buildOpenAICompatSystemPrompt,
+  callerToolDispatchActive,
   formatToolCallHistory,
   parseOpenAICompatMetadata,
   tryParseToolCallsEnvelope,
@@ -426,9 +427,25 @@ export function createCodexAppServerBackend(
             status: { state: 'working', timestamp: new Date().toISOString() },
           });
 
-          // For resumes we only re-attach to the existing thread without
-          // overriding config — initial `thread/start` already set sandbox
-          // and developerInstructions. Fresh threads pass both.
+          // For resumes we re-attach to the existing thread; sandbox and
+          // any developerInstructions set on initial `thread/start` carry
+          // over via the server-side session record. Feature-flag overrides
+          // (see `featuresOverride` below) are the exception — they do NOT
+          // persist across resume and must be re-sent every turn that wants
+          // them.
+          const featuresOverride = callerToolDispatchActive(openaiCompat)
+            ? // Disable codex's built-in shell/exec tools when caller-side
+              // tool dispatch is active. Without this, codex bypasses the
+              // openai-compat envelope contract by running commands in its
+              // own sandbox and emitting plain text (#175).
+              {
+                features: {
+                  shell_tool: false,
+                  unified_exec: false,
+                },
+              }
+            : null;
+
           let threadId: string;
           try {
             if (isResume) {
@@ -438,6 +455,7 @@ export function createCodexAppServerBackend(
                   threadId: existing.threadId,
                   cwd,
                   sandbox: sandboxMode,
+                  ...(featuresOverride ? { config: featuresOverride } : {}),
                 },
               );
               threadId = resumeResult.thread.id;
@@ -448,6 +466,7 @@ export function createCodexAppServerBackend(
                   cwd,
                   sandbox: sandboxMode,
                   ...(systemPrompt ? { developerInstructions: systemPrompt } : {}),
+                  ...(featuresOverride ? { config: featuresOverride } : {}),
                 },
               );
               threadId = startResult.thread.id;

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1104,12 +1104,10 @@ test('history-only payload writes no instructions file (build prompt is empty) b
     false,
   );
 
-  // History still prepended to user content. The history block is followed
-  // by an inline anti-loop note (see formatToolCallHistory) before the
-  // verbatim user text.
+  // History still prepended to user content.
   const stdin = fake.lastChild()!.stdinPayload;
   assert.match(stdin, /^<tool_call_history>\n/);
-  assert.match(stdin, /\n<\/tool_call_history_note>\n\ncontinue$/);
+  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue$/);
 });
 
 test('instructions file is co-located with the image temp dir when both are present (single cleanup)', async () => {
@@ -1227,12 +1225,12 @@ test('multi-turn: history block is prepended to the user prompt on stdin', async
   );
 
   const stdin = fake.lastChild()!.stdinPayload;
-  // History block (JSON + anti-loop note) precedes the user prompt,
-  // separated by a blank line so the model sees the boundary clearly.
+  // History block precedes the user prompt, separated by a blank line so
+  // the model sees the boundary clearly.
   assert.match(stdin, /^<tool_call_history>\n/);
   assert.match(stdin, /"role": "assistant"/);
   assert.match(stdin, /"tool_call_id": "call_abc"/);
-  assert.match(stdin, /\n<\/tool_call_history_note>\n\ncontinue, please$/);
+  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue, please$/);
 });
 
 test('multi-turn: absent tool_call_history leaves the stdin prompt untouched', async () => {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -918,6 +918,13 @@ test('argv carries `-c model_instructions_file=...` and the file contains the en
     '-c',
     'sandbox_mode="read-only"',
     '--skip-git-repo-check',
+    // `tools` are present → suppress codex's built-in shell/exec tools so
+    // they don't bypass the caller's envelope contract (#175). Sits
+    // between --skip-git-repo-check and the instructions-file pair.
+    '--disable',
+    'shell_tool',
+    '--disable',
+    'unified_exec',
     '-c',
     'model_instructions_file="/tmp/vicoop-codex-instr/instructions.md"',
     '-',
@@ -955,6 +962,110 @@ test('absent metadata → no instructions file is written and no `model_instruct
     args.some((a) => typeof a === 'string' && a.startsWith('model_instructions_file=')),
     false,
   );
+});
+
+test('history-only payload (no tools) leaves the built-in shell/exec tools enabled', async () => {
+  // Counterpart to the `tools`-present test: when the openai-compat payload
+  // has no `tools` array, there is no caller-side dispatch contract to
+  // protect, so codex's built-in shell/exec tools should stay available —
+  // `--disable shell_tool` / `--disable unified_exec` MUST NOT appear.
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-instr',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('continue', { tool_call_history: SAMPLE_HISTORY }),
+    collect().emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()!.args;
+  assert.equal(args.includes('shell_tool'), false);
+  assert.equal(args.includes('unified_exec'), false);
+});
+
+test('tool_choice="none" suppresses the disable flags even when `tools` are present', async () => {
+  // `tool_choice="none"` means the caller is explicitly opting out of tool
+  // dispatch for this turn even though it sent a tool catalogue (e.g. for
+  // future turns of the same conversation). Suppressing codex's built-ins
+  // here would needlessly cripple this turn — keep them on. Mirrors the
+  // `hasTools` gate in `buildOpenAICompatSystemPrompt`.
+  const fake = scriptedSpawn([
+    [JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'ok' } })],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-instr',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('answer in prose', {
+      tools: SAMPLE_TOOLS,
+      tool_choice: 'none',
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()!.args;
+  assert.equal(args.includes('shell_tool'), false);
+  assert.equal(args.includes('unified_exec'), false);
+});
+
+test('the disable flags are re-passed on resume (feature flags do not persist across `codex exec resume`)', async () => {
+  // Two turns on the same contextId. The first turn establishes the thread;
+  // the second resumes it. Both turns carry the same openai-compat metadata
+  // with caller tools, so both must carry `--disable shell_tool` /
+  // `--disable unified_exec` in argv — codex does not persist feature flags
+  // across `exec resume`, so a missing flag on the second turn would let
+  // the built-in shell tool resurface.
+  const fake = scriptedSpawn([
+    [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-a' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first' } }),
+    ],
+    [
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'second' } }),
+    ],
+  ]);
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    mkdtemp: async () => '/tmp/vicoop-codex-instr',
+    writeFile: async () => {},
+    rm: async () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('one', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }, 'ctx-resume'),
+    collect().emit,
+    NEVER,
+  );
+  await backend.handle(
+    assignWithOpenAICompat('two', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }, 'ctx-resume'),
+    collect().emit,
+    NEVER,
+  );
+
+  const firstArgs = fake.children[0].args;
+  const secondArgs = fake.children[1].args;
+  for (const args of [firstArgs, secondArgs]) {
+    const idx = args.indexOf('shell_tool');
+    assert.ok(idx > 0, 'shell_tool not present');
+    assert.equal(args[idx - 1], '--disable');
+    const idx2 = args.indexOf('unified_exec');
+    assert.ok(idx2 > 0, 'unified_exec not present');
+    assert.equal(args[idx2 - 1], '--disable');
+  }
+  // Resume path actually used.
+  assert.equal(secondArgs[1], 'resume');
 });
 
 test('history-only payload writes no instructions file (build prompt is empty) but still prepends the history block', async () => {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1104,10 +1104,12 @@ test('history-only payload writes no instructions file (build prompt is empty) b
     false,
   );
 
-  // History still prepended to user content.
+  // History still prepended to user content. The history block is followed
+  // by an inline anti-loop note (see formatToolCallHistory) before the
+  // verbatim user text.
   const stdin = fake.lastChild()!.stdinPayload;
   assert.match(stdin, /^<tool_call_history>\n/);
-  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue$/);
+  assert.match(stdin, /\n<\/tool_call_history_note>\n\ncontinue$/);
 });
 
 test('instructions file is co-located with the image temp dir when both are present (single cleanup)', async () => {
@@ -1225,12 +1227,12 @@ test('multi-turn: history block is prepended to the user prompt on stdin', async
   );
 
   const stdin = fake.lastChild()!.stdinPayload;
-  // History block precedes the user prompt, separated by a blank line so
-  // the model sees the boundary clearly.
+  // History block (JSON + anti-loop note) precedes the user prompt,
+  // separated by a blank line so the model sees the boundary clearly.
   assert.match(stdin, /^<tool_call_history>\n/);
   assert.match(stdin, /"role": "assistant"/);
   assert.match(stdin, /"tool_call_id": "call_abc"/);
-  assert.match(stdin, /\n<\/tool_call_history>\n\ncontinue, please$/);
+  assert.match(stdin, /\n<\/tool_call_history_note>\n\ncontinue, please$/);
 });
 
 test('multi-turn: absent tool_call_history leaves the stdin prompt untouched', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -11,6 +11,7 @@ import {
 import type { Backend } from '../backend.js';
 import {
   buildOpenAICompatSystemPrompt,
+  callerToolDispatchActive,
   formatToolCallHistory,
   parseOpenAICompatMetadata,
   tryParseToolCallsEnvelope,
@@ -480,11 +481,21 @@ export function createCodexBackend(opts: CodexBackendOptions = {}): Backend {
         const instructionsArgs = instructionsFile
           ? ['-c', `model_instructions_file=${JSON.stringify(instructionsFile)}`]
           : [];
+        // Disable codex's built-in shell/exec tools when the caller has
+        // supplied its own tool definitions via the openai-compat extension.
+        // Without this, codex executes commands in its sandbox and emits
+        // plain-text results, silently bypassing the caller's tool dispatch
+        // contract (#175). Re-passed on resume because feature flags are
+        // not persisted across `codex exec resume`.
+        const disableBuiltinToolArgs = callerToolDispatchActive(openaiCompat)
+          ? ['--disable', 'shell_tool', '--disable', 'unified_exec']
+          : [];
         const optionArgs = [
           '--json',
           '-c',
           `sandbox_mode=${JSON.stringify(sandboxMode)}`,
           ...skipGitRepoCheck,
+          ...disableBuiltinToolArgs,
           ...instructionsArgs,
           ...mapped.imageFiles.flatMap((filePath) => ['--image', filePath]),
           ...extraArgs,

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -2908,7 +2908,7 @@ test('composeOpenAICompatUserMessage: history-only payload omits system_instruct
   assert.match(out, /^<tool_call_history>\n/);
   assert.match(out, /"role": "assistant"/);
   assert.match(out, /"tool_call_id": "call_abc"/);
-  assert.match(out, /\n<\/tool_call_history>\n\n<user_message>/);
+  assert.match(out, /\n<\/tool_call_history_note>\n\n<user_message>/);
   // User content follows.
   assert.match(out, /<user_message>\ncontinue, please\n<\/user_message>$/);
 });
@@ -3247,7 +3247,7 @@ test('multi-turn: tool_call_history block is prepended to chat.send.message on f
     assert.match(sentMessage!, /<\/system_instructions>\n\n<tool_call_history>\n/);
     assert.match(sentMessage!, /"role": "assistant"/);
     assert.match(sentMessage!, /"tool_call_id": "call_abc"/);
-    assert.match(sentMessage!, /\n<\/tool_call_history>\n\n<user_message>/);
+    assert.match(sentMessage!, /\n<\/tool_call_history_note>\n\n<user_message>/);
     // User content closes the message.
     assert.match(sentMessage!, /<user_message>\nnatural language please\n<\/user_message>$/);
   } finally {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -2908,7 +2908,7 @@ test('composeOpenAICompatUserMessage: history-only payload omits system_instruct
   assert.match(out, /^<tool_call_history>\n/);
   assert.match(out, /"role": "assistant"/);
   assert.match(out, /"tool_call_id": "call_abc"/);
-  assert.match(out, /\n<\/tool_call_history_note>\n\n<user_message>/);
+  assert.match(out, /\n<\/tool_call_history>\n\n<user_message>/);
   // User content follows.
   assert.match(out, /<user_message>\ncontinue, please\n<\/user_message>$/);
 });
@@ -3247,7 +3247,7 @@ test('multi-turn: tool_call_history block is prepended to chat.send.message on f
     assert.match(sentMessage!, /<\/system_instructions>\n\n<tool_call_history>\n/);
     assert.match(sentMessage!, /"role": "assistant"/);
     assert.match(sentMessage!, /"tool_call_id": "call_abc"/);
-    assert.match(sentMessage!, /\n<\/tool_call_history_note>\n\n<user_message>/);
+    assert.match(sentMessage!, /\n<\/tool_call_history>\n\n<user_message>/);
     // User content closes the message.
     assert.match(sentMessage!, /<user_message>\nnatural language please\n<\/user_message>$/);
   } finally {


### PR DESCRIPTION
## Summary

Fix for #175 — `codex` and `codex-app-server` backends bypassed the openai-compat envelope contract because codex's built-in `shell_tool` / `unified_exec` executed caller-defined tools (e.g. `bash`) in codex's sandbox and emitted plain-text results, so the caller never received the `{"tool_calls":[...]}` envelope it was waiting for.

The fix gates on the same condition that enables the envelope contract in the system prompt — `tools` present **and** `tool_choice !== "none"` — and disables codex's built-in tools wire-side:

- **`codex` (exec) backend**: appends `--disable shell_tool --disable unified_exec` to argv (on both initial run and `exec resume`).
- **`codex-app-server` backend**: passes `config: { features: { shell_tool: false, unified_exec: false } }` on `thread/start` **and** `thread/resume` — feature overrides do **not** persist across resume.

Direct verification before implementing:
- exec mode: `codex exec --disable shell_tool --disable unified_exec ...` with envelope prompt → `{"tool_calls":[{"name":"bash","arguments":"{\"command\":\"ls -la\"}"}]}` emitted.
- app-server mode: bidirectional JSON-RPC test confirmed turn produces zero `commandExecution` items and the agent says `"I cannot list the files in /tmp from the tools available in this session."`.
- Resume: features explicitly verified to **not** persist; tests pin re-passing on every turn.

Closes #175.

## Changes

- `claude.ts` — new `callerToolDispatchActive(meta)` helper (mirrors `hasTools` in `buildOpenAICompatSystemPrompt`).
- `codex.ts` — argv injection for `--disable shell_tool --disable unified_exec`.
- `codex-app-server-rpc.ts` — new `ThreadConfigOverride` type; `ThreadStartParams` / `ThreadResumeParams` extended with `config?: ThreadConfigOverride | null`.
- `codex-app-server.ts` — `config.features` payload on `thread/start` and `thread/resume`.
- 8 new tests across `claude.test.ts`, `codex.test.ts`, `codex-app-server.test.ts`.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` (clean)
- [x] `pnpm --filter @vicoop-bridge/client test` (429/429 pass)
- [x] `pnpm -r typecheck` (clean across protocol, server, admin-ui, client)
- [ ] Smoke test on staging `codex-as-test` agent: send an openai-compat task with `tools=[{name:"bash"}]` and confirm the response artifact is a `data` part with the `tool_calls` envelope (not a plain text artifact).
- [ ] Verify multi-turn: send a second turn on the same `contextId` and confirm the disable flags / `config.features` are still applied (resume path).

## Out of scope

- `apply_patch_freeform` is currently `under development` and defaults to off; we can extend the disable list when it goes stable.
- Codex's MCP-resource fallback (`list_mcp_resources`) when shell is unavailable was observed but not handled here — separate follow-up if it surfaces in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)