### PR TITLE
[codex] Unify server agent persistence

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -298,9 +298,9 @@ runtime config (#189 §5) — secrets and overrides live in `config.json`
 If you omit `--caller`, `setup` succeeds but prints a warning that the
 agent will be public until you restrict callers:
 
-> `setup --caller` requires a bridge server version that can pre-create
-> `agent_policies` for registered client agent ids. If you are testing against
-> your own deployment, deploy the matching server/schema before this step.
+> `setup --caller` requires a bridge server version that stores caller
+> allowlists on registered agents. If you are testing against your own
+> deployment, deploy the matching server/schema before this step.
 
 > ⚠ The `CLIENT_TOKEN` is unrecoverable after this single output.
 > `config.json` is the only place it persists; back it up if you need to
@@ -322,11 +322,11 @@ stdout):
 CLIENT_TOKEN=$(jq -r .client_token /tmp/vicoop-setup.json)
 ```
 
-`--agent-ids` is a comma-separated allowlist. Include every id you plan to
-run under this single token if you know them up front; amend later via
-the `updateClientAllowedAgents` GraphQL mutation (backed by
-`update_client_allowed_agents()` in `schema.sql`) without issuing a new
-token.
+`--agent-ids` is a legacy plural flag, but the current server model is
+1:1: one setup call creates one agent registration and the flag must contain
+exactly one id. To change that id later, use the `updateClientAllowedAgents`
+GraphQL compatibility mutation (backed by `update_client_allowed_agents()`
+in `schema.sql`) without issuing a new token.
 
 ### What login and setup do
 
@@ -447,7 +447,7 @@ you can copy the mention / acct / agent-card URL from here directly:
 
 After that:
 
-- The bridge loads the `agent_policies` row for your agent. If Step 4 setup
+- The bridge loads the `allowed_callers` list for your agent. If Step 4 setup
   included `--caller`, that allowlist is already in place; otherwise
   `allowed_callers` is empty, meaning **publicly callable** until you restrict it.
 - `POST $BRIDGE_URL/agents/$AGENT_ID` with a JSON-RPC `message/send` payload
@@ -782,12 +782,10 @@ section of `docs/local-testing.md` for the same note.
 ## Troubleshooting
 
 - **`agent id owned by a different principal`** (WS register) — your
-  principal is not the `owner_principal` on the existing `agent_policies`
-  row. Pick a different `agent_id`, amend the existing client's allowlist
-  via `updateClientAllowedAgents` (no token rotation), and restart
-  `vicoop-client` with the new `AGENT_ID`. Re-run Step 4 only if you
-  intentionally want a new client/token; otherwise sign in from the
-  original owner.
+  principal is not the `owner_principal` on the existing agent registration.
+  Pick a different `agent_id`, or sign in from the original owner before
+  changing that registration. Re-run Step 4 only if you intentionally want a
+  new client/token.
 
 - **`permission denied for function register_client`** (or similar) on
   GraphQL — the caller token was missing, malformed, or expired, so the
@@ -800,17 +798,16 @@ section of `docs/local-testing.md` for the same note.
   browser approval is delayed past that, re-run `login`; the previous
   device code is invalidated automatically.
 
-- **Client reconnects but `/agents/:id` returns 404** — the
-  `agent_policies` row exists but no WS session is live. Check the client
-  log; the row is re-used on reconnect but dispatch requires an active
-  session.
+- **Client reconnects but `/agents/:id` returns 404** — the agent
+  registration exists but no WS session is live. Check the client log;
+  dispatch requires an active session.
 
 - **Lost the `CLIENT_TOKEN`** — the raw value is unrecoverable, but you
   don't need to create a new client identity. Rotate the token in place
   via the `rotateClientToken` GraphQL mutation (backed by
   `rotate_client_token()` in `schema.sql`): it mints a fresh raw token for
-  the existing `clients` row and invalidates the old hash, so your
-  `allowedAgentIds` and `agent_policies` carry over. Re-run Step 4 only if
+  the existing agent registration and invalidates the old hash, so your
+  agent id and caller allowlist carry over. Re-run Step 4 only if
   you intentionally want a new client identity; in that case the old
   `clients` row can be revoked from the CLI — see
   [Inspecting and revoking your clients](#inspecting-and-revoking-your-clients).
@@ -827,9 +824,10 @@ vicoop-client list-clients
 ```
 
 Columns are `client_id`, `client_name`, `allowed_agent_ids`, `revoked`,
-`connected`, `created_at`. The `connected` flag reflects in-memory
-registry state, so a row with `connected: false` is exactly the kind of
-orphan you want to clean up.
+`connected`, `created_at` (newer servers may also include `agent_id` in
+JSON output). The `connected` flag reflects in-memory registry state, so a
+row with `connected: false` is exactly the kind of orphan you want to clean
+up.
 
 To revoke a client — and disconnect its live WebSocket if one is bound —
 use either the UUID `client_id` or a unique `client_name`:
