### PR TITLE
feat(client)!: ship native single-file binaries; drop Node.js install prereq

### DIFF
--- a/.changeset/native-binary-release.md
+++ b/.changeset/native-binary-release.md
@@ -1,0 +1,41 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Ship `@vicoop-bridge/client` as a self-contained native binary per platform
+(macOS arm64/x64, Linux arm64/x64, Windows x64) instead of a Node.js
+portable bundle (#188). The release no longer requires Node.js on the
+host: `install.sh` now downloads
+`vicoop-client-<version>-<os>-<arch>[.exe]` + its `.sha256`, verifies
+integrity, and drops the macOS quarantine xattr so first launch isn't
+Gatekeeper-blocked. The binary is produced by `bun build --compile` from
+a single Linux runner via cross-compile (`oven-sh/setup-bun@v2` in
+`release.yml`).
+
+The asset layout, install path, and upgrade flow change in lock-step:
+
+- **Install path**: `$INSTALL_DIR/vicoop-client` (single file), not
+  `$INSTALL_DIR/bin/vicoop-client` + `dist/` + `node_modules/`. Anything
+  else the operator leaves under `$INSTALL_DIR` is preserved by upgrades
+  by construction (the swap only moves three filenames).
+- **`vicoop-client upgrade`**: rewritten for the binary model. Downloads
+  the matching per-platform asset, sha256-verifies, runs `--version` as
+  a healthcheck, atomically renames `vicoop-client` →
+  `vicoop-client.prev` and `vicoop-client.new` → `vicoop-client`. Dev
+  workspace invocations (`tsx src/cli.ts upgrade`, `node dist/cli.js
+  upgrade`) are now rejected up front because `process.execPath` ends in
+  `node` / `tsx` / `bun` rather than `vicoop-client[.exe]`.
+- **Released-bundle `cards/` directory is gone** (closes the A side of
+  #164). The bridge already publishes the canonical card per backend;
+  `--card <path>` (or `"card"` in `config.json`) is the operator
+  override path, and source-tree
+  [`packages/client/cards/`](https://github.com/planetarium/vicoop-bridge/tree/main/packages/client/cards)
+  remains the documented reference for authoring overrides.
+- **Prerequisites**: Node.js 20+ and `tar` are no longer required by the
+  install path. `curl` + `sha256sum`/`shasum` is enough; `jq` is added
+  only when `install.sh` auto-resolves the latest tag (skip-able with
+  `VERSION=@vicoop-bridge/client@<x.y.z>`).
+
+This is breaking for anyone who currently scripts against
+`$INSTALL_DIR/bin/vicoop-client` or extracts the released `.tgz`
+directly — both go away.

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -6,6 +6,8 @@ on:
       - '.github/workflows/client-ci.yml'
       - 'packages/client/**'
       - 'packages/protocol/**'
+      - 'scripts/**'
+      - 'install.sh'
       - 'pnpm-lock.yaml'
       - 'package.json'
   push:
@@ -14,8 +16,11 @@ on:
       - '.github/workflows/client-ci.yml'
       - 'packages/client/**'
       - 'packages/protocol/**'
+      - 'scripts/**'
+      - 'install.sh'
       - 'pnpm-lock.yaml'
       - 'package.json'
+  workflow_dispatch: {}
 
 jobs:
   validate:
@@ -36,6 +41,14 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Mirrors the version pinned in release.yml so the cross-compile
+      # dry-run below exercises the exact same toolchain that publishes
+      # release assets.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.20
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -50,3 +63,28 @@ jobs:
 
       - name: Build client
         run: pnpm --filter @vicoop-bridge/client build
+
+      # Cross-compile dry-run: produces every per-platform release binary
+      # (macOS arm64/x64, Linux arm64/x64, Windows x64) plus its .sha256
+      # sidecar into dist-release/, without uploading anything. Catches
+      # regressions in scripts/package-client-release.sh, the bun
+      # cross-compile matrix, and any code path that breaks under
+      # `bun build --compile` (e.g. unembeddable native modules) before
+      # the release workflow has to discover it on `main`. Whichever tag
+      # we feed only affects the asset filename — the build artefacts
+      # themselves are version-agnostic for this check.
+      - name: Cross-compile release binaries (dry-run)
+        run: |
+          CLIENT_VERSION="$(node -p "require('./packages/client/package.json').version")"
+          ./scripts/package-client-release.sh "@vicoop-bridge/client@${CLIENT_VERSION}"
+
+      - name: Sanity-check Linux x64 binary
+        run: |
+          CLIENT_VERSION="$(node -p "require('./packages/client/package.json').version")"
+          BIN="dist-release/vicoop-client-${CLIENT_VERSION}-linux-x64"
+          GOT="$("$BIN" --version)"
+          if [[ "$GOT" != "$CLIENT_VERSION" ]]; then
+            echo "::error::compiled binary reported '$GOT', expected '$CLIENT_VERSION'"
+            exit 1
+          fi
+          echo "linux-x64 binary --version: $GOT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,15 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # Bun cross-compiles the per-platform vicoop-client binaries from a
+      # single Linux runner via `bun build --compile --target=…`. The
+      # asset-upload step (scripts/package-client-release.sh) invokes it;
+      # changesets/action above only needs Node.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.20
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the client include a changeset describing the change; merging them keeps a
 single "Version Packages" PR up to date with the resulting version + changelog
 entry. Merging that Version PR triggers
 [`.github/workflows/release.yml`](./.github/workflows/release.yml), which
-builds the portable bundle and publishes the `@vicoop-bridge/client@<version>`
+cross-compiles per-platform native binaries (macOS/Linux/Windows) with Bun
+and publishes them as assets on the `@vicoop-bridge/client@<version>`
 GitHub release.
 
 Day-to-day flow for contributors:
@@ -42,8 +43,10 @@ Before merging a Version Packages PR, verify that
 bundle being released:
 
 - shipped backends listed in the doc match `packages/client/src/cli.ts`
-- bundled example cards listed in the doc match `packages/client/cards/`
 - backend-specific launch examples still reflect the released client behavior
+- the asset filename matrix in `scripts/package-client-release.sh` and
+  `install.sh`'s platform-detect block still agree with
+  `resolvePlatformAsset()` in `packages/client/src/upgrade.ts`
 
 ## Status
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -29,8 +29,14 @@ one-liner fetching a published `@vicoop-bridge/client@*` bundle). Contrast with:
 
 ## Prerequisites
 
-- Node.js 20 or newer (`node -v`).
-- `curl`, `tar`, and one of `sha256sum` / `shasum`.
+- `curl` and one of `sha256sum` / `shasum`. `jq` is also required when
+  `install.sh` resolves the latest release for you (skip-able by pinning
+  `VERSION` to the exact tag).
+- The released client is a self-contained native binary — **no Node.js
+  runtime on the host**. Supported platforms: macOS arm64/x64, Linux
+  arm64/x64. Windows operators: a PowerShell installer is tracked in
+  issue #188; in the meantime download `vicoop-client-<version>-windows-x64.exe`
+  from the release page by hand and skip Step 1.
 - A reachable bridge URL. The public deployment is
   `https://vicoop-bridge-server.fly.dev`; substitute your own below if you
   run the server yourself.
@@ -53,10 +59,11 @@ one-liner fetching a published `@vicoop-bridge/client@*` bundle). Contrast with:
 - For the Codex backend specifically: the local `codex` CLI installed and
   authenticated (`codex --version` should succeed).
 
-## Step 1 — Install the client bundle
+## Step 1 — Install the client binary
 
-The one-liner downloads the latest `@vicoop-bridge/client@*` release, verifies
-its `.sha256`, and extracts into `$INSTALL_DIR`:
+The one-liner detects your OS/arch, downloads the matching
+`vicoop-client-<version>-<os>-<arch>[.exe]` asset, verifies its `.sha256`,
+and installs it as `$INSTALL_DIR/vicoop-client`:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh \
@@ -70,26 +77,26 @@ would still default to `/data/vicoop-bridge-client`.
 | Env | Default | Purpose |
 |---|---|---|
 | `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
-| `VERSION` | latest `@vicoop-bridge/client@*` | Pin a specific tag, e.g. `@vicoop-bridge/client@0.1.1`. |
+| `VERSION` | latest `@vicoop-bridge/client@*` | Pin a specific tag, e.g. `@vicoop-bridge/client@0.1.1`. With `VERSION` set, `jq` is no longer required. |
 | `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
 
-What you get after extraction:
+What you get after install:
 
 ```
 $INSTALL_DIR/
-├── bin/vicoop-client        # bash wrapper that execs node dist/cli.js
-├── dist/                    # compiled JS
-├── cards/openclaw.json      # OpenClaw example card
-├── cards/claude.json        # Claude Code example card
-├── cards/codex.json         # Codex CLI example card
-├── cards/echo.json          # Echo test card
-├── node_modules/            # pruned prod deps
-└── package.json
+└── vicoop-client        # self-contained native binary (Bun --compile)
 ```
 
-The script targets Linux (Fly.io persistent volumes are the original target
-deployment); on macOS it prints a warning and proceeds. See #17 / #21 for
-background.
+The released binary embeds everything the daemon needs — there are no
+sidecar files. Operator-managed state (`~/.vicoop/config.json`,
+`~/.vicoop/owner-session.json`, any operator-authored agent cards) lives
+outside `$INSTALL_DIR` so the upgrade flow can replace the binary without
+touching it.
+
+On macOS, `install.sh` strips the `com.apple.quarantine` xattr right after
+the download so first launch isn't Gatekeeper-blocked. Developer ID
+signing + notarization are planned (issue #188 follow-up); until then this
+keeps `curl | sh` a true one-liner.
 
 > The installer no longer generates an always-on service unit. The design
 > for unattended operation (systemd, launchd, etc.) is still in flux —
@@ -100,7 +107,7 @@ background.
 
 If `$INSTALL_DIR` already existed before Step 1, `install.sh` refuses to
 overwrite it unless you pass `FORCE=1`. That's intentional: an existing
-directory may contain a working client, saved env file, or an older bundle
+directory may contain a working client binary or operator-authored files
 you don't want clobbered by accident.
 
 If you do want to replace a non-empty install directory, rerun Step 1 with
@@ -119,15 +126,11 @@ Before continuing, verify that the installed bundle is recent enough to
 include the `login` command used in Step 4:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" -v
-"$INSTALL_DIR/bin/vicoop-client" login --help
+"$INSTALL_DIR/vicoop-client" -v
+"$INSTALL_DIR/vicoop-client" login --help
 ```
 
-If `login --help` prints usage, you're on a current bundle. If it instead
-fails with the daemon usage (`--server`, `--token`, `--agentId`, `--backend`)
-or doesn't recognize `login`, you're still on an older pre-device-flow
-release and should reinstall into a fresh directory or rerun Step 1 with
-`FORCE=1`.
+If `login --help` prints usage, you're on a current binary and can move on.
 
 ## Step 3 — Pick an agent id
 
@@ -171,9 +174,9 @@ required.
 HOSTNAME=$(hostname)
 CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 
-"$INSTALL_DIR/bin/vicoop-client" login
+"$INSTALL_DIR/vicoop-client" login
 
-"$INSTALL_DIR/bin/vicoop-client" setup \
+"$INSTALL_DIR/vicoop-client" setup \
   --client-name "$CLIENT_NAME" \
   --agent-ids "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
@@ -311,7 +314,7 @@ want to compose with shell tooling (no disk side effects, raw response on
 stdout):
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" setup \
+"$INSTALL_DIR/vicoop-client" setup \
   --client-name "$CLIENT_NAME" \
   --agent-ids "$AGENT_ID" \
   --caller "eth:0x<40-hex>" --json \
@@ -366,11 +369,15 @@ server publishes the canonical card for that backend at
 metadata/capability fixes on the faster server deploy path instead of
 requiring every operator to upgrade their client bundle.
 
-The bundle still ships backend-specific starter cards under
-`$INSTALL_DIR/cards/` (`openclaw.json`, `claude.json`, `codex.json`, `echo.json`) for
-operator overrides and compatibility with older bridge servers. Pass
-`--card <path>` (or set `AGENT_CARD` / `"card"` in `config.json`) only
-when you intentionally want to override the server card, for example to:
+Starter cards for the built-in backends (`openclaw.json`, `claude.json`,
+`codex.json`, `echo.json`) live in the source tree under
+[`packages/client/cards/`](https://github.com/planetarium/vicoop-bridge/tree/main/packages/client/cards) —
+download whichever one you want to base an override on. The native binary
+itself doesn't ship them on disk (the bridge already publishes the
+canonical card per backend, and the daemon only reads cards from disk when
+you explicitly pass `--card`). Pass `--card <path>` (or set `"card"` in
+`config.json`) only when you intentionally want to override the server
+card, for example to:
 
 - Rename `name` to something meaningful (it defaults to `openclaw`).
 - Tighten `description` to what this specific instance actually does.
@@ -382,13 +389,17 @@ that `vicoop-client whoami` prints — see ["Check your agent's mention /
 acct"](#check-your-agents-mention--acct-any-backend) in Step 6.
 
 Schema reference: `packages/protocol/src/index.ts` (`AgentCard` Zod schema,
-validated by the client at startup when `--card` / `AGENT_CARD` is set —
-invalid cards exit with a Zod error).
+validated by the client at startup when `--card` is set — invalid cards
+exit with a Zod error).
 
-For custom backends, write a fresh card:
+For custom backends, write a fresh card anywhere on disk and point
+`--card` (or `"card"` in `config.json`) at it. The single-file binary
+keeps `$INSTALL_DIR` clean for upgrades, so the conventional spot is
+under your vicoop config dir, e.g. `~/.vicoop/cards/my-agent.json`:
 
 ```sh
-cat > "$INSTALL_DIR/cards/my-agent.json" <<'JSON'
+mkdir -p ~/.vicoop/cards
+cat > ~/.vicoop/cards/my-agent.json <<'JSON'
 {
   "name": "my-agent",
   "description": "...",
@@ -411,14 +422,14 @@ the daemon picks up `server_url`, `server_token`, and `agent_id` on its own;
 pick the backend with `--backend`:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" --backend openclaw
+"$INSTALL_DIR/vicoop-client" --backend openclaw
 ```
 
 Precedence at startup is **CLI flag > `--config <path>` > canonical
 `config.json` > built-in default**. Env vars are not consulted for
 runtime config (#189 §5). With `"backend": "openclaw"` persisted in
 `config.json`, the daemon needs no flags at all:
-`"$INSTALL_DIR/bin/vicoop-client"`.
+`"$INSTALL_DIR/vicoop-client"`.
 
 On success you'll see a `[client] connected, sending hello` log followed
 by an identity block — same data `vicoop-client whoami` would print, so
@@ -500,7 +511,7 @@ For the Claude backend, pass `--backend claude` (or persist
 different repository than the one `vicoop-client` itself runs in:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" \
+"$INSTALL_DIR/vicoop-client" \
   --backend claude \
   --claude-cwd "$HOME/vicoop-bridge"
 ```
@@ -508,7 +519,7 @@ different repository than the one `vicoop-client` itself runs in:
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
 (`cwd`, `settings`) so the foreground command shrinks to just
-`"$INSTALL_DIR/bin/vicoop-client"`; the flag wins over config, mirroring
+`"$INSTALL_DIR/vicoop-client"`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
 | Flag | `backends.claude.*` |
@@ -553,7 +564,7 @@ identifier external callers will see for this agent — the WebFinger acct, the
 `@<agentId>@<host>` mention, the JSON-RPC endpoint, and the agent-card URL.
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" whoami
+"$INSTALL_DIR/vicoop-client" whoami
 # agentId:    my-agent
 # host:       bridge.example.com
 # mention:    @my-agent@bridge.example.com
@@ -575,11 +586,11 @@ Typical follow-ups from this output:
 2. **Confirm which card the bridge advertises.** `curl` the `a2a card` URL —
    that's the canonical card external callers receive, which is the
    server-published default for the selected backend unless you pass
-   `--card <path>` (or set `AGENT_CARD`) to override it (see Step 5). If the
+   `--card <path>` (or `"card"` in `config.json`) to override it (see Step 5). If the
    response doesn't match what you expect, that's the cue to override.
 
    ```sh
-   CARD_URL=$("$INSTALL_DIR/bin/vicoop-client" whoami --json | jq -r .a2aCardUrl)
+   CARD_URL=$("$INSTALL_DIR/vicoop-client" whoami --json | jq -r .a2aCardUrl)
    curl -sf "$CARD_URL" | jq .
    ```
 3. **Verify WebFinger actually resolves the acct.** `whoami --verify`
@@ -598,7 +609,7 @@ For the Codex backend, pass `--backend codex` (or persist
 different repository / loosen the sandbox:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" \
+"$INSTALL_DIR/vicoop-client" \
   --backend codex \
   --codex-cwd "$HOME/vicoop-bridge" \
   --codex-sandbox workspace-write
@@ -606,7 +617,7 @@ different repository / loosen the sandbox:
 
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.codex` so the
-foreground command can shrink to just `"$INSTALL_DIR/bin/vicoop-client"`.
+foreground command can shrink to just `"$INSTALL_DIR/vicoop-client"`.
 The flag wins over config.
 
 | Flag | `backends.codex.*` |
@@ -653,26 +664,26 @@ scope (`is_admin()`) is wallet-only and gates only the cross-owner tools.
 
 ### Option A: `vicoop-client` subcommands (recommended for scripts)
 
-These subcommands require **bundle version 0.8.0 or newer**. Older
-installs only know the daemon flags; check before using and upgrade if
-needed:
+Check that you're on a current release before using the admin subcommands
+below — `upgrade --check` reports the live version against the latest
+published release:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" -v
-"$INSTALL_DIR/bin/vicoop-client" upgrade --check   # report latest vs current
-"$INSTALL_DIR/bin/vicoop-client" upgrade           # upgrade in place if behind
+"$INSTALL_DIR/vicoop-client" -v
+"$INSTALL_DIR/vicoop-client" upgrade --check   # report latest vs current
+"$INSTALL_DIR/vicoop-client" upgrade           # upgrade in place if behind
 ```
 
 ```sh
 # Step 4 login saves the owner-session bearer, so these work without re-authenticating:
-"$INSTALL_DIR/bin/vicoop-client" setup \
+"$INSTALL_DIR/vicoop-client" setup \
   --client-name "$CLIENT_NAME" \
   --agent-ids "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
-"$INSTALL_DIR/bin/vicoop-client" list-agents
-"$INSTALL_DIR/bin/vicoop-client" list-callers "$AGENT_ID" --json
-"$INSTALL_DIR/bin/vicoop-client" add-caller "$AGENT_ID" "eth:0x<40-hex>"
-"$INSTALL_DIR/bin/vicoop-client" remove-caller "$AGENT_ID" "google:email:caller@example.com"
+"$INSTALL_DIR/vicoop-client" list-agents
+"$INSTALL_DIR/vicoop-client" list-callers "$AGENT_ID" --json
+"$INSTALL_DIR/vicoop-client" add-caller "$AGENT_ID" "eth:0x<40-hex>"
+"$INSTALL_DIR/vicoop-client" remove-caller "$AGENT_ID" "google:email:caller@example.com"
 
 # Pass --json for machine-readable output, or --bridge / --token to override
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
@@ -686,7 +697,7 @@ that `login` writes alongside it). If the saved bearer is missing or expired,
 refresh it without registering a new client:
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" login
+"$INSTALL_DIR/vicoop-client" login
 ```
 
 (Self-hosting? Pass `--bridge https://<your-bridge>`.)
@@ -716,51 +727,53 @@ restart needed.
 ## Updating the client
 
 Once installed, the client updates itself — do not re-run `install.sh`. The
-installer's `FORCE=1` path is destructive (it `rm -rf`s `$INSTALL_DIR` and
-wipes any operator-added cards / files), so it's reserved for bootstrapping.
+installer's `FORCE=1` path is destructive (it `rm -rf`s `$INSTALL_DIR`) and
+is reserved for bootstrapping.
 
 ```sh
-"$INSTALL_DIR/bin/vicoop-client" upgrade --check      # report latest vs current
-"$INSTALL_DIR/bin/vicoop-client" upgrade              # upgrade to latest @vicoop-bridge/client@*
-"$INSTALL_DIR/bin/vicoop-client" upgrade --version 0.2.0   # pin / downgrade (bare version, v0.2.0, or @vicoop-bridge/client@0.2.0 all accepted)
-"$INSTALL_DIR/bin/vicoop-client" upgrade --force      # reinstall the resolved target even if already on it
+"$INSTALL_DIR/vicoop-client" upgrade --check      # report latest vs current
+"$INSTALL_DIR/vicoop-client" upgrade              # upgrade to latest @vicoop-bridge/client@*
+"$INSTALL_DIR/vicoop-client" upgrade --version 0.2.0   # pin / downgrade (bare version, v0.2.0, or @vicoop-bridge/client@0.2.0 all accepted)
+"$INSTALL_DIR/vicoop-client" upgrade --force      # reinstall the resolved target even if already on it
 ```
 
 The upgrade command:
 
 1. Queries GitHub releases for the latest `@vicoop-bridge/client@*` tag (or
-   the `--version` you pin).
-2. Downloads `.tgz` + `.sha256` to a temp directory and verifies the checksum.
-3. Extracts into `$INSTALL_DIR.new/` (sibling of the current install).
-4. Copies operator files that don't ship with the bundle — notably any
-   `cards/*.json` you added or files placed directly under `$INSTALL_DIR`.
-   Shipped cards (`openclaw.json`, `echo.json`, `claude.json`, `codex.json`) are kept for
-   optional overrides and older server compatibility; they are always
-   replaced with the new release's versions.
-5. Runs `node $INSTALL_DIR.new/dist/cli.js --version` as a healthcheck. If it
-   exits non-zero or reports the wrong version, `$INSTALL_DIR.new` is deleted
-   and the upgrade aborts with no change to the live install.
-6. Atomically swaps: `$INSTALL_DIR` → `$INSTALL_DIR.prev`,
-   `$INSTALL_DIR.new` → `$INSTALL_DIR`. A failure mid-swap restores the
-   original.
-7. Keeps `$INSTALL_DIR.prev` around for manual rollback (`mv` it back into
-   place if needed). Delete it once you've confirmed the new version works.
+   the `--version` you pin) and resolves the per-platform asset name from
+   `process.platform` / `process.arch` (must match this host).
+2. Downloads `vicoop-client-<version>-<os>-<arch>[.exe]` + its `.sha256`
+   into `$INSTALL_DIR` as `vicoop-client.new`, verifies the checksum, and
+   chmods +x.
+3. Runs `$INSTALL_DIR/vicoop-client.new --version` as a healthcheck. If it
+   exits non-zero or reports the wrong version, `.new` is deleted and the
+   upgrade aborts with no change to the live binary.
+4. Atomically swaps: `$INSTALL_DIR/vicoop-client` → `vicoop-client.prev`,
+   `vicoop-client.new` → `vicoop-client`. A failure mid-swap restores the
+   original. On unix the running daemon keeps executing from the unlinked
+   inode — the file swap is safe under load (see "Manual restart" below).
+5. Keeps `vicoop-client.prev` around for manual rollback (`mv` it back over
+   `vicoop-client` if needed). Delete it once the new version is proven.
 
 **Permissions**: for a system-scope install (root-owned `$INSTALL_DIR`),
 run the upgrade via `sudo`. The command checks write access up front and
 fails fast with a clear error otherwise.
 
-**Operator-owned state is not touched by `upgrade`.** That covers
-`~/.vicoop/config.json` (the canonical daemon config — Step 4) and
-`~/.vicoop/owner-session.json` (the owner bearer — `login`). `FORCE=1`
-deletes everything under `$INSTALL_DIR` first — back up any operator-added
-cards or files before running it.
+**Operator-owned state is not touched by `upgrade`.** The binary swap
+only ever moves three filenames inside `$INSTALL_DIR` (`vicoop-client`,
+`vicoop-client.new`, `vicoop-client.prev`). Anything else you've left
+under `$INSTALL_DIR` (operator-authored cards, notes, scratch files) is
+preserved automatically. Outside `$INSTALL_DIR`, your canonical
+`~/.vicoop/config.json` (Step 4) and `~/.vicoop/owner-session.json`
+(`login`) are out of scope for upgrades entirely. `FORCE=1` on
+`install.sh` deletes everything under `$INSTALL_DIR` first — back up any
+operator-added files before running it.
 
 **Manual restart after upgrade.** The atomic swap leaves your running
 client process attached to the previous bundle. Stop it and start it again
 with your usual command (foreground / screen / tmux) so the new version
 takes effect — `upgrade` cannot signal a process it didn't start. To check
-for stragglers, run `pgrep -fl 'vicoop-client|dist/cli\.js'` and kill any
+for stragglers, run `pgrep -fl vicoop-client` and kill any
 old process before starting the new one. Multiple client processes
 connecting with the **same `SERVER_TOKEN`** for one `AGENT_ID` collide and
 the older WS is closed with code 4009 (harmless but noisy); see the Gotchas
@@ -855,7 +868,7 @@ Both subcommands use the same owner-session bearer as `add-caller` /
   No token rotation needed.
 - **Different backends**: in the published bundle today, pass
   `--backend openclaw`, `--backend claude`, `--backend codex`, or `--backend echo`. Set
-  `--card`/`AGENT_CARD` only when you need to override the server's
+  `--card` (or `"card"` in `config.json`) only when you need to override the server's
   canonical card. Custom/future backends are still described in
   `docs/design.md` §5 but are not shipped yet.
 - **Audit/revoke access**: the admin agent exposes `list_caller_tokens`,

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -199,7 +199,7 @@ curl -s -X POST http://localhost:8787/agents/echo-agent \
 ```
 
 > Working from a published client bundle instead of source? Swap `$CLI`
-> for `"$INSTALL_DIR/bin/vicoop-client"` (the path
+> for `"$INSTALL_DIR/vicoop-client"` (the path
 > [`docs/install-client.md`](./install-client.md) sets up). The
 > subcommands are identical.
 

--- a/install.sh
+++ b/install.sh
@@ -5,16 +5,16 @@
 #   curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh | sh
 #
 # Environment overrides:
-#   INSTALL_DIR           Target directory (default: /data/vicoop-bridge-client)
-#   VERSION               Specific tag to install, e.g. @vicoop-bridge/client@0.1.0
-#                         (default: latest @vicoop-bridge/client@* release)
-#   FORCE                 If "1", overwrite a non-empty INSTALL_DIR
+#   INSTALL_DIR  Target directory (default: /data/vicoop-bridge-client)
+#   VERSION      Specific tag, e.g. @vicoop-bridge/client@0.16.0
+#                (default: latest @vicoop-bridge/client@* release)
+#   FORCE        If "1", overwrite a non-empty INSTALL_DIR
 #
 # What it does:
-#   1. Verifies prerequisites (Linux warning, Node.js >= 20, curl, tar, sha256 tool).
-#   2. Resolves the latest (or pinned) @vicoop-bridge/client@* GitHub release.
-#   3. Downloads the .tgz + .sha256 and verifies integrity.
-#   4. Extracts the bundle into INSTALL_DIR.
+#   1. Verifies prerequisites (curl, sha256 tool, jq when auto-resolving).
+#   2. Detects OS/arch and resolves the matching release asset.
+#   3. Downloads the binary + .sha256, verifies integrity, chmod +x.
+#   4. Drops macOS quarantine xattr so first launch isn't Gatekeeper-blocked.
 #   5. Prints next-step instructions for login and a foreground first run.
 
 set -eu
@@ -32,21 +32,8 @@ need() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
 }
 
-# ---- 1. Prerequisites -------------------------------------------------------
-OS="$(uname -s)"
-case "$OS" in
-  Linux) ;;
-  *) log "warning: this installer targets Linux (Fly.io containers); detected $OS — proceeding anyway" ;;
-esac
-
+# ---- 1. Prereqs + platform detect ------------------------------------------
 need curl
-need tar
-need node
-
-NODE_MAJOR="$(node -e 'process.stdout.write(String(process.versions.node.split(".")[0]))')"
-if [ "$NODE_MAJOR" -lt 20 ]; then
-  die "Node.js >= 20 required (found $(node -v))"
-fi
 
 if command -v sha256sum >/dev/null 2>&1; then
   SHA_CMD="sha256sum"
@@ -56,94 +43,81 @@ else
   die "missing required command: sha256sum or shasum"
 fi
 
+# Asset slug + extension mapping. Must stay aligned with
+# resolvePlatformAsset() in packages/client/src/upgrade.ts and the build
+# matrix in scripts/package-client-release.sh.
+OS_NAME="$(uname -s)"
+ARCH_NAME="$(uname -m)"
+case "$OS_NAME/$ARCH_NAME" in
+  Darwin/arm64)         ASSET_SLUG="macos-arm64"; ASSET_EXT="" ;;
+  Darwin/x86_64)        ASSET_SLUG="macos-x64";   ASSET_EXT="" ;;
+  Linux/aarch64|Linux/arm64)
+                        ASSET_SLUG="linux-arm64"; ASSET_EXT="" ;;
+  Linux/x86_64|Linux/amd64)
+                        ASSET_SLUG="linux-x64";   ASSET_EXT="" ;;
+  *)
+    die "unsupported platform/arch combination: $OS_NAME/$ARCH_NAME (Windows users: see docs/install-client.md for the install.ps1 path)"
+    ;;
+esac
+
 # ---- 2. Resolve release tag -------------------------------------------------
 TAG_PREFIX="@vicoop-bridge/client@"
 
 if [ -z "$VERSION" ]; then
+  # Auto-resolution needs JSON parsing to filter out draft/prerelease
+  # entries. When VERSION is pinned explicitly, jq isn't required.
+  need jq
   log "resolving latest $TAG_PREFIX* release from GitHub"
-  # Pull recent releases (default 30) and pick the newest non-draft,
-  # non-prerelease release whose tag matches the changesets monorepo
-  # prefix. Avoid /releases/latest because it may point at a non-client
-  # release. Parse with node (already a hard prereq above) rather than
-  # grepping tag_name, so the draft/prerelease flags are honored the same
-  # way `vicoop-client upgrade` honors them.
-  #
-  # `set -e` doesn't catch failures on the upstream end of a POSIX-sh
-  # pipeline, so curl is run on its own first — otherwise a network /
-  # rate-limit error would let node read empty input, exit 0, and surface
-  # as a misleading "no published release found" later.
+  # `set -e` doesn't catch failures inside a POSIX-sh pipeline, so the
+  # curl step runs first — otherwise a network / rate-limit error would
+  # let jq read empty input, exit 0, and surface as a misleading
+  # "no published release found" later.
   api_json="$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=30")" \
     || die "GitHub release API request failed"
-  # node exits non-zero on a malformed or non-array payload (rate-limit
-  # error object, abuse-detection response, etc.) so those failures don't
-  # masquerade as "no release found"; an empty stdout with exit 0 is the
-  # genuine no-match case.
+  # `--exit-status` makes jq exit non-zero when the filter yields null /
+  # nothing, so missing-release cases surface explicitly instead of as an
+  # empty VERSION string.
   VERSION="$(
     printf '%s' "$api_json" \
-      | TAG_PREFIX="$TAG_PREFIX" node -e '
-let data = "";
-process.stdin.setEncoding("utf8");
-process.stdin.on("data", (c) => { data += c; });
-process.stdin.on("end", () => {
-  let releases;
-  try {
-    releases = JSON.parse(data);
-  } catch (e) {
-    process.stderr.write(`error: GitHub API response was not valid JSON: ${e.message}\n`);
-    process.exit(1);
-  }
-  if (!Array.isArray(releases)) {
-    const msg = releases && typeof releases.message === "string"
-      ? releases.message
-      : JSON.stringify(releases).slice(0, 200);
-    process.stderr.write(`error: GitHub API returned a non-array payload: ${msg}\n`);
-    process.exit(1);
-  }
-  const prefix = process.env.TAG_PREFIX;
-  if (!prefix) {
-    process.stderr.write("error: TAG_PREFIX env var missing\n");
-    process.exit(1);
-  }
-  for (const r of releases) {
-    if (!r || typeof r.tag_name !== "string") continue;
-    if (!r.tag_name.startsWith(prefix)) continue;
-    if (r.draft || r.prerelease) continue;
-    process.stdout.write(r.tag_name);
-    return;
-  }
-});
-'
-  )" || die "failed to parse GitHub release list (see error above)"
-  [ -n "$VERSION" ] || die "no published (non-draft, non-prerelease) $TAG_PREFIX* release found in $REPO"
+      | jq -r --arg prefix "$TAG_PREFIX" --exit-status '
+          if type != "array" then
+            error("GitHub API returned a non-array payload: " + (.message // tostring))
+          else
+            (map(select(
+              .tag_name != null
+              and (.tag_name | startswith($prefix))
+              and (.draft != true)
+              and (.prerelease != true)
+            )) | first | .tag_name)
+          end
+        ' 2>&1
+  )" || die "no published (non-draft, non-prerelease) $TAG_PREFIX* release found in $REPO (jq said: $VERSION)"
 fi
 
 # Defense in depth: even when the operator pins VERSION via env, refuse to
-# proceed if it doesn't carry the expected prefix. Otherwise the
-# `${VERSION#$TAG_PREFIX}` expansion below leaves arbitrary characters in
-# VERSION_NUM, which then lands in the archive filename and URL.
+# proceed if it doesn't carry the expected prefix.
 case "$VERSION" in
   "$TAG_PREFIX"*) ;;
   *) die "VERSION must start with $TAG_PREFIX (got: $VERSION)" ;;
 esac
 
-log "installing $VERSION"
+log "installing $VERSION ($ASSET_SLUG)"
 
-VERSION_NUM="${VERSION#$TAG_PREFIX}"
+VERSION_NUM="${VERSION#"$TAG_PREFIX"}"
 # After stripping the prefix, the bare version still has to be safe to
-# interpolate into a local filename and a URL — the prefix check alone
-# wouldn't catch e.g. `@vicoop-bridge/client@0.3.0/../../etc`. Mirrors
-# packages/client/src/upgrade.ts's TAG_RE: first char must be alphanumeric
-# (rejects ".0.3.0", "-1", and other option-like names), remaining chars
-# limited to [A-Za-z0-9.+-], and no consecutive dots.
+# interpolate into a filename and URL. Mirrors
+# packages/client/src/upgrade.ts's TAG_RE.
 case "$VERSION_NUM" in
   ''|[!A-Za-z0-9]*|*[!A-Za-z0-9.+-]*|*..*)
     die "version contains unsafe characters: $VERSION_NUM"
     ;;
 esac
