### PR TITLE
fix(client): stop codex app-server child on shutdown + drop systemd auto-registration (#186)

### DIFF
--- a/.changeset/backend-stop-shutdown-hook.md
+++ b/.changeset/backend-stop-shutdown-hook.md
@@ -1,0 +1,19 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Fix the codex backend leaving an orphaned `codex app-server` subprocess
+after the daemon exits (#186). The `Backend` interface gains an optional
+`stop()` hook; `Client.stop()` invokes it before returning, and the codex
+backend uses it to SIGTERM the long-lived `app-server` child that
+otherwise outlived SIGINT/SIGTERM on the daemon.
+
+Always-on service registration has been removed pending a redesign:
+`install.sh` no longer writes a `vicoop-client.service` unit or env
+template (the `INSTALL_SKIP_SERVICE` / `INSTALL_SERVICE_SCOPE` env vars
+are gone), and `vicoop-client upgrade` no longer tries to
+`systemctl try-restart` after swapping the bundle. Restart the daemon
+manually with whatever supervisor you use until the new design lands.
+`setup --write-env-file` is unchanged; it now describes itself as a
+generic shell-sourceable env file rather than a systemd
+`EnvironmentFile=`.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -71,8 +71,6 @@ would still default to `/data/vicoop-bridge-client`.
 | `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
 | `VERSION` | latest `@vicoop-bridge/client@*` | Pin a specific tag, e.g. `@vicoop-bridge/client@0.1.1`. |
 | `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
-| `INSTALL_SKIP_SERVICE` | `0` | If `1`, skip the optional systemd unit + env template even on systemd hosts. |
-| `INSTALL_SERVICE_SCOPE` | `auto` | Force `user`, `system`, or `none` instead of auto-detecting by `id -u`. `system` requires root; an explicit `system` without root is refused with a warning. |
 
 What you get after extraction:
 
@@ -92,13 +90,10 @@ The script targets Linux (Fly.io persistent volumes are the original target
 deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
 background.
 
-When systemd is the host init, `install.sh` may also write an optional
-`vicoop-client.service` unit plus a `vicoop-client.env` template (scope
-auto-detected: `system` as root, `user` otherwise). It does not enable or
-start the service. Use the foreground run in Step 6 first; enable the service
-later only if this host should keep the client online unattended. Opt out with
-`INSTALL_SKIP_SERVICE=1`, or force a scope with
-`INSTALL_SERVICE_SCOPE=user|system|none`.
+> The installer no longer generates an always-on service unit. The design
+> for unattended operation (systemd, launchd, etc.) is still in flux —
+> issue #186 tracks the rework. For now the supported entrypoint is the
+> foreground run in Step 6.
 
 ## Step 2 — Verify the installed bundle
 
@@ -195,7 +190,7 @@ like:
 The CLIENT_TOKEN is one-time — the bridge cannot reissue it.
   setup persists it to the canonical config below; --json prints it to
   stdout instead. Back up that file before rotating hosts.
-  To also stash it in a systemd EnvironmentFile, pass --write-env-file
+  To also stash it in a shell-sourceable env file, pass --write-env-file
   on this same setup invocation — rerunning setup later would call
   registerClient again and mint a NEW CLIENT_TOKEN, invalidating this
   one. To populate an env file from an already-issued token, copy
@@ -256,7 +251,7 @@ The schema also accepts a top-level `card` mirroring the `--card` flag /
 canonical card per backend — see Step 5).
 
 Daemon precedence is **CLI flag > env var > `--config <path>` > canonical
-`config.json`**, so env values still win (handy for systemd `EnvironmentFile=`
+`config.json`**, so env values still win (handy for shell-sourced env files
 or CI overrides). `setup` only ever touches `server_url`, `server_token`, and
 `agent_id` — hand-edits to the other fields survive `setup` re-runs.
 
@@ -318,7 +313,7 @@ token.
    that bearer, receives `{client_id, client_token, owner_principal,
    allowed_agent_ids}`, and writes the daemon credentials into
    `~/.vicoop/config.json` (mode 600). With `--write-env-file <path>` it
-   additionally emits a systemd-shaped env file at that path. It never
+   additionally emits a shell-sourceable env file at that path. It never
    sees a `vbc_caller_*` token.
 
 This means a Google-only operator can stand up a bridge client without
@@ -696,10 +691,7 @@ The upgrade command:
 6. Atomically swaps: `$INSTALL_DIR` → `$INSTALL_DIR.prev`,
    `$INSTALL_DIR.new` → `$INSTALL_DIR`. A failure mid-swap restores the
    original.
-7. Detects a matching `vicoop-client.service` unit (system or user scope) and
-   runs `systemctl [--user] try-restart vicoop-client.service`. If no unit
-   exists, prints a reminder to restart the client yourself.
-8. Keeps `$INSTALL_DIR.prev` around for manual rollback (`mv` it back into
+7. Keeps `$INSTALL_DIR.prev` around for manual rollback (`mv` it back into
    place if needed). Delete it once you've confirmed the new version works.
 
 **Permissions**: for a system-scope install (root-owned `$INSTALL_DIR`),
@@ -707,20 +699,17 @@ run the upgrade via `sudo`. The command checks write access up front and
 fails fast with a clear error otherwise.
 
 **Operator-owned state is not touched by `upgrade`.** That covers
-`~/.vicoop/config.json` (the canonical daemon config — Step 4),
-`~/.vicoop/owner-session.json` (the owner bearer — `login`), and
-`/etc/vicoop-client.env` plus the systemd unit file (written by
-`install.sh` only). If a release ever changes the unit layout, re-run
-`install.sh` once to refresh the scaffolding. Note that `FORCE=1` deletes
-everything under `$INSTALL_DIR` first — back up any operator-added cards or
-files before running it.
+`~/.vicoop/config.json` (the canonical daemon config — Step 4) and
+`~/.vicoop/owner-session.json` (the owner bearer — `login`). `FORCE=1`
+deletes everything under `$INSTALL_DIR` first — back up any operator-added
+cards or files before running it.
 
-**Manual restart on non-systemd hosts.** The atomic swap leaves your running
+**Manual restart after upgrade.** The atomic swap leaves your running
 client process attached to the previous bundle. Stop it and start it again
-with your usual command (foreground / screen / tmux / launchd) so the new
-version takes effect — `upgrade` cannot signal a process it didn't start.
-To check for stragglers, run `pgrep -fl 'vicoop-client|dist/cli\.js'` and kill
-any old process before starting the new one. Multiple client processes
+with your usual command (foreground / screen / tmux) so the new version
+takes effect — `upgrade` cannot signal a process it didn't start. To check
+for stragglers, run `pgrep -fl 'vicoop-client|dist/cli\.js'` and kill any
+old process before starting the new one. Multiple client processes
 connecting with the **same `SERVER_TOKEN`** for one `AGENT_ID` collide and
 the older WS is closed with code 4009 (harmless but noisy); see the Gotchas
 section of `docs/local-testing.md` for the same note.

--- a/install.sh
+++ b/install.sh
@@ -9,17 +9,13 @@
 #   VERSION               Specific tag to install, e.g. @vicoop-bridge/client@0.1.0
 #                         (default: latest @vicoop-bridge/client@* release)
 #   FORCE                 If "1", overwrite a non-empty INSTALL_DIR
-#   INSTALL_SKIP_SERVICE  If "1", skip systemd unit registration
-#   INSTALL_SERVICE_SCOPE Override detection: "auto" | "user" | "system" | "none" (default: auto)
 #
 # What it does:
 #   1. Verifies prerequisites (Linux warning, Node.js >= 20, curl, tar, sha256 tool).
 #   2. Resolves the latest (or pinned) @vicoop-bridge/client@* GitHub release.
 #   3. Downloads the .tgz + .sha256 and verifies integrity.
 #   4. Extracts the bundle into INSTALL_DIR.
-#   5. On systemd hosts, drops an optional vicoop-client.service unit + env
-#      template (does NOT enable/start — verify a foreground run first).
-#   6. Prints next-step instructions for login and a foreground first run.
+#   5. Prints next-step instructions for login and a foreground first run.
 
 set -eu
 
@@ -27,8 +23,6 @@ REPO="planetarium/vicoop-bridge"
 INSTALL_DIR="${INSTALL_DIR:-/data/vicoop-bridge-client}"
 VERSION="${VERSION:-}"
 FORCE="${FORCE:-0}"
-INSTALL_SKIP_SERVICE="${INSTALL_SKIP_SERVICE:-0}"
-INSTALL_SERVICE_SCOPE="${INSTALL_SERVICE_SCOPE:-auto}"
 
 log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
@@ -212,301 +206,7 @@ fi
 
 chmod +x "$INSTALL_DIR/bin/vicoop-client" 2>/dev/null || true
 
-# ---- 5. Optional systemd service registration -------------------------------
-# The unit reads config from an EnvironmentFile (k3s-style) so the operator can
-# populate secrets after install without editing the unit itself. We never
-# overwrite an existing env file — the unit file is regenerated on every run.
-SERVICE_INSTALLED=""
-SERVICE_ENABLE_CMD=""
-SERVICE_ENV_FILE=""
-
-register_service() {
-  # Picks the scope, logs exactly one reason when skipping, and delegates to
-  # install_service when it can. Set SERVICE_INSTALLED on success.
-  if [ "$INSTALL_SKIP_SERVICE" = "1" ]; then
-    log "INSTALL_SKIP_SERVICE=1 — skipping service registration"
-    return
-  fi
-
-  case "$INSTALL_SERVICE_SCOPE" in
-    none)
-      log "INSTALL_SERVICE_SCOPE=none — skipping service registration"
-      return
-      ;;
-    user)
-      install_service user
-      return
-      ;;
-    system)
-      # Explicit system scope requires root — refuse early with a clear message
-      # rather than letting the later `cat > /etc/...` fail under `set -e`.
-      if [ "$(id -u)" != "0" ]; then
-        log "warning: INSTALL_SERVICE_SCOPE=system requires root; skipping service registration (rerun with sudo, or set INSTALL_SERVICE_SCOPE=user)"
-        return
-      fi
-      install_service system
-      return
-      ;;
-    auto) ;;
-    *)
-      log "warning: unknown INSTALL_SERVICE_SCOPE='$INSTALL_SERVICE_SCOPE', treating as auto"
-      ;;
-  esac
-
-  # systemd must be the init (PID 1) — otherwise systemctl may exist but the
-  # unit will never actually run (common in Docker, WSL1, macOS with homebrew).
-  if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
-    log "systemd not detected — skipping optional service registration"
-    return
-  fi
-
-  if [ "$(id -u)" = "0" ]; then
-    install_service system
-  else
-    install_service user
-  fi
-}
-
-install_service() {
-  scope="$1"
-
-  # Resolve node's absolute path at install time. Invoking node directly (not
-  # via bin/vicoop-client) means the unit works under nvm/asdf/Volta layouts
-  # where systemd's default PATH wouldn't find node.
-  node_bin="$(command -v node 2>/dev/null || true)"
-  [ -n "$node_bin" ] || { log "warning: node not on PATH — skipping service registration"; return; }
-  cli_entry="$INSTALL_DIR/dist/cli.js"
-
-  case "$scope" in
-    system)
-      unit_dir="/etc/systemd/system"
-      env_file="/etc/vicoop-client.env"
-      env_ref="$env_file"
-      want="multi-user.target"
-      # network-online.target is a system-instance unit; keep the ordering
-      # dependency only for system scope.
-      net_deps='After=network-online.target
-Wants=network-online.target'
-      # The client has no privileged operations, so drop root for system
-      # scope. DynamicUser allocates a transient UID; EnvironmentFile is
-      # read before the user switch so /etc/vicoop-client.env can stay
-      # root-owned 0600. NoNewPrivileges/ProtectSystem/ProtectHome/PrivateTmp
-      # are cheap defense-in-depth. User-scope units inherit the caller's
-      # identity and don't need (or accept) these knobs.
-      #
-      # Refuse to generate a system-scope unit when node or the bundle
-      # lives under /home or /root. Falling back to a root-run unit from a
-      # user-writable directory (e.g. nvm under /home, or `sudo sh
-      # install.sh` pulling node from /root/.nvm) turns this into
-      # "root executes code from a potentially user-controlled path at
-      # boot" — a real privilege-escalation vector. Skip service
-      # registration and tell the operator how to recover; extraction
-      # already succeeded, so the install is still usable manually.
-      case "$node_bin $cli_entry" in
-        */home/*|*/root/*)
-          log "warning: refusing to install a system-scope service because node or the bundle lives under /home or /root (node=$node_bin, cli=$cli_entry)."
-          log "  reason: a root-owned unit executing code from a user-writable or home-owned path is unsafe."
-          log "  options: reinstall with INSTALL_DIR under a root-only system path (e.g. /opt/vicoop-bridge-client) and a system-path node, or re-run with INSTALL_SERVICE_SCOPE=user."
-          return
-          ;;
-      esac
-      unit_hardening='DynamicUser=yes
-NoNewPrivileges=yes
-ProtectSystem=strict
-ProtectHome=yes
-PrivateTmp=yes'
-      # Root running the installer (the auto-detected system path) gets an
-      # un-prefixed command; sudo is only suggested for later reinvocations by
-      # a non-root operator. Minimal images often lack sudo entirely.
-      if [ "$(id -u)" = "0" ]; then
-        SERVICE_RELOAD_CMD="systemctl daemon-reload"
-        SERVICE_ENABLE_CMD="systemctl enable --now vicoop-client"
-      else
-        SERVICE_RELOAD_CMD="sudo systemctl daemon-reload"
-        SERVICE_ENABLE_CMD="sudo systemctl enable --now vicoop-client"
-      fi
-      ;;
-    user)
-      [ -n "${HOME:-}" ] || { log "warning: HOME unset — skipping service registration"; return; }
-      unit_dir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
-      env_file="${XDG_CONFIG_HOME:-$HOME/.config}/vicoop-client.env"
-      env_ref="$env_file"
-      want="default.target"
-      # User-instance systemd doesn't know about network-online.target;
-      # declaring it produces "unit not found" noise and buys nothing.
-      net_deps=''
-      # NoNewPrivileges is safe to apply in --user scope; the heavier
-      # ProtectSystem / DynamicUser family is system-scope only.
-      unit_hardening='NoNewPrivileges=yes'
-      SERVICE_RELOAD_CMD="systemctl --user daemon-reload"
-      SERVICE_ENABLE_CMD="systemctl --user enable --now vicoop-client"
-      ;;
-    *) return ;;
-  esac
-
-  # systemd's ExecStart tokenises on whitespace and EnvironmentFile doesn't
-  # cleanly round-trip paths with spaces either. Rather than hand-roll the
-  # quoting rules, refuse to register and let the operator pick a clean path.
-  for p in "$node_bin" "$cli_entry" "$unit_dir" "$env_file"; do
-    case "$p" in
-      *[[:space:]]*)
-        log "warning: path contains whitespace ('$p') — skipping service registration, run the client manually or reinstall under a space-free path"
-        return
-        ;;
-    esac
-  done
-
-  mkdir -p "$unit_dir"
-  unit_path="$unit_dir/vicoop-client.service"
-
-  # Assemble the [Unit] body so the net_deps block drops out cleanly for user
-  # scope without leaving a stray blank line.
-  unit_unit_section="Description=vicoop-bridge-client ($scope scope)"
-  if [ -n "$net_deps" ]; then
-    unit_unit_section="$unit_unit_section
-$net_deps"
-  fi
-
-  cat > "$unit_path" <<UNIT
-# Generated by vicoop-bridge install.sh for $VERSION.
-# Edit $env_file to configure the client before enabling.
-[Unit]
-$unit_unit_section
-
-[Service]
-Type=simple
-EnvironmentFile=$env_ref
-ExecStart=$node_bin $cli_entry
-Restart=on-failure
-RestartSec=5s
-$unit_hardening
-
-[Install]
-WantedBy=$want
-UNIT
-
-  if [ ! -e "$env_file" ]; then
-    mkdir -p "$(dirname "$env_file")"
-    # Write the env template with restrictive perms *before* content lands,
-    # in case the file survives a later failure.
-    ( umask 077 && : > "$env_file" )
-    env_fresh=1
-    cat > "$env_file" <<ENVF
-# vicoop-client environment — populated by the agent/operator after install.
-# Restrict perms (chmod 600) if this file is ever copied elsewhere.
-#
-# This file is the systemd EnvironmentFile= layout (one assignment per line,
-# no shell). For interactive / non-systemd installs, prefer the canonical
-# vicoop config.json that \`vicoop-client setup\` writes by default — its
-# directory is resolved as \$VICOOP_HOME > (existing) ~/.vicoop >
-# \$XDG_CONFIG_HOME/vicoop > ~/.vicoop. The daemon merges both with env
-# taking precedence (see #137).
-
-# Bare WS(S) origin of the bridge server (the client appends /connect).
-SERVER_URL=wss://vicoop-bridge-server.fly.dev
-
-# Raw client token from registerClient GraphQL mutation (unrecoverable).
-SERVER_TOKEN=
-
-# One of the agent IDs allowed for this client token.
-AGENT_ID=
-
-# One of: echo, openclaw, claude.
-BACKEND=openclaw
-
-# Optional operator override for the published AgentCard metadata. Leave unset
-# for the bridge server's canonical card for BACKEND. Double-quote paths with
-# spaces if you enable this in systemd EnvironmentFile syntax.
-#AGENT_CARD="$INSTALL_DIR/cards/openclaw.json"
-
-# --- OpenClaw-only (uncomment if overriding defaults) ---
-#OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789
-#OPENCLAW_GATEWAY_TOKEN=
-#OPENCLAW_AGENT=main
-#OPENCLAW_TASK_TIMEOUT_MS=
-
-# --- Claude-backend-only (uncomment if BACKEND=claude) ---
-# Working directory for the spawned claude subprocess. Defaults to the
-# daemon's pwd. Set this to a dedicated work tree so sandbox.filesystem
-# default write rules (cwd-only) and Read tool defaults are scoped to a
-# directory that does NOT contain operator credentials.
-#CLAUDE_CWD=/srv/agent-work
-
-# Inline --settings JSON forwarded to every \`claude -p\` (issue #138).
-# Enables the OS-level sandbox (Seatbelt on macOS, bubblewrap on Linux)
-# AND permission-rule deny lists for Claude's internal Read/Edit (which
-# the OS sandbox does not cover). Single line only (systemd EnvironmentFile
-# is one assignment per line); compact your JSON before pasting.
-#
-# Starter profile vetted on macOS Seatbelt with claude 2.1.139. Three
-# non-obvious gotchas were verified empirically and folded in below:
-#
-#   1. allowedDomains MUST be nested under sandbox.network. Placing it at
-#      sandbox.allowedDomains is silently ignored.
-#   2. npm/pnpm need ~/.npm and ~/.cache/pnpm in allowWrite or every
-#      registry fetch fails at the cache-write step (EPERM), even with
-#      the registry domain allowed.
-#   3. \`gh\` cannot read its macOS Keychain token under Seatbelt
-#      (\`gh auth status\` fails regardless of network). If the agent needs
-#      gh, inject the token via env: GH_TOKEN=<pat> on this systemd unit.
-#
-# Broaden filesystem.allowWrite, network.allowedDomains, and the
-# permission deny list as your agent's toolchain requires.
-#CLAUDE_SETTINGS_JSON={"sandbox":{"enabled":true,"failIfUnavailable":true,"allowUnsandboxedCommands":false,"filesystem":{"denyRead":["~/.ssh","~/.aws","~/.gnupg","~/.netrc"],"allowWrite":["/tmp/vicoop","~/.npm","~/.cache/pnpm"]},"network":{"allowManagedDomainsOnly":true,"allowedDomains":["github.com","api.github.com","codeload.github.com","objects.githubusercontent.com","uploads.github.com","registry.npmjs.org"]}},"permissions":{"deny":["Read(~/.ssh/**)","Read(~/.aws/**)","Read(~/.netrc)","Read(**/.env*)","Bash(ping:*)","Bash(nslookup:*)","Bash(dig:*)","Bash(host:*)","Bash(curl:*)","Bash(wget:*)","Bash(nc:*)","Bash(socat:*)"]}}
-
-# Personal access token injected when the agent uses \`gh\` — Seatbelt
-# blocks Keychain access so the stored gh credential is unreachable
-# inside the sandbox. Use a fine-grained PAT scoped to the repos the
-# agent actually needs.
-#GH_TOKEN=
-
-# --- Observability (optional, OpenTelemetry) ---
-# claude-code is OTEL-native. The bridge daemon just inherits these
-# variables and claude exports tool-call / prompt traces directly. Point
-# OTEL_EXPORTER_OTLP_ENDPOINT at your collector and the SIEM gets a
-# queryable, tamper-evident audit trail (the agent cannot suppress
-# exported spans). All four vars are needed for full fidelity.
-#OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.local:4317
-#OTEL_LOG_TOOL_DETAILS=1
-#OTEL_LOG_TOOL_CONTENT=1
-#OTEL_LOG_USER_PROMPTS=1
-ENVF
-    env_created="new"
-  else
-    env_fresh=0
-    env_created="kept"
-  fi
-
-  # Always enforce 0600 — an existing env file may have been copied in with
-  # permissive perms, and SERVER_TOKEN being world-readable is the worst
-  # failure mode we could leave behind.
-  chmod 600 "$env_file" 2>/dev/null || log "warning: could not chmod 600 $env_file"
-
-  # Warn if a kept env file's optional AGENT_CARD still points at a different
-  # install root than the one we just extracted into. We don't rewrite —
-  # the operator may have intentionally pointed at a different card — but
-  # an invisible stale pointer after \`INSTALL_DIR=\` reinstalls is worse
-  # than a noisy log line.
-  if [ "$env_fresh" = "0" ]; then
-    prev_card="$(sed -n 's/^[[:space:]]*AGENT_CARD=\(.*\)/\1/p' "$env_file" | tail -n1 | sed -E 's/^"//; s/"$//')"
-    new_card="$INSTALL_DIR/cards/openclaw.json"
-    if [ -n "$prev_card" ] && [ "$prev_card" != "$new_card" ]; then
-      case "$prev_card" in
-        */cards/openclaw.json)
-          log "warning: $env_file has AGENT_CARD=$prev_card but INSTALL_DIR is now $INSTALL_DIR — update the env file if that pointer is stale"
-          ;;
-      esac
-    fi
-  fi
-
-  SERVICE_INSTALLED="$scope"
-  SERVICE_ENV_FILE="$env_file"
-  log "wrote systemd unit $unit_path ($env_created env: $env_file)"
-}
-
-register_service
-
-# ---- 6. Next steps ----------------------------------------------------------
+# ---- 5. Next steps ----------------------------------------------------------
 cat <<EOF
 
 ==> installed $VERSION to $INSTALL_DIR