@@ -838,9 +836,8 @@ use either the UUID `client_id` or a unique `client_name`:
 vicoop-client revoke-client <client-id-or-name>
 ```
 
-- A revoked client's row is kept (`revoked = true`) so audit history
-  survives; existing `agent_policies` cascade-deleted only when the
-  underlying row is later hard-deleted.
+- A revoked client's compatibility row is kept (`revoked = true`) so audit
+  history survives.
 - A unique name resolves automatically; an ambiguous name exits non-zero
   with a list of matching `client_id`s so you can retry with the id.
 - If the daemon is alive at the moment of revocation, its WebSocket is

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -231,6 +231,65 @@ COMMENT ON COLUMN clients.token_hash IS E'@omit';
 -- Clients must be created through register_client() which generates the token.
 COMMENT ON TABLE clients IS E'@omit create';
 
+-- ============================================================
+-- 3b. Agents table (unified server-side persistence model)
+-- ============================================================
+-- Source of truth for one operator-facing agent registration. The legacy
+-- `clients` and `agent_policies` tables are kept for compatibility during the
+-- migration, but server runtime paths should prefer this table.
+CREATE TABLE IF NOT EXISTS agents (
+  id                TEXT PRIMARY KEY,
+  client_id         TEXT NOT NULL UNIQUE DEFAULT gen_random_uuid()::text,
+  owner_principal   TEXT NOT NULL,
+  owner_email       TEXT,
+  name              TEXT NOT NULL,
+  token_hash        TEXT NOT NULL UNIQUE,
+  allowed_callers   TEXT[] NOT NULL DEFAULT '{}',
+  revoked           BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_email TEXT;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS client_id TEXT UNIQUE DEFAULT gen_random_uuid()::text;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS allowed_callers TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+UPDATE agents SET client_id = gen_random_uuid()::text WHERE client_id IS NULL;
+ALTER TABLE agents ALTER COLUMN client_id SET NOT NULL;
+
+ALTER TABLE agents ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS agents_select ON agents;
+CREATE POLICY agents_select ON agents
+  FOR SELECT TO app_authenticated
+  USING (owner_principal = current_principal() OR is_admin());
+
+DROP POLICY IF EXISTS agents_insert ON agents;
+CREATE POLICY agents_insert ON agents
+  FOR INSERT TO app_authenticated
+  WITH CHECK (owner_principal = current_principal() OR is_admin());
+
+DROP POLICY IF EXISTS agents_update ON agents;
+CREATE POLICY agents_update ON agents
+  FOR UPDATE TO app_authenticated
+  USING (owner_principal = current_principal() OR is_admin())
+  WITH CHECK (owner_principal = current_principal() OR is_admin());
+
+DROP POLICY IF EXISTS agents_delete ON agents;
+CREATE POLICY agents_delete ON agents
+  FOR DELETE TO app_authenticated
+  USING (owner_principal = current_principal() OR is_admin());
+
+DROP POLICY IF EXISTS agents_postgraphile ON agents;
+CREATE POLICY agents_postgraphile ON agents
+  FOR ALL TO app_postgraphile
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON COLUMN agents.token_hash IS E'@omit';
+COMMENT ON TABLE agents IS E'@omit create';
+
 -- ------------------------------------------------------------
 -- 3a. Client CRUD mutations (exposed by PostGraphile)
 -- ------------------------------------------------------------
@@ -284,6 +343,21 @@ CREATE TRIGGER clients_assert_no_reserved_agent_ids
   BEFORE INSERT OR UPDATE OF allowed_agent_ids ON clients
   FOR EACH ROW EXECUTE FUNCTION trg_clients_assert_no_reserved_agent_ids();
 
+CREATE OR REPLACE FUNCTION trg_agents_assert_no_reserved_agent_id()
+RETURNS TRIGGER
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM assert_no_reserved_agent_ids(ARRAY[NEW.id]);
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS agents_assert_no_reserved_agent_id ON agents;
+CREATE TRIGGER agents_assert_no_reserved_agent_id
+  BEFORE INSERT OR UPDATE OF id ON agents
+  FOR EACH ROW EXECUTE FUNCTION trg_agents_assert_no_reserved_agent_id();
+
 -- Token-carrying return type for register / rotate.
 -- Wrapped in DO so the migration is idempotent.
 DO $$ BEGIN
@@ -318,9 +392,15 @@ DECLARE
   v_raw_token  TEXT;
   v_token_hash TEXT;
   v_owner      TEXT;
+  v_agent_id   TEXT;
+  v_client_id  TEXT;
   v_row        client_with_token;
 BEGIN
   PERFORM assert_no_reserved_agent_ids(register_client.allowed_agent_ids);
+  IF COALESCE(array_length(register_client.allowed_agent_ids, 1), 0) <> 1 THEN
+    RAISE EXCEPTION 'exactly one allowed_agent_id is required';
+  END IF;
+  v_agent_id := register_client.allowed_agent_ids[1];
 
   v_raw_token  := encode(gen_random_bytes(32), 'hex');
   v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
@@ -334,14 +414,29 @@ BEGIN
     v_owner := current_principal();
   END IF;
 
-  INSERT INTO clients AS c (owner_principal, client_name, token_hash, allowed_agent_ids)
+  INSERT INTO agents AS a (id, owner_principal, name, token_hash)
   VALUES (
+    v_agent_id,
+    v_owner,
+    register_client.client_name,
+    v_token_hash
+  )
+  RETURNING a.client_id INTO v_client_id;
+
+  -- Compatibility shadow for existing GraphQL clients and direct SQL tooling.
+  INSERT INTO clients AS c (id, owner_principal, client_name, token_hash, allowed_agent_ids)
+  VALUES (
+    v_client_id,
     v_owner,
     register_client.client_name,
     v_token_hash,
-    COALESCE(register_client.allowed_agent_ids, '{}')
+    ARRAY[v_agent_id]
   )
-  RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  ON CONFLICT (id) DO NOTHING;
+
+  SELECT v_client_id, a.owner_principal, a.name, ARRAY[a.id], a.revoked, a.created_at, v_raw_token
+  FROM agents a
+  WHERE a.id = v_agent_id
   INTO v_row;
 
   RETURN v_row;
@@ -361,8 +456,12 @@ AS $$
 DECLARE
   v_row clients;
 BEGIN
+  UPDATE agents AS a SET revoked = TRUE, updated_at = now()
+  WHERE a.client_id = revoke_client.client_id OR a.id = revoke_client.client_id;
+
   UPDATE clients AS c SET revoked = TRUE
   WHERE c.id = revoke_client.client_id
+     OR c.id = (SELECT client_id FROM agents WHERE id = revoke_client.client_id)
   RETURNING c.* INTO v_row;
 
   IF NOT FOUND THEN
@@ -385,8 +484,12 @@ AS $$
 DECLARE
   v_row clients;
 BEGIN
+  UPDATE agents AS a SET revoked = FALSE, updated_at = now()
+  WHERE a.client_id = unrevoke_client.client_id OR a.id = unrevoke_client.client_id;
+
   UPDATE clients AS c SET revoked = FALSE
   WHERE c.id = unrevoke_client.client_id
+     OR c.id = (SELECT client_id FROM agents WHERE id = unrevoke_client.client_id)
   RETURNING c.* INTO v_row;
 
   IF NOT FOUND THEN
@@ -415,9 +518,14 @@ BEGIN
   v_raw_token  := encode(gen_random_bytes(32), 'hex');
   v_token_hash := encode(digest(v_raw_token, 'sha256'), 'hex');
 
+  UPDATE agents AS a
+  SET token_hash = v_token_hash, updated_at = now()
+  WHERE a.client_id = rotate_client_token.client_id OR a.id = rotate_client_token.client_id;
+
   UPDATE clients AS c
   SET token_hash = v_token_hash
   WHERE c.id = rotate_client_token.client_id
+     OR c.id = (SELECT client_id FROM agents WHERE id = rotate_client_token.client_id)
   RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
   INTO v_row;
 
@@ -432,7 +540,8 @@ $$;
 COMMENT ON FUNCTION rotate_client_token(TEXT) IS
   'Issue a new bearer token for a client. Returns the raw token — shown only once. Previous tokens are immediately invalidated for new connections.';
 
--- Replace the allowed_agent_ids list on a client.
+-- Compatibility wrapper for replacing the single agent id bound to a legacy
+-- client registration.
 CREATE OR REPLACE FUNCTION update_client_allowed_agents(
   client_id         TEXT,
   allowed_agent_ids TEXT[]
@@ -442,12 +551,29 @@ CREATE OR REPLACE FUNCTION update_client_allowed_agents(
 AS $$
 DECLARE
   v_row clients;
+  v_target_client_id TEXT;
 BEGIN
   PERFORM assert_no_reserved_agent_ids(update_client_allowed_agents.allowed_agent_ids);
+  IF COALESCE(array_length(update_client_allowed_agents.allowed_agent_ids, 1), 0) <> 1 THEN
+    RAISE EXCEPTION 'exactly one allowed_agent_id is required';
+  END IF;
+
+  SELECT a.client_id INTO v_target_client_id
+  FROM agents a
+  WHERE a.client_id = update_client_allowed_agents.client_id
+     OR a.id = update_client_allowed_agents.client_id;
+
+  IF v_target_client_id IS NULL THEN
+    RAISE EXCEPTION 'client not found or not authorized: %', update_client_allowed_agents.client_id;
+  END IF;
+
+  UPDATE agents AS a
+  SET id = update_client_allowed_agents.allowed_agent_ids[1], updated_at = now()
+  WHERE a.client_id = v_target_client_id;
 
   UPDATE clients AS c
-  SET allowed_agent_ids = COALESCE(update_client_allowed_agents.allowed_agent_ids, '{}')
-  WHERE c.id = update_client_allowed_agents.client_id
+  SET allowed_agent_ids = update_client_allowed_agents.allowed_agent_ids
+  WHERE c.id = v_target_client_id
   RETURNING c.* INTO v_row;
 
   IF NOT FOUND THEN
@@ -459,7 +585,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) IS
-  'Replace the allowed_agent_ids list on a client.';
+  'Compatibility wrapper for replacing the single agent id bound to a client registration.';
 
 -- ============================================================
 -- 4. Infra schema (not exposed via PostGraphile / GraphQL)
@@ -508,8 +634,8 @@ CREATE INDEX IF NOT EXISTS idx_agent_policies_client_id
 
 ALTER TABLE agent_policies ENABLE ROW LEVEL SECURITY;
 
--- agent_policies rows are server-managed (auto-created on WS registration).
--- Only expose SELECT to authenticated users; all mutations go through custom tools.
+-- Legacy compatibility table. New server runtime paths use agents.allowed_callers.
+-- Keep this hidden from generated mutations while old databases migrate.
 COMMENT ON TABLE agent_policies IS E'@omit create,update,delete';
 COMMENT ON COLUMN agent_policies.allowed_callers IS E'@omit create,update';
 
@@ -547,14 +673,42 @@ CREATE POLICY agent_policies_postgraphile ON agent_policies
   USING (true)
   WITH CHECK (true);
 
+-- One-time compatibility backfill. Legacy rows allowed multiple agent ids per
+-- client token; the new model is 1:1 and the daemon config only stores one
+-- agent_id, so we migrate the first allowed id as the persisted agent id.
+INSERT INTO agents (
+  id,
+  client_id,
+  owner_principal,
+  owner_email,
+  name,
+  token_hash,
+  allowed_callers,
+  revoked,
+  created_at,
+  updated_at
+)
+SELECT
+  c.allowed_agent_ids[1],
+  c.id,
+  c.owner_principal,
+  c.owner_email,
+  c.client_name,
+  c.token_hash,
+  COALESCE(ap.allowed_callers, '{}'),
+  c.revoked,
+  c.created_at,
+  COALESCE(ap.updated_at, c.created_at)
+FROM clients c
+LEFT JOIN agent_policies ap ON ap.agent_id = c.allowed_agent_ids[1]
+WHERE array_length(c.allowed_agent_ids, 1) >= 1
+ON CONFLICT (id) DO NOTHING;
+
 -- ------------------------------------------------------------
 -- 5a. Agent id availability probe
 -- ------------------------------------------------------------
--- registerClient() accepts an allowed_agent_ids list but does not verify that
--- the ids are free — collisions surface only at first WS register
--- (packages/server/src/ws.ts ensureAgentPolicy → 'agent id owned by a
--- different principal'), by which point the CLIENT_TOKEN has already been
--- issued and rotation is needed. agent_policies_select RLS also hides rows
+-- registerClient() accepts the legacy allowed_agent_ids list but now requires
+-- exactly one id and writes it to agents.id. agents_select RLS hides rows
 -- owned by other principals, so a non-admin cannot distinguish 'free' from
 -- 'taken by someone else' with a direct query.
 --
@@ -569,7 +723,7 @@ CREATE OR REPLACE FUNCTION agent_id_available(agent_id TEXT)
   -- pg_catalog first, public second, and pg_temp is intentionally absent:
   -- with pg_temp in the path any role that can CREATE TEMP could shadow an
   -- unqualified reference and hijack a definer-privileged resolution. The
-  -- function schema-qualifies agent_policies for the same reason.
+  -- function schema-qualifies agents for the same reason.
   SET search_path = pg_catalog, public
 AS $$
 BEGIN
@@ -582,8 +736,8 @@ BEGIN
       USING ERRCODE = 'invalid_parameter_value';
   END IF;
   RETURN NOT EXISTS(
-    SELECT 1 FROM public.agent_policies ap
-    WHERE ap.agent_id = agent_id_available.agent_id
+    SELECT 1 FROM public.agents a
+    WHERE a.id = agent_id_available.agent_id
   );
 END;
 $$;
@@ -591,12 +745,12 @@ $$;
 -- Schema setup runs as a superuser, so without an explicit ALTER OWNER the
 -- definer context would be superuser — overkill for reading one table and a
 -- latent escalation surface for future edits. app_postgraphile already has
--- the RLS-bypass policy on agent_policies, which is exactly (and only) what
--- this function needs to cross-principal SELECT.
+-- the RLS-bypass policy on agents, which is exactly (and only) what this
+-- function needs to cross-principal SELECT.
 ALTER FUNCTION agent_id_available(TEXT) OWNER TO app_postgraphile;
 
 COMMENT ON FUNCTION agent_id_available(TEXT) IS
-  'Check whether an agent_id is free to claim. Returns true when no agent_policies row holds the id, false when any principal (including the caller) already owns it. Never exposes owner_principal or other metadata — boolean only. Intended as a pre-registration probe so callers can avoid issuing a CLIENT_TOKEN bound to an agent id that the WS register step would reject.';
+  'Check whether an agent_id is free to claim. Returns true when no agents row holds the id, false when any principal (including the caller) already owns it. Never exposes owner_principal or other metadata — boolean only.';
 
 -- ============================================================
 -- 6. Session tokens: opaque tokens issued via SIWE / device flow

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -51,20 +51,21 @@ async function setupOwner(
   ownerPrincipal: string,
 ): Promise<SetupResult> {
   const agentId = `admin-api-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const clients = await sql<{ id: string }[]>`
-    INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
+  const agents = await sql<{ client_id: string }[]>`
+    INSERT INTO agents (id, owner_principal, name, token_hash)
     VALUES (
+      ${agentId},
       ${ownerPrincipal},
       'admin-api-test',
-      ${`fake-hash-${agentId}`},
-      ARRAY[${agentId}]
+      ${`fake-hash-${agentId}`}
     )
