### PR TITLE
fix(client): steer codex away from host-side scaffolding under openai-compat + recover prose-prefixed envelopes (#207)

### DIFF
--- a/.changeset/codex-openai-compat-suppress-leftover-tools.md
+++ b/.changeset/codex-openai-compat-suppress-leftover-tools.md
@@ -38,6 +38,23 @@ surrounding JSON object (respecting strings + escapes), and parse the
 slice. False positives are bounded by the marker specificity + valid-JSON
 + `tool_calls`-array gate.
 
+Also overrides `sandbox` to `workspace-write` on `thread/start` /
+`thread/resume` whenever caller-side dispatch is active. A second 5-run
+re-test caught two runs (030, 031) where the model read codex's
+built-in permissions text ("`sandbox_mode` is `read-only`") and
+explicitly refused the caller's writable tools:
+
+> "this session is currently in a read-only filesystem sandbox, so I
+>  can't create `index.html`, `styles.css`, or `script.js` from here."
+
+The model never executes locally under caller-side dispatch
+(`environments: []` removes every shell / write / apply_patch handler),
+so the operator-configured sandbox value only matters for the
+permissions-text rendering. Forcing it to `workspace-write` aligns the
+text the model reads with its actual contract (emit envelopes the caller
+will execute against the caller's workspace). Non-openai-compat callers
+still get the operator-configured sandbox unchanged.
+
 Not addressed by this PR (tracked separately):
 
 - `list_mcp_resources` / `list_mcp_resource_templates` /

--- a/.changeset/codex-openai-compat-suppress-leftover-tools.md
+++ b/.changeset/codex-openai-compat-suppress-leftover-tools.md
@@ -8,14 +8,17 @@ chaining host-side scaffolding (issue #207).
 
 Two seams:
 
-- **`config.mcp_servers: {}` on `thread/start` / `thread/resume`** — empties
-  the MCP server map at thread scope, which trips the
-  `if params.mcp_tools.is_some()` gate in codex-rs `spec_plan.rs` and
-  prevents `list_mcp_resources`, `list_mcp_resource_templates`, and
+- **`config.mcp_servers: {}` on `thread/start` / `thread/resume` for any
+  openai-compat call** — empties the MCP server map at thread scope, which
+  trips the `if params.mcp_tools.is_some()` gate in codex-rs `spec_plan.rs`
+  and prevents `list_mcp_resources`, `list_mcp_resource_templates`, and
   `read_mcp_resource` from being pushed into the tool registry. In the
   observed #207 session the model burned three turns on
   `list_mcp_resources({server:"local"})` before bailing with text-only
-  output.
+  output. Gated to all openai-compat calls (not just caller-side dispatch)
+  because MCP discovery never fits the LLM-endpoint mental model of an
+  openai-compat caller, regardless of whether `tools` are supplied or
+  `tool_choice` is `"none"`.
 
 - **`CODEX_LEFTOVER_TOOL_DIRECTIVE` appended to `developerInstructions`** —
   `update_plan` and `request_user_input` are unconditional

--- a/.changeset/codex-openai-compat-suppress-leftover-tools.md
+++ b/.changeset/codex-openai-compat-suppress-leftover-tools.md
@@ -1,0 +1,30 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Suppress remaining codex built-in tool leaks under openai-compat caller-side
+dispatch so the model falls back to the `tool_calls` envelope instead of
+chaining host-side scaffolding (issue #207).
+
+Two seams:
+
+- **`config.mcp_servers: {}` on `thread/start` / `thread/resume`** — empties
+  the MCP server map at thread scope, which trips the
+  `if params.mcp_tools.is_some()` gate in codex-rs `spec_plan.rs` and
+  prevents `list_mcp_resources`, `list_mcp_resource_templates`, and
+  `read_mcp_resource` from being pushed into the tool registry. In the
+  observed #207 session the model burned three turns on
+  `list_mcp_resources({server:"local"})` before bailing with text-only
+  output.
+
+- **`CODEX_LEFTOVER_TOOL_DIRECTIVE` appended to `developerInstructions`** —
+  `update_plan` and `request_user_input` are unconditional
+  `executors.push(...)` entries in `spec_plan.rs` with no feature gate, so
+  config-level disable is not possible. The directive names both tools
+  explicitly and tells the model they are host scaffolding outside this
+  task's tool surface — the only legitimate outputs are a `tool_calls`
+  envelope or a natural-language reply. Gated to caller-side dispatch so
+  non-openai-compat callers keep their normal codex affordances.
+
+No change to the existing `environments: []` / `config.features.*=false`
+suppression set or to non-openai-compat paths.

--- a/.changeset/codex-openai-compat-suppress-leftover-tools.md
+++ b/.changeset/codex-openai-compat-suppress-leftover-tools.md
@@ -26,6 +26,18 @@ re-test against a deployed `codex-Mac-pr208` agent showed
 model now emits the envelope and tasks complete (vs the silent
 text-only completion observed in #207).
 
+Also relaxes `tryParseToolCallsEnvelope` to recover envelopes the model
+prefixed with prose (or wrapped in a code fence). A 5-run re-test caught
+one case where the model emitted
+`"<short narration>{"tool_calls":[…]}"` — a fully-formed envelope at
+the suffix that the strict pre-relaxation path discarded, producing a
+silent run failure even though the call payload was complete. The
+relaxed path keeps the fast (clean-envelope) check unchanged and adds a
+slow fallback: locate the `{"tool_calls":` marker, balance-match the
+surrounding JSON object (respecting strings + escapes), and parse the
+slice. False positives are bounded by the marker specificity + valid-JSON
++ `tool_calls`-array gate.
+
 Not addressed by this PR (tracked separately):
 
 - `list_mcp_resources` / `list_mcp_resource_templates` /

--- a/.changeset/codex-openai-compat-suppress-leftover-tools.md
+++ b/.changeset/codex-openai-compat-suppress-leftover-tools.md
@@ -2,32 +2,41 @@
 '@vicoop-bridge/client': patch
 ---
 
-Suppress remaining codex built-in tool leaks under openai-compat caller-side
-dispatch so the model falls back to the `tool_calls` envelope instead of
-chaining host-side scaffolding (issue #207).
+Steer the codex model away from host-side scaffolding tools under
+openai-compat caller-side dispatch so it falls back to emitting the
+`tool_calls` envelope instead of chaining unsuppressable codex
+internals (issue #207).
 
-Two seams:
+`update_plan` and `request_user_input` are unconditional
+`executors.push(...)` entries in codex-rs `spec_plan.rs` with no
+feature gate, so config-level disable is not possible. The
+`CODEX_LEFTOVER_TOOL_DIRECTIVE` appended to `developerInstructions`
+names both tools explicitly and tells the model they are host
+scaffolding outside this task's tool surface — the only legitimate
+outputs are a `tool_calls` envelope or a natural-language reply.
+Gated to caller-side dispatch so non-openai-compat callers keep their
+normal codex affordances.
 
-- **`config.mcp_servers: {}` on `thread/start` / `thread/resume` for any
-  openai-compat call** — empties the MCP server map at thread scope, which
-  trips the `if params.mcp_tools.is_some()` gate in codex-rs `spec_plan.rs`
-  and prevents `list_mcp_resources`, `list_mcp_resource_templates`, and
-  `read_mcp_resource` from being pushed into the tool registry. In the
-  observed #207 session the model burned three turns on
-  `list_mcp_resources({server:"local"})` before bailing with text-only
-  output. Gated to all openai-compat calls (not just caller-side dispatch)
-  because MCP discovery never fits the LLM-endpoint mental model of an
-  openai-compat caller, regardless of whether `tools` are supplied or
-  `tool_choice` is `"none"`.
+Verified against the #207 session jsonl (`019e3a10-…`): the auto-injected
+`<environment_context>` already had no `<cwd>` / `<shell>` tags thanks
+to the existing `environments: []`, so the remaining surface for the
+model to misuse was the host-side scaffolding addressed here. Live
+re-test against a deployed `codex-Mac-pr208` agent showed
+`request_user_input` calls dropped to zero across four sessions; the
+model now emits the envelope and tasks complete (vs the silent
+text-only completion observed in #207).
 
-- **`CODEX_LEFTOVER_TOOL_DIRECTIVE` appended to `developerInstructions`** —
-  `update_plan` and `request_user_input` are unconditional
-  `executors.push(...)` entries in `spec_plan.rs` with no feature gate, so
-  config-level disable is not possible. The directive names both tools
-  explicitly and tells the model they are host scaffolding outside this
-  task's tool surface — the only legitimate outputs are a `tool_calls`
-  envelope or a natural-language reply. Gated to caller-side dispatch so
-  non-openai-compat callers keep their normal codex affordances.
+Not addressed by this PR (tracked separately):
 
-No change to the existing `environments: []` / `config.features.*=false`
-suppression set or to non-openai-compat paths.
+- `list_mcp_resources` / `list_mcp_resource_templates` /
+  `read_mcp_resource` are gated in `spec_plan.rs` by
+  `if params.mcp_tools.is_some()`, which traces back to
+  `mcp_connection_manager.has_servers()` — a session/process-level
+  manager. Thread-level overrides (`config.mcp_servers: {}` on
+  `thread/start`) are silently merged with no effect. Process-level
+  `-c mcp_servers.<name>.enabled=false` per server flips
+  `codex mcp list` to disabled but does not suppress `has_servers()`
+  in app-server mode on cli 0.130 — see PR #208 review for the
+  detailed trace.
+- `update_plan` registration cannot be config-killed; the directive
+  reduces but does not eliminate calls.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1909,12 +1909,6 @@ test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves
 test('tryParseToolCallsEnvelope: rejects prose, non-objects, and missing tool_calls', () => {
   assert.equal(tryParseToolCallsEnvelope(''), null);
   assert.equal(tryParseToolCallsEnvelope('I will not call any tool.'), null);
-  // Prose before the brace short-circuits the parse — keeps the cost off
-  // the JSON.parse on conversational turns.
-  assert.equal(
-    tryParseToolCallsEnvelope('Sure! {"tool_calls":[{"id":"call_x"}]}'),
-    null,
-  );
   // Trimmed whitespace is fine; the model occasionally pads with newlines.
   assert.ok(tryParseToolCallsEnvelope('  \n{"tool_calls":[]}\n  '));
   // Top-level array is not the envelope shape.
@@ -1924,6 +1918,61 @@ test('tryParseToolCallsEnvelope: rejects prose, non-objects, and missing tool_ca
   assert.equal(tryParseToolCallsEnvelope('{"tool_calls":"nope"}'), null);
   // Malformed JSON falls through to null rather than throwing.
   assert.equal(tryParseToolCallsEnvelope('{"tool_calls":'), null);
+  // Conversational prose without the envelope marker → null even after
+  // relaxation; the marker check (`{"tool_calls":`) is the gate.
+  assert.equal(
+    tryParseToolCallsEnvelope('No tool needed, here is the answer.'),
+    null,
+  );
+});
+
+test('tryParseToolCallsEnvelope: recovers envelopes the model prefixed with narration (PR #208 review)', () => {
+  // Live #207 reproduction (codex-Mac-pr208, run 028) caught the model
+  // emitting "<short narration>{tool_calls:[…]}" — a fully-formed
+  // envelope at the suffix, prose preamble in front. The strict
+  // pre-relaxation path discarded it; the relaxed path recovers it by
+  // locating the marker and balance-matching the surrounding object.
+  const recovered = tryParseToolCallsEnvelope(
+    'Creating the three static app files now.{"tool_calls":[{"id":"call_x","function":{"name":"write","arguments":{"filePath":"/tmp/a"}}}]}',
+  );
+  assert.ok(recovered);
+  assert.equal(recovered.tool_calls.length, 1);
+});
+
+test('tryParseToolCallsEnvelope: recovers envelope wrapped in a markdown code fence', () => {
+  const recovered = tryParseToolCallsEnvelope(
+    'Sure, here is the call:\n```json\n{"tool_calls":[{"id":"c1","function":{"name":"x"}}]}\n```',
+  );
+  assert.ok(recovered);
+  assert.equal(recovered.tool_calls.length, 1);
+});
+
+test('tryParseToolCallsEnvelope: balance-match respects strings containing braces', () => {
+  // A function argument string containing `}` chars must not prematurely
+  // close the surrounding JSON object — the balance walker tracks string
+  // state.
+  const recovered = tryParseToolCallsEnvelope(
+    'prose {"tool_calls":[{"id":"c","function":{"name":"x","arguments":{"q":"a } b { c"}}}]}',
+  );
+  assert.ok(recovered);
+  assert.equal((recovered.tool_calls[0] as { id: string }).id, 'c');
+});
+
+test('tryParseToolCallsEnvelope: prose-prefixed but unbalanced JSON yields null, no throw', () => {
+  // Marker is present, but the object never closes — extractBalancedJsonObject
+  // returns null and the parser falls through cleanly.
+  assert.equal(
+    tryParseToolCallsEnvelope('prose {"tool_calls":[{"id":"x"'),
+    null,
+  );
+});
+
+test('tryParseToolCallsEnvelope: trailing prose after envelope is tolerated', () => {
+  const recovered = tryParseToolCallsEnvelope(
+    'before {"tool_calls":[{"id":"c"}]} and then some after-text',
+  );
+  assert.ok(recovered);
+  assert.equal((recovered.tool_calls[0] as { id: string }).id, 'c');
 });
 
 test('spawn argv carries --append-system-prompt with the tool envelope when metadata is present', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -642,16 +642,50 @@ export function formatToolCallHistory(history: OpenAICompatHistoryEntry[]): stri
 // the SYSTEM_INSTRUCTION above teaches the model to emit. Returns the parsed
 // envelope verbatim (preserving unknown keys) when the trimmed text parses as
 // a JSON object carrying a `tool_calls` array; otherwise null so the caller
-// falls back to a text artifact. Strict: a leading non-`{` character (prose
-// preamble, code fence, etc.) short-circuits without paying the JSON.parse.
+// falls back to a text artifact.
+//
+// Two-stage recognition:
+//
+// - Fast path: text starts with `{` after trim — assume the model honored
+//   the contract ("emit nothing outside the JSON object") and parse the
+//   whole string. Cheap for the common envelope-only turn AND for pure
+//   conversational turns (the leading `{` check rejects them before any
+//   JSON.parse).
+//
+// - Slow path: locate a `{"tool_calls": …` marker anywhere in the trimmed
+//   string and balance-match the surrounding JSON object, then parse the
+//   slice. Recovers envelopes the model prefixed with narration (or
+//   wrapped in a code fence). Observed in PR #208 review against
+//   `codex-Mac-pr208`: out of 5 reproduction runs one failed solely
+//   because the model emitted
+//
+//       "Creating the three static app files now …{"tool_calls":[ … ]}"
+//
+//   and the strict prefix check discarded a fully-formed envelope. False
+//   positives are bounded by the marker specificity + valid-JSON +
+//   tool_calls-array checks; a prose mention of the literal string is
+//   highly unlikely to also satisfy the balance-match + JSON.parse path.
 export function tryParseToolCallsEnvelope(
   text: string,
 ): (Record<string, unknown> & { tool_calls: unknown[] }) | null {
   const trimmed = text.trim();
-  if (!trimmed.startsWith('{')) return null;
+  if (trimmed.startsWith('{')) {
+    const fast = parseAsToolCallsEnvelope(trimmed);
+    if (fast) return fast;
+  }
+  const marker = trimmed.search(/\{\s*"tool_calls"\s*:/);
+  if (marker < 0) return null;
+  const sliced = extractBalancedJsonObject(trimmed, marker);
+  if (sliced === null) return null;
+  return parseAsToolCallsEnvelope(sliced);
+}
+
+function parseAsToolCallsEnvelope(
+  s: string,
+): (Record<string, unknown> & { tool_calls: unknown[] }) | null {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(trimmed);
+    parsed = JSON.parse(s);
   } catch {
     return null;
   }
@@ -659,6 +693,41 @@ export function tryParseToolCallsEnvelope(
   const obj = parsed as Record<string, unknown>;
   if (!Array.isArray(obj.tool_calls)) return null;
   return obj as Record<string, unknown> & { tool_calls: unknown[] };
+}
+
+// Walk a string from `start` (which must point at `{`) and find the
+// matching `}`, respecting string literals and their escape sequences.
+// Returns the inclusive substring, or null if the depth never returns
+// to zero or `start` is not `{`. Used to extract the envelope object out
+// of mixed `<prose> { … } <prose>` outputs without false-cutting on
+// braces that appear inside JSON string values.
+function extractBalancedJsonObject(s: string, start: number): string | null {
+  if (s[start] !== '{') return null;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = start; i < s.length; i++) {
+    const c = s[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === '\\') escape = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return s.substring(start, i + 1);
+    }
+  }
+  return null;
 }
 
 // Pull `tool_use` blocks out of an `assistant`-role message's content

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1324,3 +1324,163 @@ test('thread/resume re-passes `config.features` because feature flags do not per
   assert.deepEqual(startFeatures, EXPECTED_OPENAI_COMPAT_DISABLES);
   assert.deepEqual(resumeFeatures, EXPECTED_OPENAI_COMPAT_DISABLES);
 });
+
+test('thread/start sends `config.mcp_servers: {}` when caller tools are active (#207)', async () => {
+  // The model in the #207 session (`019e3a10-…`) burned multiple turns
+  // calling `list_mcp_resources({server:"local"})` /
+  // `list_mcp_resource_templates(...)` before giving up with text-only
+  // output. Those handlers are gated in codex-rs `spec_plan.rs` by
+  // `if params.mcp_tools.is_some()`; an empty mcp_servers map at
+  // thread scope leaves `mcp_tools` empty/None so the three handlers
+  // (`list_mcp_resources`, `list_mcp_resource_templates`,
+  // `read_mcp_resource`) are not pushed into the registry.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('do it', 'ctx-mcp-empty', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'do it' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { mcp_servers?: Record<string, unknown> } };
+  }).params;
+  assert.deepEqual(params?.config?.mcp_servers, {});
+});
+
+test('thread/resume re-passes `config.mcp_servers: {}` (#207)', async () => {
+  // Same rationale as the `config.features` resume test: the thread-
+  // scoped config override does not persist across resume, so a missing
+  // mcp_servers on resume would silently re-expose `list_mcp_resources`
+  // and siblings for that turn.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const meta = {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+    },
+  };
+  await backend.handle(
+    assign('one', 'ctx-mcp-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [{ kind: 'text', text: 'one' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  await backend.handle(
+    assign('two', 'ctx-mcp-resume', {
+      message: {
+        role: 'user',
+        messageId: 'm2',
+        parts: [{ kind: 'text', text: 'two' }],
+        metadata: meta,
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const frames = fake.lastChild().stdinFrames();
+  const start = findRequest(frames, 'thread/start');
+  const resume = findRequest(frames, 'thread/resume');
+  const startMcp = (start as { params?: { config?: { mcp_servers?: unknown } } })
+    .params?.config?.mcp_servers;
+  const resumeMcp = (resume as { params?: { config?: { mcp_servers?: unknown } } })
+    .params?.config?.mcp_servers;
+  assert.deepEqual(startMcp, {});
+  assert.deepEqual(resumeMcp, {});
+});
+
+test('developerInstructions includes the leftover-tool directive under caller-side dispatch (#207)', async () => {
+  // `update_plan` and `request_user_input` are unconditionally registered
+  // by codex (`spec_plan.rs`) with no feature gate. The directive in
+  // `CODEX_LEFTOVER_TOOL_DIRECTIVE` is the only seam we have to steer
+  // the model away from them under caller-side dispatch — the #207
+  // session chained these instead of emitting the envelope.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('do it', 'ctx-leftover-directive', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'do it' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const dev = (tsFrame as { params?: { developerInstructions?: string } })
+    .params?.developerInstructions;
+  assert.ok(typeof dev === 'string', 'developerInstructions present');
+  assert.ok(
+    dev!.includes('`update_plan`') && dev!.includes('`request_user_input`'),
+    'leftover-tool directive names both unsuppressable codex tools',
+  );
+  assert.ok(
+    dev!.includes('Do NOT call'),
+    'leftover-tool directive instructs the model not to call them',
+  );
+});
+
+test('developerInstructions omits the leftover-tool directive when no caller tools are supplied', async () => {
+  // openai-compat with only a `system` field (or only history) — there
+  // is no envelope contract to enforce and `update_plan` / `request_user_input`
+  // are legitimate codex affordances. Do not inject the directive.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('hi', 'ctx-no-leftover-directive', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            system: 'be terse',
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const dev = (tsFrame as { params?: { developerInstructions?: string } })
+    .params?.developerInstructions ?? '';
+  assert.equal(
+    dev.includes('update_plan'),
+    false,
+    'directive must not appear without caller tools',
+  );
+  assert.equal(
+    dev.includes('request_user_input'),
+    false,
+    'directive must not appear without caller tools',
+  );
+});

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1233,7 +1233,10 @@ test('thread/resume does NOT send `environments` (sticky on start; ResumeParams 
   assert.equal(resumeParams?.environments, undefined);
 });
 
-test('thread/start omits `config` when no caller tools are supplied', async () => {
+test('thread/start omits `config` entirely for plain (non-openai-compat) tasks', async () => {
+  // Non-openai-compat callers get full codex behaviour: native MCP
+  // discovery, every feature flag at its operator default, etc. The
+  // override only kicks in when openai-compat metadata is present.
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
   // Plain text task with no openai-compat metadata.
@@ -1244,10 +1247,14 @@ test('thread/start omits `config` when no caller tools are supplied', async () =
   assert.equal(params?.config, undefined);
 });
 
-test('history-only openai-compat payload (no `tools`) does not disable codex built-ins', async () => {
-  // Mirror of the codex (exec) backend test. With tools absent there is no
-  // caller-side dispatch contract to protect; do not handicap codex's
-  // built-ins for this turn.
+test('history-only openai-compat payload (no `tools`) clears MCP servers but does not disable codex built-in features', async () => {
+  // With `tools` absent there is no caller-side dispatch contract for
+  // codex's hosted modalities / multi-agent / etc. surfaces to compete
+  // with — keep `config.features` off so non-dispatch openai-compat
+  // callers don't lose them. But MCP discovery (`list_mcp_resources` &
+  // siblings) still doesn't fit the openai-compat mental model at all
+  // — the caller is an LLM endpoint, not a codex agent — so `mcp_servers`
+  // is cleared on every openai-compat call regardless of `tools`.
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
   await backend.handle(
@@ -1271,8 +1278,46 @@ test('history-only openai-compat payload (no `tools`) does not disable codex bui
   );
 
   const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
-  const params = (tsFrame as { params?: { config?: unknown } }).params;
-  assert.equal(params?.config, undefined);
+  const params = (tsFrame as {
+    params?: { config?: { mcp_servers?: unknown; features?: unknown } };
+  }).params;
+  assert.deepEqual(params?.config?.mcp_servers, {}, 'mcp_servers cleared for any openai-compat');
+  assert.equal(params?.config?.features, undefined, 'features untouched without caller-side dispatch');
+});
+
+test('openai-compat with tool_choice="none" clears MCP servers but does not disable codex built-in features', async () => {
+  // `tool_choice: "none"` means the caller explicitly does NOT want the
+  // model to emit a `tool_calls` envelope; caller-side dispatch is off
+  // by definition (`callerToolDispatchActive` returns false). Same
+  // contract as the history-only case: `mcp_servers` is still cleared
+  // (no MCP discovery for an LLM-shaped caller) but `features` stays
+  // untouched.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('answer', 'ctx-tc-none', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'answer' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            tool_choice: 'none',
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { mcp_servers?: unknown; features?: unknown } };
+  }).params;
+  assert.deepEqual(params?.config?.mcp_servers, {});
+  assert.equal(params?.config?.features, undefined);
 });
 
 test('thread/resume re-passes `config.features` because feature flags do not persist across resume (#175)', async () => {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1325,6 +1325,87 @@ test('thread/resume re-passes `config.features` because feature flags do not per
   assert.deepEqual(resumeFeatures, EXPECTED_OPENAI_COMPAT_DISABLES);
 });
 
+test('thread/start overrides sandbox to workspace-write under caller-side dispatch (#207)', async () => {
+  // Live test rounds for #207 showed two runs (030, 031) failing because
+  // the model read codex's built-in permissions text ("sandbox_mode is
+  // `read-only`") and refused the caller's writable tools, declaring
+  // "this session is in a read-only filesystem sandbox" and ending the
+  // turn with no envelope. Under caller-side dispatch the model never
+  // executes locally (environments: [] removes the write/exec handlers),
+  // so a read-only permissions block only confuses it. Override to
+  // workspace-write so the permissions text matches the model's actual
+  // contract.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn, sandboxMode: 'read-only' });
+  await backend.handle(
+    assign('do it', 'ctx-sandbox-override', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'do it' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            tools: [{ type: 'function', function: { name: 'write', parameters: {} } }],
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { sandbox?: string } }).params;
+  assert.equal(params?.sandbox, 'workspace-write');
+});
+
+test('thread/start passes the operator sandbox through when no caller tools are supplied', async () => {
+  // Non-openai-compat callers still get the operator-configured sandbox
+  // — the override is gated on `callerToolDispatchActive`. Regression
+  // check for plain codex usage.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn, sandboxMode: 'read-only' });
+  await backend.handle(assign('hi', 'ctx-sandbox-passthrough'), collect().emit, NEVER);
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { sandbox?: string } }).params;
+  assert.equal(params?.sandbox, 'read-only');
+});
+
+test('thread/resume also overrides sandbox to workspace-write under caller-side dispatch (#207)', async () => {
+  // Sandbox setting is re-sent on resume in codex.ts; verify the
+  // caller-side-dispatch override applies symmetrically so the model
+  // doesn't suddenly read "read-only" on follow-up turns and refuse
+  // the caller's tools.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn, sandboxMode: 'read-only' });
+  const meta = {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [{ type: 'function', function: { name: 'write', parameters: {} } }],
+    },
+  };
+  await backend.handle(
+    assign('one', 'ctx-sandbox-resume', {
+      message: { role: 'user', messageId: 'm1', parts: [{ kind: 'text', text: 'one' }], metadata: meta },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  await backend.handle(
+    assign('two', 'ctx-sandbox-resume', {
+      message: { role: 'user', messageId: 'm2', parts: [{ kind: 'text', text: 'two' }], metadata: meta },
+    }),
+    collect().emit,
+    NEVER,
+  );
+
+  const frames = fake.lastChild().stdinFrames();
+  const resume = findRequest(frames, 'thread/resume');
+  assert.ok(resume, 'thread/resume observed');
+  const params = (resume as { params?: { sandbox?: string } }).params;
+  assert.equal(params?.sandbox, 'workspace-write');
+});
+
 test('developerInstructions includes the leftover-tool directive under caller-side dispatch (#207)', async () => {
   // `update_plan` and `request_user_input` are unconditionally registered
   // by codex (`spec_plan.rs`) with no feature gate. The directive in

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1233,10 +1233,7 @@ test('thread/resume does NOT send `environments` (sticky on start; ResumeParams 
   assert.equal(resumeParams?.environments, undefined);
 });
 
-test('thread/start omits `config` entirely for plain (non-openai-compat) tasks', async () => {
-  // Non-openai-compat callers get full codex behaviour: native MCP
-  // discovery, every feature flag at its operator default, etc. The
-  // override only kicks in when openai-compat metadata is present.
+test('thread/start omits `config` when no caller tools are supplied', async () => {
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
   // Plain text task with no openai-compat metadata.
@@ -1247,14 +1244,10 @@ test('thread/start omits `config` entirely for plain (non-openai-compat) tasks',
   assert.equal(params?.config, undefined);
 });
 
-test('history-only openai-compat payload (no `tools`) clears MCP servers but does not disable codex built-in features', async () => {
-  // With `tools` absent there is no caller-side dispatch contract for
-  // codex's hosted modalities / multi-agent / etc. surfaces to compete
-  // with — keep `config.features` off so non-dispatch openai-compat
-  // callers don't lose them. But MCP discovery (`list_mcp_resources` &
-  // siblings) still doesn't fit the openai-compat mental model at all
-  // — the caller is an LLM endpoint, not a codex agent — so `mcp_servers`
-  // is cleared on every openai-compat call regardless of `tools`.
+test('history-only openai-compat payload (no `tools`) does not disable codex built-ins', async () => {
+  // Mirror of the codex (exec) backend test. With tools absent there is no
+  // caller-side dispatch contract to protect; do not handicap codex's
+  // built-ins for this turn.
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
   await backend.handle(
@@ -1278,46 +1271,8 @@ test('history-only openai-compat payload (no `tools`) clears MCP servers but doe
   );
 
   const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
-  const params = (tsFrame as {
-    params?: { config?: { mcp_servers?: unknown; features?: unknown } };
-  }).params;
-  assert.deepEqual(params?.config?.mcp_servers, {}, 'mcp_servers cleared for any openai-compat');
-  assert.equal(params?.config?.features, undefined, 'features untouched without caller-side dispatch');
-});
-
-test('openai-compat with tool_choice="none" clears MCP servers but does not disable codex built-in features', async () => {
-  // `tool_choice: "none"` means the caller explicitly does NOT want the
-  // model to emit a `tool_calls` envelope; caller-side dispatch is off
-  // by definition (`callerToolDispatchActive` returns false). Same
-  // contract as the history-only case: `mcp_servers` is still cleared
-  // (no MCP discovery for an LLM-shaped caller) but `features` stays
-  // untouched.
-  const fake = makeFakeSpawn(() => happyPath());
-  const backend = createCodexBackend({ spawn: fake.spawn });
-  await backend.handle(
-    assign('answer', 'ctx-tc-none', {
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'answer' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
-            tool_choice: 'none',
-          },
-        },
-      },
-    }),
-    collect().emit,
-    NEVER,
-  );
-
-  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
-  const params = (tsFrame as {
-    params?: { config?: { mcp_servers?: unknown; features?: unknown } };
-  }).params;
-  assert.deepEqual(params?.config?.mcp_servers, {});
-  assert.equal(params?.config?.features, undefined);
+  const params = (tsFrame as { params?: { config?: unknown } }).params;
+  assert.equal(params?.config, undefined);
 });
 
 test('thread/resume re-passes `config.features` because feature flags do not persist across resume (#175)', async () => {
@@ -1368,89 +1323,6 @@ test('thread/resume re-passes `config.features` because feature flags do not per
     .params?.config?.features;
   assert.deepEqual(startFeatures, EXPECTED_OPENAI_COMPAT_DISABLES);
   assert.deepEqual(resumeFeatures, EXPECTED_OPENAI_COMPAT_DISABLES);
-});
-
-test('thread/start sends `config.mcp_servers: {}` when caller tools are active (#207)', async () => {
-  // The model in the #207 session (`019e3a10-…`) burned multiple turns
-  // calling `list_mcp_resources({server:"local"})` /
-  // `list_mcp_resource_templates(...)` before giving up with text-only
-  // output. Those handlers are gated in codex-rs `spec_plan.rs` by
-  // `if params.mcp_tools.is_some()`; an empty mcp_servers map at
-  // thread scope leaves `mcp_tools` empty/None so the three handlers
-  // (`list_mcp_resources`, `list_mcp_resource_templates`,
-  // `read_mcp_resource`) are not pushed into the registry.
-  const fake = makeFakeSpawn(() => happyPath());
-  const backend = createCodexBackend({ spawn: fake.spawn });
-  await backend.handle(
-    assign('do it', 'ctx-mcp-empty', {
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'do it' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
-          },
-        },
-      },
-    }),
-    collect().emit,
-    NEVER,
-  );
-
-  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
-  const params = (tsFrame as {
-    params?: { config?: { mcp_servers?: Record<string, unknown> } };
-  }).params;
-  assert.deepEqual(params?.config?.mcp_servers, {});
-});
-
-test('thread/resume re-passes `config.mcp_servers: {}` (#207)', async () => {
-  // Same rationale as the `config.features` resume test: the thread-
-  // scoped config override does not persist across resume, so a missing
-  // mcp_servers on resume would silently re-expose `list_mcp_resources`
-  // and siblings for that turn.
-  const fake = makeFakeSpawn(() => happyPath());
-  const backend = createCodexBackend({ spawn: fake.spawn });
-  const meta = {
-    [OPENAI_COMPAT_EXTENSION_URI]: {
-      tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
-    },
-  };
-  await backend.handle(
-    assign('one', 'ctx-mcp-resume', {
-      message: {
-        role: 'user',
-        messageId: 'm1',
-        parts: [{ kind: 'text', text: 'one' }],
-        metadata: meta,
-      },
-    }),
-    collect().emit,
-    NEVER,
-  );
-  await backend.handle(
-    assign('two', 'ctx-mcp-resume', {
-      message: {
-        role: 'user',
-        messageId: 'm2',
-        parts: [{ kind: 'text', text: 'two' }],
-        metadata: meta,
-      },
-    }),
-    collect().emit,
-    NEVER,
-  );
-
-  const frames = fake.lastChild().stdinFrames();
-  const start = findRequest(frames, 'thread/start');
-  const resume = findRequest(frames, 'thread/resume');
-  const startMcp = (start as { params?: { config?: { mcp_servers?: unknown } } })
-    .params?.config?.mcp_servers;
-  const resumeMcp = (resume as { params?: { config?: { mcp_servers?: unknown } } })
-    .params?.config?.mcp_servers;
-  assert.deepEqual(startMcp, {});
-  assert.deepEqual(resumeMcp, {});
 });
 
 test('developerInstructions includes the leftover-tool directive under caller-side dispatch (#207)', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -685,11 +685,10 @@ export function createCodexBackend(
 
           // For resumes we re-attach to the existing thread; sandbox and
           // any developerInstructions set on initial `thread/start` carry
-          // over via the server-side session record. Config overrides
-          // (see `configOverride` below — features + mcp_servers) are
-          // the exception: they do NOT persist across resume and must
-          // be re-sent every turn that wants them. `environments`, by
-          // contrast, IS sticky on `thread/start`
+          // over via the server-side session record. Feature-flag overrides
+          // (see `configOverride` below) are the exception — they do NOT
+          // persist across resume and must be re-sent every turn that wants
+          // them. `environments`, by contrast, IS sticky on `thread/start`
           // and `ThreadResumeParams` does not even accept it, so we only
           // send it on start.
           //
@@ -724,60 +723,47 @@ export function createCodexBackend(
           // counter them with `CODEX_LEFTOVER_TOOL_DIRECTIVE` in the
           // developer instructions instead (see systemPrompt above).
           //
-          // The override is split across two gates with different scopes:
-          //
-          // - `mcp_servers: {}` is sent for ANY openai-compat call. The
-          //   caller is treating us as an LLM endpoint, not an agentic
-          //   codex; MCP discovery tools (`list_mcp_resources` /
-          //   `list_mcp_resource_templates` / `read_mcp_resource`, gated
-          //   in `spec_plan.rs` by `if params.mcp_tools.is_some()`) never
-          //   fit that mental model — empty server map → no aggregated
-          //   mcp_tools → those handlers are not pushed into the registry.
-          //   Verified via the #207 session 019e3a10-… where the model
-          //   burned multiple turns on `list_mcp_resources({server:"local"})`
-          //   before bailing with text-only output.
-          //
-          // - `features.*: false` is restricted to caller-side dispatch
-          //   (tools provided AND tool_choice ≠ "none") because those
-          //   surfaces (image_generation, web_search, multi-agent, etc.)
-          //   may be desirable for non-dispatch openai-compat callers
-          //   (history-only resumes, system-only prompts, tool_choice="none").
-          const configOverride = openaiCompat !== null
+          // `list_mcp_resources` / `list_mcp_resource_templates` /
+          // `read_mcp_resource` are gated in `spec_plan.rs` by
+          // `if params.mcp_tools.is_some()`, which traces back to
+          // `mcp_connection_manager.has_servers()`. The manager is built
+          // at app-server process startup, so thread-level overrides
+          // (sending `config.mcp_servers: {}` on `thread/start`) do not
+          // affect it. Process-level suppression via app-server `-c`
+          // flags would work for user-configured servers but cannot
+          // disable codex's builtin MCP entries on cli 0.130 — see
+          // analysis in PR #208 review. Tracking as follow-up.
+          const configOverride = callerToolDispatchActive(openaiCompat)
             ? {
-                mcp_servers: {},
-                ...(callerToolDispatchActive(openaiCompat)
-                  ? {
-                      features: {
-                        // Hosted modalities that bypass the caller's text envelope.
-                        image_generation: false,
-                        web_search_request: false,
-                        web_search_cached: false,
-                        // Codex-side tool catalog / discovery and plugin surfaces.
-                        tool_search: false,
-                        tool_suggest: false,
-                        tool_call_mcp_elicitation: false,
-                        builtin_mcp: false,
-                        plugins: false,
-                        apps: false,
-                        enable_mcp_apps: false,
-                        // Sub-agent / fan-out orchestration bypasses the single-
-                        // agent envelope contract.
-                        multi_agent: false,
-                        multi_agent_v2: false,
-                        enable_fanout: false,
-                        // Permission-escalation prompts would block under openai-
-                        // compat (no human in loop).
-                        request_permissions_tool: false,
-                        // Experimental code surfaces.
-                        code_mode: false,
-                        goals: false,
-                        memories: false,
-                        // Workspace introspection — fs reads that could leak host
-                        // paths back into model context.
-                        workspace_dependencies: false,
-                      },
-                    }
-                  : {}),
+                features: {
+                  // Hosted modalities that bypass the caller's text envelope.
+                  image_generation: false,
+                  web_search_request: false,
+                  web_search_cached: false,
+                  // Codex-side tool catalog / discovery and plugin surfaces.
+                  tool_search: false,
+                  tool_suggest: false,
+                  tool_call_mcp_elicitation: false,
+                  builtin_mcp: false,
+                  plugins: false,
+                  apps: false,
+                  enable_mcp_apps: false,
+                  // Sub-agent / fan-out orchestration bypasses the single-
+                  // agent envelope contract.
+                  multi_agent: false,
+                  multi_agent_v2: false,
+                  enable_fanout: false,
+                  // Permission-escalation prompts would block under openai-
+                  // compat (no human in loop).
+                  request_permissions_tool: false,
+                  // Experimental code surfaces.
+                  code_mode: false,
+                  goals: false,
+                  memories: false,
+                  // Workspace introspection — fs reads that could leak host
+                  // paths back into model context.
+                  workspace_dependencies: false,
+                },
               }
             : null;
           // `environments: []` is sticky on `thread/start` and unsupported on

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -772,6 +772,24 @@ export function createCodexBackend(
           // keep their normal codex environment.
           const sendEmptyEnvironments = callerToolDispatchActive(openaiCompat);
 
+          // Under caller-side dispatch the model never executes locally —
+          // `environments: []` removes every shell / write / apply_patch
+          // handler from the registry. The operator-configured `sandbox`
+          // still flows into codex's built-in permissions text (developer
+          // message content[0]), which renders as "sandbox_mode is
+          // `<value>`. The sandbox permits …". With the default
+          // `read-only`, the model has been observed (#207 round-3 runs
+          // 030, 031) to read that text and refuse the caller's writable
+          // tools, declaring "this session is in a read-only filesystem
+          // sandbox" and ending the turn with no envelope. Override to
+          // `workspace-write` for caller-side dispatch so the permissions
+          // text matches the model's actual contract — emitting envelopes
+          // that the caller will execute against its writable workspace.
+          // Safe because the codex-side write handlers are already gone.
+          const effectiveSandbox: SandboxMode = callerToolDispatchActive(openaiCompat)
+            ? 'workspace-write'
+            : sandboxMode;
+
           let threadId: string;
           try {
             if (isResume) {
@@ -780,7 +798,7 @@ export function createCodexBackend(
                 {
                   threadId: existing.threadId,
                   cwd,
-                  sandbox: sandboxMode,
+                  sandbox: effectiveSandbox,
                   ...(configOverride ? { config: configOverride } : {}),
                 },
               );
@@ -790,7 +808,7 @@ export function createCodexBackend(
                 'thread/start',
                 {
                   cwd,
-                  sandbox: sandboxMode,
+                  sandbox: effectiveSandbox,
                   ...(systemPrompt ? { developerInstructions: systemPrompt } : {}),
                   ...(configOverride ? { config: configOverride } : {}),
                   ...(sendEmptyEnvironments ? { environments: [] } : {}),

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -348,6 +348,25 @@ export function historyToInjectItems(
   return out;
 }
 
+// Codex registers two internal tools that survive every config/feature
+// knob we have. Verified against `codex-rs/core/src/tools/spec_plan.rs`:
+//   - `update_plan`         — `executors.push(Arc::new(PlanHandler))` is
+//                             unconditional; no feature flag, no mode gate.
+//   - `request_user_input`  — registered unconditionally; calls in our
+//                             default mode fail with "request_user_input
+//                             is unavailable in Default mode", but the
+//                             tool still appears in the model's registry.
+// Under caller-side dispatch the model has been observed (#207 session
+// `019e3a10-…`) to chain calls to these two instead of emitting the
+// envelope, producing silent text-only completions because the host
+// (codex) consumes the calls and the caller (oai2a2a → opencode) never
+// sees them. Tell the model explicitly to treat them as host scaffolding
+// outside the task's tool surface so it falls back to the envelope.
+const CODEX_LEFTOVER_TOOL_DIRECTIVE = [
+  'IMPORTANT: The host runtime (codex) exposes two internal tools that are NOT part of this task\'s tool surface and are invisible to the caller: `update_plan` (host-side planning notepad) and `request_user_input` (host-side prompt UI).',
+  'Do NOT call either of them under any circumstance. They are host scaffolding; calling them wastes the turn and produces no observable effect for the caller. Your only legitimate actions are (a) emitting a `tool_calls` envelope as described above, or (b) answering in natural language.',
+].join('\n\n');
+
 // Per-task in-progress notification subscription — listens for
 // `item/agentMessage/delta`, `item/completed`, and `turn/completed`
 // scoped to the active turn, then resolves with the final state.
@@ -570,8 +589,17 @@ export function createCodexBackend(
         // instructed to interpret, eliminating the multi-turn re-call loop
         // observed under prompts like `"Use a tool to list …"` (#176).
         const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
-        const systemPrompt =
+        const baseSystemPrompt =
           openaiCompat ? buildOpenAICompatSystemPrompt(openaiCompat) : '';
+        // Append the leftover-tool directive only when caller-side dispatch
+        // is active. Outside that mode update_plan / request_user_input are
+        // legitimate codex affordances and we should not steer the model
+        // away from them.
+        const systemPrompt = callerToolDispatchActive(openaiCompat)
+          ? [baseSystemPrompt, CODEX_LEFTOVER_TOOL_DIRECTIVE]
+              .filter((s) => s.length > 0)
+              .join('\n\n')
+          : baseSystemPrompt;
         const historyInjectItems = openaiCompat?.tool_call_history
           ? historyToInjectItems(openaiCompat.tool_call_history)
           : null;
@@ -657,10 +685,11 @@ export function createCodexBackend(
 
           // For resumes we re-attach to the existing thread; sandbox and
           // any developerInstructions set on initial `thread/start` carry
-          // over via the server-side session record. Feature-flag overrides
-          // (see `featuresOverride` below) are the exception — they do NOT
-          // persist across resume and must be re-sent every turn that wants
-          // them. `environments`, by contrast, IS sticky on `thread/start`
+          // over via the server-side session record. Config overrides
+          // (see `configOverride` below — features + mcp_servers) are
+          // the exception: they do NOT persist across resume and must
+          // be re-sent every turn that wants them. `environments`, by
+          // contrast, IS sticky on `thread/start`
           // and `ThreadResumeParams` does not even accept it, so we only
           // send it on start.
           //
@@ -689,14 +718,12 @@ export function createCodexBackend(
           //    handlers do not depend on `environment_mode` and must each be
           //    explicitly disabled by their feature key.
           //
-          // Surfaces we can't disable from here: `update_plan` and
-          // `request_user_input` are unconditional in codex's tool registry;
-          // they have no feature key. They are benign in practice (plan
-          // mutation is session-local; request_user_input blocks on an MCP
-          // elicitation reply that never arrives under openai-compat).
-          // `list_mcp_resources` and siblings are gated by codex's per-server
-          // `mcp_tools` config — out of scope for this flag plumbing.
-          const featuresOverride = callerToolDispatchActive(openaiCompat)
+          // Surfaces we still can't disable from here: `update_plan` and
+          // `request_user_input` are unconditional `executors.push(...)`
+          // entries in codex-rs `spec_plan.rs` with no feature key. We
+          // counter them with `CODEX_LEFTOVER_TOOL_DIRECTIVE` in the
+          // developer instructions instead (see systemPrompt above).
+          const configOverride = callerToolDispatchActive(openaiCompat)
             ? {
                 features: {
                   // Hosted modalities that bypass the caller's text envelope.
@@ -727,6 +754,16 @@ export function createCodexBackend(
                   // paths back into model context.
                   workspace_dependencies: false,
                 },
+                // Drop every configured MCP server for this thread. This is
+                // the gate for `list_mcp_resources` / `list_mcp_resource_templates`
+                // / `read_mcp_resource` registration in codex-rs
+                // `spec_plan.rs` (`if params.mcp_tools.is_some()` —
+                // empty server map → no aggregated mcp_tools → those
+                // handlers not pushed into the registry). Verified via
+                // the #207 session 019e3a10-… where the model burned
+                // multiple turns on `list_mcp_resources({server:"local"})`
+                // before bailing with text-only output.
+                mcp_servers: {},
               }
             : null;
           // `environments: []` is sticky on `thread/start` and unsupported on
@@ -744,7 +781,7 @@ export function createCodexBackend(
                   threadId: existing.threadId,
                   cwd,
                   sandbox: sandboxMode,
-                  ...(featuresOverride ? { config: featuresOverride } : {}),
+                  ...(configOverride ? { config: configOverride } : {}),
                 },
               );
               threadId = resumeResult.thread.id;
@@ -755,7 +792,7 @@ export function createCodexBackend(
                   cwd,
                   sandbox: sandboxMode,
                   ...(systemPrompt ? { developerInstructions: systemPrompt } : {}),
-                  ...(featuresOverride ? { config: featuresOverride } : {}),
+                  ...(configOverride ? { config: configOverride } : {}),
                   ...(sendEmptyEnvironments ? { environments: [] } : {}),
                 },
               );

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -723,47 +723,61 @@ export function createCodexBackend(
           // entries in codex-rs `spec_plan.rs` with no feature key. We
           // counter them with `CODEX_LEFTOVER_TOOL_DIRECTIVE` in the
           // developer instructions instead (see systemPrompt above).
-          const configOverride = callerToolDispatchActive(openaiCompat)
+          //
+          // The override is split across two gates with different scopes:
+          //
+          // - `mcp_servers: {}` is sent for ANY openai-compat call. The
+          //   caller is treating us as an LLM endpoint, not an agentic
+          //   codex; MCP discovery tools (`list_mcp_resources` /
+          //   `list_mcp_resource_templates` / `read_mcp_resource`, gated
+          //   in `spec_plan.rs` by `if params.mcp_tools.is_some()`) never
+          //   fit that mental model — empty server map → no aggregated
+          //   mcp_tools → those handlers are not pushed into the registry.
+          //   Verified via the #207 session 019e3a10-… where the model
+          //   burned multiple turns on `list_mcp_resources({server:"local"})`
+          //   before bailing with text-only output.
+          //
+          // - `features.*: false` is restricted to caller-side dispatch
+          //   (tools provided AND tool_choice ≠ "none") because those
+          //   surfaces (image_generation, web_search, multi-agent, etc.)
+          //   may be desirable for non-dispatch openai-compat callers
+          //   (history-only resumes, system-only prompts, tool_choice="none").
+          const configOverride = openaiCompat !== null
             ? {
-                features: {
-                  // Hosted modalities that bypass the caller's text envelope.
-                  image_generation: false,
-                  web_search_request: false,
-                  web_search_cached: false,
-                  // Codex-side tool catalog / discovery and plugin surfaces.
-                  tool_search: false,
-                  tool_suggest: false,
-                  tool_call_mcp_elicitation: false,
-                  builtin_mcp: false,
-                  plugins: false,
-                  apps: false,
-                  enable_mcp_apps: false,
-                  // Sub-agent / fan-out orchestration bypasses the single-
-                  // agent envelope contract.
-                  multi_agent: false,
-                  multi_agent_v2: false,
-                  enable_fanout: false,
-                  // Permission-escalation prompts would block under openai-
-                  // compat (no human in loop).
-                  request_permissions_tool: false,
-                  // Experimental code surfaces.
-                  code_mode: false,
-                  goals: false,
-                  memories: false,
-                  // Workspace introspection — fs reads that could leak host
-                  // paths back into model context.
-                  workspace_dependencies: false,
-                },
-                // Drop every configured MCP server for this thread. This is
-                // the gate for `list_mcp_resources` / `list_mcp_resource_templates`
-                // / `read_mcp_resource` registration in codex-rs
-                // `spec_plan.rs` (`if params.mcp_tools.is_some()` —
-                // empty server map → no aggregated mcp_tools → those
-                // handlers not pushed into the registry). Verified via
-                // the #207 session 019e3a10-… where the model burned
-                // multiple turns on `list_mcp_resources({server:"local"})`
-                // before bailing with text-only output.
                 mcp_servers: {},
+                ...(callerToolDispatchActive(openaiCompat)
+                  ? {
+                      features: {
+                        // Hosted modalities that bypass the caller's text envelope.
+                        image_generation: false,
+                        web_search_request: false,
+                        web_search_cached: false,
+                        // Codex-side tool catalog / discovery and plugin surfaces.
+                        tool_search: false,
+                        tool_suggest: false,
+                        tool_call_mcp_elicitation: false,
+                        builtin_mcp: false,
+                        plugins: false,
+                        apps: false,
+                        enable_mcp_apps: false,
+                        // Sub-agent / fan-out orchestration bypasses the single-
+                        // agent envelope contract.
+                        multi_agent: false,
+                        multi_agent_v2: false,
+                        enable_fanout: false,
+                        // Permission-escalation prompts would block under openai-
+                        // compat (no human in loop).
+                        request_permissions_tool: false,
+                        // Experimental code surfaces.
+                        code_mode: false,
+                        goals: false,
+                        memories: false,
+                        // Workspace introspection — fs reads that could leak host
+                        // paths back into model context.
+                        workspace_dependencies: false,
+                      },
+                    }
+                  : {}),
               }
             : null;
           // `environments: []` is sticky on `thread/start` and unsupported on


### PR DESCRIPTION
## Summary

Three seams against the silent text-only completion failure observed in #207, each independently verified against a deployed `codex-Mac-pr208` agent:

1. **`CODEX_LEFTOVER_TOOL_DIRECTIVE`** appended to `developerInstructions` whenever caller-side dispatch is active. Names `update_plan` and `request_user_input` — both unconditional `executors.push(...)` entries in codex-rs `spec_plan.rs` with no feature gate, so config-level disable is not possible. Tells the model they are host scaffolding outside this task's tool surface; the only legitimate outputs are a `tool_calls` envelope or a natural-language reply.

2. **`tryParseToolCallsEnvelope` relaxation** — keep the fast (clean envelope at start) path unchanged, add a slow fallback that locates a `{"tool_calls":` marker anywhere in the trimmed text, balance-matches the surrounding JSON object (respecting string literals + escapes), and parses the slice. Recovers envelopes the model prefixed with prose narration or wrapped in a code fence.

3. **Force `sandbox=workspace-write`** on `thread/start` / `thread/resume` under caller-side dispatch. The operator's configured sandbox flows into codex's built-in permissions text (developer message content[0]), and the model conflates "codex sandbox" with "caller's tool surface" — refusing the caller's writable tools when it reads "sandbox_mode is read-only". `environments: []` already removes every codex write/exec handler, so the override is cosmetic for execution but decisive for the model's reading.

Earlier commits in this branch attempted to also empty `config.mcp_servers` on `thread/start`; live test proved that path is a no-op (`mcp_connection_manager` is session/process-level — see commit `cc5c6bc`'s message). Those commits revert cleanly inside this branch.

## Live test rounds

Against `https://vicoop-bridge-server.fly.dev/agents/codex-Mac-pr208` (PR branch source via `tsx`):

| round | build state | runs | success | observed failure mode | fix landed |
|---|---|---|---|---|---|
| 1 | directive only | 4 | 4/4 | (baseline regression check) | — |
| 2 | directive | 5 | 3/5 | (026) step-2 narration without follow-through; (028) prose-prefixed envelope discarded | parser relaxation (commit `72e1cef`) |
| 3 | directive + parser | 5 | 3/5 | (030, 031) model refused on reading "sandbox_mode is `read-only`"; 0 prose-prefixed failures | sandbox override (commit `b12af01`) |
| 4 | directive + parser + sandbox | — | — | pending — daemon back up on the new build | — |

`request_user_input` stayed at 0 calls across every round (directive holding). #207 baseline emitted 0 envelopes and produced silent text-only completion; this branch produces substantive output across all successful runs.

## What this does NOT change

- `environments: []`, `config.features.*=false`, cwd handling — all preserved.
- `list_mcp_resources` / `list_mcp_resource_templates` / `read_mcp_resource` registration — gated in `spec_plan.rs` by a session/process-level `mcp_connection_manager.has_servers()` that thread-level config can't reach. Tracked as follow-up.
- `update_plan` registration — unconditional, no feature gate; directive reduces but does not eliminate.
- Non-openai-compat callers — directive + sandbox override are gated on `callerToolDispatchActive`; parser relaxation is a no-op for non-envelope text.

## Test plan

- [x] 3 new node:test cases for the sandbox override:
  - `thread/start` sends `sandbox=workspace-write` under caller-side dispatch
  - `thread/start` passes the operator sandbox through when no caller tools
  - `thread/resume` also overrides (sandbox is re-sent per turn)
- [x] 2 new node:test cases for the directive (include / omit by gate)
- [x] 5 new node:test cases for the relaxed parser (prose prefix, code fence, balanced strings, unbalanced, trailing prose)
- [x] Existing parser test updated: `'Sure! {"tool_calls":[…]}'` now returns the envelope (intentional)
- [x] Full client suite (418 tests) passes locally
- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] 3 live test rounds against `codex-Mac-pr208` — table above
- [ ] Round 4 (directive + parser + sandbox) — pending operator reproduction

## Commits

- `d0af847` initial fix (directive + ineffective `mcp_servers: {}`)
- `645d41a` refactor: broaden mcp_servers gating
- `cc5c6bc` drop ineffective mcp_servers override after live verification
- `72e1cef` relax envelope parser to recover prose-prefixed JSON
- `b12af01` force sandbox=workspace-write under caller-side dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)