-ARCHIVE="vicoop-bridge-client-$VERSION_NUM.tgz"
-CHECKSUM="$ARCHIVE.sha256"
-# GitHub's release-download endpoint takes the tag as one path segment. The
-# tag contains `/` and `@`; percent-encode both so the URL doesn't split.
+
+ASSET_NAME="vicoop-client-${VERSION_NUM}-${ASSET_SLUG}${ASSET_EXT}"
+CHECKSUM_NAME="${ASSET_NAME}.sha256"
+BINARY_NAME="vicoop-client${ASSET_EXT}"
+# GitHub's release-download endpoint takes the tag as one path segment;
+# the tag contains `/` and `@`, percent-encode both so the URL doesn't split.
 ENCODED_TAG="$(printf '%s' "$VERSION" | sed -e 's#@#%40#g' -e 's#/#%2F#g')"
 BASE_URL="https://github.com/$REPO/releases/download/$ENCODED_TAG"
 
@@ -164,87 +138,85 @@ fi
 
 mkdir -p "$INSTALL_DIR"
 
-# ---- 4. Download + verify + extract ----------------------------------------
+# ---- 4. Download + verify + install ----------------------------------------
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-log "downloading $ARCHIVE"
-curl -fsSL "$BASE_URL/$ARCHIVE" -o "$TMP_DIR/$ARCHIVE"
-curl -fsSL "$BASE_URL/$CHECKSUM" -o "$TMP_DIR/$CHECKSUM"
+log "downloading $ASSET_NAME"
+curl -fsSL "$BASE_URL/$ASSET_NAME"     -o "$TMP_DIR/$ASSET_NAME"
+curl -fsSL "$BASE_URL/$CHECKSUM_NAME"  -o "$TMP_DIR/$CHECKSUM_NAME"
 
 log "verifying checksum"