-    RETURNING id
+    RETURNING client_id
   `;
-  const clientId = clients[0]!.id;
+  const clientId = agents[0]!.client_id;
   await sql`
-    INSERT INTO agent_policies (agent_id, owner_principal, client_id)
-    VALUES (${agentId}, ${ownerPrincipal}, ${clientId})
+    INSERT INTO clients (id, owner_principal, client_name, token_hash, allowed_agent_ids)
+    VALUES (${clientId}, ${ownerPrincipal}, 'admin-api-test', ${`fake-client-hash-${agentId}`}, ARRAY[${agentId}])
+    ON CONFLICT (id) DO NOTHING
   `;
   const issued = await issueSessionToken(sql, {
     principalId: ownerPrincipal,
@@ -75,7 +76,7 @@ async function setupOwner(
 }
 
 async function teardown(sql: postgres.Sql, principalId: string, clientId: string): Promise<void> {
-  // agent_policies cascades on clients.id, callers wiped by principal_id.
+  await sql`DELETE FROM agents WHERE client_id = ${clientId}`;
   await sql`DELETE FROM clients WHERE id = ${clientId}`;
   await sql`DELETE FROM callers WHERE principal_id = ${principalId}`;
 }
@@ -245,7 +246,7 @@ test(
 );
 
 test(
-  'POST /admin-api/agents/:id/callers pre-creates policy for a registered client agent id',
+  'POST /admin-api/agents/:id/callers updates a registered agent without a live connection',
   { skip: !hasDb },
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
@@ -253,7 +254,6 @@ test(
     let setup: SetupResult | null = null;
     try {
       setup = await setupOwner(sql, owner);
-      await sql`DELETE FROM agent_policies WHERE agent_id = ${setup.agentId}`;
 
       const registry = new Registry();
       const app = createHttpApp({ db: sql, registry });
@@ -271,8 +271,8 @@ test(
 
       const rows = await sql<{ owner_principal: string; client_id: string; allowed_callers: string[] }[]>`
         SELECT owner_principal, client_id, allowed_callers
