### PR TITLE
fix(changeset): drop server bump from codex-backend rewrite changeset

### DIFF
--- a/.changeset/codex-backend-app-server-rewrite.md
+++ b/.changeset/codex-backend-app-server-rewrite.md
@@ -1,6 +1,5 @@
 ---
 '@vicoop-bridge/client': minor
-'@vicoop-bridge/server': minor
 ---
 
 Rewrite the `codex` backend to drive one persistent `codex app-server` subprocess over stdio JSON-RPC for the lifetime of the client, instead of spawning `codex exec` per task. The wire-facing A2A surface is unchanged — same `--backend codex`, same `BACKEND=codex`, same `backends.codex` config block, same openai-compat extension, same `tool_call_history`, image FileParts, traceability artifacts, and sandbox modes.


### PR DESCRIPTION
## Summary

Release workflow has been failing since #180 merged ([run 25873974796](https://github.com/planetarium/vicoop-bridge/actions/runs/25873974796)) because the changeset \`codex-backend-app-server-rewrite\` lists both \`@vicoop-bridge/client\` and \`@vicoop-bridge/server\` in its YAML header, and changesets refuses mixed bumps when one of the listed packages is in \`config.ignore\`:

\`\`\`
🦋  error Found mixed changeset codex-backend-app-server-rewrite
🦋  error Found ignored packages: @vicoop-bridge/server
🦋  error Found not ignored packages: @vicoop-bridge/client
🦋  error Mixed changesets that contain both ignored and not ignored packages are not allowed
\`\`\`

The server-side touches in #180 (cards/codex-app-server.json deletion + card-resolver entry removal) are operational cleanup — server isn't versioned at all per \`.changeset/config.json\`. Drop the server line; client minor bump alone is correct.

After merging this, the existing Version Packages PR (#171) will refresh and the 0.15.0 release can proceed.

## Test plan

- [x] Local diff confirms only the YAML header changed; release notes body untouched.
- [ ] Release workflow turns green on this commit (will verify after merge).