-# The .sha256 file from package-client-release.sh contains an absolute path from
-# the build host. Rewrite it to reference the local archive name before checking.
-EXPECTED_HASH="$(awk '{print $1}' "$TMP_DIR/$CHECKSUM")"
-[ -n "$EXPECTED_HASH" ] || die "could not parse expected hash from $CHECKSUM"
-printf '%s  %s\n' "$EXPECTED_HASH" "$ARCHIVE" > "$TMP_DIR/$CHECKSUM"
-( cd "$TMP_DIR" && $SHA_CMD -c "$CHECKSUM" >/dev/null ) || die "checksum verification failed"
+# The .sha256 sidecar produced by package-client-release.sh already has
+# `<hash>  <bare-filename>` shape (cd-into-OUT_DIR before shasum), so no
+# rewrite is needed here.
+( cd "$TMP_DIR" && $SHA_CMD -c "$CHECKSUM_NAME" >/dev/null ) || die "checksum verification failed"
 
-log "extracting into $INSTALL_DIR"
-# Bundle root inside the archive is vicoop-bridge-client-<version>/; strip it
-# so files land directly in INSTALL_DIR.
-tar -xzf "$TMP_DIR/$ARCHIVE" -C "$INSTALL_DIR" --strip-components=1
+log "installing into $INSTALL_DIR/$BINARY_NAME"
+mv "$TMP_DIR/$ASSET_NAME" "$INSTALL_DIR/$BINARY_NAME"
+chmod +x "$INSTALL_DIR/$BINARY_NAME"
 
-# Portable ownership normalization. We can't rely on `tar --no-same-owner`
-# everywhere (busybox tar lacks the long option), so we chown after the
-# fact. Only actually matters under `sudo`: otherwise tar extracts as the
-# current uid/gid already. When root *is* extracting, the archive's stored
-# uid (typically ~1000, whoever built the release) would otherwise end up
-# owning a root-run service's files — that's a privilege-escalation vector.
-# After chown-to-root, also strip any setuid/setgid bits tar may have
-# restored — those'd now be *root-owned* suid files, which is far worse
-# than the build-uid case. Archive has no setuid bits today; this is a
-# defense-in-depth invariant.
+# Under sudo: normalize ownership so the binary doesn't end up owned by
+# whoever happened to build the release / whoever ran install.sh.
 if [ "$(id -u)" = "0" ]; then
