### PR TITLE
fix(client): close codex built-in tool leak under openai-compat via `environments: []` (#183)

### DIFF
--- a/.changeset/codex-openai-compat-environments-disable.md
+++ b/.changeset/codex-openai-compat-environments-disable.md
@@ -1,0 +1,13 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Close the built-in-tool leak in the codex backend's openai-compat dispatch path (#183). Under openai-compat the caller's `tools` array is the only legitimate dispatch surface, but `features.shell_tool: false` alone was leaving `exec_command` (and its fallback handlers `local_shell` / `shell_command` / `container.exec`) callable in codex CLI 0.130 — we observed codex actually execute `git clone` via `exec_command` despite the feature disables.
+
+Two changes on `thread/start` when caller-side tool dispatch is active:
+
+1. Send `environments: []`. This is sticky on the thread and structurally removes every handler that `spec_plan.rs` gates on `environment_mode.has_environment()` — `shell`, `unified_exec`, `exec_command`, `write_stdin`, `shell_command`, `local_shell`, `container.exec`, `apply_patch`, `view_image` — from the tool registry, regardless of which feature flags are set. The model can no longer dispatch these handlers by name. `ThreadResumeParams` does not accept `environments`, so we only send it on start (relying on app-server's sticky behavior).
+
+2. Trim `config.features` to the surfaces NOT covered by `environments: []`: hosted modalities (image_generation, web_search_*), plugin / MCP discovery (tool_search, tool_suggest, tool_call_mcp_elicitation, builtin_mcp, plugins, apps, enable_mcp_apps), multi-agent / fan-out (multi_agent, multi_agent_v2, enable_fanout), request_permissions_tool, experimental code surfaces (code_mode, goals, memories), and workspace_dependencies. The previous shell_tool / unified_exec / apply_patch_freeform / apply_patch_streaming_events / browser_* / computer_use / in_app_browser entries are now redundant — `environments: []` covers them structurally.
+
+Surfaces still un-disable-able from this seam: `update_plan` and `request_user_input` are unconditional in codex's tool registry. They are benign in practice (plan mutation is session-local; `request_user_input` blocks on an MCP elicitation reply that never arrives under openai-compat). `list_mcp_resources` / `list_mcp_resource_templates` / `read_mcp_resource` are gated by codex's per-server `mcp_tools` config rather than a feature flag — out of scope for this change.

--- a/packages/client/src/backends/codex-rpc.ts
+++ b/packages/client/src/backends/codex-rpc.ts
@@ -71,6 +71,11 @@ export interface ThreadStartParams {
   developerInstructions?: string | null;
   baseInstructions?: string | null;
   config?: ThreadConfigOverride | null;
+  // Per-thread environment specs. Empty array = no execution environment,
+  // which structurally removes shell / unified_exec / apply_patch / view_image
+  // handlers from the tool registry for this thread (sticky across resumes).
+  // We model as opaque `unknown[]` because the only value we ever send is `[]`.
+  environments?: unknown[] | null;
 }
 
 export interface ThreadResumeParams {

--- a/packages/client/src/backends/codex-rpc.ts
+++ b/packages/client/src/backends/codex-rpc.ts
@@ -42,8 +42,22 @@ export const defaultAppServerSpawn: AppServerSpawnFn = (command, args, options) 
 
 export type SandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
 
+// Client-side capability opt-ins announced at initialize time. codex
+// app-server gates a number of fields behind `experimentalApi` — the gate
+// we care about is `thread/start.environments`, which we use to disable
+// codex's built-in execution surfaces under openai-compat dispatch (#183).
+// Other gated features (`thread/turns/list`, `process/spawn`, etc.) become
+// reachable too, but we don't call them, so opting in is no-op for them.
+// Safe to opt in unconditionally — codex marks individual fields stable
+// independently of the capability, and any future graduation just makes
+// the gate disappear.
+export interface InitializeCapabilities {
+  experimentalApi?: boolean;
+}
+
 export interface InitializeParams {
   clientInfo: { name: string; title: string; version: string };
+  capabilities?: InitializeCapabilities;
 }
 
 export interface InitializeResult {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -372,7 +372,13 @@ test('first task runs initialize + thread/start + turn/start and emits agent art
 
   // Sent frames must include initialize → initialized (notif) → thread/start → turn/start.
   const sent = child.stdinFrames();
-  assert.ok(findRequest(sent, 'initialize'), 'initialize sent');
+  const initReq = findRequest(sent, 'initialize') as
+    | { params?: { capabilities?: { experimentalApi?: boolean } } }
+    | undefined;
+  assert.ok(initReq, 'initialize sent');
+  // experimentalApi opt-in is required for `thread/start.environments` (#183).
+  // Send it unconditionally so the codex app-server accepts our env clamp.
+  assert.equal(initReq.params?.capabilities?.experimentalApi, true);
   const init = sent.find((f) => (f as { method?: string }).method === 'initialized') as
     | Record<string, unknown>
     | undefined;

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1021,16 +1021,20 @@ test('openai-compat envelope agent message is emitted as a data part', async () 
 // fails loudly rather than silently widening the agent's surface back
 // out to direct execution. If you update this list, also update the
 // matching block in `codex.ts` and call out the addition in the PR.
+// Features the openai-compat dispatch path zeroes out via `config.features`.
+// This list is INTENTIONALLY narrower than the full set of codex built-ins
+// because `environments: []` (asserted separately below) structurally removes
+// every handler gated on `environment_mode.has_environment()` — shell /
+// unified_exec / exec_command / write_stdin / shell_command / local_shell /
+// container.exec / apply_patch / view_image — without needing a feature flag.
+// What remains here is the set of surfaces NOT gated by environment: hosted
+// modalities, plugin/MCP discovery, multi-agent orchestration, etc.
+// If you update this list, also update the matching block in `codex.ts` and
+// call out the addition in the PR.
 const EXPECTED_OPENAI_COMPAT_DISABLES: Record<string, boolean> = {
-  shell_tool: false,
-  unified_exec: false,
-  browser_use: false,
-  browser_use_external: false,
-  computer_use: false,
-  in_app_browser: false,
-  apply_patch_freeform: false,
-  apply_patch_streaming_events: false,
   image_generation: false,
+  web_search_request: false,
+  web_search_cached: false,
   tool_search: false,
   tool_suggest: false,
   tool_call_mcp_elicitation: false,
@@ -1039,17 +1043,26 @@ const EXPECTED_OPENAI_COMPAT_DISABLES: Record<string, boolean> = {
   apps: false,
   enable_mcp_apps: false,
   multi_agent: false,
+  multi_agent_v2: false,
+  enable_fanout: false,
+  request_permissions_tool: false,
+  code_mode: false,
+  goals: false,
+  memories: false,
   workspace_dependencies: false,
 };
 
-test('thread/start disables every codex direct-execution feature when caller tools are active (#175, PR #180)', async () => {
+test('thread/start disables every codex direct-execution feature when caller tools are active (#175, PR #180, #183)', async () => {
   // Without this, codex would execute the caller's "bash" call itself in
   // its sandbox and emit a plain-text result instead of the openai-compat
-  // envelope the caller is waiting for. Beyond shell_tool / unified_exec
-  // (#175), every other codex surface that lets the model do something
-  // directly — browser, computer use, patch tools, image generation,
-  // plugins / apps / MCP, multi-agent, workspace introspection — is also
-  // disabled so the only legitimate dispatch is the caller's tools.
+  // envelope the caller is waiting for. Defense is on two seams:
+  // `environments: []` (asserted in a separate test) drops every handler
+  // gated on `environment_mode.has_environment()` — shell / unified_exec /
+  // exec_command / write_stdin / shell_command / local_shell / container.exec
+  // / apply_patch / view_image. This test covers the surfaces NOT covered by
+  // that: hosted modalities (image gen, web search), plugin/MCP discovery,
+  // multi-agent / fan-out, request_permissions, experimental code surfaces,
+  // and workspace introspection.
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
   await backend.handle(
@@ -1074,6 +1087,97 @@ test('thread/start disables every codex direct-execution feature when caller too
     params?: { config?: { features?: Record<string, boolean> } };
   }).params;
   assert.deepEqual(params?.config?.features, EXPECTED_OPENAI_COMPAT_DISABLES);
+});
+
+test('thread/start sends `environments: []` when caller tools are active (#183)', async () => {
+  // `environments: []` is the wholesale lever that drops every codex
+  // handler whose registration is gated on `environment_mode.has_environment()`
+  // — most importantly the entire exec/shell surface (`shell`,
+  // `unified_exec`, `exec_command`, `write_stdin`, `shell_command`,
+  // `local_shell`, `container.exec`) and `apply_patch` / `view_image`.
+  // Without this, `features.shell_tool: false` alone leaves `exec_command`
+  // callable (see #183: codex cli 0.130 actually executed `git clone` via
+  // `exec_command` despite our feature disables).
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('list files', 'ctx-env-empty', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'list files' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { environments?: unknown[] } }).params;
+  assert.deepEqual(params?.environments, []);
+});
+
+test('thread/start omits `environments` when no caller tools are supplied', async () => {
+  // Non-openai-compat callers (or openai-compat without tools) still expect
+  // codex to behave as a normal coding agent with its full environment, so
+  // we must NOT clamp environments to []. Gate matches `callerToolDispatchActive`.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(assign('hi', 'ctx-no-env-clamp'), collect().emit, NEVER);
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { environments?: unknown } }).params;
+  assert.equal(params?.environments, undefined);
+});
+
+test('thread/resume does NOT send `environments` (sticky on start; ResumeParams does not accept it) (#183)', async () => {
+  // `environments` is set once on `thread/start` and carries across resumes
+  // via the server-side session record. `ThreadResumeParams` in codex
+  // app-server-protocol has no `environments` field, so sending it on
+  // resume would either be ignored or rejected. Verify we only send it on
+  // start.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const meta = {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+    },
+  };
+  await backend.handle(
+    assign('one', 'ctx-env-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [{ kind: 'text', text: 'one' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  await backend.handle(
+    assign('two', 'ctx-env-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm2',
+        parts: [{ kind: 'text', text: 'two' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const frames = fake.lastChild().stdinFrames();
+  const resume = findRequest(frames, 'thread/resume');
+  assert.ok(resume, 'thread/resume observed');
+  const resumeParams = (resume as { params?: { environments?: unknown } }).params;
+  assert.equal(resumeParams?.environments, undefined);
 });
 
 test('thread/start omits `config` when no caller tools are supplied', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -639,56 +639,80 @@ export function createCodexBackend(
           // over via the server-side session record. Feature-flag overrides
           // (see `featuresOverride` below) are the exception — they do NOT
           // persist across resume and must be re-sent every turn that wants
-          // them.
+          // them. `environments`, by contrast, IS sticky on `thread/start`
+          // and `ThreadResumeParams` does not even accept it, so we only
+          // send it on start.
           //
           // When caller-side tool dispatch is active (openai-compat with
-          // tools), every codex surface that lets the model do something
-          // directly is disabled. The caller's `tools` array is the ONLY
-          // legitimate dispatch surface — anything codex can call itself
-          // (shell, exec, browser, computer use, patch tools, image
-          // generation, plugins / multi-agent / MCP, workspace
-          // introspection) would bypass the envelope contract. This is
-          // broader than the original #175 fix (`shell_tool` +
-          // `unified_exec`); see PR #180 review for the full rationale.
-          // The model is reduced to "emit text" or "emit a tool_calls
-          // envelope" only.
+          // tools), the caller's `tools` array is the ONLY legitimate
+          // dispatch surface — anything codex can call itself would bypass
+          // the envelope contract. We defend on two seams:
+          //
+          // 1. `environments: []` — structurally drops every handler that
+          //    `spec_plan.rs` gates on `environment_mode.has_environment()`:
+          //    `shell` / `local_shell` / `shell_command` / `exec_command` /
+          //    `write_stdin` / `container.exec` / `apply_patch` / `view_image`.
+          //    This is wholesale and not whack-a-mole: the model can't dispatch
+          //    these handlers by name because they are not in the registry,
+          //    regardless of which feature flags are set or which tool the
+          //    model decides to invent. See #183 — `features.shell_tool=false`
+          //    alone left `exec_command` callable in cli 0.130 because exec
+          //    handlers have fallback registrations that survive the
+          //    `ConfigShellToolType::Disabled` branch; `environments: []`
+          //    closes that gap by removing the environment those handlers
+          //    require.
+          //
+          // 2. `features.*: false` — for surfaces NOT covered by
+          //    `environments: []`: hosted web search, image generation,
+          //    multi-agent / fan-out, plugin / MCP discovery, etc. These
+          //    handlers do not depend on `environment_mode` and must each be
+          //    explicitly disabled by their feature key.
+          //
+          // Surfaces we can't disable from here: `update_plan` and
+          // `request_user_input` are unconditional in codex's tool registry;
+          // they have no feature key. They are benign in practice (plan
+          // mutation is session-local; request_user_input blocks on an MCP
+          // elicitation reply that never arrives under openai-compat).
+          // `list_mcp_resources` and siblings are gated by codex's per-server
+          // `mcp_tools` config — out of scope for this flag plumbing.
           const featuresOverride = callerToolDispatchActive(openaiCompat)
             ? {
                 features: {
-                  // Direct execution surfaces — anything that lets codex
-                  // do work itself instead of asking the caller.
-                  shell_tool: false,
-                  unified_exec: false,
-                  browser_use: false,
-                  browser_use_external: false,
-                  computer_use: false,
-                  in_app_browser: false,
-                  apply_patch_freeform: false,
-                  apply_patch_streaming_events: false,
-                  // Text-only output: caller asked for textual responses,
-                  // not generated images or other modalities.
+                  // Hosted modalities that bypass the caller's text envelope.
                   image_generation: false,
-                  // Codex-side tool catalog / discovery — under openai-
-                  // compat the caller's `tools` array is the only legit
-                  // tool surface, so codex shouldn't be searching, suggesting,
-                  // or eliciting MCP tools of its own.
+                  web_search_request: false,
+                  web_search_cached: false,
+                  // Codex-side tool catalog / discovery and plugin surfaces.
                   tool_search: false,
                   tool_suggest: false,
                   tool_call_mcp_elicitation: false,
                   builtin_mcp: false,
-                  // Plugin / app integrations expose third-party tools
-                  // codex could call directly.
                   plugins: false,
                   apps: false,
                   enable_mcp_apps: false,
-                  // Subagent spawning bypasses the single-agent contract.
+                  // Sub-agent / fan-out orchestration bypasses the single-
+                  // agent envelope contract.
                   multi_agent: false,
-                  // Workspace introspection — fs reads that could leak
-                  // host paths back into model context.
+                  multi_agent_v2: false,
+                  enable_fanout: false,
+                  // Permission-escalation prompts would block under openai-
+                  // compat (no human in loop).
+                  request_permissions_tool: false,
+                  // Experimental code surfaces.
+                  code_mode: false,
+                  goals: false,
+                  memories: false,
+                  // Workspace introspection — fs reads that could leak host
+                  // paths back into model context.
                   workspace_dependencies: false,
                 },
               }
             : null;
+          // `environments: []` is sticky on `thread/start` and unsupported on
+          // `thread/resume`, so we only send it on start. Gated by the same
+          // condition as the feature override so non-openai-compat callers
+          // keep their normal codex environment.
+          const sendEmptyEnvironments = callerToolDispatchActive(openaiCompat);
 
           let threadId: string;
           try {
@@ -711,6 +735,7 @@ export function createCodexBackend(
                   sandbox: sandboxMode,
                   ...(systemPrompt ? { developerInstructions: systemPrompt } : {}),
                   ...(featuresOverride ? { config: featuresOverride } : {}),
+                  ...(sendEmptyEnvironments ? { environments: [] } : {}),
                 },
               );
               threadId = startResult.thread.id;

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -465,6 +465,15 @@ export function createCodexBackend(
             title: 'vicoop-bridge client',
             version: '1',
           },
+          // `experimentalApi: true` is required to send
+          // `thread/start.environments` — the wholesale lever we use to
+          // remove codex's built-in execution surfaces under openai-compat
+          // dispatch (#183). Codex's app-server rejects the request with
+          // `thread/start.environments requires experimentalApi capability`
+          // otherwise. Opt-in is documented as the public stable handshake
+          // for accessing gated fields; individual fields graduate
+          // independently so this opt-in remains safe across upgrades.
+          capabilities: { experimentalApi: true },
         };
         const result = await withTimeout(
           c.request<InitializeResult>('initialize', initParams),


### PR DESCRIPTION
## Summary

Closes the codex built-in-tool leak under openai-compat dispatch reported in #183. We observed codex actually execute `git clone` via `exec_command` despite our `features.shell_tool: false` / `unified_exec: false` disables — the feature flags weren't enough because codex registers fallback handlers (`local_shell`, `shell_command`, `container.exec`) that survive the `ConfigShellToolType::Disabled` branch.

## Approach

Switch from whack-a-mole feature allowlist to a structural lever.

1. **Send `environments: []` on `thread/start`** when caller-side tool dispatch is active. In codex cli 0.130 (`codex-rs/core/src/tools/spec_plan.rs`), every handler whose registration is gated on `environment_mode.has_environment()` — `shell`, `unified_exec`, `exec_command`, `write_stdin`, `shell_command`, `local_shell`, `container.exec`, `apply_patch`, `view_image` — is structurally removed from the tool registry, so the model cannot dispatch them by name regardless of which feature flags are set. Sticky across resumes (`ThreadResumeParams` has no `environments` field), so we only send it on start.

2. **Trim `config.features`** to the surfaces NOT covered by `environments: []`: hosted modalities (`image_generation`, `web_search_*`), plugin / MCP discovery (`tool_search`, `tool_suggest`, `tool_call_mcp_elicitation`, `builtin_mcp`, `plugins`, `apps`, `enable_mcp_apps`), multi-agent / fan-out (`multi_agent`, `multi_agent_v2`, `enable_fanout`), `request_permissions_tool`, experimental code surfaces (`code_mode`, `goals`, `memories`), and `workspace_dependencies`. The previous `shell_tool` / `unified_exec` / `apply_patch_*` / `browser_*` / `computer_use` / `in_app_browser` entries are now redundant — they only existed to cover handlers that `environments: []` already removes.

## Out of scope (caveats called out in the changeset)

- `update_plan` and `request_user_input` are unconditional in codex's tool registry — no feature key. Benign in practice (plan mutation is session-local; `request_user_input` blocks on an MCP elicitation reply that never arrives under openai-compat).
- `list_mcp_resources` / `list_mcp_resource_templates` / `read_mcp_resource` are gated by codex's per-server `mcp_tools` config rather than a feature flag.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 393/393 pass, including 3 new tests for `environments: []` (sent under openai-compat / omitted otherwise / not sent on resume) and the updated openai-compat features assertion
- [x] `pnpm build` — clean
- [ ] Live re-run of the #183 reproduction prompt (`opencode run` → clone + README) — verify codex no longer emits `exec_command` in its session rollout

## Repro reference

The #183 reproduction had codex emit:

```json
{"type":"function_call",
 "name":"exec_command",
 "arguments":{"cmd":"git clone https://github.com/planetarium/vicoop-bridge vicoop-bridge-readme-test-2",
              "sandbox_permissions":"require_escalated"}}
```

…in a thread that had `features.shell_tool: false` and `features.unified_exec: false` set. With `environments: []` that handler is no longer registered, so the model can't call it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)