### PR TITLE
[codex] Persist forwarded task history

### DIFF
--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -35,6 +35,7 @@ import {
   listCallers,
   removeCaller,
 } from './admin-api.js';
+import { appendHistoryMessage } from './executor.js';
 
 export { getAdminWallets } from './admin-scope.js';
 
@@ -345,7 +346,7 @@ class AdminA2XExecutor extends AgentExecutor {
     // consumer can render it immediately (matches pre-migration behavior
     // that emitted a status-update with state='working' carrying the
     // user message).
-    yield {
+    const initialStatus: TaskStatusUpdateEvent = {
       taskId,
       contextId,
       final: false,
@@ -355,6 +356,8 @@ class AdminA2XExecutor extends AgentExecutor {
         message,
       },
     };
+    task.history = appendHistoryMessage(task.history ?? [], initialStatus.status.message);
+    yield initialStatus;
 
     const controller = new AbortController();
     this.abortControllers.set(taskId, controller);
@@ -399,7 +402,7 @@ class AdminA2XExecutor extends AgentExecutor {
         timestamp: nowIso(),
         message: final,
       };
-      task.history = [...(task.history ?? []), message, final];
+      task.history = appendHistoryMessage(task.history ?? [], task.status.message);
 
       try {
         await this.taskStoreImpl.updateTask(taskId, {
@@ -424,7 +427,7 @@ class AdminA2XExecutor extends AgentExecutor {
       const final = agentMessage(text, taskId, contextId);
 
       task.status = { state, timestamp: nowIso(), message: final };
-      task.history = [...(task.history ?? []), message, final];
+      task.history = appendHistoryMessage(task.history ?? [], task.status.message);
 
       try {
         await this.taskStoreImpl.updateTask(taskId, {
@@ -521,4 +524,3 @@ export function createAdminA2XAgent(opts: AdminAgentOptions): {
   const handler = new DefaultRequestHandler(a2xAgent);
   return { a2xAgent, handler, taskStore };
 }
-

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -33,6 +33,18 @@ function noopTaskStore(): TaskStore {
   } as unknown as TaskStore;
 }
 
+function captureTaskStore(): TaskStore & { updates: unknown[] } {
+  const updates: unknown[] = [];
+  return {
+    updates,
+    save: async () => {},
+    load: async () => undefined,
+    updateTask: async (_taskId: string, update: unknown) => {
+      updates.push(update);
+    },
+  } as unknown as TaskStore & { updates: unknown[] };
+}
+
 function makeWsCapture(): { ws: WebSocket; sent: string[] } {
   const sent: string[] = [];
   const ws = {
@@ -233,4 +245,105 @@ test('executor binding has no principalId when message metadata is absent', asyn
   binding.sink.finish();
   await firstEvent;
   for await (const _event of gen) void _event;
+});
+
+test('executor persists inbound and agent status messages in task history', async () => {
+  const { ws } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a4',
+    clientId: 'c4',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const taskStore = captureTaskStore();
+  const executor = new WSForwardingExecutor('a4', registry, taskStore);
+  const task = {
+    id: 't-4',
+    contextId: 'ctx-4',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-4',
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  const firstEvent = gen.next();
+  const binding = registry.getBinding('t-4')!;
+
+  binding.sink.pushStatus({
+    taskId: 't-4',
+    contextId: 'ctx-4',
+    final: false,
+    status: {
+      state: TaskState.WORKING,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: 'agent',
+        parts: [{ text: 'working' }],
+        messageId: 'agent-working',
+        taskId: 't-4',
+        contextId: 'ctx-4',
+      },
+    },
+  });
+  binding.sink.pushStatus({
+    taskId: 't-4',
+    contextId: 'ctx-4',
+    final: true,
+    status: {
+      state: TaskState.COMPLETED,
+      timestamp: new Date().toISOString(),
+      message: {
+        role: 'agent',
+        parts: [{ text: 'done' }],
+        messageId: 'agent-done',
+        taskId: 't-4',
+        contextId: 'ctx-4',
+      },
+    },
+  });
+  binding.sink.finish();
+
+  await firstEvent;
+  for await (const _event of gen) void _event;
+
+  const update = taskStore.updates.at(-1) as { history?: Message[] };
+  assert.deepEqual(
+    update.history?.map((m) => m.messageId),
+    ['m-4', 'agent-working', 'agent-done'],
+  );
+  assert.deepEqual(
+    task.history?.map((m) => m.messageId),
+    ['m-4', 'agent-working', 'agent-done'],
+  );
+});
+
+test('executor persists history when agent is unreachable', async () => {
+  const registry = new Registry();
+  const taskStore = captureTaskStore();
+  const executor = new WSForwardingExecutor('missing', registry, taskStore);
+  const task = {
+    id: 't-5',
+    contextId: 'ctx-5',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-5',
+  } as unknown as Message;
+
+  for await (const _event of executor.executeStream(task, message)) void _event;
+
+  const update = taskStore.updates.at(-1) as { history?: Message[] };
+  assert.deepEqual(
+    update.history?.map((m) => m.messageId),
+    ['m-5', 't-5-unreach'],
+  );
 });

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -4,7 +4,11 @@ import type { WebSocket } from 'ws';
 import { TaskState, type Message, type Task, type TaskStore } from '@a2x/sdk';
 import { parseDownFrame, type AgentCard } from '@vicoop-bridge/protocol';
 import { Registry, type ClientConnection } from './registry.js';
-import { WSForwardingExecutor, stripInternalMetadata } from './executor.js';
+import {
+  WSForwardingExecutor,
+  appendHistoryMessage,
+  stripInternalMetadata,
+} from './executor.js';
 
 // Issue #128 (B): the /agents/:id route stashes the verified caller's
 // principalId on `message.metadata._principalId`. The executor must (1)
@@ -77,6 +81,30 @@ test('stripInternalMetadata preserves a regular metadata object as-is', () => {
     keepMe: 1,
     nested: { x: 2 },
   });
+});
+
+test('appendHistoryMessage appends messages once by messageId', () => {
+  const first = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-1',
+  } as unknown as Message;
+  const duplicate = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi again' }],
+    messageId: 'm-1',
+  } as unknown as Message;
+  const second = {
+    role: 'agent',
+    parts: [{ text: 'done' }],
+    messageId: 'm-2',
+  } as unknown as Message;
+
+  const withFirst = appendHistoryMessage([], first);
+  const withDuplicate = appendHistoryMessage(withFirst, duplicate);
+  const withSecond = appendHistoryMessage(withDuplicate, second);
+
+  assert.deepEqual(withSecond.map((m) => m.messageId), ['m-1', 'm-2']);
 });
 
 test('executor records principalId in binding and strips _principalId from outgoing WS frame', async () => {

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -58,7 +58,7 @@ export function stripInternalMetadata(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
-function appendHistoryMessage(history: Message[], message: Message | undefined): Message[] {
+export function appendHistoryMessage(history: Message[], message: Message | undefined): Message[] {
   if (message === undefined) return history;
   if (history.some((existing) => existing.messageId === message.messageId)) return history;
   return [...history, message];

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -58,6 +58,12 @@ export function stripInternalMetadata(
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+function appendHistoryMessage(history: Message[], message: Message | undefined): Message[] {
+  if (message === undefined) return history;
+  if (history.some((existing) => existing.messageId === message.messageId)) return history;
+  return [...history, message];
+}
+
 /**
  * AgentExecutor that forwards A2A requests to a WebSocket-connected
  * client and pipes the client's task.* frames back as A2A streaming
@@ -128,6 +134,9 @@ export class WSForwardingExecutor extends AgentExecutor {
       ...(principalId !== undefined ? { principalId } : {}),
     });
 
+    let history = appendHistoryMessage(task.history ?? [], message);
+    task.history = history;
+
     const sent = this.registry.sendToAgent(this.agentId, {
       type: 'task.assign',
       taskId,
@@ -169,11 +178,16 @@ export class WSForwardingExecutor extends AgentExecutor {
         },
       };
       task.status = failEvent.status;
+      history = appendHistoryMessage(history, failEvent.status.message);
+      task.history = history;
       this.registry.unbindTask(taskId);
       this.abortControllers.delete(taskId);
       yield failEvent;
       try {
-        await this.taskStore.updateTask(taskId, { status: task.status });
+        await this.taskStore.updateTask(taskId, {
+          status: task.status,
+          history: task.history,
+        });
       } catch (err) {
         logEvent('task_persist_error', { taskId, error: String(err) });
       }
@@ -194,6 +208,8 @@ export class WSForwardingExecutor extends AgentExecutor {
           continue;
         }
         // status event
+        history = appendHistoryMessage(history, event.status.message);
+        task.history = history;
         if (TERMINAL_STATES.has(event.status.state)) {
           // Terminal — mutate task in place so the request-handler's
           // post-stream read reflects the final state.
@@ -222,6 +238,7 @@ export class WSForwardingExecutor extends AgentExecutor {
       try {
         await this.taskStore.updateTask(taskId, {
           status: task.status,
+          history: task.history,
           ...(accumulatedArtifacts.length > 0 ? { artifacts: accumulatedArtifacts } : {}),
         });
       } catch (err) {


### PR DESCRIPTION
## Summary

- persist forwarded client-agent task history for inbound user messages and agent status messages
- include unreachable-agent failures in task history
- add executor tests for normal status-message accumulation and unreachable failures

## Root Cause

The WS forwarding executor only persisted final status and artifacts. It never passed `history` to the task store, so `tasks/get --history N` could return an empty history for client-agent tasks even after a message was sent and status messages were emitted.

## Validation

- `pnpm --filter @vicoop-bridge/server typecheck`
- `pnpm --filter @vicoop-bridge/protocol build`
- `pnpm --filter @vicoop-bridge/server exec tsx --test src/executor.test.ts`