-  chown -R 0:0 "$INSTALL_DIR" || die "chown -R 0:0 $INSTALL_DIR failed — refusing to leave root-extracted files with non-root ownership"
-  # POSIX `-exec ... {} \;` (one-per-file) rather than `{} +` so this works
-  # on older busybox find too. Our archive ships no setuid files, so the
-  # per-file fork overhead is effectively zero in practice.
-  find "$INSTALL_DIR" -type f \( -perm -4000 -o -perm -2000 \) -exec chmod u-s,g-s {} \; \
-    || die "failed to strip setuid/setgid bits under $INSTALL_DIR after root extraction"
+  chown 0:0 "$INSTALL_DIR/$BINARY_NAME" \
+    || die "chown 0:0 $INSTALL_DIR/$BINARY_NAME failed — refusing to leave root-installed file with non-root ownership"
+  # Defense-in-depth: strip suid/sgid in case a future build accidentally
+  # ships them. After chown, any such bit would yield a root-owned suid
+  # binary inside $INSTALL_DIR.
+  current_mode="$(stat -c '%a' "$INSTALL_DIR/$BINARY_NAME" 2>/dev/null \
+                  || stat -f '%Lp' "$INSTALL_DIR/$BINARY_NAME")"
+  case "$current_mode" in
+    [4-7]???) chmod u-s,g-s "$INSTALL_DIR/$BINARY_NAME" ;;
+  esac
 fi
 
-chmod +x "$INSTALL_DIR/bin/vicoop-client" 2>/dev/null || true
+# macOS quarantine attribute attaches to anything `curl` downloaded; first
+# launch would otherwise be Gatekeeper-blocked with "Apple cannot verify
+# this software". Stripping it here keeps `install.sh | sh` a true one-liner
+# until proper Developer ID signing + notarization land (issue #188
+# follow-up). xattr is part of the macOS base system; the check guards
+# against the rare Linux case where it isn't.
+if [ "$OS_NAME" = "Darwin" ] && command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$INSTALL_DIR/$BINARY_NAME" 2>/dev/null || true
+fi
 
 # ---- 5. Next steps ----------------------------------------------------------
 cat <<EOF
 
-==> installed $VERSION to $INSTALL_DIR
+==> installed $VERSION to $INSTALL_DIR/$BINARY_NAME
 
 Next steps (the agent that owns this client should perform these):
 
-  1. Verify the installed bundle and register with device flow:
+  1. Verify and sign in (device flow). The owner-session bearer is saved
+     to ~/.vicoop/owner-session.json; admin subcommands pick it up:
 
-       "$INSTALL_DIR/bin/vicoop-client" -v
-       "$INSTALL_DIR/bin/vicoop-client" login --help
+       "$INSTALL_DIR/$BINARY_NAME" --version
+       "$INSTALL_DIR/$BINARY_NAME" login
 
