### PR TITLE
fix(changeset): drop server bump from list-revoke-client-cli changeset

### DIFF
--- a/.changeset/list-revoke-client-cli.md
+++ b/.changeset/list-revoke-client-cli.md
@@ -1,6 +1,5 @@
 ---
 "@vicoop-bridge/client": minor
-"@vicoop-bridge/server": minor
 ---
 
 Add `vicoop-client list-clients` and `vicoop-client revoke-client` subcommands so an owner can inspect and clean up their own `clients` rows from the CLI without dropping into admin GraphQL or psql (issue #166).


### PR DESCRIPTION
Same root cause as #181: \`@vicoop-bridge/server\` is in \`config.ignore\`, so a changeset listing both client and server fails the release workflow with \"Mixed changesets that contain both ignored and not ignored packages are not allowed\".

PR #168 (list-clients / revoke-client CLI) added matching server-side admin endpoints, but server isn't versioned per \`.changeset/config.json\`. Drop the server line.

After this lands the release workflow should clear all four pending changesets into a single 0.15.0 Version Packages PR refresh.

## Test plan

- [x] Same single-line YAML edit pattern as #181.
- [ ] Release workflow turns green on this commit.