### PR TITLE
fix(client): disable claude built-in tools under openai-compat caller dispatch

### DIFF
--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1983,6 +1983,84 @@ test('absent metadata → no openai-compat --append-system-prompt is injected', 
   assert.equal(hasEnvelope, false);
 });
 
+test('caller tools active → spawn argv carries `--tools ""` to disable claude built-ins', async () => {
+  // Without this, claude silently uses its own Read / Glob / Bash to satisfy
+  // requests that should round-trip through the caller's tool dispatch — see
+  // #178. Mirrors the codex backend's `--disable shell_tool` /
+  // `--disable unified_exec` gating on the same `callerToolDispatchActive`.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { tools: SAMPLE_TOOLS, tool_choice: 'auto' }),
+    emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()?.args ?? [];
+  const idx = args.indexOf('--tools');
+  assert.ok(idx >= 0, 'expected --tools in argv when caller tools are active');
+  // The empty-string value is the documented switch for blanket-disabling
+  // built-ins; any other value would re-enable the offending tools.
+  assert.equal(args[idx + 1], '');
+});
+
+test('history-only payload (no tools) leaves claude built-in tools enabled', async () => {
+  // Counterpart to the active-tools case: when the caller's payload carries
+  // only `tool_call_history` (replay context for a follow-up turn) and no
+  // `tools` array, there is no caller-side dispatch contract to protect this
+  // turn — `--tools ""` MUST NOT appear or claude would lose its built-ins
+  // for a turn the caller never intended to constrain.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('continue', { tool_call_history: SAMPLE_HISTORY }),
+    emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()?.args ?? [];
+  assert.equal(args.includes('--tools'), false);
+});
+
+test('tool_choice="none" suppresses `--tools ""` even when `tools` are present', async () => {
+  // `tool_choice="none"` is the caller explicitly opting out of tool
+  // dispatch for this turn even though it sent a catalogue (e.g. for future
+  // turns of the same conversation). The envelope contract block in the
+  // system prompt is suppressed under the same gate, so handicapping
+  // claude's built-ins here would be incoherent.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { tools: SAMPLE_TOOLS, tool_choice: 'none' }),
+    emit,
+    NEVER,
+  );
+
+  const args = fake.lastChild()?.args ?? [];
+  assert.equal(args.includes('--tools'), false);
+});
+
 test('assistant {"tool_calls":[...]} reply becomes a data-part artifact when extension is active', async () => {
   const envelope = {
     tool_calls: [

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -494,12 +494,14 @@ function parseToolCallHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null
 // True when the caller has supplied tool definitions AND has not explicitly
 // disabled tool use (`tool_choice === "none"`). Backends consult this to
 // decide whether to suppress agent-side built-in tools that would otherwise
-// bypass the envelope-emit contract — see issue #175 for the codex case
-// where the built-in shell/exec tools executed `ls` directly instead of
-// emitting a `tool_calls` envelope for the caller's `bash` definition.
-// The condition mirrors `hasTools` in `buildOpenAICompatSystemPrompt` so
-// the gate that enables the envelope contract in the prompt is the same
-// gate that disables the conflicting built-ins.
+// bypass the envelope-emit contract — see #175 for the codex case (built-in
+// shell/exec executed `ls` directly instead of emitting a `tool_calls`
+// envelope for the caller's `bash` definition) and #178 for the same
+// pattern in claude (built-in Read/Glob/Bash served a `ls` request without
+// surfacing the caller's `List`). The condition mirrors `hasTools` in
+// `buildOpenAICompatSystemPrompt` so the gate that enables the envelope
+// contract in the prompt is the same gate that disables the conflicting
+// built-ins.
 export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boolean {
   if (!meta) return false;
   if (meta.tools === undefined) return false;
@@ -1049,6 +1051,18 @@ export function createClaudeBackend(
       const openaiCompatArgs: readonly string[] = openaiCompat
         ? ['--append-system-prompt', buildOpenAICompatSystemPrompt(openaiCompat)]
         : [];
+      // Disable claude's built-in tools (Read / Glob / Bash / Edit / Write /
+      // ...) when the caller has supplied its own tool definitions via the
+      // openai-compat extension. Without this, claude silently uses its own
+      // tools to satisfy a request like "list the cwd" and emits the result
+      // as plain text, bypassing the caller's `tool_calls` envelope contract
+      // — see #178 for the observed case (envelope absent, response served
+      // from agent-side filesystem). `--tools ""` is the documented switch
+      // for blanket-disabling built-ins; MCP-registered tools (e.g.
+      // `send_file`) continue to load via `--mcp-config`.
+      const disableBuiltinToolArgs: readonly string[] = callerToolDispatchActive(openaiCompat)
+        ? ['--tools', '']
+        : [];
 
       const args: string[] = [
         '-p',
@@ -1072,6 +1086,7 @@ export function createClaudeBackend(
           : []),
         ...identityArgs,
         ...openaiCompatArgs,
+        ...disableBuiltinToolArgs,
         ...settingsArgs,
         ...extraArgs,
       ];


### PR DESCRIPTION
## Summary

- claude 백엔드가 openai-compat extension 의 caller-defined tools 를 받았을 때, 내장 Read / Glob / Bash 가 caller 의 `tool_calls` envelope 을 silently 우회해 daemon cwd 파일을 plain text 로 응답하던 contract 위반을 차단 (#178).
- argv 에 `--tools \"\"` 를 inject — `callerToolDispatchActive(meta)` (= `tools && tool_choice !== \"none\"`) 일 때만. MCP-등록 도구 (`send_file`) 는 `--mcp-config` 로 별도 로드돼 영향 없음.
- codex 백엔드의 `--disable shell_tool` / `--disable unified_exec` (#175 / #176) 와 동일 패턴, 동일 게이트.

## Context

#178 의 controlled 재현으로 확인된 사항:
- daemon cwd 를 `/tmp/claude-test-178` (caller 가 모르는 임의 파일) 로 두고 opencode 를 다른 cwd 에서 실행해도 응답이 daemon cwd 의 파일들로 옴
- 그러나 opencode 로그에 `type=tool-call` / `type=tool-result` 없음 → claude 가 caller envelope 우회해 자기 built-in 으로 처리

`--tools \"\"` 가 들어가면 모델이 caller tool 만 사용 가능 → envelope emit 강제 → opencode 측에서 일관된 관측성 확보 + 정보 누출 위험 차단.

## Test plan

- [x] `pnpm typecheck` (client)
- [x] `pnpm test` (client) — 424 tests, all pass
- [x] 신규 unit 3건:
  - `caller tools active → spawn argv carries '--tools \"\"' to disable claude built-ins`
  - `history-only payload (no tools) leaves claude built-in tools enabled`
  - `tool_choice=\"none\" suppresses '--tools \"\"' even when tools are present`
- [ ] opencode 로 wire 검증 — daemon 띄워둔 상태 (`agents/claude-fix178`), 사용자가 직접 시험 예정

Closes #178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)