### PR TITLE
fix(client): stop duplicating openai-compat envelope on status.message (#200)

### DIFF
--- a/.changeset/openai-compat-envelope-status-message.md
+++ b/.changeset/openai-compat-envelope-status-message.md
@@ -1,0 +1,23 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Fix openai-compat envelope being duplicated on `task.complete.status.message.parts`
+in addition to the `data` artifact (issue #200).
+
+When the `openai-compat/v1` extension is active and the model emits a
+`{"tool_calls":[…]}` envelope, the codex, claude, and openclaw backends
+correctly route it as a `data` part on a `task.artifact`. They also used to
+re-stamp the raw envelope JSON as a `text` part on the terminal
+`task.complete.status.message`. Per A2A spec §3.7 — "Messages SHOULD NOT be
+used to deliver task outputs" — that mirror is a spec violation, and the
+upstream `oai2a2a` gateway re-parsed the text part as `tool_calls` and emitted
+them a second time on the OpenAI streaming response. OpenAI clients
+concatenate `tool_calls[].function.arguments` by index, so the duplicate
+emission produced invalid JSON like `{…}{…}` and silently broke tool-calling
+clients (root cause of planetarium/oai2a2a#50, #51).
+
+All three backends now omit the envelope text from `status.message.parts` when
+it has already been routed via a data artifact. The `usage` metadata path on
+`status.message.metadata` is unchanged, so per-spec usage delivery still
+works.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2100,6 +2100,23 @@ test('assistant {"tool_calls":[...]} reply becomes a data-part artifact when ext
   assert.deepEqual(part.data, envelope);
   // Artifact carries the extension URI so downstream filters can route on it.
   assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+
+  // The envelope is the complete task output and must NOT be re-stamped on
+  // status.message.parts: per A2A "Messages SHOULD NOT be used to deliver
+  // task outputs", and downstream gateways (oai2a2a) used to re-parse the
+  // text part as tool_calls, double-emitting them and corrupting OpenAI
+  // streaming clients. See issue #200.
+  const complete = frames.find((f) => f.type === 'task.complete');
+  assert.ok(complete && complete.type === 'task.complete');
+  const messageParts = complete.status.message?.parts ?? [];
+  for (const p of messageParts) {
+    if (p.kind !== 'text') continue;
+    assert.equal(
+      p.text.includes('"tool_calls"'),
+      false,
+      'status.message.parts must not echo the openai-compat envelope JSON',
+    );
+  }
 });
 
 test('non-envelope assistant text still streams as a text artifact under the extension', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1476,7 +1476,19 @@ export function createClaudeBackend(
       }
 
       const completeText = finalText ?? '';
-      const parts: Part[] = completeText ? [{ kind: 'text', text: completeText }] : [];
+      // If the finalText is the openai-compat `{"tool_calls":[…]}`
+      // envelope, it was already routed to a `data` artifact via
+      // emitAssistantArtifact. Re-stamping the raw JSON onto
+      // status.message.parts violates A2A's "Messages SHOULD NOT be used
+      // to deliver task outputs" and causes downstream gateways
+      // (oai2a2a) to re-extract and re-emit the same tool_calls,
+      // corrupting OpenAI streaming clients that concatenate arguments
+      // by index. See issue #200.
+      const envelopeAlreadyRouted =
+        openaiCompat !== null && tryParseToolCallsEnvelope(completeText) !== null;
+      const parts: Part[] = !envelopeAlreadyRouted && completeText
+        ? [{ kind: 'text', text: completeText }]
+        : [];
 
       // Streaming produced nothing (e.g. claude only wrote a `result` event).
       // Emit the final text once so clients that ignore task.complete still
@@ -1499,7 +1511,7 @@ export function createClaudeBackend(
       // Per spec the carrier is `Task.status.message.metadata[<URI>].usage`,
       // so when usage is present but there is no completion text we still
       // emit a message frame (with empty parts) to carry the metadata.
-      const hasMessage = completeText.length > 0 || finalUsage !== null;
+      const hasMessage = parts.length > 0 || finalUsage !== null;
       const messageMetadata = finalUsage
         ? makeOpenAICompatUsageMetadata(finalUsage)
         : undefined;

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1041,6 +1041,23 @@ test('openai-compat envelope agent message is emitted as a data part', async () 
     assert.ok(artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
   }
 
+  // The envelope is the complete task output and must NOT be re-stamped on
+  // status.message.parts: per A2A "Messages SHOULD NOT be used to deliver
+  // task outputs", and downstream gateways (oai2a2a) used to re-parse the
+  // text part as tool_calls, double-emitting them and corrupting OpenAI
+  // streaming clients. See issue #200.
+  const complete = frames.find((f) => f.type === 'task.complete');
+  assert.ok(complete && complete.type === 'task.complete');
+  const messageParts = complete.status.message?.parts ?? [];
+  for (const p of messageParts) {
+    if (p.kind !== 'text') continue;
+    assert.equal(
+      p.text.includes('"tool_calls"'),
+      false,
+      'status.message.parts must not echo the openai-compat envelope JSON',
+    );
+  }
+
   // developerInstructions must have been included in thread/start.
   const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
   const params = (tsFrame as { params?: { developerInstructions?: string } }).params;

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -1087,7 +1087,17 @@ export function createCodexBackend(
           }
 
           const completeText = outcome.finalText ?? '';
-          const parts: Part[] = completeText
+          // If the finalText is the openai-compat `{"tool_calls":[…]}`
+          // envelope, it was already routed to a `data` artifact via
+          // emitAgentArtifact. Re-stamping the raw JSON onto
+          // status.message.parts violates A2A's "Messages SHOULD NOT be
+          // used to deliver task outputs" and causes downstream gateways
+          // (oai2a2a) to re-extract and re-emit the same tool_calls,
+          // corrupting OpenAI streaming clients that concatenate
+          // arguments by index. See issue #200.
+          const envelopeAlreadyRouted =
+            openaiCompat !== null && tryParseToolCallsEnvelope(completeText) !== null;
+          const parts: Part[] = !envelopeAlreadyRouted && completeText
             ? [{ kind: 'text', text: completeText }]
             : [];
           if (!emittedAnyArtifact && completeText) {

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -3151,6 +3151,13 @@ test('envelope JSON on session.message becomes a data-part artifact tagged with 
     if (part.kind !== 'data') throw new Error('expected data part');
     assert.deepEqual(part.data, envelope);
     assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+
+    // The envelope is the complete task output and must NOT be stamped on
+    // status.message.parts as well: per A2A "Messages SHOULD NOT be used
+    // to deliver task outputs". See issue #200.
+    const complete = frames.find((f) => f.type === 'task.complete');
+    assert.ok(complete && complete.type === 'task.complete');
+    assert.equal(complete.status.message, undefined);
   } finally {
     await fake.close();
   }
@@ -3202,14 +3209,14 @@ test('envelope JSON arriving only on the terminal chat event (no session.message
     if (part.kind !== 'data') throw new Error('expected data part');
     assert.deepEqual(part.data, envelope);
     assert.deepEqual(artifacts[0].artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
-    // task.complete still carries the envelope JSON as text in status.message
-    // (mirrors claude/codex: data-part is the primary surface, text in the
-    // terminal slot is the conventional A2A mirror).
+    // The envelope is the complete task output and must NOT be stamped on
+    // status.message.parts as well: per A2A "Messages SHOULD NOT be used
+    // to deliver task outputs", and downstream gateways (oai2a2a) used to
+    // re-parse the text part as tool_calls, double-emitting them and
+    // corrupting OpenAI streaming clients. See issue #200.
     const complete = frames.find((f) => f.type === 'task.complete');
     assert.ok(complete && complete.type === 'task.complete');
-    const stamped = complete.status.message?.parts[0];
-    assert.equal(stamped?.kind, 'text');
-    if (stamped?.kind === 'text') assert.equal(stamped.text, JSON.stringify(envelope));
+    assert.equal(complete.status.message, undefined);
   } finally {
     await fake.close();
   }

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -1831,20 +1831,19 @@ export function createOpenclawBackend(
                 lastChunk: true,
               });
             }
+            // The envelope is the complete task output and was already
+            // routed via the `data` artifact above. Per A2A "Messages
+            // SHOULD NOT be used to deliver task outputs"; re-stamping
+            // the raw envelope JSON on status.message.parts caused
+            // downstream gateways (oai2a2a) to re-extract and re-emit
+            // the same tool_calls, corrupting OpenAI streaming clients
+            // that concatenate arguments by index. See issue #200.
             emit({
               type: 'task.complete',
               taskId: task.taskId,
               status: {
                 state: 'completed',
                 timestamp: new Date().toISOString(),
-                message: {
-                  role: 'agent',
-                  messageId: randomUUID(),
-                  // text2 is the raw envelope JSON string; stamp it on
-                  // status.message for callers that pull terminal content
-                  // from the conventional A2A slot. Mirrors claude/codex.
-                  parts: [{ kind: 'text', text: text2 }],
-                },
               },
             });
             return;


### PR DESCRIPTION
## Summary

When the `openai-compat/v1` extension is active and the model emits a `{"tool_calls":[…]}` envelope, the codex, claude, and openclaw backends correctly routed it as a `data` part on a `task.artifact` — **but also** re-stamped the raw envelope JSON as a `text` part on the terminal `task.complete.status.message`. Per A2A spec §3.7 "Messages SHOULD NOT be used to deliver task outputs", and the upstream `oai2a2a` gateway re-parsed the text part as `tool_calls` and emitted them a second time on the OpenAI streaming response. OpenAI clients concatenate `tool_calls[].function.arguments` by index, so the duplicate produced invalid JSON like `{…}{…}` and silently broke tool-calling clients (root cause of planetarium/oai2a2a#50 and #51).

All three backends now omit the envelope text from `status.message.parts` when it has already been routed via a data artifact. The `usage` metadata path on `status.message.metadata` is unchanged, so per-spec usage delivery still works.

## Changes

- `packages/client/src/backends/codex.ts`: gate the terminal text `parts` on `!envelopeAlreadyRouted` (using the same `tryParseToolCallsEnvelope` check the artifact path uses).
- `packages/client/src/backends/claude.ts`: same gate; also switch `hasMessage` from `completeText.length > 0` to `parts.length > 0` so we don't emit an empty-parts message frame when the envelope was the only content and there's no usage to attach.
- `packages/client/src/backends/openclaw.ts`: in the non-streaming envelope path, omit `status.message` entirely on the terminal `task.complete`. Removes the old comment that explicitly rationalized the duplication.
- Tests:
  - `codex.test.ts` / `claude.test.ts`: extend the existing envelope-as-data-part tests with assertions that `status.message.parts` never echoes the envelope JSON.
  - `openclaw.test.ts`: update the non-streaming envelope test (previously asserted the envelope text WAS stamped on `status.message`) to assert `status.message === undefined`. Streaming envelope test gets the same assertion.

## A2A spec basis

Per [A2A §3.7](https://a2a-protocol.org/latest/specification/):

> "Messages SHOULD NOT be used to deliver task outputs."
>
> "Results SHOULD BE returned using Artifacts associated with a Task. This separation allows for a clear distinction between communication (Messages) and data output (Artifacts)."

The envelope IS the task output (it carries `tool_calls`), so it belongs on the artifact channel, not the message channel.

## Test plan

- [x] `pnpm typecheck` (all 4 packages)
- [x] `pnpm test` in `packages/client` — 408/408 pass
- [ ] After merge, verify against a real task with `a2a-wallet a2a tasks get` that the terminal `status.message` no longer carries the envelope JSON
- [ ] Verify with `opencode run` against `codex-Mac`/`claude-Mac` that tool calls land cleanly without duplicate `function.arguments` concatenation

🤖 Generated with [Claude Code](https://claude.com/claude-code)