-     Then follow docs/install-client.md steps 3-6 to pick AGENT_ID, run
-     login, choose a backend, and start the client.
+  2. Register this client. \`setup\` writes the one-time CLIENT_TOKEN plus
+     server_url / agent_id into the canonical ~/.vicoop/config.json
+     (mode 600); the daemon picks those up on its next launch:
 
-  2. Run the client in the foreground. After \`login\` + \`setup\` from
-     docs/install-client.md, the canonical \`~/.vicoop/config.json\`
-     (mode 600) already holds server_url / server_token / agent_id —
-     the daemon needs no further args:
+       "$INSTALL_DIR/$BINARY_NAME" setup \\
+         --client-name "my client" --agent-ids "\$AGENT_ID"
 
-       "$INSTALL_DIR/bin/vicoop-client" --backend openclaw
+  3. Run the daemon in the foreground. With config.json populated, only
+     the backend choice (echo / openclaw / claude / codex) is left:
+
+       "$INSTALL_DIR/$BINARY_NAME" --backend openclaw
 
      Or persist \`"backend": "openclaw"\` in config.json and run with no
      flags at all:
 
-       "$INSTALL_DIR/bin/vicoop-client"
+       "$INSTALL_DIR/$BINARY_NAME"
 
-     Backend-specific knobs (CLAUDE_CWD, CODEX_SANDBOX_MODE, OPENCLAW_*)
-     are passed as CLI flags (\`--claude-cwd\`, \`--codex-sandbox\`,
-     \`--openclaw-gateway\`, …) or persisted in \`backends.*\` inside
-     config.json — env vars are no longer consulted for runtime config.
+     An always-on supervisor (systemd unit, launchd plist, …) is not
+     provided by this installer; the foreground run above is the
+     supported entrypoint while the design is in flux (issue #190).
 
-     An always-on supervisor story (systemd unit, launchd plist, etc.) is
-     not currently provided by this installer; the foreground run above is
-     the supported entrypoint while the design is in flux (issue #190).
-
-  Future updates: run \`"$INSTALL_DIR/bin/vicoop-client" upgrade\` — no need
+  Future updates: run \`"$INSTALL_DIR/$BINARY_NAME" upgrade\` — no need
   to re-run this installer. Pass --check to see if a newer release is
-  available. The quotes keep the command correct even if \$INSTALL_DIR
-  contains whitespace.
+  available.
 
 EOF

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -1,9 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { assertLooksLikeInstall, normalizeTag, parseChecksum, preserveOperatorFiles, sha256File, stripSuidBits } from './upgrade.js';
+import {
+  assertLooksLikeInstall,
+  assetName,
+  normalizeTag,
+  parseChecksum,
+  resolvePlatformAsset,
+  sha256File,
+  stripSuidBits,
+} from './upgrade.js';
 
 test('normalizeTag accepts full tag, bare version, and v-prefixed version', () => {
   assert.equal(normalizeTag('@vicoop-bridge/client@0.3.0'), '@vicoop-bridge/client@0.3.0');
@@ -18,9 +26,6 @@ test('normalizeTag accepts full tag, bare version, and v-prefixed version', () =
 });
 
 test('normalizeTag wrong-scope error names the expected prefix, not a doubled string', () => {
-  // The error should call out the bad prefix on the raw input, not show a
-  // confusing post-normalization string like
-  // "@vicoop-bridge/client@@evil/client@0.3.0".
   assert.throws(
     () => normalizeTag('@evil/client@0.3.0'),
     /expected tag to start with @vicoop-bridge\/client@/,
@@ -38,10 +43,7 @@ test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () 
     '@vicoop-bridge/client@0.3.0;rm -rf /',
     '@vicoop-bridge/client@0.3.0\nfoo',
     '@vicoop-bridge/client@',
-    // Slash anywhere inside the version segment would split the URL path.
     '@vicoop-bridge/client@0.3.0/extra',
-    // Wrong scope shouldn't squeak through — `startsWith` check + the
-    // anchored regex must agree.
     '@evil/client@0.3.0',
     '@vicoop-bridge/server@0.3.0',
     '',
@@ -52,7 +54,7 @@ test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () 
 
 test('parseChecksum extracts hash from `<hash>  <path>` and bare-hash forms', () => {
   const hash = 'a'.repeat(64);
-  assert.equal(parseChecksum(`${hash}  vicoop-bridge-client-0.3.0.tgz`), hash);
+  assert.equal(parseChecksum(`${hash}  vicoop-client-0.3.0-linux-x64`), hash);
   assert.equal(parseChecksum(`${hash}\n`), hash);
   assert.equal(parseChecksum(`${'F'.repeat(64)}  whatever`), 'f'.repeat(64));
 });
@@ -69,7 +71,6 @@ test('sha256File streams the file and matches a known-answer', async () => {
   try {
     const path = join(dir, 'f.bin');
     writeFileSync(path, 'hello world');
-    // Known sha256 of "hello world".
     const want = 'b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9';
     assert.equal(await sha256File(path), want);
   } finally {
@@ -77,105 +78,39 @@ test('sha256File streams the file and matches a known-answer', async () => {
   }
 });
 
-test('preserveOperatorFiles keeps operator-added cards and top-level non-bundle files', () => {
-  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
-  try {
-    const oldDir = join(base, 'old');
-    const newDir = join(base, 'new');
-
-    // Old install: shipped bundle entries + operator additions.
-    mkdirSync(join(oldDir, 'cards'), { recursive: true });
-    mkdirSync(join(oldDir, 'bin'), { recursive: true });
-    mkdirSync(join(oldDir, 'dist'), { recursive: true });
-    mkdirSync(join(oldDir, 'node_modules'), { recursive: true });
-    writeFileSync(join(oldDir, 'package.json'), '{"version":"0.3.0"}');
-    writeFileSync(join(oldDir, 'cards', 'openclaw.json'), '{"marker":"old-shipped"}');
-    writeFileSync(join(oldDir, 'cards', 'my-custom.json'), '{"marker":"operator"}');
-    writeFileSync(join(oldDir, 'operator-notes.txt'), 'hello');
-
-    // Fresh bundle just extracted: has new shipped cards, none of operator's additions.
-    mkdirSync(join(newDir, 'cards'), { recursive: true });
-    mkdirSync(join(newDir, 'bin'), { recursive: true });
-    mkdirSync(join(newDir, 'dist'), { recursive: true });
-    mkdirSync(join(newDir, 'node_modules'), { recursive: true });
-    writeFileSync(join(newDir, 'package.json'), '{"version":"0.4.0"}');
-    writeFileSync(join(newDir, 'cards', 'openclaw.json'), '{"marker":"new-shipped"}');
-
-    preserveOperatorFiles(oldDir, newDir);
-
-    // Shipped card untouched — new bundle wins.
-    assert.equal(JSON.parse(readFileSync(join(newDir, 'cards', 'openclaw.json'), 'utf8')).marker, 'new-shipped');
-    // Operator-added card copied over.
-    assert.equal(readFileSync(join(newDir, 'cards', 'my-custom.json'), 'utf8'), '{"marker":"operator"}');
-    // Top-level operator file preserved.
-    assert.equal(readFileSync(join(newDir, 'operator-notes.txt'), 'utf8'), 'hello');
-    // Shipped top-level files not duplicated.
-    assert.equal(JSON.parse(readFileSync(join(newDir, 'package.json'), 'utf8')).version, '0.4.0');
-  } finally {
-    rmSync(base, { recursive: true, force: true });
-  }
+test('resolvePlatformAsset maps every supported (platform, arch) pair', () => {
+  assert.deepEqual(resolvePlatformAsset('darwin', 'arm64'), { slug: 'macos-arm64', ext: '' });
+  assert.deepEqual(resolvePlatformAsset('darwin', 'x64'),   { slug: 'macos-x64',   ext: '' });
+  assert.deepEqual(resolvePlatformAsset('linux',  'arm64'), { slug: 'linux-arm64', ext: '' });
+  assert.deepEqual(resolvePlatformAsset('linux',  'x64'),   { slug: 'linux-x64',   ext: '' });
+  assert.deepEqual(resolvePlatformAsset('win32',  'x64'),   { slug: 'windows-x64', ext: '.exe' });
 });
 
-test('preserveOperatorFiles handles missing cards/ on either side without throwing', () => {
-  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
-  try {
-    const oldDir = join(base, 'old');
-    const newDir = join(base, 'new');
-    mkdirSync(oldDir);
-    mkdirSync(newDir);
-    writeFileSync(join(oldDir, 'operator.txt'), 'x');
-
-    preserveOperatorFiles(oldDir, newDir);
-    assert.equal(readFileSync(join(newDir, 'operator.txt'), 'utf8'), 'x');
-    // No cards/ gets fabricated.
-    assert.ok(!readdirSync(newDir).includes('cards'));
-  } finally {
-    rmSync(base, { recursive: true, force: true });
-  }
+test('resolvePlatformAsset rejects unsupported combinations', () => {
+  // 32-bit windows, ppc64, freebsd, etc. — nothing in the build matrix.
+  assert.throws(() => resolvePlatformAsset('win32', 'ia32'), /unsupported platform/);
+  assert.throws(() => resolvePlatformAsset('freebsd' as NodeJS.Platform, 'x64'), /unsupported platform/);
+  assert.throws(() => resolvePlatformAsset('linux', 'ppc64'), /unsupported platform/);
 });
 
-test('assertLooksLikeInstall accepts a bundle-shaped directory', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
-  try {
-    mkdirSync(join(dir, 'bin'), { recursive: true });
-    mkdirSync(join(dir, 'dist'), { recursive: true });
-    mkdirSync(join(dir, 'node_modules'), { recursive: true });
-    writeFileSync(join(dir, 'bin', 'vicoop-client'), '#!/usr/bin/env bash\nexec node ../dist/cli.js\n');
-    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
-    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@vicoop-bridge/client', version: '0.3.0' }));
-    assert.doesNotThrow(() => assertLooksLikeInstall(dir));
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+test('assetName builds the published filename for each platform', () => {
+  assert.equal(assetName('0.16.0', { slug: 'macos-arm64', ext: '' }), 'vicoop-client-0.16.0-macos-arm64');
+  assert.equal(assetName('0.16.0', { slug: 'linux-x64',   ext: '' }), 'vicoop-client-0.16.0-linux-x64');
+  assert.equal(assetName('0.16.0', { slug: 'windows-x64', ext: '.exe' }), 'vicoop-client-0.16.0-windows-x64.exe');
 });
 
-test('assertLooksLikeInstall rejects directories missing bundle markers', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
-  try {
-    // Dev-workspace-shaped: has dist/, package.json, node_modules, but no bin/vicoop-client.
-    mkdirSync(join(dir, 'dist'), { recursive: true });
-    mkdirSync(join(dir, 'node_modules'), { recursive: true });
-    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
-    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@vicoop-bridge/client', version: '0.3.0' }));
-    assert.throws(() => assertLooksLikeInstall(dir), /bin\/vicoop-client/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+test('assertLooksLikeInstall accepts an execPath ending in the expected binary name', () => {
+  const expected = process.platform === 'win32' ? 'vicoop-client.exe' : 'vicoop-client';
+  assert.doesNotThrow(() => assertLooksLikeInstall(`/opt/vicoop/${expected}`));
+  assert.doesNotThrow(() => assertLooksLikeInstall(`/data/vicoop-bridge-client/${expected}`));
 });
 
-test('assertLooksLikeInstall rejects bundles with wrong package name', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'vicoop-marker-'));
-  try {
-    mkdirSync(join(dir, 'bin'), { recursive: true });
-    mkdirSync(join(dir, 'dist'), { recursive: true });
-    mkdirSync(join(dir, 'node_modules'), { recursive: true });
-    writeFileSync(join(dir, 'bin', 'vicoop-client'), '# stub');
-    writeFileSync(join(dir, 'dist', 'cli.js'), '// stub');
-    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'some-other-package', version: '0.3.0' }));
-    assert.throws(() => assertLooksLikeInstall(dir), /unexpected name/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+test('assertLooksLikeInstall rejects dev-workspace invocations (tsx / node / bun)', () => {
+  // `tsx src/cli.ts upgrade` lands here with execPath = the node binary.
+  assert.throws(() => assertLooksLikeInstall('/usr/local/bin/node'), /expected 'vicoop-client/);
+  assert.throws(() => assertLooksLikeInstall('/opt/homebrew/bin/bun'), /expected 'vicoop-client/);
+  // Wrong basename inside an otherwise-plausible install dir.
+  assert.throws(() => assertLooksLikeInstall('/opt/vicoop/vicoop-client-old'), /expected 'vicoop-client/);
 });
 
 test('stripSuidBits clears setuid and setgid bits while leaving other modes untouched', () => {
@@ -185,47 +120,27 @@ test('stripSuidBits clears setuid and setgid bits while leaving other modes unto
     const suid = join(dir, 'suid');
     const sgid = join(dir, 'sgid');
     const both = join(dir, 'both');
-    const nestedDir = join(dir, 'nested');
-    const nested = join(nestedDir, 'binary');
-    mkdirSync(nestedDir);
     writeFileSync(plain, '');
     writeFileSync(suid, '');
     writeFileSync(sgid, '');
     writeFileSync(both, '');
-    writeFileSync(nested, '');
 
     chmodSync(plain, 0o755);
     chmodSync(suid, 0o4755);
     chmodSync(sgid, 0o2755);
     chmodSync(both, 0o6755);
-    chmodSync(nested, 0o4750);
 
-    stripSuidBits(dir);
+    stripSuidBits(plain);
+    stripSuidBits(suid);
+    stripSuidBits(sgid);
+    stripSuidBits(both);
 
-    // Mask to the low 12 bits so platform-added type bits don't interfere.
     const mode = (p: string) => statSync(p).mode & 0o7777;
     assert.equal(mode(plain), 0o755, 'plain file unchanged');
     assert.equal(mode(suid), 0o755, 'setuid cleared');
     assert.equal(mode(sgid), 0o755, 'setgid cleared');
     assert.equal(mode(both), 0o755, 'both cleared');
-    assert.equal(mode(nested), 0o750, 'recurses into subdirectories');
   } finally {
     rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test('preserveOperatorFiles recurses into operator-added subdirectories', () => {
-  const base = mkdtempSync(join(tmpdir(), 'vicoop-preserve-'));
-  try {
-    const oldDir = join(base, 'old');
-    const newDir = join(base, 'new');
-    mkdirSync(join(oldDir, 'custom-state', 'nested'), { recursive: true });
-    writeFileSync(join(oldDir, 'custom-state', 'nested', 'data.bin'), 'payload');
-    mkdirSync(newDir);
-
-    preserveOperatorFiles(oldDir, newDir);
-    assert.equal(readFileSync(join(newDir, 'custom-state', 'nested', 'data.bin'), 'utf8'), 'payload');
-  } finally {
-    rmSync(base, { recursive: true, force: true });
   }
 });

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -4,71 +4,43 @@ import {
   accessSync,
   constants as fsConstants,
   chmodSync,
-  cpSync,
   createReadStream,
   createWriteStream,
   existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  readdirSync,
   renameSync,
   rmSync,
   statSync,
+  unlinkSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { clientVersion, installDir } from './version.js';
 
 const REPO = 'planetarium/vicoop-bridge';
 
-// Top-level entries that the release bundle owns. Anything else under
-// $INSTALL_DIR is assumed operator-placed and preserved on upgrade.
-const SHIPPED_TOP_LEVEL = new Set(['bin', 'cards', 'dist', 'node_modules', 'package.json', 'README.md']);
-
-// Cap for the new-bundle --version probe. It's meant to be instantaneous;
-// anything close to the timeout indicates a regression we'd rather surface
-// than block on.
+// Cap for the new-binary --version probe. Should be near-instant; anything
+// close to this timeout is a regression we'd rather surface than block on.
 const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
-// Short cap for GitHub API calls (just listing tags). A stalled DNS resolution
-// or captive portal shouldn't strand the operator with a hung process.
+// Short cap for GitHub API calls. A stalled DNS resolution or captive portal
+// shouldn't strand the operator on a hung process.
 const API_TIMEOUT_MS = 15_000;
 
-// Generous cap for the actual release-asset download. `AbortSignal.timeout` is
-// a total-operation timeout, so this needs to cover slow-but-real networks
-// pulling a multi-MB bundle; lower it and we'd false-abort on plausible home
-// connections. If the upstream is genuinely dead the operator notices within
-// this window and can Ctrl-C sooner.
+// Generous cap for the actual asset download. `AbortSignal.timeout` is a
+// total-operation timeout, so this has to cover slow-but-real networks
+// pulling a ~60MB binary; lower it and we'd false-abort on plausible home
+// connections.
 const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
-// Fixed prefix used by changesets/action for monorepo package releases. The
-// version portion (after the prefix) is what gets interpolated into local
-// filenames; the prefix itself only appears in the GitHub download URL and is
-// url-encoded there (the `/` would otherwise split the URL path).
 const TAG_PREFIX = '@vicoop-bridge/client@';
 
-// Accepted release-tag shape. Restrictive on purpose: the version portion is
-// interpolated into local filenames (archive name, temp path joins), so we
-// reject anything that could path-traverse or smuggle shell metacharacters
-// before it's used. The literal `/` in the prefix is the only `/` allowed;
-// the version character class still excludes it. Permissive enough for
-// semver-ish tags including pre-release/build suffixes
-// (`@vicoop-bridge/client@1.0.0-rc.1`, `...+sha.abc`).
-//
-// Derived from TAG_PREFIX so the prefix lives in one place. `@` and `/`
-// aren't regex metacharacters in JavaScript, so interpolating the prefix
-// verbatim is safe; if the prefix ever picks up a real metacharacter (`.`
-// `*` `?` etc.) this needs explicit escaping.
+// Accepted tag shape. The version portion is interpolated into the asset
+// filename, so we reject anything that could path-traverse or smuggle shell
+// metacharacters. The `/` inside the prefix is the only slash allowed; the
+// version character class still excludes it. Permissive enough for
+// pre-release / build-metadata variants (`...-rc.1`, `...+sha.abc`).
 const TAG_RE = new RegExp(`^${TAG_PREFIX}[A-Za-z0-9][A-Za-z0-9.+\\-]*$`);
-
-// Top-level entries a legitimate release bundle must contain. Missing any one
-// of these is taken as "not an installed bundle" and aborts upgrade before
-// anything on disk can move — guards against running the command from a dev
-// workspace where `packages/client` lacks the synthesized bin wrapper.
-const BUNDLE_MARKERS = ['bin/vicoop-client', 'dist/cli.js', 'package.json', 'node_modules'];
 
 export interface UpgradeOptions {
   check: boolean;
@@ -76,11 +48,43 @@ export interface UpgradeOptions {
   version?: string;
 }
 
+interface PlatformAsset {
+  // Slug used in the asset filename (`macos-arm64`, `linux-x64`, ...).
+  slug: string;
+  // Extension appended to the binary on this platform (`.exe` on win32).
+  ext: string;
+}
+
+export function resolvePlatformAsset(
+  plat: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): PlatformAsset {
+  if (plat === 'darwin' && arch === 'arm64') return { slug: 'macos-arm64', ext: '' };
+  if (plat === 'darwin' && arch === 'x64')   return { slug: 'macos-x64',   ext: '' };
+  if (plat === 'linux'  && arch === 'arm64') return { slug: 'linux-arm64', ext: '' };
+  if (plat === 'linux'  && arch === 'x64')   return { slug: 'linux-x64',   ext: '' };
+  if (plat === 'win32'  && arch === 'x64')   return { slug: 'windows-x64', ext: '.exe' };
+  throw new Error(`upgrade: unsupported platform/arch combination ${plat}/${arch}`);
+}
+
+export function assetName(version: string, asset: PlatformAsset = resolvePlatformAsset()): string {
+  return `vicoop-client-${version}-${asset.slug}${asset.ext}`;
+}
+
 export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
-  log(`current: ${clientVersion} (${installDir})`);
+  const execPath = process.execPath;
+  log(`current: ${clientVersion} (${execPath})`);
 
   try {
-    assertLooksLikeInstall(installDir);
+    assertLooksLikeInstall(execPath);
+  } catch (e) {
+    err((e as Error).message);
+    return 1;
+  }
+
+  let asset: PlatformAsset;
+  try {
+    asset = resolvePlatformAsset();
   } catch (e) {
     err((e as Error).message);
     return 1;
@@ -106,160 +110,112 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
     return 0;
   }
 
-  // Preflight: the operations that actually matter are parent-directory
-  // renames (moving $INSTALL_DIR aside + $INSTALL_DIR.new into place) and
-  // reading through the current bundle (version.ts + preserveOperatorFiles).
-  // So: parent must be writable + executable, installDir itself only needs
-  // read + execute. A hardened chmod 555 install that the operator intends
-  // to leave read-only passes here and upgrades cleanly.
+  // Stage the new binary alongside the current one so the final rename is on
+  // the same filesystem (atomic). Operator's `cards/`, config, etc. living in
+  // installDir are untouched by a single-file swap.
+  const newPath = `${execPath}.new`;
+  const prevPath = `${execPath}.prev`;
+
   try {
-    accessSync(installDir, fsConstants.R_OK | fsConstants.X_OK);
-    accessSync(dirname(installDir), fsConstants.W_OK | fsConstants.X_OK);
+    accessSync(installDir, fsConstants.W_OK | fsConstants.X_OK);
   } catch {
-    err(`$INSTALL_DIR must be readable/executable and its parent must be writable (${installDir}).`);
+    err(`install directory must be writable/executable to upgrade (${installDir}).`);
     err('If this is a system-scope install, re-run with sudo.');
     return 1;
   }
 
-  const newDir = `${installDir}.new`;
-  const prevDir = `${installDir}.prev`;
-  try {
-    rmSync(newDir, { recursive: true, force: true });
-  } catch (e) {
-    err(`could not clean up stale ${newDir}: ${(e as Error).message}`);
-    return 1;
+  // Clean up a stale .new from a previous interrupted upgrade.
+  if (existsSync(newPath)) {
+    try {
+      unlinkSync(newPath);
+    } catch (e) {
+      err(`could not remove stale ${newPath}: ${(e as Error).message}`);
+      return 1;
+    }
   }
 
-  const dlDir = mkdtempSync(join(tmpdir(), 'vicoop-upgrade-'));
+  const archiveName = assetName(targetVersion, asset);
+  const checksumName = `${archiveName}.sha256`;
+  // The tag contains `/` and `@`; both must be percent-encoded as a single
+  // path segment so the URL points at one release, not into a subpath.
+  const baseUrl = `https://github.com/${REPO}/releases/download/${encodeURIComponent(targetTag)}`;
 
