### PR TITLE
[codex] support OpenClaw gateway protocol v4

### DIFF
--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -196,6 +196,110 @@ function makeTask(taskId: string, text: string): TaskAssignFrame {
   };
 }
 
+test('connect advertises OpenClaw gateway protocol range 3..4', async () => {
+  let connectMinProtocol: number | undefined;
+  let connectMaxProtocol: number | undefined;
+  const fake = await createFakeGateway({
+    autoHandshake: false,
+    onRequest: (sock, req) => {
+      if (req.method === 'connect') {
+        const params = req.params as { minProtocol?: number; maxProtocol?: number };
+        connectMinProtocol = params.minProtocol;
+        connectMaxProtocol = params.maxProtocol;
+        sock.send(
+          JSON.stringify({
+            type: 'res',
+            id: req.id,
+            ok: true,
+            payload: { type: 'hello-ok', protocol: 4 },
+          }),
+        );
+        return;
+      }
+      if (req.method === 'chat.send') {
+        const params = req.params as { idempotencyKey: string; sessionKey: string };
+        const runId = `run-${params.idempotencyKey}`;
+        sock.send(
+          JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+        );
+        setImmediate(() => {
+          fake.emitChat(sock, {
+            runId,
+            sessionKey: params.sessionKey,
+            seq: 1,
+            state: 'final',
+            message: { text: 'done' },
+          });
+        });
+      }
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t-proto', 'hi'), () => {}, NEVER);
+    assert.equal(connectMinProtocol, 3);
+    assert.equal(connectMaxProtocol, 4);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('v4 chat deltaText is used when final message is absent', async () => {
+  const frames: UpFrame[] = [];
+  const fake = await createFakeGateway({
+    onRequest: (sock, req) => {
+      if (req.method !== 'chat.send') return;
+      const params = req.params as { idempotencyKey: string; sessionKey: string };
+      const runId = `run-${params.idempotencyKey}`;
+      sock.send(
+        JSON.stringify({ type: 'res', id: req.id, ok: true, payload: { runId, status: 'started' } }),
+      );
+      setImmediate(() => {
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 1,
+          state: 'delta',
+          deltaText: 'ignored',
+        });
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 2,
+          state: 'delta',
+          deltaText: 'PO',
+          replace: true,
+        });
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 3,
+          state: 'delta',
+          deltaText: 'NG',
+        });
+        fake.emitChat(sock, {
+          runId,
+          sessionKey: params.sessionKey,
+          seq: 4,
+          state: 'final',
+        });
+      });
+    },
+  });
+  try {
+    const backend = createOpenclawBackend({ url: fake.url });
+    await backend.handle(makeTask('t-v4-delta', 'hi'), (f) => frames.push(f), NEVER);
+    const artifact = frames.find((f) => f.type === 'task.artifact');
+    assert.ok(artifact);
+    assert.deepEqual(artifact!.artifact.parts, [{ kind: 'text', text: 'PONG' }]);
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete);
+    assert.deepEqual(complete!.status.message?.parts, [{ kind: 'text', text: 'PONG' }]);
+  } finally {
+    await fake.close();
+  }
+});
+
 test('happy path: chat.send → final event → task completes', async () => {
   const frames: UpFrame[] = [];
   const fake = await createFakeGateway({

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -33,7 +33,40 @@ import { clientVersion } from '../version.js';
 
 const execFileP = promisify(execFile);
 
-const GATEWAY_PROTOCOL_VERSION = 3;
+const MIN_GATEWAY_PROTOCOL_VERSION = 3;
+const MAX_GATEWAY_PROTOCOL_VERSION = 4;
+
+interface OpenclawGatewayProtocolRange {
+  minProtocol: number;
+  maxProtocol: number;
+}
+
+interface OpenclawChatDeltaAccumulator {
+  text: string;
+}
+
+function openclawGatewayProtocolRange(): OpenclawGatewayProtocolRange {
+  return {
+    minProtocol: MIN_GATEWAY_PROTOCOL_VERSION,
+    maxProtocol: MAX_GATEWAY_PROTOCOL_VERSION,
+  };
+}
+
+function applyOpenclawChatDelta(
+  state: OpenclawChatDeltaAccumulator,
+  evt: ChatEventPayload,
+): boolean {
+  if (evt.state !== 'delta' || typeof evt.deltaText !== 'string') return false;
+  state.text = evt.replace ? evt.deltaText : state.text + evt.deltaText;
+  return true;
+}
+
+function finalTextForOpenclawChatEvent(
+  evt: ChatEventPayload,
+  delta: OpenclawChatDeltaAccumulator,
+): string {
+  return extractFinalText(evt.message) || delta.text;
+}
 
 interface DeviceIdentity {
   deviceId: string;
@@ -112,6 +145,8 @@ interface ChatEventPayload {
   seq: number;
   state: 'delta' | 'final' | 'aborted' | 'error';
   message?: unknown;
+  deltaText?: string;
+  replace?: boolean;
   errorMessage?: string;
   stopReason?: string;
 }
@@ -138,6 +173,11 @@ interface ChatSendAck {
   status: 'started' | 'in_flight';
 }
 
+interface HelloOkPayload {
+  type?: 'hello-ok';
+  protocol?: number;
+}
+
 type EventHandler = (evt: EventFrame) => void;
 
 type ClientState = 'idle' | 'connecting' | 'ready' | 'closed';
@@ -154,6 +194,7 @@ class GatewayClient {
   private nonce: string | null = null;
   private identity: DeviceIdentity;
   private handshakeTimer: ReturnType<typeof setTimeout> | null = null;
+  private _protocol: number | null = null;
 
   constructor(
     private readonly url: string,
@@ -165,6 +206,10 @@ class GatewayClient {
 
   get state(): ClientState {
     return this._state;
+  }
+
+  get protocol(): number | null {
+    return this._protocol;
   }
 
   connect(): Promise<void> {
@@ -319,8 +364,7 @@ class GatewayClient {
       });
       const signature = signPayload(this.identity.privateKeyPem, payload);
       const params = {
-        minProtocol: GATEWAY_PROTOCOL_VERSION,
-        maxProtocol: GATEWAY_PROTOCOL_VERSION,
+        ...openclawGatewayProtocolRange(),
         client: {
           id: clientId,
           displayName: 'vicoop-bridge-client',
@@ -340,7 +384,8 @@ class GatewayClient {
           nonce: this.nonce!,
         },
       };
-      await this.request('connect', params);
+      const hello = await this.request<HelloOkPayload>('connect', params);
+      if (typeof hello?.protocol === 'number') this._protocol = hello.protocol;
       if (this._state === 'connecting') {
         this._state = 'ready';
         if (this.handshakeTimer) {
@@ -1581,7 +1626,9 @@ export function createOpenclawBackend(
       const settled = new Promise<FinalizerEvent>((r) => {
         resolveSettled = r;
       });
+      const chatDelta: OpenclawChatDeltaAccumulator = { text: '' };
       const finalizer = (evt: FinalizerEvent) => {
+        if (applyOpenclawChatDelta(chatDelta, evt)) return;
         if (evt.state === 'final' || evt.state === 'error' || evt.state === 'aborted') {
           resolveSettled(evt);
         }
@@ -1757,7 +1804,7 @@ export function createOpenclawBackend(
           return;
         }
 
-        const text2 = extractFinalText(result.message);
+        const text2 = finalTextForOpenclawChatEvent(result, chatDelta);
 
         // Non-streaming fallback path for the envelope: when no streaming
         // subscription delivered a session.message artifact (e.g. the


### PR DESCRIPTION
## Summary

- negotiate OpenClaw gateway protocol `3..4` instead of sending only `3`
- record the negotiated `hello-ok.protocol` from the gateway handshake
- handle OpenClaw protocol v4 `chat` deltas via `deltaText` and optional `replace`
- add regression coverage for protocol range negotiation and v4 delta fallback

## Root Cause

OpenClaw `2026.5.12` expects gateway protocol `4`, while vicoop's openclaw backend sent `minProtocol=maxProtocol=3`. The gateway rejected the connection during protocol negotiation before any task traffic.

Closes #193.

## Validation

- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/client exec tsx --test src/backends/openclaw.test.ts`
- `pnpm --filter @vicoop-bridge/client build`
- local OpenClaw `2026.5.12` container smoke test: protocol mismatch is gone; same-network-namespace execution reaches `chat.send` / agent execution