-        FROM agent_policies
-        WHERE agent_id = ${setup.agentId}
+        FROM agents
+        WHERE id = ${setup.agentId}
       `;
       assert.equal(rows.length, 1);
       assert.equal(rows[0]!.owner_principal, owner);
@@ -479,7 +479,7 @@ test(
     try {
       setup = await setupOwner(sql, owner);
       // Rename the just-created row so we can target it by name.
-      await sql`UPDATE clients SET client_name = ${uniqueName} WHERE id = ${setup.clientId}`;
+      await sql`UPDATE agents SET name = ${uniqueName} WHERE client_id = ${setup.clientId}`;
 
       const registry = new Registry();
       const app = createHttpApp({ db: sql, registry });
@@ -511,7 +511,7 @@ test(
       setupA = await setupOwner(sql, owner);
       setupB = await setupOwner(sql, owner);
       // Both rows are owned by the same principal and share the same name.
-      await sql`UPDATE clients SET client_name = ${dupName} WHERE id IN (${setupA.clientId}, ${setupB.clientId})`;
+      await sql`UPDATE agents SET name = ${dupName} WHERE client_id IN (${setupA.clientId}, ${setupB.clientId})`;
 
       const registry = new Registry();
       const app = createHttpApp({ db: sql, registry });

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -83,12 +83,12 @@ export async function addCaller(
     const result = await db.begin(async (tx) => {
       await setRlsContext(tx, principalId);
       return tx`