@@ -520,50 +220,10 @@ Next steps (the agent that owns this client should perform these):
 
      Then follow docs/install-client.md steps 3-6 to pick AGENT_ID, run
      login, choose a backend, and start the client.
-EOF
 
-if [ -n "$SERVICE_INSTALLED" ]; then
-  cat <<EOF
-  2. First run the client in the foreground. \`vicoop-client setup\`
-     persists credentials (mode 600) to the resolved vicoop config dir's
-     config.json — \$VICOOP_HOME > (existing) ~/.vicoop >
-     \$XDG_CONFIG_HOME/vicoop > ~/.vicoop, default ~/.vicoop. The daemon
-     picks them up automatically. See docs/install-client.md step 6.
-
-  3. Optional: after the foreground run works, populate $SERVICE_ENV_FILE
-     for the systemd unit. Either run \`vicoop-client setup\` once with
-     \`--write-env-file $SERVICE_ENV_FILE\` (mints token + writes both
-     outputs in one shot) or copy SERVER_URL / SERVER_TOKEN / AGENT_ID
-     from the canonical config.json by hand. Re-running setup just to
-     refresh the env file would mint a NEW CLIENT_TOKEN and invalidate
-     the previously persisted one. Then reload systemd and enable +
-     start the service:
-
-       $SERVICE_RELOAD_CMD
-       $SERVICE_ENABLE_CMD
-
-  Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
-  to re-run this installer. Pass --check to see if a newer release is
-  available. The quotes keep the command correct even if \$INSTALL_DIR
-  contains whitespace.
-
-EOF
-  if [ "$SERVICE_INSTALLED" = "user" ]; then
-    cat <<'EOF'
-     For 24/7 operation on a headless host, also run (once):
-
-       sudo loginctl enable-linger "$USER"
-
-     Otherwise the user's systemd manager stops when the last login session
-     closes, taking the client with it.
-
-EOF
-  fi
-else
-  cat <<EOF
   2. Run the client in the foreground (supply config via env or flags).
-     Paths are quoted so
-     the snippet works even when \$INSTALL_DIR contains whitespace:
+     Paths are quoted so the snippet works even when \$INSTALL_DIR contains
+     whitespace:
 
        SERVER_URL=wss://your-server-host \\
        SERVER_TOKEN=... \\
@@ -571,8 +231,9 @@ else
        BACKEND=openclaw \\
          "$INSTALL_DIR/bin/vicoop-client"
 
-     Persistent operation is optional after the foreground run works
-     (systemd EnvironmentFile=, screen, tmux, launchd, etc.).
+     An always-on supervisor story (systemd unit, launchd plist, etc.) is
+     not currently provided by this installer; the foreground run above is
+     the supported entrypoint while the design is in flux (issue #186).
 
   Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
   to re-run this installer. Pass --check to see if a newer release is
@@ -580,4 +241,3 @@ else
   contains whitespace.
 
 EOF
-fi

--- a/packages/client/src/backend.ts
+++ b/packages/client/src/backend.ts
@@ -23,4 +23,13 @@ export interface Backend {
   // version support). Returning `{}` — or throwing — leaves the card's
   // declared capabilities unchanged.
   resolveCapabilities?(): Promise<DetectedCapabilities>;
+  // Optional process-wide cleanup invoked from `Client.stop()` before the
+  // daemon exits. Per-task cancellation already flows through `signal` in
+  // `handle()`, but long-lived upstream resources held across tasks (e.g.
+  // codex's `app-server` subprocess) would otherwise leak as orphaned
+  // children when the daemon receives SIGINT/SIGTERM. Must be synchronous
+  // and best-effort — callers do not await it before `process.exit`, so
+  // implementations should send a kill signal / close a socket and return
+  // immediately rather than wait for graceful shutdown.
+  stop?(): void;
 }

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -404,6 +404,36 @@ test('first task runs initialize + thread/start + turn/start and emits agent art
   assert.equal(last?.type === 'task.complete' && last.status.state, 'completed');
 });
 
+test('backend.stop() sends SIGTERM to the long-lived app-server child (#186)', async () => {
+  // Daemon shutdown path: Client.stop() forwards to Backend.stop(), which
+  // the codex backend uses to tear down the singleton `codex app-server`
+  // process. Without this signal the child is re-parented to init after
+  // the daemon exits and leaks (see issue #186, macOS report). Verify a
+  // SIGTERM is dispatched to the active child, and that calling stop()
+  // before any task has spawned a child is a safe no-op (the codex
+  // backend lazily spawns on the first task).
+  const fake = makeFakeSpawn(() => happyPath({ agentMessageText: 'OK' }));
+  const backend = createCodexBackend({ spawn: fake.spawn });
+
+  // No child yet — stop must not throw.
+  assert.doesNotThrow(() => backend.stop?.());
+  assert.equal(fake.children.length, 0);
+
+  // Run one task to materialize the singleton child, then stop.
+  const { emit } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+  assert.equal(fake.children.length, 1);
+  const child = fake.lastChild();
+  assert.equal(child.killed, false, 'child must be alive before stop');
+
+  backend.stop?.();
+  assert.equal(child.killed, true, 'stop must kill the app-server child');
+  assert.equal(child.killSignal, 'SIGTERM');
+
+  // Idempotent: a second stop after the child has closed must not throw.
+  assert.doesNotThrow(() => backend.stop?.());
+});
+
 test('follow-up task with same contextId uses thread/resume not thread/start', async () => {
   const fake = makeFakeSpawn(() => happyPath({ threadId: 'thr-1' }));
   const backend = createCodexBackend({ spawn: fake.spawn });

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -492,6 +492,18 @@ export function createCodexBackend(
   return {
     name: 'codex',
 
+    // Daemon shutdown hook. Per-task abort flows through `signal` in
+    // `handle()`, but the `codex app-server` subprocess is a singleton kept
+    // alive across tasks via `ensureClient()` — without an explicit kill on
+    // SIGINT/SIGTERM it would be re-parented to init and linger after the
+    // daemon exits (issue #186). Best-effort SIGTERM; the OS delivers it
+    // before `process.exit` runs even though we don't await the close.
+    stop(): void {
+      if (rpcClient && !rpcClient.isClosed()) {
+        rpcClient.kill('SIGTERM');
+      }
+    },
+
     async handle(task, rawEmit, signal) {
       let lastEmitAt = now();
       const recorder = createTimingRecorder({

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -232,6 +232,79 @@ test('Client logs identity block (mention/acct/a2a/card/webfinger) once on conne
   }
 });
 
+test('Client.stop invokes backend.stop so long-lived children are torn down (#186)', async () => {
+  // The codex backend keeps a `codex app-server` subprocess alive across
+  // tasks via its `AppServerRpcClient` singleton — per-task AbortSignal
+  // doesn't reach it. Without an explicit `backend.stop()` on daemon
+  // shutdown, the child gets re-parented to init and lingers, which is
+  // what the macOS report in #186 observed. Assert here that Client.stop
+  // calls the optional hook, and tolerates a throwing implementation
+  // without crashing the shutdown path (the daemon entrypoint follows
+  // stop() with process.exit, so an unhandled throw would suppress the
+  // exit semantics callers depend on).
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  let stopCalls = 0;
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: {
+      name: 'stub',
+      handle: async () => {
+        /* no tasks */
+      },
+      stop: () => {
+        stopCalls++;
+      },
+    },
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+  });
+
+  try {
+    client.start();
+    await waitFor(() => wss.clients.size === 1, 'expected one ws client');
+    client.stop();
+    assert.equal(stopCalls, 1, 'Client.stop must invoke backend.stop exactly once');
+
+    // A throwing stop must not propagate out of Client.stop — the daemon
+    // entrypoint calls process.exit on the next line and shouldn't be
+    // hijacked by a buggy backend.
+    const throwingClient = new Client({
+      serverUrl,
+      token: 'client-token',
+      agentId: 'agent-2',
+      backendKind: 'echo',
+      backend: {
+        name: 'stub',
+        handle: async () => {
+          /* no tasks */
+        },
+        stop: () => {
+          throw new Error('boom');
+        },
+      },
+      reconnectDelayMs: 10,
+      reconnectMaxDelayMs: 10,
+      reconnectJitterRatio: 0,
+      reconnectStableMs: 0,
+      heartbeatIntervalMs: 0,
+    });
+    throwingClient.start();
+    await waitFor(() => wss.clients.size === 1, 'expected one ws client after second start');
+    assert.doesNotThrow(() => throwingClient.stop());
+  } finally {
+    await closeServer(server, wss);
+  }
+});
+
 test('Client reconnects after WebSocket close and sends hello again', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -127,6 +127,16 @@ export class Client {
     // running to completion after the WS is gone.
     for (const controller of this.inflight.values()) controller.abort();
     this.ws?.close();
+    // Tear down long-lived backend resources (e.g. codex app-server child).
+    // Per-task abort above covers per-handle subprocesses; this hook is for
+    // upstreams the backend keeps across tasks. Best-effort and synchronous
+    // so callers can `process.exit` on the next line — errors from a buggy
+    // backend cleanup must not block daemon shutdown.
+    try {
+      this.opts.backend.stop?.();
+    } catch (err) {
+      this.logger.warn(`backend stop threw: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   private resolveEffectiveCard(): Promise<AgentCard | undefined> {

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -1,8 +1,7 @@
 // `vicoop-client setup` — create a bridge client token using an existing
 // owner-session bearer, then persist the daemon credentials to the canonical
 // `config.json`. `--write-env-file` remains as an opt-in for operators who
-// want a systemd `EnvironmentFile=` (or shell-sourceable file) alongside the
-// canonical config — see #137.
+// want a shell-sourceable env file alongside the canonical config — see #137.
 
 import { existsSync } from 'node:fs';
 import { atomicWriteFile, resolveOwnerSession } from './owner-session.js';
@@ -123,7 +122,7 @@ function shSingleQuote(value: string): string {
 
 // Convert the bridge's HTTP(S) URL to the WebSocket scheme the daemon
 // connects with. Shared by both the canonical config writer and the
-// systemd env-file emitter so the rewrite rule has one source of truth.
+// env-file emitter so the rewrite rule has one source of truth.
 function wsUrlFromBridge(bridgeUrl: string): string {
   return bridgeUrl.replace(/^http(s?):\/\//, (_m, s) => (s === 's' ? 'wss://' : 'ws://'));
 }
@@ -389,7 +388,7 @@ export async function runSetup(args: string[]): Promise<number> {
       'The CLIENT_TOKEN is one-time — the bridge cannot reissue it.\n' +
       '  setup persists it to the canonical config below; --json prints it to\n' +
       '  stdout instead. Back up that file before rotating hosts.\n' +
-      '  To also stash it in a systemd EnvironmentFile, pass --write-env-file\n' +
+      '  To also stash it in a shell-sourceable env file, pass --write-env-file\n' +
       '  on this same setup invocation — rerunning setup later would call\n' +
       '  registerClient again and mint a NEW CLIENT_TOKEN, invalidating this\n' +
       '  one. To populate an env file from an already-issued token, copy\n' +
@@ -423,7 +422,7 @@ export async function runSetup(args: string[]): Promise<number> {
     return 1;
   }
 
-  // Optional env-file emission for systemd `EnvironmentFile=`. Errors here
+  // Optional env-file emission (shell-sourceable). Errors here
   // are NOT recovery situations: the token is already safe in canonical
   // config.json. Surface a targeted warning that tells the operator how
   // to populate the env file by hand without rotating the token (rerunning

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -281,18 +281,10 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
     safeRemove(dlDir);
   }
 
-  const unit = detectSystemdUnit();
-  if (unit) {
-    log(`restarting systemd unit (${unit.scope} scope)`);
-    if (!tryRestartSystemd(unit.scope)) {
-      err('systemctl try-restart failed; restart the service manually');
-    }
-  } else {
-    log(
-      'no systemd unit detected — your running client (if any) keeps the previous bundle ' +
-        'until you stop it and start it again with your usual command',
-    );
-  }
+  log(
+    'a running client (if any) keeps the previous bundle in memory until ' +
+      'you stop it and start it again with your usual command',
+  );
 
   log(`upgraded ${clientVersion} -> ${targetVersion}`);
   log(`previous install kept at ${prevDir} (delete when satisfied)`);
@@ -502,44 +494,6 @@ function runHealthcheck(newDir: string, expected: string): HealthcheckResult {
     return { ok: false, detail: `reported '${got}', expected '${expected}'` };
   }
   return { ok: true };
-}
-
-function detectSystemdUnit(): { scope: 'system' | 'user' } | null {
-  if (existsSync('/etc/systemd/system/vicoop-client.service')) return { scope: 'system' };
-  const home = process.env.HOME;
-  if (home) {
-    // `||` rather than `??` so an empty `XDG_CONFIG_HOME=` (common
-    // accidental mis-export, and what shells treat as unset via
-    // `${XDG_CONFIG_HOME:-...}`) falls back to $HOME/.config instead of
-    // turning the path relative.
-    const userCfg = process.env.XDG_CONFIG_HOME || join(home, '.config');
-    if (existsSync(join(userCfg, 'systemd', 'user', 'vicoop-client.service'))) {
-      return { scope: 'user' };
-    }
-  }
-  return null;
-}
-
-function tryRestartSystemd(scope: 'system' | 'user'): boolean {
-  const args = scope === 'user'
-    ? ['--user', 'try-restart', 'vicoop-client.service']
-    : ['try-restart', 'vicoop-client.service'];
-  const r = spawnSync('systemctl', args, { stdio: 'inherit' });
-  if (r.error) {
-    const code = (r.error as NodeJS.ErrnoException).code;
-    const hint = code === 'ENOENT' ? ' (systemctl not on PATH)' : '';
-    err(`systemctl spawn failed${hint}: ${r.error.message}`);
-    return false;
-  }
-  if (r.signal) {
-    err(`systemctl terminated by signal ${r.signal}`);
-    return false;
-  }
-  if (r.status !== 0) {
-    err(`systemctl try-restart exited with status ${r.status}`);
-    return false;
-  }
-  return true;
 }
 
 // Recursively clear the setuid (04000) and setgid (02000) bits on every file


### PR DESCRIPTION
## Summary

Fixes #186, plus a related scope reduction the issue review surfaced.

- **Bug fix**: `codex app-server` no longer lingers as an orphan after the daemon exits. `Backend` gains an optional `stop()` hook, `Client.stop()` invokes it, and the codex backend SIGTERMs its RPC child. The other backends don't need it: claude/openclaw don't hold long-lived children across tasks. (commit 1)
- **Scope reduction**: remove the half-built systemd auto-registration from `install.sh` and `vicoop-client upgrade`. The always-on supervisor story isn't settled yet and the existing impl only covered systemd hosts, so it was promising a path we don't intend to keep as-is. `setup --write-env-file` survives as a generic shell-sourceable env-file emitter. (commit 2)

Issue review for #186 noted that the reporter also hit `nohup ... &` exiting immediately on macOS — that one is unreproduced from this side (no TTY/stdin reads in the daemon path, wrapper is a plain `exec node …`), so it's intentionally left for the reporter to confirm with extra diagnostics before we touch code.

## Changes by file

- `packages/client/src/backend.ts` — add optional `Backend.stop?()`
- `packages/client/src/client.ts` — call `backend.stop?.()` from `Client.stop()`, swallow exceptions so a buggy backend can't hijack `process.exit`
- `packages/client/src/backends/codex.ts` — implement `stop()` → `rpcClient?.kill('SIGTERM')`
- `packages/client/src/{client,backends/codex}.test.ts` — 2 new tests
- `install.sh` — strip 286 lines of systemd unit / env-template generation, drop `INSTALL_SKIP_SERVICE` / `INSTALL_SERVICE_SCOPE`
- `packages/client/src/upgrade.ts` — drop `detectSystemdUnit` / `tryRestartSystemd` + call site
- `packages/client/src/setup.ts` — reword systemd references to "shell-sourceable env file"
- `docs/install-client.md` — strip systemd content from env table, install section, upgrade section

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 392/392 pass (includes 2 new)
- [x] `bash -n install.sh` clean
- [ ] manual: run client on macOS, send SIGTERM, confirm `codex app-server` exits within ~1s (no orphan in `ps`)
- [ ] manual: run `install.sh` end-to-end on a clean linux box, confirm no `.service` file is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)