-  // `swapDone` gates the .new cleanup: any exit path before the atomic swap
-  // completes (explicit `return`, thrown exception, failed rollback) must
-  // leave the original install in place and remove .new. The outer finally
-  // checks this flag so we don't have to duplicate cleanup at every failure
-  // site.
+  // `swapDone` gates cleanup of `.new`. Any exit path before the swap
+  // completes must leave the current binary in place and remove `.new`.
   let swapDone = false;
 
   try {
     try {
-      const archiveName = `vicoop-bridge-client-${targetVersion}.tgz`;
-      const checksumName = `${archiveName}.sha256`;
-      // The tag contains `/` and `@`; both must be percent-encoded as a single
-      // path segment so the URL points at one release, not into a subpath.
-      const baseUrl = `https://github.com/${REPO}/releases/download/${encodeURIComponent(targetTag)}`;
-
       log(`downloading ${archiveName}`);
-      await download(`${baseUrl}/${archiveName}`, join(dlDir, archiveName));
-      await download(`${baseUrl}/${checksumName}`, join(dlDir, checksumName));
+      await download(`${baseUrl}/${archiveName}`, newPath);
 
       log('verifying checksum');
-      const expected = parseChecksum(readFileSync(join(dlDir, checksumName), 'utf8'));
-      const actual = await sha256File(join(dlDir, archiveName));
+      const checksumText = await downloadText(`${baseUrl}/${checksumName}`);
+      const expected = parseChecksum(checksumText);
+      const actual = await sha256File(newPath);
       if (expected !== actual) {
         err(`checksum mismatch: expected ${expected}, got ${actual}`);
         return 1;
       }
 
-      log(`extracting into ${newDir}`);
-      mkdirSync(newDir, { recursive: true });
-      const tarRes = spawnSync(
-        'tar',
-        ['-xzf', join(dlDir, archiveName), '-C', newDir, '--strip-components=1'],
-        { stdio: 'inherit' },
-      );
-      if (tarRes.error) {
-        // Most common failure: `tar` missing on PATH. spawnSync flags it via
-        // an ENOENT on `error.code`. Keep the message specific so an operator
-        // knows to install `tar` instead of chasing a bad-archive hypothesis.
-        const code = (tarRes.error as NodeJS.ErrnoException).code;
-        const hint = code === 'ENOENT' ? ' (tar not found on PATH — install it and retry)' : '';
-        err(`extraction failed: ${tarRes.error.message}${hint}`);
-        return 1;
-      }
-      if (tarRes.signal) {
-        err(`extraction failed: tar terminated by signal ${tarRes.signal}`);
-        return 1;
-      }
-      if (tarRes.status !== 0) {
-        err(`extraction failed: tar exited with status ${tarRes.status}`);
+      // chmod +x so the healthcheck can spawn it. 0o755 mirrors install.sh.
+      try {
+        chmodSync(newPath, 0o755);
+      } catch (e) {
+        err(`could not chmod +x ${newPath}: ${(e as Error).message}`);
         return 1;
       }
 
-      // Portable replacement for `tar --no-same-owner`: busybox tar lacks
-      // the long option, so we normalize ownership after the fact. Non-root
-      // tar already extracts as the current uid/gid (kernel enforces), so
-      // the chown only actually matters under `sudo vicoop-client upgrade`
-      // — where the archive's stored uid (typically ~1000, whatever built
-      // the release) would otherwise end up owning a root-run service's
-      // files. That's a privilege-escalation vector: any local user with
-      // that uid could modify `dist/cli.js` between restarts.
-      //
-      // Under root we also strip setuid/setgid bits that tar may have
-      // restored from the archive. After the chown above, any such bits
-      // would become root-owned suid files under $INSTALL_DIR — much worse
-      // than the build-host-uid case. The archive has no setuid bits today;
-      // this is a defense-in-depth invariant so we don't silently start
-      // shipping a privileged binary if someone adds one.
+      // Under sudo, normalize ownership so the staged binary doesn't end up
+      // owned by the operator's uid while the install runs as root.
+      // Defense-in-depth: also strip suid/sgid bits.
       if (process.getuid?.() === 0) {
-        const chownRes = spawnSync('chown', ['-R', '0:0', newDir], { stdio: 'inherit' });
+        const chownRes = spawnSync('chown', ['0:0', newPath], { stdio: 'inherit' });
         if (chownRes.error || chownRes.signal || chownRes.status !== 0) {
           const detail = chownRes.error?.message ?? `signal ${chownRes.signal ?? 'none'}, status ${chownRes.status}`;
-          err(`chown -R 0:0 on ${newDir} failed (${detail}) — refusing to leave root-extracted files with non-root ownership`);
+          err(`chown 0:0 on ${newPath} failed (${detail}) — refusing to leave root-extracted file with non-root ownership`);
           return 1;
         }
         try {
-          stripSuidBits(newDir);
+          stripSuidBits(newPath);
         } catch (e) {
-          err(`failed to strip setuid/setgid bits under ${newDir}: ${(e as Error).message}`);
+          err(`failed to strip setuid/setgid bits on ${newPath}: ${(e as Error).message}`);
           return 1;
         }
       }
 
-      preserveOperatorFiles(installDir, newDir);
-
-      // Re-strip setuid/setgid after preservation. `cpSync` preserves mode
-      // bits, so any operator file that had suid/sgid bits set in the old
-      // install would arrive in newDir with those bits intact — and under
-      // `sudo vicoop-client upgrade` that file's dest would be owned by
-      // root (cpSync as root) or left owner-preserved, either way yielding
-      // a privileged binary inside the next install. Second strip closes
-      // that gap; non-root path is a no-op beyond the directory walk.
-      if (process.getuid?.() === 0) {
-        try {
-          stripSuidBits(newDir);
-        } catch (e) {
-          err(`failed to strip setuid/setgid bits under ${newDir} after preserving operator files: ${(e as Error).message}`);
-          return 1;
-        }
-      }
-
-      const health = runHealthcheck(newDir, targetVersion);
+      const health = runHealthcheck(newPath, targetVersion);
       if (!health.ok) {
-        err(`new bundle failed --version healthcheck; aborting${health.detail ? ` (${health.detail})` : ''}`);
+        err(`new binary failed --version healthcheck; aborting${health.detail ? ` (${health.detail})` : ''}`);
         return 1;
       }
 
-      // Atomic swap. Both renames inside a guarded block so any failure
-      // restores the original install dir; the outer `finally` still deletes
-      // `.new` since `swapDone` stays false.
-      try {
-        rmSync(prevDir, { recursive: true, force: true });
-      } catch (e) {
-        err(`could not clear existing ${prevDir}: ${(e as Error).message}`);
-        return 1;
+      // Atomic swap. On unix the running process keeps executing from the
+      // unlinked inode, so replacing the file mid-flight is safe; the next
+      // launch picks up the new binary. Windows can't rename an executable
+      // that's currently mapped — that case is handled by install.sh, not
+      // here (this branch will fail loudly with EBUSY-equivalent).
+      if (existsSync(prevPath)) {
+        try {
+          unlinkSync(prevPath);
+        } catch (e) {
+          err(`could not clear existing ${prevPath}: ${(e as Error).message}`);
+          return 1;
+        }
       }
       let movedOriginal = false;
       try {
-        log(`swap: ${installDir} -> ${prevDir}`);
-        renameSync(installDir, prevDir);
+        log(`swap: ${execPath} -> ${prevPath}`);
+        renameSync(execPath, prevPath);
         movedOriginal = true;
-        log(`swap: ${newDir} -> ${installDir}`);
-        renameSync(newDir, installDir);
+        log(`swap: ${newPath} -> ${execPath}`);
+        renameSync(newPath, execPath);
         swapDone = true;
       } catch (e) {
         err(`swap failed, rolling back: ${(e as Error).message}`);
-        if (movedOriginal && !existsSync(installDir)) {
+        if (movedOriginal && !existsSync(execPath)) {
           try {
-            renameSync(prevDir, installDir);
+            renameSync(prevPath, execPath);
           } catch (rollbackErr) {
             err(`rollback rename failed: ${(rollbackErr as Error).message}`);
           }
@@ -269,42 +225,37 @@ export async function runUpgrade(opts: UpgradeOptions): Promise<number> {
     } catch (e) {
       err(`upgrade failed: ${(e as Error).message}`);
       return 1;
-    } finally {
-      // Cleanup paths must not mask the operation's real exit code. `rmSync`
-      // with `force: true` silences ENOENT but still throws on EACCES /
-      // EPERM / EBUSY, so a finally-block rmSync can turn a clean failure
-      // (or a clean success) into an uncaught exception. Downgrade to a
-      // warning instead.
-      if (!swapDone) safeRemove(newDir);
     }
   } finally {
-    safeRemove(dlDir);
+    // Cleanup must not mask a real failure. `rmSync force: true` silences
+    // ENOENT but still throws on EACCES / EBUSY, so a finally-block rmSync
+    // can turn a clean error into an uncaught exception. Downgrade to a
+    // warning instead.
+    if (!swapDone) safeRemove(newPath);
   }
 
   log(
-    'a running client (if any) keeps the previous bundle in memory until ' +
+    'a running client (if any) keeps the previous binary in memory until ' +
       'you stop it and start it again with your usual command',
   );
 
   log(`upgraded ${clientVersion} -> ${targetVersion}`);
-  log(`previous install kept at ${prevDir} (delete when satisfied)`);
+  log(`previous binary kept at ${prevPath} (delete when satisfied)`);
   return 0;
 }
 
 export function normalizeTag(v: string): string {
   // A leading `@` signals the operator meant to pass a full scoped tag. If
-  // the prefix doesn't match (e.g. `@evil/client@0.3.0`), surface that
-  // directly — otherwise the prefix is prepended unconditionally and
-  // assertSafeTag's "got" value reads like the double-prefixed
-  // `@vicoop-bridge/client@@evil/client@0.3.0`, which is hard to parse.
+  // the prefix doesn't match, surface that directly — otherwise the prefix
+  // is prepended unconditionally and the error message reads like the
+  // double-prefixed `@vicoop-bridge/client@@evil/client@0.3.0`.
   if (v.startsWith('@') && !v.startsWith(TAG_PREFIX)) {
     throw new Error(`invalid version '${v}': expected tag to start with ${TAG_PREFIX}`);
   }
   // Peel the prefix if present so the leading-`v` strip applies whether the
   // operator typed the bare version, the v-prefixed bare version, or the
-  // full tag (`@vicoop-bridge/client@v0.3.0` should resolve the same as
-  // `@vicoop-bridge/client@0.3.0`). Without this peel, the full-tag form
-  // would slip a `v` into the archive filename and miss the real asset.
+  // full tag — `@vicoop-bridge/client@v0.3.0` should normalize the same as
+  // `@vicoop-bridge/client@0.3.0`.
   const versionPart = (v.startsWith(TAG_PREFIX) ? v.slice(TAG_PREFIX.length) : v).replace(/^v/, '');
   const candidate = `${TAG_PREFIX}${versionPart}`;
   assertSafeTag(candidate, v);
@@ -312,20 +263,10 @@ export function normalizeTag(v: string): string {
 }
 
 function versionFromTag(tag: string): string {
-  // assertSafeTag is the gate that proves the prefix is present; callers
-  // should only pass tags that have already passed that check.
   return tag.slice(TAG_PREFIX.length);
 }
 
 function assertSafeTag(tag: string, raw: string = tag): void {
-  // The bare version portion of the tag is interpolated into local paths
-  // (archive name / temp joins); reject anything that could path-traverse or
-  // inject shell metacharacters before it reaches `join(dlDir, ...)`. The
-  // version regex is intentionally looser than strict semver — we want to
-  // accept future pre-release and build-metadata variants — so the error
-  // describes the literal character set rather than implying semver. The
-  // single `/` in the prefix is fine because the download URL goes through
-  // encodeURIComponent before being used.
   if (!TAG_RE.test(tag) || tag.includes('..')) {
     throw new Error(
       `invalid version '${raw}': expected ${TAG_PREFIX}<version> with only [A-Za-z0-9.+-] in the version (no '..'), got '${tag}'`,
@@ -342,11 +283,9 @@ async function resolveLatestTag(): Promise<string> {
   );
   if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
   const body = (await res.json()) as unknown;
-  // GitHub returns an object (`{ message, documentation_url, ... }`) for
-  // rate-limit / abuse / auth errors with a 2xx-shaped body on some legacy
-  // paths, so don't trust the HTTP status alone — confirm we got an array
-  // before iterating, otherwise `for...of` would throw "X is not
-  // iterable" which is harder to act on than the upstream error message.
+  // GitHub returns an object (`{ message, ... }`) for rate-limit/abuse/auth
+  // errors with 2xx-shaped bodies on some legacy paths, so don't trust the
+  // HTTP status alone — confirm we got an array before iterating.
   if (!Array.isArray(body)) {
     const msg = (body as { message?: unknown })?.message;
     const detail = typeof msg === 'string' ? msg : JSON.stringify(body).slice(0, 200);
@@ -355,14 +294,7 @@ async function resolveLatestTag(): Promise<string> {
   const releases = body as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
   for (const r of releases) {
     if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith(TAG_PREFIX)) continue;
-    // Skip drafts (no uploaded assets — the .tgz download would 404) and
-    // prereleases (assets exist but operators on the default channel don't
-    // want them). `--version <tag>` with an explicit prerelease tag still
-    // lets an operator pin one when they want to test it.
     if (r.draft === true || r.prerelease === true) continue;
-    // Defensively validate the API response — a future rename or a
-    // compromised upstream shouldn't get to interpolate arbitrary strings
-    // into local filenames.
     assertSafeTag(r.tag_name);
     return r.tag_name;
   }
@@ -373,10 +305,6 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
   try {
     return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
   } catch (e) {
-    // Node surfaces AbortSignal.timeout expiry as TimeoutError; older
-    // behavior / proxied fetches sometimes report AbortError. Translate
-    // either into a human-friendly message so operators know to check the
-    // network rather than chase a spurious stack trace.
     const name = (e as Error).name;
     if (name === 'TimeoutError' || name === 'AbortError') {
       throw new Error(`${url} timed out after ${timeoutMs}ms`);
@@ -385,30 +313,19 @@ async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: numbe
   }
 }
 
-export function assertLooksLikeInstall(dir: string): void {
-  for (const rel of BUNDLE_MARKERS) {
-    if (!existsSync(join(dir, rel))) {
-      throw new Error(
-        `${dir} does not look like an installed vicoop-client bundle ` +
-          `(missing ${rel}). Run install.sh for first-time setup; upgrade only manages existing installs.`,
-      );
-    }
-  }
-  // The workspace package.json at packages/client has the same name, so this
-  // isn't definitive on its own — but combined with the bin/vicoop-client
-  // check above (which the dev workspace lacks) it's enough to catch a
-  // `tsx src/cli.ts upgrade` or `node packages/client/dist/cli.js upgrade`
-  // run-from-source invocation before it mutates anything.
-  try {
-    const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8')) as { name?: unknown };
-    if (pkg.name !== '@vicoop-bridge/client') {
-      throw new Error(`${dir}/package.json has unexpected name '${String(pkg.name)}' — refusing to upgrade`);
-    }
-  } catch (e) {
-    if (e instanceof SyntaxError) {
-      throw new Error(`${dir}/package.json is not valid JSON — refusing to upgrade`);
-    }
-    throw e;
+// Validates that the running process is actually our installed binary, not
+// a `tsx src/cli.ts upgrade` or `node dist/cli.js upgrade` run from a dev
+// workspace. The binary is the only thing in installDir we own; if `tsx`
+// or `node` invoked us, `process.execPath` points at that interpreter, not
+// at our installed file.
+export function assertLooksLikeInstall(execPath: string): void {
+  const expectedBase = process.platform === 'win32' ? 'vicoop-client.exe' : 'vicoop-client';
+  const actualBase = basename(execPath);
+  if (actualBase !== expectedBase) {
+    throw new Error(
+      `current executable is '${actualBase}' at ${execPath}, expected '${expectedBase}'. ` +
+        `Upgrade only manages installs created by install.sh; run install.sh for first-time setup.`,
+    );
   }
 }
 
@@ -420,6 +337,14 @@ async function download(url: string, dest: string): Promise<void> {
   await pipeline(Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(dest));
 }
 
+async function downloadText(url: string): Promise<string> {
+  const res = await fetchWithTimeout(url, { redirect: 'follow' }, API_TIMEOUT_MS);
+  if (!res.ok) {
+    throw new Error(`download failed: ${res.status} ${res.statusText || ''} (${url})`.trim());
+  }
+  return res.text();
+}
+
 export async function sha256File(path: string): Promise<string> {
   const hash = createHash('sha256');
   await pipeline(createReadStream(path), hash);
@@ -427,7 +352,7 @@ export async function sha256File(path: string): Promise<string> {
 }
 
 export function parseChecksum(contents: string): string {
-  // Matches install.sh: take the first whitespace-separated token from the first line.
+  // Take the first whitespace-separated token from the first line.
   const first = contents.trim().split(/\s+/)[0];
   if (!first || !/^[0-9a-f]{64}$/i.test(first)) {
     throw new Error(`could not parse sha256 hash from checksum file (got: ${contents.slice(0, 80)})`);
@@ -435,54 +360,25 @@ export function parseChecksum(contents: string): string {
   return first.toLowerCase();
 }
 
-export function preserveOperatorFiles(oldDir: string, newDir: string): void {
-  for (const entry of readdirSync(oldDir)) {
-    if (SHIPPED_TOP_LEVEL.has(entry)) continue;
-    const src = join(oldDir, entry);
-    const dst = join(newDir, entry);
-    if (existsSync(dst)) continue;
-    cpSync(src, dst, { recursive: true });
-  }
-
-  const oldCards = join(oldDir, 'cards');
-  const newCards = join(newDir, 'cards');
-  if (!existsSync(oldCards) || !existsSync(newCards)) return;
-  for (const entry of readdirSync(oldCards)) {
-    const dst = join(newCards, entry);
-    if (existsSync(dst)) continue;
-    cpSync(join(oldCards, entry), dst, { recursive: true });
-  }
-}
-
 interface HealthcheckResult {
   ok: boolean;
   detail?: string;
 }
 
-function runHealthcheck(newDir: string, expected: string): HealthcheckResult {
-  const cli = join(newDir, 'dist', 'cli.js');
-  const r = spawnSync(process.execPath, [cli, '--version'], {
+function runHealthcheck(newBinary: string, expected: string): HealthcheckResult {
+  const r = spawnSync(newBinary, ['--version'], {
     encoding: 'utf8',
     timeout: HEALTHCHECK_TIMEOUT_MS,
   });
   const stderrSnippet = (r.stderr ?? '').trim().split('\n').slice(0, 3).join(' | ').slice(0, 200);
   const withStderr = (msg: string) => (stderrSnippet ? `${msg}; stderr: ${stderrSnippet}` : msg);
 
-  // spawnSync's `timeout` option kills the child with SIGTERM on expiry; flag
-  // that path separately so the operator can distinguish a hang from a normal
-  // non-zero exit. Older Node versions surface the timeout via
-  // `error.message` instead of setting `signal`.
   if (r.signal === 'SIGTERM' || r.error?.message?.includes('ETIMEDOUT')) {
     return { ok: false, detail: `timeout after ${HEALTHCHECK_TIMEOUT_MS}ms` };
   }
-  // `r.error` is set when spawn itself failed (ENOENT on the node binary, for
-  // example). Report it separately from "process ran and exited non-zero".
   if (r.error) {
     return { ok: false, detail: withStderr(`spawn failed: ${r.error.message}`) };
   }
-  // Any other terminating signal (SIGKILL from the OOM killer, SIGBUS from a
-  // native-module crash, etc.) — make the signal visible instead of falling
-  // through to `exit null`.
   if (r.signal) {
     return { ok: false, detail: withStderr(`terminated by signal ${r.signal}`) };
   }
@@ -496,18 +392,11 @@ function runHealthcheck(newDir: string, expected: string): HealthcheckResult {
   return { ok: true };
 }
 
-// Recursively clear the setuid (04000) and setgid (02000) bits on every file
-// under `dir`. Exported for tests.
-export function stripSuidBits(dir: string): void {
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const p = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      stripSuidBits(p);
-    } else if (entry.isFile()) {
-      const mode = statSync(p).mode;
-      if (mode & 0o6000) chmodSync(p, mode & ~0o6000);
-    }
-  }
+// Clears setuid (04000) and setgid (02000) bits on the file at `path`.
+// Exported for tests.
+export function stripSuidBits(path: string): void {
+  const mode = statSync(path).mode;
+  if (mode & 0o6000) chmodSync(path, mode & ~0o6000);
 }
 
 function safeRemove(path: string): void {

--- a/packages/client/src/version.ts
+++ b/packages/client/src/version.ts
@@ -1,20 +1,19 @@
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import pkg from '../package.json' with { type: 'json' };
 
-// In the shipped bundle, this file compiles to $INSTALL_DIR/dist/version.js and
-// package.json sits at $INSTALL_DIR/package.json. Resolving from import.meta.url
-// gives us both the running version and the install root in one step, without
-// any build-time codegen.
-const here = dirname(fileURLToPath(import.meta.url));
+// `clientVersion` is captured at build time. Under tsc the import resolves to
+// $INSTALL_DIR/package.json at runtime; under `bun build --compile` the JSON
+// is inlined into the single-file binary, so the version survives even
+// though there's no package.json on disk.
+export const clientVersion: string = pkg.version;
 
-export const installDir: string = dirname(here);
-
-export const clientVersion: string = (() => {
-  try {
-    const pkg = JSON.parse(readFileSync(join(installDir, 'package.json'), 'utf8')) as { version?: unknown };
-    return typeof pkg.version === 'string' ? pkg.version : 'unknown';
-  } catch {
-    return 'unknown';
-  }
-})();
+// In a tgz install this file lands at $INSTALL_DIR/dist/version.js, so the
+// install root is two dirnames up from import.meta.url. In a Bun single-file
+// build import.meta.url points at the embedded virtual fs (file:///$bunfs/…),
+// which isn't a real path — fall back to the binary's own location, which is
+// where install.sh places it.
+const metaPath = fileURLToPath(import.meta.url);
+export const installDir: string = metaPath.startsWith('/$bunfs/')
+  ? dirname(process.execPath)
+  : dirname(dirname(metaPath));

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Cross-compile per-platform vicoop-client binaries + sha256 sidecars into
+# dist-release/. Idempotent: re-running rebuilds everything.
+#
+# Usage: scripts/package-client-release.sh <tag>
+#
+# The asset filename convention must stay in lock-step with
+# packages/client/src/upgrade.ts (resolvePlatformAsset + assetName) and
+# install.sh — both rely on `vicoop-client-<version>-<slug>[.exe]` and a
+# sibling `.sha256` whose first whitespace-separated token is the hash.
+
 if [[ $# -ne 1 ]]; then
   echo "usage: $0 <tag>" >&2
   exit 1
@@ -9,90 +19,79 @@ fi
 TAG="$1"
 TAG_PREFIX="@vicoop-bridge/client@"
 
-# Caller passes the full tag (upload-client-release-assets.sh does this)
-# so the README and archive name agree on the version. Fail fast if it doesn't
-# carry the expected prefix or if the stripped version has anything that
-# could path-traverse / inject shell metacharacters into BUNDLE_DIR or
-# ARCHIVE_PATH below.
 case "$TAG" in
   "$TAG_PREFIX"*) ;;
   *) echo "error: TAG must start with $TAG_PREFIX (got: $TAG)" >&2; exit 1 ;;
 esac
 VERSION="${TAG#$TAG_PREFIX}"
-# Mirrors packages/client/src/upgrade.ts's TAG_RE: first char must be
-# alphanumeric (no ".x" or "-x"), remaining chars limited to
-# [A-Za-z0-9.+-], and no consecutive dots.
+# Mirrors packages/client/src/upgrade.ts's TAG_RE: first char alphanumeric,
+# remaining chars [A-Za-z0-9.+-], no `..`. The version portion gets
+# interpolated into the output filename, so reject anything that could
+# path-traverse before it reaches the filesystem.
 case "$VERSION" in
   ''|[!A-Za-z0-9]*|*[!A-Za-z0-9.+-]*|*..*)
     echo "error: version portion contains unsafe characters: $VERSION" >&2
     exit 1
     ;;
 esac
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT_DIR="$ROOT_DIR/dist-release"
-WORK_DIR="$OUT_DIR/work"
-BUNDLE_DIR="$WORK_DIR/vicoop-bridge-client-$VERSION"
-ARCHIVE_PATH="$OUT_DIR/vicoop-bridge-client-$VERSION.tgz"
-CHECKSUM_PATH="$ARCHIVE_PATH.sha256"
 
-if [[ ! -f "$ROOT_DIR/packages/client/dist/cli.js" ]]; then
-  echo "error: packages/client/dist/cli.js missing — run 'pnpm --filter @vicoop-bridge/protocol --filter @vicoop-bridge/client build' first" >&2
+# Bun resolves `@vicoop-bridge/protocol` via the workspace package's
+# `exports.import` (dist/index.js), so the protocol package must be built
+# before we compile the client. Tsc-building the client itself is no
+# longer required — `bun build --compile` reads src/cli.ts directly.
+pnpm --dir "$ROOT_DIR" --filter @vicoop-bridge/protocol build
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+CLIENT_DIR="$ROOT_DIR/packages/client"
+
+# (bun-target, asset-slug, file-extension) — keep this table identical to
+# resolvePlatformAsset() in upgrade.ts. Anything added here also needs a
+# matching branch there, otherwise `vicoop-client upgrade` will fail to
+# look up the asset on that platform.
+TARGETS=(
+  "bun-darwin-arm64 macos-arm64 "
+  "bun-darwin-x64   macos-x64   "
+  "bun-linux-arm64  linux-arm64 "
+  "bun-linux-x64    linux-x64   "
+  "bun-windows-x64  windows-x64 .exe"
+)
+
+# sha256 tool selection mirrors install.sh's logic so a build host without
+# GNU coreutils (e.g. a Mac dev box) still produces the same checksum file
+# shape (<hash>  <filename>).
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA_CMD="shasum -a 256"
+else
+  echo "error: need sha256sum or shasum on PATH" >&2
   exit 1
 fi
 
-rm -rf "$WORK_DIR" "$ARCHIVE_PATH" "$CHECKSUM_PATH"
-mkdir -p "$WORK_DIR"
+for entry in "${TARGETS[@]}"; do
+  # shellcheck disable=SC2206  # split on whitespace intentionally
+  parts=( $entry )
+  target="${parts[0]}"
+  slug="${parts[1]}"
+  ext="${parts[2]:-}"
+  asset="vicoop-client-${VERSION}-${slug}${ext}"
 
-pnpm --dir "$ROOT_DIR" --filter @vicoop-bridge/client deploy --prod "$BUNDLE_DIR"
-mkdir -p "$BUNDLE_DIR/bin"
+  echo "==> building $target -> $asset"
+  ( cd "$CLIENT_DIR" && bun build --compile --target="$target" src/cli.ts --outfile "$OUT_DIR/$asset" )
+  chmod +x "$OUT_DIR/$asset"
 
-cat > "$BUNDLE_DIR/bin/vicoop-client" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
+  # Write the checksum file with a *bare filename*, not the absolute build
+  # path, so `sha256sum -c` works in install.sh's $TMP_DIR without
+  # rewriting. The cd-before-shasum keeps the path bare.
+  ( cd "$OUT_DIR" && $SHA_CMD "$asset" > "$asset.sha256" )
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-exec node -- "$SCRIPT_DIR/../dist/cli.js" "$@"
-EOF
+  echo "    $(ls -lh "$OUT_DIR/$asset" | awk '{print $5}')  $(cat "$OUT_DIR/$asset.sha256")"
+done
 
-chmod +x "$BUNDLE_DIR/bin/vicoop-client"
-
-cat > "$BUNDLE_DIR/README.md" <<EOF
-# vicoop-bridge-client $VERSION
-
-Portable release bundle for the standalone client daemon.
-
-## Quick start
-
-\`\`\`bash
-AGENT_ID=my-agent
-
-# 1. Sign in as the client owner (saves an owner-session bearer to
-#    ~/.vicoop/owner-session.json; admin subcommands pick it up).
-#    --bridge defaults to https://vicoop-bridge-server.fly.dev; pass
-#    --bridge https://your-bridge if you self-host.
-./bin/vicoop-client login
-
-# 2. Register a bridge client. setup writes the one-time CLIENT_TOKEN
-#    plus server_url / agent_id into the canonical ~/.vicoop/config.json
-#    (mode 600). The daemon picks those up on its next launch.
-./bin/vicoop-client setup \\
-  --client-name "my client" \\
-  --agent-ids "\$AGENT_ID"
-
-# 3. Start the daemon. With config.json populated, the only thing left
-#    to choose is the backend (echo / openclaw / claude / codex).
-./bin/vicoop-client --backend openclaw
-\`\`\`
-
-## Notes
-
-- This bundle is built from the Git tag \`$TAG\`.
-- Node.js 20 or newer is required.
-- The \`bin/vicoop-client\` wrapper runs \`node dist/cli.js\` for convenience.
-EOF
-
-tar -C "$WORK_DIR" -czf "$ARCHIVE_PATH" "vicoop-bridge-client-$VERSION"
-shasum -a 256 "$ARCHIVE_PATH" > "$CHECKSUM_PATH"
-
-echo "created $ARCHIVE_PATH"
-echo "created $CHECKSUM_PATH"
+echo
+echo "built $(ls "$OUT_DIR" | wc -l | tr -d ' ') files in $OUT_DIR"

--- a/scripts/upload-client-release-assets.sh
+++ b/scripts/upload-client-release-assets.sh
@@ -4,19 +4,20 @@
 # package.json, looks up the matching `@vicoop-bridge/client@<version>`
 # release, and converges to one of three states:
 #
-#   - complete: release has both expected asset filenames attached → exit 0
-#   - partial:  release exists but one or both expected asset filenames
-#               are missing → rebuild and `gh release upload --clobber`
+#   - complete: release has every expected per-platform binary + .sha256
+#               attached → exit 0
+#   - partial:  release exists but one or more expected asset filenames
+#               are missing → rebuild all and `gh release upload --clobber`
 #               (content drift isn't checked — we trust that what was
-#                uploaded under the right name is the right bundle)
+#                uploaded under the right name is the right binary)
 #   - missing:  release doesn't exist yet (no publish this run, or a
 #               different package was published) → exit 0
 #
 # The release object is created by changesets/action (createGithubReleases),
 # so this script only ever attaches assets — it never creates the
-# release. The convergence shape exists so a workflow rerun (e.g.
-# manual workflow_dispatch after an upload-step failure) can finish the
-# job even though `changeset tag` will have nothing to print on rerun.
+# release. The convergence shape exists so a workflow rerun (e.g. manual
+# workflow_dispatch after an upload-step failure) can finish the job even
+# though `changeset tag` will have nothing to print on rerun.
 
 set -euo pipefail
 
@@ -25,13 +26,20 @@ cd "$ROOT_DIR"
 
 VERSION="$(node -p "require('./packages/client/package.json').version")"
 TAG="@vicoop-bridge/client@${VERSION}"
-ARCHIVE="dist-release/vicoop-bridge-client-${VERSION}.tgz"
-CHECKSUM="${ARCHIVE}.sha256"
-ARCHIVE_NAME="$(basename "${ARCHIVE}")"
-CHECKSUM_NAME="$(basename "${CHECKSUM}")"
+OUT_DIR="dist-release"
+
+# Asset filenames expected on the release. Must stay aligned with
+# scripts/package-client-release.sh and packages/client/src/upgrade.ts.
+EXPECTED_ASSETS=(
+  "vicoop-client-${VERSION}-macos-arm64"
+  "vicoop-client-${VERSION}-macos-x64"
+  "vicoop-client-${VERSION}-linux-arm64"
+  "vicoop-client-${VERSION}-linux-x64"
+  "vicoop-client-${VERSION}-windows-x64.exe"
+)
 
 # Distinguish "release genuinely doesn't exist" (cheap-exit case) from
-# transport / auth failures (must fail loudly). gh release view exits
+# transport / auth failures (must fail loudly). `gh release view` exits
 # nonzero with stderr "release not found" only for the missing-release
 # case; auth, network, and API errors carry different stderr.
 gh_err="$(mktemp)"
@@ -50,13 +58,29 @@ else
   exit "$rc"
 fi
 
-if grep -Fqx "${ARCHIVE_NAME}" <<<"${existing_assets}" \
-    && grep -Fqx "${CHECKSUM_NAME}" <<<"${existing_assets}"; then
-  echo "release ${TAG} already has ${ARCHIVE_NAME} + ${CHECKSUM_NAME} — nothing to do"
+missing=0
+for asset in "${EXPECTED_ASSETS[@]}"; do
+  if ! grep -Fqx "${asset}" <<<"${existing_assets}"; then
+    missing=1; break
+  fi
+  if ! grep -Fqx "${asset}.sha256" <<<"${existing_assets}"; then
+    missing=1; break
+  fi
+done
+
+if [[ $missing -eq 0 ]]; then
+  echo "release ${TAG} already has all ${#EXPECTED_ASSETS[@]} binaries + checksums — nothing to do"
   exit 0
 fi
 
-echo "release ${TAG} missing one or both expected assets — building and uploading"
-pnpm --filter @vicoop-bridge/protocol --filter @vicoop-bridge/client build
+echo "release ${TAG} missing one or more expected assets — building and uploading"
 ./scripts/package-client-release.sh "${TAG}"
-gh release upload "${TAG}" --clobber "${ARCHIVE}" "${CHECKSUM}"
+
+# Upload every binary + sidecar in one call so partial-failure leaves a
+# diagnosable state (gh tells us which assets failed). --clobber is safe
+# because the convergence model treats "right name = right bundle".
+upload_args=()
+for asset in "${EXPECTED_ASSETS[@]}"; do
+  upload_args+=( "${OUT_DIR}/${asset}" "${OUT_DIR}/${asset}.sha256" )
+done
+gh release upload "${TAG}" --clobber "${upload_args[@]}"


### PR DESCRIPTION
## Summary

Closes #188. Realises the option-A direction of #164 as a side effect.

Ship `@vicoop-bridge/client` as a self-contained native binary per
platform (macOS arm64/x64, Linux arm64/x64, Windows x64) produced by
`bun build --compile` from a single Linux runner via cross-compile,
replacing the previous tgz + Node.js portable bundle.

- `install.sh` no longer requires Node.js / tar. It detects the host
  platform, downloads `vicoop-client-<version>-<os>-<arch>[.exe]` +
  its `.sha256`, verifies integrity, strips the macOS
  `com.apple.quarantine` xattr, and installs the binary as
  `\$INSTALL_DIR/vicoop-client`. `jq` is added as a prereq only when
  `install.sh` auto-resolves the latest tag (skip-able with explicit
  `VERSION`).
- `vicoop-client upgrade` is rewritten for the single-file model. It
  downloads the matching per-platform asset alongside the live
  binary, sha256-verifies, runs the new binary's `--version` as a
  healthcheck, then atomically renames `vicoop-client` →
  `vicoop-client.prev` and `vicoop-client.new` → `vicoop-client`.
  Dev-workspace invocations (`tsx src/cli.ts upgrade`, `node
  dist/cli.js upgrade`) are rejected up front because
  `process.execPath` doesn't end in `vicoop-client[.exe]`.
- Release pipeline: `.github/workflows/release.yml` adds
  `oven-sh/setup-bun@v2` (bun 1.2.20).
  `scripts/package-client-release.sh` produces 5 binaries + 5
  `.sha256` sidecars under `dist-release/`.
  `scripts/upload-client-release-assets.sh` is now an idempotent
  10-asset converger.

### Realises #164 (option A — single source of truth for cards)

The released asset stops shipping a `cards/` directory. The bridge
already publishes the canonical agent card per backend, so the daemon
only needs `--card` (or `\"card\"` in `config.json`) when an operator
explicitly overrides it. Starter cards stay in-tree at
[`packages/client/cards/`](https://github.com/planetarium/vicoop-bridge/tree/main/packages/client/cards)
as the documented reference for authoring overrides. This eliminates
the client/server dual-source drift root cause behind #163.

### Breaking change

Anything that scripted against `\$INSTALL_DIR/bin/vicoop-client` or
extracted the released `.tgz` directly. The new install path is
`\$INSTALL_DIR/vicoop-client`. \`docs/install-client.md\`, \`README.md\`,
\`docs/local-testing.md\` updated to match.

### Local PoC checks

- \`pnpm --filter @vicoop-bridge/client test\` — 400/400
- \`bun build --compile\` produced all 5 targets (58–114 MB each) on a
  Darwin/arm64 dev box
- Darwin/arm64 binary: \`--version\` reports the embedded \`0.15.1\`,
  \`upgrade --check\` walks the GitHub API end-to-end and reports
  \"up to date\", and a fake-token daemon run against the live
  \`wss://vicoop-bridge-server.fly.dev\` reaches the 4005-bad-token
  close branch (i.e. \`ws\` package keeps working under
  \`--compile\` without code changes)
- \`shellcheck -s sh install.sh\` clean
- jq filter validated against real GitHub Releases API output
- \`scripts/package-client-release.sh\` cross-check: built filenames
  ↔ \`EXPECTED_ASSETS\` in the upload script diff 0

## Test plan

- [ ] CI: \`Client CI\` (typecheck + node --test, no behavior change)
- [ ] CI: \`Release\` workflow on merge to \`main\` — verify the bun
      setup step lands and all 5 cross-compile targets succeed on
      \`ubuntu-latest\` (the only one not exercised locally is
      \`bun-windows-x64\`, though it built fine on Darwin)
- [ ] After the next changesets \"Version Packages\" PR merges, walk
      \`install.sh | sh\` end-to-end on Darwin and Linux: confirm the
      binary lands at \`\$INSTALL_DIR/vicoop-client\`, runs, and
      \`vicoop-client upgrade --check\` reports \"up to date\"
- [ ] On the same install, sanity-check \`vicoop-client login\` →
      \`setup\` → \`--backend echo\` against the public bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)