-        UPDATE agent_policies
+        UPDATE agents
         SET allowed_callers = array_append(allowed_callers, ${normalized}),
             updated_at = now()
-        WHERE agent_id = ${agentId}
+        WHERE id = ${agentId}
           AND NOT (${normalized} = ANY(allowed_callers))
-        RETURNING agent_id, owner_principal, allowed_callers
+        RETURNING id AS agent_id, owner_principal, allowed_callers
       `;
     });
     if (result.length > 0) {
@@ -99,7 +99,7 @@ export async function addCaller(
 
     const existing = await db.begin(async (tx) => {
       await setRlsContext(tx, principalId);
-      return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}`;
+      return tx`SELECT allowed_callers FROM agents WHERE id = ${agentId}`;
     });
     if (existing.length === 0) return null;
 
@@ -117,45 +117,13 @@ export async function addCaller(
         message: 'Principal already in allowed callers',
       };
     }
-    throw new AdminApiError('Not authorized to modify this agent policy.', 403);
+    throw new AdminApiError('Not authorized to modify this agent.', 403);
   };
 
   const updated = await updateExisting();
   if (updated) return updated;
 
-  const created = await db.begin(async (tx) => {
-    await setRlsContext(tx, principalId);
-    return tx`
-      WITH owning_client AS (
-        SELECT id, owner_principal
-        FROM clients
-        WHERE ${agentId} = ANY(allowed_agent_ids)
-          AND revoked = false
-        ORDER BY created_at DESC
-        LIMIT 1
-      )
-      INSERT INTO agent_policies (agent_id, owner_principal, client_id, allowed_callers)
-      SELECT ${agentId}, owner_principal, id, ARRAY[${normalized}]::text[]
-      FROM owning_client
-      ON CONFLICT (agent_id) DO UPDATE
-        SET allowed_callers = array_append(agent_policies.allowed_callers, ${normalized}),
-            updated_at = now()
-        WHERE NOT (${normalized} = ANY(agent_policies.allowed_callers))
-      RETURNING agent_id, owner_principal, allowed_callers
-    `;
-  });
-  if (created.length > 0) {
-    const callers = created[0].allowed_callers as string[];
-    registry.updateAllowedCallers(agentId, callers);
-    return { agent_id: agentId, principal: normalized, allowed_callers: callers };
-  }
-
-  // Another process may have created the policy with this caller already in
-  // place, or RLS may have blocked the conflict update. Retry the normal
-  // update/idempotency path once so races converge before reporting 404.
-  const retried = await updateExisting();
-  if (retried) return retried;
-  throw new AdminApiError('Agent policy not found or not authorized.', 404);
+  throw new AdminApiError('Agent not found or not authorized.', 404);
 }
 
 export async function removeCaller(
@@ -173,22 +141,22 @@ export async function removeCaller(
   const result = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
     return tx`
-      UPDATE agent_policies
+      UPDATE agents
       SET allowed_callers = array_remove(allowed_callers, ${normalized}),
           updated_at = now()
-      WHERE agent_id = ${agentId}
+      WHERE id = ${agentId}
         AND ${normalized} = ANY(allowed_callers)
-      RETURNING agent_id, owner_principal, allowed_callers
+      RETURNING id AS agent_id, owner_principal, allowed_callers
     `;
   });
 
   if (result.length === 0) {
     const existing = await db.begin(async (tx) => {
       await setRlsContext(tx, principalId);
-      return tx`SELECT allowed_callers FROM agent_policies WHERE agent_id = ${agentId}`;
+      return tx`SELECT allowed_callers FROM agents WHERE id = ${agentId}`;
     });
     if (existing.length === 0) {
-      throw new AdminApiError('Agent policy not found or not authorized.', 404);
+      throw new AdminApiError('Agent not found or not authorized.', 404);
     }
     const callers = existing[0].allowed_callers as string[];
     // Same convergence as addCaller's no-op path: hot-reload the registry
@@ -215,12 +183,12 @@ export async function listCallers(
   const result = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
     return tx`
-      SELECT agent_id, owner_principal, allowed_callers, created_at, updated_at
-      FROM agent_policies WHERE agent_id = ${agentId}
+      SELECT id AS agent_id, owner_principal, allowed_callers, created_at, updated_at
+      FROM agents WHERE id = ${agentId}
     `;
   });
   if (result.length === 0) {
-    throw new AdminApiError('Agent policy not found.', 404);
+    throw new AdminApiError('Agent not found.', 404);
   }
   const policy = result[0];
   const callers = policy.allowed_callers as string[];
@@ -252,6 +220,7 @@ export function listActiveAgents(
 
 export interface ClientListItem {
   client_id: string;
+  agent_id: string;
   client_name: string;
   owner_principal: string;
   allowed_agent_ids: string[];
@@ -274,8 +243,8 @@ export async function listClientsForOwner(
   const rows = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
     return tx`
-      SELECT id, owner_principal, client_name, allowed_agent_ids, revoked, created_at
-      FROM clients
+      SELECT client_id, id, owner_principal, name, revoked, created_at
+      FROM agents
       ORDER BY created_at DESC
     `;
   });
@@ -289,16 +258,17 @@ export async function listClientsForOwner(
   }
 
   return rows.map((r) => ({
-    client_id: r.id as string,
-    client_name: r.client_name as string,
+    client_id: r.client_id as string,
+    agent_id: r.id as string,
+    client_name: r.name as string,
     owner_principal: r.owner_principal as string,
-    allowed_agent_ids: (r.allowed_agent_ids as string[]) ?? [],
+    allowed_agent_ids: [r.id as string],
     revoked: r.revoked as boolean,
     created_at:
       r.created_at instanceof Date
         ? r.created_at.toISOString()
         : (r.created_at as string),
-    connected: connectedClientIds.has(r.id as string),
+    connected: connectedClientIds.has(r.client_id as string),
   }));
 }
 
@@ -326,7 +296,7 @@ async function resolveClient(
   // so any string can in principle be an id.
   const byId = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
-    return tx`SELECT id, client_name FROM clients WHERE id = ${target}`;
+    return tx`SELECT client_id AS id, name AS client_name FROM agents WHERE client_id = ${target} OR id = ${target}`;
   });
   if (byId.length === 1) {
     return { id: byId[0].id as string, client_name: byId[0].client_name as string };
@@ -334,7 +304,7 @@ async function resolveClient(
 
   const byName = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
-    return tx`SELECT id, client_name FROM clients WHERE client_name = ${target}`;
+    return tx`SELECT client_id AS id, name AS client_name FROM agents WHERE name = ${target}`;
   });
   if (byName.length === 0) {
     throw new AdminApiError(`No client found matching "${target}".`, 404);
@@ -365,7 +335,16 @@ export async function revokeClientForOwner(
     // inside will succeed (or NOT FOUND if a concurrent delete happened, in
     // which case the function raises — we let that propagate as 500 because
     // it's a genuinely unexpected race, not a user-facing error condition).
-    await tx`SELECT revoke_client(${resolved.id})`;
+    await tx`
+      UPDATE agents
+      SET revoked = TRUE, updated_at = now()
+      WHERE client_id = ${resolved.id}
+    `;
+    await tx`
+      UPDATE clients
+      SET revoked = TRUE
+      WHERE id = ${resolved.id}
+    `;
   });
 
   // Close every live WebSocket session bound to this client. The daemon

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -109,10 +109,10 @@ function describePrincipal(principalId: string, email?: string): string {
 function buildSystemPrompt(principalId: string, email: string | undefined, sdl?: string): string {
   const admin = isAdmin(principalId);
   const scope = admin
-    ? 'You are logged in as an **admin**. You can see and manage ALL clients across all owners.'
-    : `You are logged in as ${describePrincipal(principalId, email)}. You can only see and manage clients you own (RLS enforced).`;
+    ? 'You are logged in as an **admin**. You can see and manage ALL agents across all owners.'
+    : `You are logged in as ${describePrincipal(principalId, email)}. You can only see and manage agents you own (RLS enforced).`;
 
-  let prompt = `You are the Server Admin Agent for vicoop-bridge. You manage client registrations and access control.
+  let prompt = `You are the Server Admin Agent for vicoop-bridge. You manage agent registrations and access control.
 
 ## Current User
 
@@ -120,23 +120,24 @@ ${scope}
 
 ## What you manage
 
-Clients are services that connect to the server via WebSocket to register A2A agents. Each client has:
-- **id**: Unique identifier (UUID)
+Agents are local services that connect to the server via WebSocket and expose an A2A endpoint. Each agent has:
+- **id**: Agent ID and external routing key
+- **client_id**: Compatibility registration identifier for legacy client APIs
 - **owner_principal**: Principal of the owner (e.g. \`eth:0x<40 hex>\` or \`google:sub:<sub>\`)
-- **client_name**: Human-readable name
-- **allowed_agent_ids**: List of agent IDs this client is authorized to register
-- **revoked**: Whether this client has been revoked
+- **name**: Human-readable label
+- **allowed_callers**: Principals allowed to call this agent; empty means public
+- **revoked**: Whether this agent registration has been revoked
 - **created_at**: When it was created
 - **token_hash**: Not exposed via GraphQL — use \`mutate_registerClient\` or \`mutate_rotateClientToken\` to obtain tokens
 
 ## Tool Usage
 
-- Use \`query_*\` tools to read clients and agent policies. RLS enforces ownership (admins see all).
+- Use \`query_*\` tools to read agents and compatibility client rows. RLS enforces ownership (admins see all).
 - Client lifecycle mutations are exposed as custom GraphQL functions:
-  - \`mutate_registerClient(clientName, allowedAgentIds, ownerPrincipal?)\` — creates a new client and returns the raw bearer token (shown only once). Admins may pass \`ownerPrincipal\` to create on behalf of another principal; non-admins always own the resulting client.
+  - \`mutate_registerClient(clientName, allowedAgentIds, ownerPrincipal?)\` — compatibility wrapper that creates one agent registration and returns the raw bearer token (shown only once). \`allowedAgentIds\` must contain exactly one id. Admins may pass \`ownerPrincipal\` to create on behalf of another principal; non-admins always own the resulting agent.
   - \`mutate_revokeClient(clientId)\` / \`mutate_unrevokeClient(clientId)\` — toggle the \`revoked\` flag. Existing WebSocket sessions stay connected until they reconnect.
   - \`mutate_rotateClientToken(clientId)\` — issues a new bearer token and invalidates the previous one. Returns the raw token once.
-  - \`mutate_updateClientAllowedAgents(clientId, allowedAgentIds)\` — replaces the agent allowlist.
+  - \`mutate_updateClientAllowedAgents(clientId, allowedAgentIds)\` — compatibility wrapper for changing the single agent id; \`allowedAgentIds\` must contain exactly one id.
 - Do NOT use the auto-generated \`mutate_updateClientById\` or \`mutate_deleteClientById\` for revoke/token rotation — always prefer the semantic mutations above.
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
@@ -145,7 +146,7 @@ Clients are services that connect to the server via WebSocket to register A2A ag
 
 ## Agent Access Control
 
-Each agent has an access policy (\`agent_policies\` table) with an \`allowed_callers\` list:
+Each agent row has an \`allowed_callers\` list:
 - **Empty \`allowed_callers\`**: Agent is public — anyone can call it via A2A.
 - **Non-empty \`allowed_callers\`**: Agent requires an authenticated Bearer token, and only listed principals can call.
 
@@ -155,7 +156,7 @@ Supported principal formats in \`allowed_callers\` (and as \`owner_principal\`):
 - \`google:email:<email>\` — Google account by email (pinned to sub on first match)
 - \`google:domain:<domain>\` — any verified Google Workspace account from the domain (allowed_callers only)
 
-When an agent registers via WebSocket, a default policy (public) is auto-created. Use \`add_caller\` to restrict access. The agent card automatically advertises \`securitySchemes\` when callers are configured.
+New agents are public until callers are configured. Use \`add_caller\` to restrict access. The agent card automatically advertises \`securitySchemes\` when callers are configured.
 
 ## Conversation memory
 
@@ -167,7 +168,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 - When registering on behalf of another principal (admin only), echo back the chosen \`ownerPrincipal\` so the user can confirm.
 - When adding a caller, explain that the agent will require an authenticated bearer token from that point on (either SIWE-exchanged or Google-device-flow-issued, depending on the principal format).
 - Present data clearly in tables or lists.
-- If asked about something outside client management, politely explain your scope.
+- If asked about something outside agent management, politely explain your scope.
 
 ## PostGraphile Conventions
 

--- a/packages/server/src/agent-id-available.test.ts
+++ b/packages/server/src/agent-id-available.test.ts
@@ -26,29 +26,22 @@ test(
 );
 
 test(
-  'returns false once an agent_policies row holds the id',
+  'returns false once an agents row holds the id',
   { skip: !hasDb },
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
     try {
       const agentId = `availability-taken-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const owner = 'eth:0x1111111111111111111111111111111111111111';
-      const clients = await sql<{ id: string }[]>`
-        INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
-        VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
-        RETURNING id
-      `;
-      const clientId = clients[0]!.id;
       try {
         await sql`
-          INSERT INTO agent_policies (agent_id, owner_principal, client_id)
-          VALUES (${agentId}, ${owner}, ${clientId})
+          INSERT INTO agents (id, owner_principal, name, token_hash)
+          VALUES (${agentId}, ${owner}, 'availability-test', ${`fake-hash-${agentId}`})
         `;
 
         assert.equal(await callAvailable(sql, agentId), false);
       } finally {
-        // agent_policies row cascades via ON DELETE CASCADE.
-        await sql`DELETE FROM clients WHERE id = ${clientId}`;
+        await sql`DELETE FROM agents WHERE id = ${agentId}`;
       }
 
       // Once cleaned up, the id is free again.
@@ -63,7 +56,7 @@ test(
   'authenticated caller from a different principal still sees available=false (RLS bypass)',
   { skip: !hasDb },
   async () => {
-    // Guards the SECURITY DEFINER posture: agent_policies_select restricts
+    // Guards the SECURITY DEFINER posture: agents_select restricts
     // SELECT to the owning principal, so without RLS bypass a different
     // principal's direct query would return no rows and the function would
     // wrongly report the id as available. Exercising app_authenticated with a
@@ -74,16 +67,10 @@ test(
       const owner = 'eth:0x2222222222222222222222222222222222222222';
       const other = 'eth:0x3333333333333333333333333333333333333333';
 
-      const clients = await sql<{ id: string }[]>`
-        INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
-        VALUES (${owner}, 'availability-test', ${`fake-hash-${agentId}`}, ARRAY[${agentId}])
-        RETURNING id
-      `;
-      const clientId = clients[0]!.id;
       try {
         await sql`
-          INSERT INTO agent_policies (agent_id, owner_principal, client_id)
-          VALUES (${agentId}, ${owner}, ${clientId})
+          INSERT INTO agents (id, owner_principal, name, token_hash)
+          VALUES (${agentId}, ${owner}, 'availability-test', ${`fake-hash-${agentId}`})
         `;
 
         const available = await sql.begin(async (tx) => {
@@ -96,7 +83,7 @@ test(
         });
         assert.equal(available, false);
       } finally {
-        await sql`DELETE FROM clients WHERE id = ${clientId}`;
+        await sql`DELETE FROM agents WHERE id = ${agentId}`;
       }
     } finally {
       await sql.end();

--- a/packages/server/src/auth/device-flow.ts
+++ b/packages/server/src/auth/device-flow.ts
@@ -351,8 +351,9 @@ export function mountDeviceFlow(app: Hono, opts: DeviceFlowOptions): void {
           if (!r) throw new Error('register_client returned no row');
 
           // Stamp owner_email so admin tooling can render a human-readable
-          // identity for Google-onboarded clients (sub is opaque).
+          // identity for Google-onboarded agents/clients (sub is opaque).
           if (email) {
+            await tx`UPDATE agents SET owner_email = ${email}, updated_at = now() WHERE client_id = ${r.id}`;
             await tx`UPDATE clients SET owner_email = ${email} WHERE id = ${r.id}`;
           }
 

--- a/packages/server/src/auth/principal.ts
+++ b/packages/server/src/auth/principal.ts
@@ -1,4 +1,4 @@
-// Principal string parsing and matching for agent_policies.allowed_callers.
+// Principal string parsing and matching for agents.allowed_callers.
 //
 // Format:
 //   eth:0x<40 hex>              SIWE-authenticated Ethereum address

--- a/packages/server/src/reserved-agent-ids.ts
+++ b/packages/server/src/reserved-agent-ids.ts
@@ -1,6 +1,6 @@
-// Agent ids the bridge reserves for itself. A client cannot register one,
-// list one in `clients.allowed_agent_ids`, nor send a hello frame with one
-// — all three intake points enforce this set.
+// Agent ids the bridge reserves for itself. A registration cannot claim one,
+// and a daemon cannot send a hello frame with one — both intake points enforce
+// this set.
 //
 // `admin` is reserved because the bridge surfaces its built-in admin agent
 // at `@admin@<host>` via Mentionable WebFinger; letting a client register

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -18,56 +18,18 @@ import { resolveHelloAgentCard } from './card-resolver.js';
 
 interface ClientRow {
   id: string;
-  owner_principal: string;
-  allowed_agent_ids: string[];
-}
-
-async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
-  const rows = await sql<ClientRow[]>`
-    SELECT id, owner_principal, allowed_agent_ids FROM clients WHERE token_hash = ${hash} AND revoked = false
-  `;
-  return rows[0] ?? null;
-}
-
-interface PolicyRow {
+  client_id: string;
   owner_principal: string;
   allowed_callers: string[];
 }
 
-async function ensureAgentPolicy(
-  sql: Sql,
-  agentId: string,
-  ownerPrincipal: string,
-  clientId: string,
-): Promise<{ ok: true; allowedCallers: string[] } | { ok: false; reason: string }> {
-  // Refresh client_id on re-registration so cascade follows the currently
-  // registering client. Principals are stored in canonical form (lowercased
-  // for eth/email/domain at issuance time; google:sub: is numeric so case is
-  // moot), so direct equality is sufficient. The IS DISTINCT FROM guard skips
-  // the write when nothing actually changed to avoid WAL churn on frequent
-  // reconnects.
-  await sql`
-    INSERT INTO agent_policies (agent_id, owner_principal, client_id)
-    VALUES (${agentId}, ${ownerPrincipal}, ${clientId})
-    ON CONFLICT (agent_id) DO UPDATE
-      SET owner_principal = EXCLUDED.owner_principal,
-          client_id = EXCLUDED.client_id,
-          updated_at = now()
-      WHERE agent_policies.owner_principal = EXCLUDED.owner_principal
-        AND (
-          agent_policies.client_id IS DISTINCT FROM EXCLUDED.client_id
-        )
+async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
+  const rows = await sql<ClientRow[]>`
+    SELECT id, client_id, owner_principal, allowed_callers
+    FROM agents
+    WHERE token_hash = ${hash} AND revoked = false
   `;
-  const rows = await sql<PolicyRow[]>`
-    SELECT owner_principal, allowed_callers FROM agent_policies WHERE agent_id = ${agentId}
-  `;
-  if (rows.length === 0) {
-    return { ok: false, reason: 'failed to create agent policy' };
-  }
-  if (rows[0].owner_principal !== ownerPrincipal) {
-    return { ok: false, reason: 'agent id owned by a different principal' };
-  }
-  return { ok: true, allowedCallers: rows[0].allowed_callers };
+  return rows[0] ?? null;
 }
 
 export interface ServerWsOptions {
@@ -116,16 +78,16 @@ async function authenticateAndRegister(
     logEvent('client_rejected', { reason: 'bad token', agentId: frame.agentId });
     return { ok: false, code: 4005, reason: 'bad token' };
   }
-  if (!client.allowed_agent_ids.includes(frame.agentId)) {
+  if (client.id !== frame.agentId) {
     logEvent('client_rejected', {
       reason: 'agent not allowed',
       agentId: frame.agentId,
-      clientId: client.id,
-      allowed: client.allowed_agent_ids,
+      clientId: client.client_id,
+      allowed: [client.id],
     });
     return { ok: false, code: 4008, reason: 'agent id not authorized for this client' };
   }
-  const clientId = client.id;
+  const clientId = client.client_id;
   const ownerPrincipal = client.owner_principal;
 
   const resolvedCard = resolveHelloAgentCard(frame);
@@ -141,22 +103,12 @@ async function authenticateAndRegister(
     return { ok: false, code: resolvedCard.code, reason: resolvedCard.reason };
   }
 
-  const policyResult = await ensureAgentPolicy(opts.db, frame.agentId, ownerPrincipal, clientId);
-  if (!policyResult.ok) {
-    logEvent('client_rejected', {
-      reason: policyResult.reason,
-      agentId: frame.agentId,
-      clientId,
-    });
-    return { ok: false, code: 4010, reason: policyResult.reason };
-  }
-
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
     ownerPrincipal,
     agentCard: resolvedCard.agentCard,
-    allowedCallers: policyResult.allowedCallers,
+    allowedCallers: client.allowed_callers,
     ws,
     connectedAt: Date.now(),
   });


### PR DESCRIPTION
## Summary

Implements the server-side portion of #219 by introducing `agents` as the unified persistence model for one operator-facing agent registration.

The legacy `clients` and `agent_policies` tables remain for compatibility, but server runtime paths now prefer `agents`:

- `agents.id` is the agent id / routing key
- `agents.client_id` preserves the legacy registration id used by existing client APIs
- `agents.allowed_callers` replaces runtime dependence on `agent_policies`
- `register_client(...)` remains as the compatibility GraphQL function, but now requires exactly one `allowed_agent_id`
- `/admin-api/clients` and `DELETE /admin-api/clients/:target` remain compatible while reading/writing through `agents`
- WS authentication now validates the token against `agents` and requires `hello.agentId === agents.id`

## Validation

- `pnpm --filter @vicoop-bridge/server typecheck`
- Restored a dump from `vicoop-bridge-server-db` into local Postgres 17 and applied the new `schema.sql`
- Re-applied `schema.sql` on the restored DB to check idempotency
- `DATABASE_URL="postgres://postgres:postgres@localhost:55433/vicoop_bridge_server" pnpm --filter @vicoop-bridge/server exec tsx --test --test-reporter=spec src/admin-api.test.ts src/agent-id-available.test.ts`
  - 19 passed, 0 failed
- Started the current server code against the restored/migrated Fly dump and verified the existing CLI surface still works:
  - `list-clients`
  - `list-agents`
  - `list-callers`
  - `add-caller`
  - `remove-caller`
  - daemon connection using existing `server_token + agent_id`

## Data note

The restored Fly data had 58 legacy `clients` rows and one row with multiple `allowed_agent_ids`: `{openclaw-Mac, claude-swen-2026042801}`. The migration follows the documented compatibility rule and backfills only the first id, producing `agents.id = openclaw-Mac` for that row.

Closes #219.
