### PR TITLE
feat(client): unify CLI surface under `agent` + `auth` (#218, #224)

### DIFF
--- a/.changeset/agent-subcommand.md
+++ b/.changeset/agent-subcommand.md
@@ -2,9 +2,9 @@
 '@vicoop-bridge/client': minor
 ---
 
-Add `vicoop-client agent` command group as the operator-facing primary
-surface for agent state (#218, #224, follow-up to server-side unification
-in #219).
+Add `vicoop-client agent` and `vicoop-client auth` command groups as the
+operator-facing primary surfaces (#218, #224, follow-up to server-side
+unification in #219).
 
 New commands:
 
@@ -27,14 +27,21 @@ New commands:
   `revoke-client`).
 - `vicoop-client agent callers {list,add,remove}` — manage an agent's
   allowed-callers list.
+- `vicoop-client auth login` — owner-session sign-in (Google OAuth device
+  flow); identical behavior to the legacy `login`.
+- `vicoop-client auth logout` — revoke the owner-session bearer
+  server-side (RFC 7009) and delete the local copy. `--local-only` and
+  `--keep-local` still split the two effects.
+- `vicoop-client auth whoami` — print the agent's A2A identity (mention /
+  acct / WebFinger URL); also supports `--verify`.
 
-The older flat aliases (`setup`, `list-agents`, `list-clients`,
-`revoke-client`, `add-caller`, `remove-caller`, `list-callers`) keep
-working but now print a one-line deprecation warning to stderr pointing
-at their `agent <sub>` replacement. The legacy commands also keep their
-client-first vocabulary on stderr (`client_id`, `client_name`,
-`CLIENT_TOKEN`) so scripts that parse stderr are unaffected. They will
-be removed in a future release.
+The older flat aliases (`setup`, `login`, `logout`, `whoami`,
+`list-agents`, `list-clients`, `revoke-client`, `add-caller`,
+`remove-caller`, `list-callers`) keep working but now print a one-line
+deprecation warning to stderr pointing at their `agent <sub>` /
+`auth <sub>` replacement. `setup` additionally retains its client-first
+stderr vocabulary (`client_id`, `client_name`, `CLIENT_TOKEN`) so scripts
+that parse it are unaffected. All will be removed in a future release.
 
 The wire contracts and `--json` payload shape are unchanged: `agent
 register` calls the same `registerClient` GraphQL mutation as `setup`

--- a/.changeset/agent-subcommand.md
+++ b/.changeset/agent-subcommand.md
@@ -3,11 +3,17 @@
 ---
 
 Add `vicoop-client agent` command group as the operator-facing primary
-surface for agent state (#218, follow-up to server-side unification in
-#219).
+surface for agent state (#218, #224, follow-up to server-side unification
+in #219).
 
 New commands:
 
+- `vicoop-client agent register --name NAME --agent-id ID [--caller PRINCIPAL ...]`
+  — register an agent and persist daemon credentials. Replaces the older
+  `setup --client-name N --agent-ids ID1` shape with singular agent-first
+  flags. The stderr success block surfaces `agent_id`, `name`, and
+  `AGENT_TOKEN` (the operator-supplied id, not the server's registration
+  UUID).
 - `vicoop-client agent list [--connected]` — list agent registrations
   under this owner. Renders a whitespace-padded table with columns
   `AGENT_ID`, `NAME`, `CONNECTED`, `REVOKED`, `REGISTERED_AT`. The legacy
@@ -22,13 +28,19 @@ New commands:
 - `vicoop-client agent callers {list,add,remove}` — manage an agent's
   allowed-callers list.
 
-The older flat aliases (`list-agents`, `list-clients`, `revoke-client`,
-`add-caller`, `remove-caller`, `list-callers`) keep working but now
-print a one-line deprecation warning to stderr pointing at their
-`agent <sub>` replacement. They will be removed in a future release.
+The older flat aliases (`setup`, `list-agents`, `list-clients`,
+`revoke-client`, `add-caller`, `remove-caller`, `list-callers`) keep
+working but now print a one-line deprecation warning to stderr pointing
+at their `agent <sub>` replacement. The legacy commands also keep their
+client-first vocabulary on stderr (`client_id`, `client_name`,
+`CLIENT_TOKEN`) so scripts that parse stderr are unaffected. They will
+be removed in a future release.
 
-The wire contracts are unchanged: `agent list` calls the same
-`/admin-api/clients` endpoint (now backed by the unified `agents`
-table from #219, which already returns `agent_id`), and
-`agent revoke` calls the same `DELETE /admin-api/clients/<target>`.
-No server-side changes ship in this changeset.
+The wire contracts and `--json` payload shape are unchanged: `agent
+register` calls the same `registerClient` GraphQL mutation as `setup`
+and returns the same response fields (`client_id`, `client_token`,
+`client_name`, `allowed_agent_ids`); `agent list` calls the same
+`/admin-api/clients` endpoint (now backed by the unified `agents` table
+from #219, which already returns `agent_id`); `agent revoke` calls the
+same `DELETE /admin-api/clients/<target>`. No server-side changes ship
+in this changeset.

--- a/.changeset/agent-subcommand.md
+++ b/.changeset/agent-subcommand.md
@@ -1,0 +1,34 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add `vicoop-client agent` command group as the operator-facing primary
+surface for agent state (#218, follow-up to server-side unification in
+#219).
+
+New commands:
+
+- `vicoop-client agent list [--connected]` — list agent registrations
+  under this owner. Renders a whitespace-padded table with columns
+  `AGENT_ID`, `NAME`, `CONNECTED`, `REVOKED`, `REGISTERED_AT`. The legacy
+  `client_id` UUID is omitted from the human view (it remains in `--json`
+  for backward-compat scripts). `--connected` filters to agents whose
+  daemon is currently live; without it, every registration (including
+  disconnected/revoked ones) is shown.
+- `vicoop-client agent revoke AGENT_ID` — revoke an agent. The argument
+  resolves against the agent id, the legacy registration id, or a unique
+  registration name (same server-side resolver as the previous
+  `revoke-client`).
+- `vicoop-client agent callers {list,add,remove}` — manage an agent's
+  allowed-callers list.
+
+The older flat aliases (`list-agents`, `list-clients`, `revoke-client`,
+`add-caller`, `remove-caller`, `list-callers`) keep working but now
+print a one-line deprecation warning to stderr pointing at their
+`agent <sub>` replacement. They will be removed in a future release.
+
+The wire contracts are unchanged: `agent list` calls the same
+`/admin-api/clients` endpoint (now backed by the unified `agents`
+table from #219, which already returns `agent_id`), and
+`agent revoke` calls the same `DELETE /admin-api/clients/<target>`.
+No server-side changes ship in this changeset.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -577,8 +577,8 @@ identifier external callers will see for this agent — the WebFinger acct, the
 Typical follow-ups from this output:
 
 1. **Hand the mention to another agent.** Copy the `mention:` line and paste
-   it into the other agent's `allowed_callers` (via `add-caller` or the admin
-   agent) so it can call you. Same value goes into the **OpenClaw gateway
+   it into the other agent's `allowed_callers` (via `agent callers add` or
+   the admin agent) so it can call you. Same value goes into the **OpenClaw gateway
    persona** if you want self-reference recognition on the OpenClaw backend
    (configured via `openclaw config set ...` since `chat.send` has no
    per-message system field). `a2a` is the JSON-RPC endpoint another caller
@@ -680,10 +680,10 @@ published release:
   --client-name "$CLIENT_NAME" \
   --agent-ids "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
-"$INSTALL_DIR/vicoop-client" list-agents
-"$INSTALL_DIR/vicoop-client" list-callers "$AGENT_ID" --json
-"$INSTALL_DIR/vicoop-client" add-caller "$AGENT_ID" "eth:0x<40-hex>"
-"$INSTALL_DIR/vicoop-client" remove-caller "$AGENT_ID" "google:email:caller@example.com"
+"$INSTALL_DIR/vicoop-client" agent list --connected
+"$INSTALL_DIR/vicoop-client" agent callers list "$AGENT_ID" --json
+"$INSTALL_DIR/vicoop-client" agent callers add "$AGENT_ID" "eth:0x<40-hex>"
+"$INSTALL_DIR/vicoop-client" agent callers remove "$AGENT_ID" "google:email:caller@example.com"
 
 # Pass --json for machine-readable output, or --bridge / --token to override
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
@@ -810,36 +810,37 @@ section of `docs/local-testing.md` for the same note.
   agent id and caller allowlist carry over. Re-run Step 4 only if
   you intentionally want a new client identity; in that case the old
   `clients` row can be revoked from the CLI — see
-  [Inspecting and revoking your clients](#inspecting-and-revoking-your-clients).
+  [Inspecting and revoking your agents](#inspecting-and-revoking-your-agents).
 
-## Inspecting and revoking your clients
+## Inspecting and revoking your agents
 
-`vicoop-client list-agents` only shows *currently connected* agents. To see
-every `clients` row registered under your owner principal — including
+`vicoop-client agent list --connected` only shows *currently connected*
+agents. To see every agent registered under your owner principal — including
 orphans left behind by an aborted `setup`, an exited daemon, or a leaked
-`CLIENT_TOKEN` — use:
+`CLIENT_TOKEN` — drop the flag:
 
 ```bash
-vicoop-client list-clients
+vicoop-client agent list
 ```
 
-Columns are `client_id`, `client_name`, `allowed_agent_ids`, `revoked`,
-`connected`, `created_at` (newer servers may also include `agent_id` in
-JSON output). The `connected` flag reflects in-memory registry state, so a
+The table columns are `AGENT_ID`, `NAME`, `CONNECTED`, `REVOKED`, and
+`REGISTERED_AT`. The `connected` flag reflects in-memory registry state, so a
 row with `connected: false` is exactly the kind of orphan you want to clean
-up.
+up. (`--json` additionally returns the legacy `client_id` UUID for scripts
+that still reference it.)
 
-To revoke a client — and disconnect its live WebSocket if one is bound —
-use either the UUID `client_id` or a unique `client_name`:
+To revoke an agent — and disconnect its live WebSocket if one is bound —
+pass the agent id, the legacy registration id, or a unique registration
+name:
 
 ```bash
-vicoop-client revoke-client <client-id-or-name>
+vicoop-client agent revoke <agent-id-or-name>
 ```
 
-- A revoked client's compatibility row is kept (`revoked = true`) so audit
+- A revoked agent's compatibility row is kept (`revoked = true`) so audit
   history survives.
 - A unique name resolves automatically; an ambiguous name exits non-zero
-  with a list of matching `client_id`s so you can retry with the id.
+  with a list of matching ids so you can retry with the id.
 - If the daemon is alive at the moment of revocation, its WebSocket is
   closed with code **4014 "client revoked"** and the daemon exits
   non-zero without reconnecting.
@@ -851,11 +852,18 @@ vicoop-client revoke-client <client-id-or-name>
   indefinitely against a permanently-rejected token. The same 4005
   branch catches plain mis-typed / wrong tokens at first launch.
 - Propagation is **synchronous from the next auth attempt**: client-token
-  verification queries `clients` directly on every WS register with no
-  cache, so there is no equivalent of the 60s `callers` LRU window.
+  verification queries the unified `agents` table directly on every WS
+  register with no cache, so there is no equivalent of the 60s `callers`
+  LRU window.
 
-Both subcommands use the same owner-session bearer as `add-caller` /
-`remove-caller`; no SIWE re-sign required.
+Both subcommands use the same owner-session bearer as `agent callers add`
+/ `remove`; no SIWE re-sign required.
+
+> **Deprecated flat aliases.** The older `list-agents`, `list-clients`,
+> `revoke-client`, `add-caller`, `remove-caller`, and `list-callers`
+> commands still work but print a one-line deprecation warning to stderr
+> pointing at their `agent <sub>` replacement. They will be removed in a
+> future release.
 
 ## What's next
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -147,28 +147,30 @@ AGENT_ID="$(uuidgen | tr 'A-Z' 'a-z' | cut -c1-8)-openclaw"
 echo "$AGENT_ID"
 ```
 
-> **Self-hosting the bridge.** `login` / `setup` / the daemon all default
-> to the public bridge at `https://vicoop-bridge-server.fly.dev` (HTTPS for
-> `login` / `setup` / admin commands; `wss://…` for the daemon). If you
+> **Self-hosting the bridge.** `login` / `agent register` / the daemon all
+> default to the public bridge at `https://vicoop-bridge-server.fly.dev`
+> (HTTPS for `login` / `agent register` / admin commands; `wss://…` for the
+> daemon). If you
 > run your own bridge, pass `--bridge <https://your-bridge>` to `login` and
 > `--server <wss://your-bridge>` to the daemon (or persist `server_url`
 > in `config.json`). Every example below uses the public defaults; the
 > self-host overrides are the only place the URL has to change.
 
-`registerClient` (called for you by `vicoop-client setup` in Step 4) does
-not pre-validate availability; collisions surface only at WS connect time.
+`registerClient` (called for you by `vicoop-client agent register` in
+Step 4) does not pre-validate availability; collisions surface only at WS
+connect time.
 If you want to probe ahead, hit `agentIdAvailable(agentId)` GraphQL after
 login — it's a SECURITY DEFINER probe that returns boolean availability
 across every owner without leaking `owner_principal`. Most operators just
 pick a hostname/uuid prefix and skip the probe.
 
-## Step 4 — Login and set up your client
+## Step 4 — Login and register your agent
 
-`vicoop-client login` only signs you in as the client owner and saves an
+`vicoop-client login` only signs you in as the agent owner and saves an
 owner-session bearer to `~/.vicoop/owner-session.json`. It does **not** create
-a bridge client. `vicoop-client setup` then uses that saved owner-session to
-call `registerClient` and mint a one-time `CLIENT_TOKEN`. No wallet or SIWE
-required.
+an agent registration. `vicoop-client agent register` then uses that saved
+owner-session to call `registerClient` and mint a one-time `AGENT_TOKEN`. No
+wallet or SIWE required.
 
 ```sh
 HOSTNAME=$(hostname)
@@ -231,15 +233,15 @@ installs that already store `owner-session.json` there aren't orphaned
 when `$XDG_CONFIG_HOME` gets set later; fresh installs with `$XDG_CONFIG_HOME`
 set land under `$XDG_CONFIG_HOME/vicoop`.
 
-`setup` only writes the three credentials above; backend defaults are
-hand-edited into the same file. The common shape (every field optional —
+`agent register` only writes the three credentials above; backend defaults
+are hand-edited into the same file. The common shape (every field optional —
 omit what you don't need) is:
 
 ```json
 {
   "server_url": "wss://vicoop-bridge-server.fly.dev",
-  "server_token": "<written by setup>",
-  "agent_id": "<written by setup>",
+  "server_token": "<written by agent register>",
+  "agent_id": "<written by agent register>",
   "backend": "claude",
   "backends": {
     "claude": {
@@ -270,9 +272,9 @@ The schema also accepts a top-level `card` mirroring the `--card` flag
 Daemon precedence is **CLI flag > `--config <path>` > canonical
 `config.json` > built-in default**. Env vars are not consulted for
 runtime config (#189 §5) — secrets and overrides live in `config.json`
-(mode 600) or in flags. `setup` only ever touches `server_url`,
+(mode 600) or in flags. `agent register` only ever touches `server_url`,
 `server_token`, and `agent_id` — hand-edits to the other fields survive
-`setup` re-runs.
+re-runs.
 
 > **Top-level vs `backends.*` parity.** Every operator-tunable knob is
 > reachable as a CLI flag and as a `config.json` field — pick whichever
@@ -291,7 +293,7 @@ runtime config (#189 §5) — secrets and overrides live in `config.json`
 > that position adds no expressive power that `--config <path>` doesn't
 > already provide, but it adds invisible state (shell rc files, CI env
 > bleed, stale exports). Existing operators with env-only setups need to
-> either run `setup` (which persists `server_url` / `server_token` /
+> either run `agent register` (which persists `server_url` / `server_token` /
 > `agent_id` into `config.json`) or pass the equivalent CLI flags.
 >
 > Env vars the client still reads (different category — they pick *where*
@@ -300,19 +302,19 @@ runtime config (#189 §5) — secrets and overrides live in `config.json`
 > (admin-command owner-session bootstrap, same role as `KUBECONFIG`),
 > `VICOOP_CLIENT_LOG_LEVEL` (logging diagnostic).
 
-If you omit `--caller`, `setup` succeeds but prints a warning that the
-agent will be public until you restrict callers:
+If you omit `--caller`, `agent register` succeeds but prints a warning that
+the agent will be public until you restrict callers:
 
-> `setup --caller` requires a bridge server version that stores caller
-> allowlists on registered agents. If you are testing against your own
-> deployment, deploy the matching server/schema before this step.
+> `--caller` requires a bridge server version that stores caller allowlists
+> on registered agents. If you are testing against your own deployment,
+> deploy the matching server/schema before this step.
 
-> ⚠ The `CLIENT_TOKEN` is unrecoverable after this single output.
+> ⚠ The `AGENT_TOKEN` is unrecoverable after this single output.
 > `config.json` is the only place it persists; back it up if you need to
 > rotate hosts. To rotate the token later, use the `rotateClientToken`
 > GraphQL mutation (requires a `vbc_owner_*` session token; the default
 > login flow saves one locally for you). Rotation surfaces a new
-> CLIENT_TOKEN, also one-time.
+> AGENT_TOKEN, also one-time.
 
 For scripting, pass `--json` instead of writing `config.json` if you want to
 compose with shell tooling (no disk side effects, raw response on stdout):
@@ -456,8 +458,9 @@ you can copy the mention / acct / agent-card URL from here directly:
 
 After that:
 
-- The bridge loads the `allowed_callers` list for your agent. If Step 4 setup
-  included `--caller`, that allowlist is already in place; otherwise
+- The bridge loads the `allowed_callers` list for your agent. If Step 4 (the
+  `agent register` call) included `--caller`, that allowlist is already in
+  place; otherwise
   `allowed_callers` is empty, meaning **publicly callable** until you restrict it.
 - `POST $BRIDGE_URL/agents/$AGENT_ID` with a JSON-RPC `message/send` payload
   reaches your backend and the reply is returned inline.
@@ -662,9 +665,9 @@ setting applies to fresh and resumed Codex sessions.
 
 ## Manage caller allowlists
 
-If Step 4 setup did not include `--caller`, the policy has empty
+If Step 4 `agent register` did not include `--caller`, the policy has empty
 `allowed_callers`, which the dispatcher treats as "public". For normal use,
-pass `--caller` during initial setup, or add an allowlist entry afterward
+pass `--caller` during initial registration, or add an allowlist entry afterward
 with the `vicoop-client` subcommands (deterministic, scriptable) or a
 natural-language request to the admin agent. These paths require an
 **owner-session token** (`vbc_owner_*`). Step 4 login saves one locally;
@@ -699,11 +702,11 @@ published release:
 # work too (handy for CI).
 ```
 
-The `server_token` Step 4 setup writes into the canonical `config.json`
-is a **client** credential and is **not** accepted by these admin commands —
-they only accept an owner-session bearer (the separate `owner-session.json`
-that `login` writes alongside it). If the saved bearer is missing or expired,
-refresh it without registering a new client:
+The `server_token` Step 4 `agent register` writes into the canonical
+`config.json` is the per-**agent** credential and is **not** accepted by
+these admin commands — they only accept an owner-session bearer (the
+separate `owner-session.json` that `login` writes alongside it). If the
+saved bearer is missing or expired, refresh it without re-registering:
 
 ```sh
 "$INSTALL_DIR/vicoop-client" login
@@ -811,22 +814,22 @@ section of `docs/local-testing.md` for the same note.
   registration exists but no WS session is live. Check the client log;
   dispatch requires an active session.
 
-- **Lost the `CLIENT_TOKEN`** — the raw value is unrecoverable, but you
-  don't need to create a new client identity. Rotate the token in place
-  via the `rotateClientToken` GraphQL mutation (backed by
-  `rotate_client_token()` in `schema.sql`): it mints a fresh raw token for
-  the existing agent registration and invalidates the old hash, so your
-  agent id and caller allowlist carry over. Re-run Step 4 only if
-  you intentionally want a new client identity; in that case the old
-  `clients` row can be revoked from the CLI — see
+- **Lost the `AGENT_TOKEN`** (formerly surfaced as `CLIENT_TOKEN`) — the
+  raw value is unrecoverable, but you don't need to create a new agent
+  identity. Rotate the token in place via the `rotateClientToken` GraphQL
+  mutation (backed by `rotate_client_token()` in `schema.sql`): it mints a
+  fresh raw token for the existing agent registration and invalidates the
+  old hash, so your agent id and caller allowlist carry over. Re-run Step
+  4 only if you intentionally want a new agent identity; in that case the
+  old registration can be revoked from the CLI — see
   [Inspecting and revoking your agents](#inspecting-and-revoking-your-agents).
 
 ## Inspecting and revoking your agents
 
 `vicoop-client agent list --connected` only shows *currently connected*
 agents. To see every agent registered under your owner principal — including
-orphans left behind by an aborted `setup`, an exited daemon, or a leaked
-`CLIENT_TOKEN` — drop the flag:
+orphans left behind by an aborted `agent register`, an exited daemon, or a
+leaked `AGENT_TOKEN` — drop the flag:
 
 ```bash
 vicoop-client agent list

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -176,9 +176,9 @@ CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 
 "$INSTALL_DIR/vicoop-client" login
 
-"$INSTALL_DIR/vicoop-client" setup \
-  --client-name "$CLIENT_NAME" \
-  --agent-ids "$AGENT_ID" \
+"$INSTALL_DIR/vicoop-client" agent register \
+  --name "$CLIENT_NAME" \
+  --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
 ```
 
@@ -186,30 +186,35 @@ CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 
 `login` prints a verification URL to stderr — open it in **any** browser
 (the same machine, or your laptop while running the CLI on a headless host)
-and authorize with your Google account. `setup` registers the client, configures
-any `--caller` allowlist entries, and persists the daemon credentials to
-the resolved vicoop config dir (`~/.vicoop/config.json` by default; see the
-resolution order below for `$VICOOP_HOME` / `$XDG_CONFIG_HOME` cases), mode
-600 — see #137 for the consolidated config layout. The success output looks
-like:
+and authorize with your Google account. `agent register` calls the bridge's
+`registerClient` mutation, configures any `--caller` allowlist entries, and
+persists the daemon credentials to the resolved vicoop config dir
+(`~/.vicoop/config.json` by default; see the resolution order below for
+`$VICOOP_HOME` / `$XDG_CONFIG_HOME` cases), mode 600 — see #137 for the
+consolidated config layout. The success output looks like:
 
 ```text
-  client_id        <uuid>
+  agent_id         openclaw-my-host
   owner_principal  google:sub:<sub>
-  client_name      openclaw on my-host
-  allowed_agents   openclaw-my-host
+  name             openclaw on my-host
 
-The CLIENT_TOKEN is one-time — the bridge cannot reissue it.
-  setup persists it to the canonical config below; --json prints it to
+The AGENT_TOKEN is one-time — the bridge cannot reissue it.
+  agent register persists it to the canonical config below; --json prints it to
   stdout instead. Back up that file before rotating hosts.
   To also stash it in a shell-sourceable env file, pass --write-env-file
-  on this same setup invocation — rerunning setup later would call
-  registerClient again and mint a NEW CLIENT_TOKEN, invalidating this
+  on this same agent register invocation — rerunning agent register later would call
+  registerClient again and mint a NEW AGENT_TOKEN, invalidating this
   one. To populate an env file from an already-issued token, copy
   SERVER_URL / SERVER_TOKEN / AGENT_ID out of config.json by hand.
 
 Wrote /home/you/.vicoop/config.json (mode 600).
 ```
+
+> **Legacy `vicoop-client setup` alias.** The flat `setup` command still
+> works (with the old `--client-name` / `--agent-ids` flags and the
+> `CLIENT_TOKEN` / `client_id` / `client_name` vocabulary) but now prints
+> a one-line deprecation warning to stderr pointing at `agent register`.
+> It will be removed in a future release.
 
 Verify it landed where you expect (matters when `$VICOOP_HOME` or
 `$XDG_CONFIG_HOME` is set):
@@ -309,26 +314,30 @@ agent will be public until you restrict callers:
 > login flow saves one locally for you). Rotation surfaces a new
 > CLIENT_TOKEN, also one-time.
 
-For setup scripting, pass `--json` instead of writing `config.json` if you
-want to compose with shell tooling (no disk side effects, raw response on
-stdout):
+For scripting, pass `--json` instead of writing `config.json` if you want to
+compose with shell tooling (no disk side effects, raw response on stdout):
 
 ```sh
-"$INSTALL_DIR/vicoop-client" setup \
-  --client-name "$CLIENT_NAME" \
-  --agent-ids "$AGENT_ID" \
+"$INSTALL_DIR/vicoop-client" agent register \
+  --name "$CLIENT_NAME" \
+  --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>" --json \
-  | tee /tmp/vicoop-setup.json
-CLIENT_TOKEN=$(jq -r .client_token /tmp/vicoop-setup.json)
+  | tee /tmp/vicoop-agent.json
+AGENT_TOKEN=$(jq -r .client_token /tmp/vicoop-agent.json)
 ```
 
-`--agent-ids` is a legacy plural flag, but the current server model is
-1:1: one setup call creates one agent registration and the flag must contain
-exactly one id. To change that id later, use the `updateClientAllowedAgents`
-GraphQL compatibility mutation (backed by `update_client_allowed_agents()`
-in `schema.sql`) without issuing a new token.
+`--json` keeps the `registerClient` response shape (`client_id`,
+`client_token`, `client_name`, `allowed_agent_ids`) for back-compat with
+existing scripts. New scripts can read `allowed_agent_ids[0]` as the
+agent id and `client_token` as the agent token.
 
-### What login and setup do
+The bridge's server model is 1:1 (#219): one `agent register` call creates
+one agent registration with one id. To change that id later, use the
+`updateClientAllowedAgents` GraphQL compatibility mutation (backed by
+`update_client_allowed_agents()` in `schema.sql`) without issuing a new
+token.
+
+### What login and agent register do
 
 1. `login` calls `POST /oauth/device/code` with `intent=owner_session`; the bridge stores
    a `device_sessions` row and returns a one-time `device_code` + 8-char user
@@ -338,8 +347,8 @@ in `schema.sql`) without issuing a new token.
 3. CLI polls `POST /oauth/token`. Once status flips to `approved`, the
    bridge returns a `vbc_owner_*` bearer, and `login` saves it to
    `~/.vicoop/owner-session.json` (mode 600).
-4. `setup` calls the authenticated GraphQL `registerClient` mutation with
-   that bearer, receives `{client_id, client_token, owner_principal,
+4. `agent register` calls the authenticated GraphQL `registerClient` mutation
+   with that bearer, receives `{client_id, client_token, owner_principal,
    allowed_agent_ids}`, and writes the daemon credentials into
    `~/.vicoop/config.json` (mode 600). With `--write-env-file <path>` it
    additionally emits a shell-sourceable env file at that path — useful as
@@ -676,9 +685,9 @@ published release:
 
 ```sh
 # Step 4 login saves the owner-session bearer, so these work without re-authenticating:
-"$INSTALL_DIR/vicoop-client" setup \
-  --client-name "$CLIENT_NAME" \
-  --agent-ids "$AGENT_ID" \
+"$INSTALL_DIR/vicoop-client" agent register \
+  --name "$CLIENT_NAME" \
+  --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
 "$INSTALL_DIR/vicoop-client" agent list --connected
 "$INSTALL_DIR/vicoop-client" agent callers list "$AGENT_ID" --json

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -166,17 +166,17 @@ pick a hostname/uuid prefix and skip the probe.
 
 ## Step 4 — Login and register your agent
 
-`vicoop-client login` only signs you in as the agent owner and saves an
-owner-session bearer to `~/.vicoop/owner-session.json`. It does **not** create
-an agent registration. `vicoop-client agent register` then uses that saved
-owner-session to call `registerClient` and mint a one-time `AGENT_TOKEN`. No
-wallet or SIWE required.
+`vicoop-client auth login` only signs you in as the agent owner and saves
+an owner-session bearer to `~/.vicoop/owner-session.json`. It does **not**
+create an agent registration. `vicoop-client agent register` then uses that
+saved owner-session to call `registerClient` and mint a one-time
+`AGENT_TOKEN`. No wallet or SIWE required.
 
 ```sh
 HOSTNAME=$(hostname)
 CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
 
-"$INSTALL_DIR/vicoop-client" login
+"$INSTALL_DIR/vicoop-client" auth login
 
 "$INSTALL_DIR/vicoop-client" agent register \
   --name "$CLIENT_NAME" \
@@ -212,11 +212,14 @@ The AGENT_TOKEN is one-time — the bridge cannot reissue it.
 Wrote /home/you/.vicoop/config.json (mode 600).
 ```
 
-> **Legacy `vicoop-client setup` alias.** The flat `setup` command still
-> works (with the old `--client-name` / `--agent-ids` flags and the
-> `CLIENT_TOKEN` / `client_id` / `client_name` vocabulary) but now prints
-> a one-line deprecation warning to stderr pointing at `agent register`.
-> It will be removed in a future release.
+> **Legacy flat aliases.** The flat `setup` / `login` / `logout` / `whoami`
+> commands still work (with the same flags as their umbrella replacements)
+> but now print a one-line deprecation warning to stderr pointing at their
+> `agent register` / `auth login` / `auth logout` / `auth whoami` form.
+> `setup` additionally keeps its old `--client-name` / `--agent-ids` flags
+> and the `CLIENT_TOKEN` / `client_id` / `client_name` vocabulary on
+> stderr for script back-compat. All four will be removed in a future
+> release.
 
 Verify it landed where you expect (matters when `$VICOOP_HOME` or
 `$XDG_CONFIG_HOME` is set):
@@ -396,7 +399,7 @@ card, for example to:
 
 To see what the bridge currently advertises for this agent (before deciding
 whether to override), connect the client once and `curl` the `a2a card` URL
-that `vicoop-client whoami` prints — see ["Check your agent's mention /
+that `vicoop-client auth whoami` prints — see ["Check your agent's mention /
 acct"](#check-your-agents-mention--acct-any-backend) in Step 6.
 
 Schema reference: `packages/protocol/src/index.ts` (`AgentCard` Zod schema,
@@ -443,7 +446,7 @@ runtime config (#189 §5). With `"backend": "openclaw"` persisted in
 `"$INSTALL_DIR/vicoop-client"`.
 
 On success you'll see a `[client] connected, sending hello` log followed
-by an identity block — same data `vicoop-client whoami` would print, so
+by an identity block — same data `vicoop-client auth whoami` would print, so
 you can copy the mention / acct / agent-card URL from here directly:
 
 ```text
@@ -565,13 +568,13 @@ derived from `--agentId` and the host part of `--server`.
 > on the server side. If the two differ (e.g. a custom domain in front of
 > a Fly hostname), the model is taught a mention that doesn't match what
 > users see via WebFinger and self-reference detection won't fire. Run
-> `vicoop-client whoami --verify` to confirm the WebFinger lookup actually
+> `vicoop-client auth whoami --verify` to confirm the WebFinger lookup actually
 > resolves the agent under the derived host; align `--server` with
 > `PUBLIC_URL`'s host if it doesn't.
 
 ### Check your agent's mention / acct (any backend)
 
-After the first `connected` log, run `vicoop-client whoami` to surface every
+After the first `connected` log, run `vicoop-client auth whoami` to surface every
 identifier external callers will see for this agent — the WebFinger acct, the
 `@<agentId>@<host>` mention, the JSON-RPC endpoint, and the agent-card URL.
 
@@ -803,9 +806,9 @@ section of `docs/local-testing.md` for the same note.
   GraphQL — the caller token was missing, malformed, or expired, so the
   request fell back to the `app_anonymous` Postgres role (see
   `packages/server/src/postgraphile.ts`) which has no EXECUTE on
-  authenticated functions. Re-run `vicoop-client login` to refresh.
+  authenticated functions. Re-run `vicoop-client auth login` to refresh.
 
-- **Device flow timed out** — the `vicoop-client login` deadline matches
+- **Device flow timed out** — the `vicoop-client auth login` deadline matches
   the bridge's `device_sessions.expires_at` (10 min by default). If the
   browser approval is delayed past that, re-run `login`; the previous
   device code is invalidated automatically.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -151,7 +151,7 @@ echo "$AGENT_ID"
 > default to the public bridge at `https://vicoop-bridge-server.fly.dev`
 > (HTTPS for `login` / `agent register` / admin commands; `wss://…` for the
 > daemon). If you
-> run your own bridge, pass `--bridge <https://your-bridge>` to `login` and
+> run your own bridge, pass `--server <https://your-bridge>` to `auth login` and
 > `--server <wss://your-bridge>` to the daemon (or persist `server_url`
 > in `config.json`). Every example below uses the public defaults; the
 > self-host overrides are the only place the URL has to change.
@@ -184,7 +184,7 @@ CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
   --caller "eth:0x<40-hex>"
 ```
 
-(Self-hosting? Pass `--bridge https://<your-bridge>` to `login`.)
+(Self-hosting? Pass `--server https://<your-bridge>` to `auth login`.)
 
 `login` prints a verification URL to stderr — open it in **any** browser
 (the same machine, or your laptop while running the CLI on a headless host)
@@ -700,7 +700,7 @@ published release:
 "$INSTALL_DIR/vicoop-client" agent callers add "$AGENT_ID" "eth:0x<40-hex>"
 "$INSTALL_DIR/vicoop-client" agent callers remove "$AGENT_ID" "google:email:caller@example.com"
 
-# Pass --json for machine-readable output, or --bridge / --token to override
+# Pass --json for machine-readable output, or --server / --token to override
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
 # work too (handy for CI).
 ```
@@ -712,10 +712,10 @@ separate `owner-session.json` that `login` writes alongside it). If the
 saved bearer is missing or expired, refresh it without re-registering:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" login
+"$INSTALL_DIR/vicoop-client" auth login
 ```
 
-(Self-hosting? Pass `--bridge https://<your-bridge>`.)
+(Self-hosting? Pass `--server https://<your-bridge>`.)
 
 These talk to the bridge's `/admin-api/*` routes — same logic the admin
 agent's tools run, but without an LLM round-trip per call.

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -5,12 +5,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   runAddCaller,
+  runAgentCallersAdd,
+  runAgentCallersList,
+  runAgentCallersRemove,
+  runAgentList,
+  runAgentRevoke,
   runListAgents,
   runListCallers,
   runListClients,
   runRemoveCaller,
   runRevokeClient,
   type AddCallerArgs,
+  type AgentCallersAddArgs,
+  type AgentCallersListArgs,
+  type AgentCallersRemoveArgs,
+  type AgentListArgs,
+  type AgentRevokeArgs,
   type ListAgentsArgs,
   type ListCallersArgs,
   type ListClientsArgs,
@@ -45,6 +55,28 @@ const revokeClientArgs = (
   target: string,
   p: Partial<RevokeClientArgs> = {},
 ): RevokeClientArgs => ({ action: 'revoke-client', target, ...SHARED, ...p });
+const agentListArgsFn = (p: Partial<AgentListArgs> = {}): AgentListArgs =>
+  ({ action: 'agent-list', ...SHARED, connected: false, ...p });
+const agentRevokeArgsFn = (
+  target: string,
+  p: Partial<AgentRevokeArgs> = {},
+): AgentRevokeArgs => ({ action: 'agent-revoke', target, ...SHARED, ...p });
+const agentCallersListArgsFn = (
+  agentId: string,
+  p: Partial<AgentCallersListArgs> = {},
+): AgentCallersListArgs => ({ action: 'agent-callers-list', agentId, ...SHARED, ...p });
+const agentCallersAddArgsFn = (
+  agentId: string,
+  principal: string,
+  p: Partial<AgentCallersAddArgs> = {},
+): AgentCallersAddArgs =>
+  ({ action: 'agent-callers-add', agentId, principal, ...SHARED, ...p });
+const agentCallersRemoveArgsFn = (
+  agentId: string,
+  principal: string,
+  p: Partial<AgentCallersRemoveArgs> = {},
+): AgentCallersRemoveArgs =>
+  ({ action: 'agent-callers-remove', agentId, principal, ...SHARED, ...p });
 
 interface Captured {
   url: string;
@@ -167,7 +199,10 @@ test('list-agents calls GET /admin-api/agents and renders human output', async (
   assert.equal(calls[0].method, 'GET');
   assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents`);
   assert.equal(calls[0].headers.authorization, `Bearer ${TOKEN}`);
-  assert.match(stdout.read(), /agent_id:\s+foo/);
+  const out = stdout.read();
+  // Table-form: header row + data row, padded with whitespace.
+  assert.match(out, /AGENT_ID\s+AGENT_NAME/);
+  assert.match(out, /^foo\s+Foo\s+cid\b/m);
 });
 
 test('list-agents --json prints raw JSON', async (t) => {
@@ -310,8 +345,9 @@ test('list-clients calls GET /admin-api/clients and renders rows with connected 
   assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients`);
   assert.equal(calls[0].headers.authorization, `Bearer ${TOKEN}`);
   const out = stdout.read();
-  assert.match(out, /client_id:\s+cid-1/);
-  assert.match(out, /connected:\s+false/);
+  // Table-form: header row + data row.
+  assert.match(out, /CLIENT_ID\s+CLIENT_NAME\s+ALLOWED_AGENT_IDS/);
+  assert.match(out, /^cid-1\s+usage-test-1\s+agent-a\s+false\s+false\b/m);
 });
 
 test('list-clients --json prints raw JSON', async (t) => {
@@ -383,4 +419,185 @@ test('subcommand surfaces server error on non-2xx response', async (t) => {
   const code = await runAddCaller(addCallerArgs('foo', 'eth:0xabc'));
   assert.equal(code, 1);
   assert.match(stderr.read(), /403.*Not authorized/);
+});
+
+// ---- New `agent <sub>` command group (#218) --------------------------------
+
+// `agent list` calls the same /admin-api/clients endpoint as the legacy
+// list-clients (the server-side unified persistence in #219 makes them
+// equivalent), but renders rows agent-id-first to match the operator-facing
+// model and includes registration_id/revoked/connected fields.
+test('agent list calls GET /admin-api/clients and renders agent-centric rows', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: {
+      clients: [
+        {
+          client_id: 'cid-1',
+          agent_id: 'agent-a',
+          client_name: 'codex on Mac',
+          owner_principal: 'eth:0xabc',
+          allowed_agent_ids: ['agent-a'],
+          revoked: false,
+          connected: true,
+          created_at: '2026-05-07T00:00:00.000Z',
+        },
+      ],
+    },
+  });
+
+  const code = await runAgentList(agentListArgsFn());
+  assert.equal(code, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients`);
+  const out = stdout.read();
+  // Header row puts AGENT_ID first. The legacy client_id is intentionally
+  // omitted from the human table — it remains available via --json.
+  assert.match(out, /AGENT_ID\s+NAME\s+CONNECTED\s+REVOKED\s+REGISTERED_AT\s*$/m);
+  assert.match(out, /^agent-a\s+codex on Mac\s+true\s+false\s+\S+\s*$/m);
+  assert.doesNotMatch(out, /cid-1/);
+});
+
+// --connected filters client-side so the human view only shows live daemons
+// even though the API itself returns every registration.
+test('agent list --connected filters to connected rows in human + JSON output', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, {
+    body: {
+      clients: [
+        {
+          client_id: 'cid-1', agent_id: 'agent-a', client_name: 'live',
+          owner_principal: 'eth:0xabc', allowed_agent_ids: ['agent-a'],
+          revoked: false, connected: true,
+          created_at: '2026-05-07T00:00:00.000Z',
+        },
+        {
+          client_id: 'cid-2', agent_id: 'agent-b', client_name: 'stale',
+          owner_principal: 'eth:0xabc', allowed_agent_ids: ['agent-b'],
+          revoked: false, connected: false,
+          created_at: '2026-05-07T00:00:00.000Z',
+        },
+      ],
+    },
+  });
+
+  const code = await runAgentList(agentListArgsFn({ json: true, connected: true }));
+  assert.equal(code, 0);
+  const parsed = JSON.parse(stdout.read()) as { clients: Array<{ agent_id: string }> };
+  assert.deepEqual(parsed.clients.map((c) => c.agent_id), ['agent-a']);
+});
+
+test('agent list --connected with no live agents prints the empty-state line', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, { body: { clients: [] } });
+
+  const code = await runAgentList(agentListArgsFn({ connected: true }));
+  assert.equal(code, 0);
+  assert.match(stdout.read(), /no connected agents/);
+});
+
+// `agent revoke` keeps the legacy DELETE /admin-api/clients/<target> endpoint
+// because the server-side resolver (admin-api.ts resolveClient) accepts an
+// agent_id, the legacy client_id, or the registration name. No new endpoint
+// is required.
+test('agent revoke DELETEs /admin-api/clients/<AGENT_ID>', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: { client_id: 'cid', client_name: 'agent-a', revoked: true, closed_connections: 1 },
+  });
+
+  const code = await runAgentRevoke(agentRevokeArgsFn('agent-a'));
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'DELETE');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients/agent-a`);
+});
+
+test('agent callers list/add/remove hit the existing /admin-api/agents/:id/callers routes', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const principal = 'eth:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  const { calls } = installFetch(t, {
+    body: { agent_id: 'foo', owner_principal: 'eth:0xabc', allowed_callers: [], is_public: true },
+  });
+
+  assert.equal(await runAgentCallersList(agentCallersListArgsFn('foo')), 0);
+  assert.equal(await runAgentCallersAdd(agentCallersAddArgsFn('foo', principal)), 0);
+  assert.equal(await runAgentCallersRemove(agentCallersRemoveArgsFn('foo', principal)), 0);
+
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/callers`);
+  assert.equal(calls[1].method, 'POST');
+  assert.equal(calls[1].url, `${BRIDGE}/admin-api/agents/foo/callers`);
+  assert.deepEqual(JSON.parse(calls[1].body!), { principal });
+  assert.equal(calls[2].method, 'DELETE');
+  assert.equal(
+    calls[2].url,
+    `${BRIDGE}/admin-api/agents/foo/callers?principal=${encodeURIComponent(principal)}`,
+  );
+});
+
+// The new `agent` commands must not print a deprecation warning — that's
+// reserved for the legacy flat aliases.
+test('agent subcommands do NOT emit deprecation warnings', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, { body: { clients: [] } });
+
+  assert.equal(await runAgentList(agentListArgsFn()), 0);
+  assert.doesNotMatch(stderr.read(), /deprecated/i);
+});
+
+// ---- Deprecation warnings on legacy aliases --------------------------------
+
+test('legacy list-agents prints a deprecation warning pointing at agent list --connected', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, { body: { agents: [] } });
+
+  assert.equal(await runListAgents(listAgentsArgs()), 0);
+  assert.match(stderr.read(), /list-agents.*deprecated.*agent list --connected/s);
+});
+
+test('legacy list-clients warns and points at agent list', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, { body: { clients: [] } });
+
+  assert.equal(await runListClients(listClientsArgs()), 0);
+  assert.match(stderr.read(), /list-clients.*deprecated.*agent list/s);
+});
+
+test('legacy revoke-client warns and points at agent revoke', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, { body: { client_id: 'c', client_name: 'n', revoked: true, closed_connections: 0 } });
+
+  assert.equal(await runRevokeClient(revokeClientArgs('n')), 0);
+  assert.match(stderr.read(), /revoke-client.*deprecated.*agent revoke/s);
+});
+
+test('legacy {add,remove,list}-caller all emit the agent-callers deprecation hint', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, {
+    body: { agent_id: 'foo', owner_principal: 'eth:0xabc', allowed_callers: [], is_public: true },
+  });
+
+  const principal = 'eth:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  assert.equal(await runListCallers(listCallersArgs('foo')), 0);
+  assert.equal(await runAddCaller(addCallerArgs('foo', principal)), 0);
+  assert.equal(await runRemoveCaller(removeCallerArgs('foo', principal)), 0);
+  const out = stderr.read();
+  assert.match(out, /list-callers.*agent callers list/s);
+  assert.match(out, /add-caller.*agent callers add/s);
+  assert.match(out, /remove-caller.*agent callers remove/s);
 });

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -31,7 +31,7 @@ import {
 // `runXxx` handlers now take the parser's discriminated-union output.
 // Tests construct that shape directly. Shared auth/output fields default
 // to undefined/false so each test only specifies what it cares about.
-const SHARED = { bridge: undefined, token: undefined, json: false } as const;
+const SHARED = { server: undefined, token: undefined, json: false } as const;
 const listAgentsArgs = (p: Partial<ListAgentsArgs> = {}): ListAgentsArgs =>
   ({ action: 'list-agents', ...SHARED, ...p });
 const listClientsArgs = (p: Partial<ListClientsArgs> = {}): ListClientsArgs =>
@@ -299,7 +299,7 @@ test('subcommand exits 1 with hint when no token is available', async (t) => {
 
   const code = await runListAgents(listAgentsArgs());
   assert.equal(code, 1);
-  assert.match(stderr.read(), /vicoop-client login --bridge/);
+  assert.match(stderr.read(), /vicoop-client auth login --server/);
 });
 
 test('subcommand surfaces network errors as a clean exit-1 instead of crashing', async (t) => {

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -15,6 +15,7 @@ import { message } from '@optique/core/message';
 import type { InferValue } from '@optique/core/parser';
 import { string } from '@optique/core/valueparser';
 import { resolveOwnerSession } from './owner-session.js';
+import { agentRegisterCmd } from './setup.js';
 
 // All six admin subcommands share the same auth/output flags. Define them
 // once and splice into each command's parser to keep the surface uniform.
@@ -113,10 +114,10 @@ const agentCallersSubCmd = command(
 
 export const agentCmd = command(
   'agent',
-  longestMatch(agentListSubCmd, agentRevokeSubCmd, agentCallersSubCmd),
+  longestMatch(agentRegisterCmd, agentListSubCmd, agentRevokeSubCmd, agentCallersSubCmd),
   {
     brief: message`Manage agent registrations and their allowed callers.`,
-    description: message`Operator-facing umbrella for agent state. Subcommands: \`list\`, \`revoke\`, \`callers {list,add,remove}\`. Replaces the older flat \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`revoke\`, \`callers {list,add,remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
   },
 );
 

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -8,7 +8,7 @@
 // stored token is expired) the user gets a clear "run login" hint and the
 // process exits with code 1.
 
-import { object } from '@optique/core/constructs';
+import { longestMatch, object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
 import { argument, command, constant, flag, option } from '@optique/core/primitives';
 import { message } from '@optique/core/message';
@@ -30,6 +30,105 @@ const sharedFlags = {
   }), false),
 };
 
+// ----- New `agent <sub>` command group (#218) --------------------------------
+// `agent` is the operator-facing primary resource. The legacy `list-agents` /
+// `list-clients` / `revoke-client` / `{add,remove,list}-caller` commands below
+// remain as deprecated aliases (see DEPRECATION_HINTS).
+
+const agentListSubCmd = command(
+  'list',
+  object({
+    action: constant('agent-list' as const),
+    ...sharedFlags,
+    connected: withDefault(flag('--connected', {
+      description: message`Only show agents whose daemon is currently connected.`,
+    }), false),
+  }),
+  {
+    brief: message`List agent registrations under this owner.`,
+    description: message`Calls GET /admin-api/clients (backed by the unified \`agents\` table) and prints one block per agent, including revoked and disconnected ones. Use --connected to filter to live daemons.`,
+  },
+);
+
+const agentRevokeSubCmd = command(
+  'revoke',
+  object({
+    action: constant('agent-revoke' as const),
+    ...sharedFlags,
+    target: argument(string({ metavar: 'AGENT_ID' })),
+  }),
+  {
+    brief: message`Revoke an agent by id (or registration name).`,
+    description: message`Calls DELETE /admin-api/clients/<AGENT_ID>. Marks the agent revoked=true and, if a daemon is live, closes its WebSocket with code 4014. The row is preserved for audit history. The legacy client_id and the registration name are still accepted for backward compatibility.`,
+  },
+);
+
+const agentCallersListSubCmd = command(
+  'list',
+  object({
+    action: constant('agent-callers-list' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+  }),
+  {
+    brief: message`Show the agent's allowed-callers list.`,
+  },
+);
+
+const agentCallersAddSubCmd = command(
+  'add',
+  object({
+    action: constant('agent-callers-add' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+    principal: argument(string({ metavar: 'PRINCIPAL' })),
+  }),
+  {
+    brief: message`Add a principal to the agent's allowed-callers list.`,
+    description: message`Calls POST /admin-api/agents/<AGENT_ID>/callers. Hot-reloaded — no daemon restart needed.`,
+  },
+);
+
+const agentCallersRemoveSubCmd = command(
+  'remove',
+  object({
+    action: constant('agent-callers-remove' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+    principal: argument(string({ metavar: 'PRINCIPAL' })),
+  }),
+  {
+    brief: message`Remove a principal from the agent's allowed-callers list.`,
+    description: message`Calls DELETE /admin-api/agents/<AGENT_ID>/callers?principal=<PRINCIPAL>. Hot-reloaded.`,
+  },
+);
+
+const agentCallersSubCmd = command(
+  'callers',
+  longestMatch(agentCallersListSubCmd, agentCallersAddSubCmd, agentCallersRemoveSubCmd),
+  {
+    brief: message`Manage the agent's allowed-callers list.`,
+  },
+);
+
+export const agentCmd = command(
+  'agent',
+  longestMatch(agentListSubCmd, agentRevokeSubCmd, agentCallersSubCmd),
+  {
+    brief: message`Manage agent registrations and their allowed callers.`,
+    description: message`Operator-facing umbrella for agent state. Subcommands: \`list\`, \`revoke\`, \`callers {list,add,remove}\`. Replaces the older flat \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+  },
+);
+
+export type AgentCliArgs = InferValue<typeof agentCmd>;
+export type AgentListArgs = Extract<AgentCliArgs, { action: 'agent-list' }>;
+export type AgentRevokeArgs = Extract<AgentCliArgs, { action: 'agent-revoke' }>;
+export type AgentCallersListArgs = Extract<AgentCliArgs, { action: 'agent-callers-list' }>;
+export type AgentCallersAddArgs = Extract<AgentCliArgs, { action: 'agent-callers-add' }>;
+export type AgentCallersRemoveArgs = Extract<AgentCliArgs, { action: 'agent-callers-remove' }>;
+
+// ----- Legacy flat commands (deprecated, kept as aliases) --------------------
+
 export const addCallerCmd = command(
   'add-caller',
   object({
@@ -39,8 +138,8 @@ export const addCallerCmd = command(
     principal: argument(string({ metavar: 'PRINCIPAL' })),
   }),
   {
-    brief: message`Add a principal to the agent's allowed-callers list.`,
-    description: message`Calls POST /admin-api/agents/<AGENT_ID>/callers to add PRINCIPAL to the allowlist. Hot-reloaded — no daemon restart needed.`,
+    brief: message`[deprecated] Use \`agent callers add\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent callers add\`. Will be removed in a future release.`,
   },
 );
 
@@ -53,8 +152,8 @@ export const removeCallerCmd = command(
     principal: argument(string({ metavar: 'PRINCIPAL' })),
   }),
   {
-    brief: message`Remove a principal from the agent's allowed-callers list.`,
-    description: message`Calls DELETE /admin-api/agents/<AGENT_ID>/callers?principal=<PRINCIPAL>. Hot-reloaded.`,
+    brief: message`[deprecated] Use \`agent callers remove\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent callers remove\`. Will be removed in a future release.`,
   },
 );
 
@@ -66,7 +165,8 @@ export const listCallersCmd = command(
     agentId: argument(string({ metavar: 'AGENT_ID' })),
   }),
   {
-    brief: message`Show the agent's allowed-callers list.`,
+    brief: message`[deprecated] Use \`agent callers list\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent callers list\`. Will be removed in a future release.`,
   },
 );
 
@@ -77,7 +177,8 @@ export const listAgentsCmd = command(
     ...sharedFlags,
   }),
   {
-    brief: message`List currently connected agents under this owner.`,
+    brief: message`[deprecated] Use \`agent list --connected\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent list --connected\`. Will be removed in a future release.`,
   },
 );
 
@@ -88,8 +189,8 @@ export const listClientsCmd = command(
     ...sharedFlags,
   }),
   {
-    brief: message`List every client registration under this owner (including disconnected).`,
-    description: message`Surfaces orphan clients left behind by an aborted setup, exited daemon, or leaked CLIENT_TOKEN. Use \`revoke-client\` to clean them up.`,
+    brief: message`[deprecated] Use \`agent list\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent list\`. Will be removed in a future release.`,
   },
 );
 
@@ -101,8 +202,8 @@ export const revokeClientCmd = command(
     target: argument(string({ metavar: 'CLIENT_ID_OR_NAME' })),
   }),
   {
-    brief: message`Revoke a client by id or unique name.`,
-    description: message`Marks the clients row revoked=true and, if a daemon is live, closes its WebSocket with code 4014. Revoked clients cannot re-authenticate; the row is preserved for audit history.`,
+    brief: message`[deprecated] Use \`agent revoke\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent revoke\`. Will be removed in a future release.`,
   },
 );
 
@@ -212,6 +313,19 @@ function emit(result: ApiResult, json: boolean, humanRender: (body: unknown) => 
   return 0;
 }
 
+// Minimal whitespace-padded table renderer for list outputs. Column widths
+// are computed from the data so short rows do not get oversize gaps; trailing
+// padding on the last cell is trimmed so the output diffs cleanly. No
+// box-drawing characters — terminals, pagers, and grep all stay happy.
+function renderTable(headers: string[], rows: string[][]): string {
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)),
+  );
+  const fmt = (cells: string[]): string =>
+    cells.map((c, i) => (c ?? '').padEnd(widths[i])).join('  ').trimEnd();
+  return [fmt(headers), ...rows.map(fmt)].join('\n');
+}
+
 function renderCallerMutation(body: unknown): string {
   if (!body || typeof body !== 'object') return String(body);
   const b = body as { agent_id?: string; allowed_callers?: string[]; message?: string };
@@ -238,23 +352,56 @@ function renderCallerList(body: unknown): string {
   ].join('\n');
 }
 
+// Agent-centric renderer for `agent list`. The /admin-api/clients response
+// now carries `agent_id` (#219) which is the operator-facing primary key, so
+// that's what we surface. The legacy `client_id` (a separate UUID kept for
+// backward-compat with old GraphQL/scripts) stays in the --json output but is
+// omitted from the human table — operators don't need to read it day to day.
+function renderAgentRegistrationList(body: unknown, connectedOnly: boolean): string {
+  if (!body || typeof body !== 'object' || !('clients' in body)) return String(body);
+  let rows = (body as { clients: Array<Record<string, unknown>> }).clients;
+  if (connectedOnly) rows = rows.filter((c) => c.connected === true);
+  if (rows.length === 0) {
+    return connectedOnly ? '(no connected agents)' : '(no agents registered)';
+  }
+  const tableRows = rows.map((c) => [
+    String(c.agent_id ?? ((c.allowed_agent_ids as string[] | undefined)?.[0] ?? '')),
+    String(c.client_name ?? ''),
+    String(c.connected),
+    String(c.revoked),
+    String(c.created_at ?? ''),
+  ]);
+  return renderTable(
+    ['AGENT_ID', 'NAME', 'CONNECTED', 'REVOKED', 'REGISTERED_AT'],
+    tableRows,
+  );
+}
+
+// Filter `clients[]` to connected==true while preserving the response envelope
+// when emitting JSON, so `agent list --connected --json` returns the same
+// shape as `agent list --json` minus disconnected rows.
+function filterConnected(body: unknown): unknown {
+  if (!body || typeof body !== 'object' || !('clients' in body)) return body;
+  const clients = (body as { clients: Array<Record<string, unknown>> }).clients;
+  return { ...(body as object), clients: clients.filter((c) => c.connected === true) };
+}
+
 function renderClientList(body: unknown): string {
   if (!body || typeof body !== 'object' || !('clients' in body)) return String(body);
   const clients = (body as { clients: Array<Record<string, unknown>> }).clients;
   if (clients.length === 0) return '(no clients registered)';
-  return clients
-    .map((c) => {
-      const agents = (c.allowed_agent_ids as string[] | undefined)?.join(', ') ?? '';
-      return [
-        `client_id:         ${c.client_id}`,
-        `client_name:       ${c.client_name}`,
-        `allowed_agent_ids: ${agents}`,
-        `revoked:           ${c.revoked}`,
-        `connected:         ${c.connected}`,
-        `created_at:        ${c.created_at}`,
-      ].join('\n');
-    })
-    .join('\n---\n');
+  const tableRows = clients.map((c) => [
+    String(c.client_id ?? ''),
+    String(c.client_name ?? ''),
+    (c.allowed_agent_ids as string[] | undefined)?.join(',') ?? '',
+    String(c.revoked),
+    String(c.connected),
+    String(c.created_at ?? ''),
+  ]);
+  return renderTable(
+    ['CLIENT_ID', 'CLIENT_NAME', 'ALLOWED_AGENT_IDS', 'REVOKED', 'CONNECTED', 'CREATED_AT'],
+    tableRows,
+  );
 }
 
 function renderRevokeResult(body: unknown): string {
@@ -277,22 +424,85 @@ function renderAgentList(body: unknown): string {
   if (!body || typeof body !== 'object' || !('agents' in body)) return String(body);
   const agents = (body as { agents: Array<Record<string, unknown>> }).agents;
   if (agents.length === 0) return '(no connected agents)';
-  return agents
-    .map((a) => {
-      const callers = (a.allowed_callers as string[] | undefined)?.join(', ') ?? '';
-      return [
-        `agent_id:    ${a.agent_id}`,
-        `agent_name:  ${a.agent_name}`,
-        `client_id:   ${a.client_id}`,
-        `connected:   ${a.connected_at}`,
-        `is_public:   ${(a.allowed_callers as string[] | undefined)?.length === 0}`,
-        `callers:     ${callers}`,
-      ].join('\n');
-    })
-    .join('\n---\n');
+  const tableRows = agents.map((a) => {
+    const callers = a.allowed_callers as string[] | undefined;
+    return [
+      String(a.agent_id ?? ''),
+      String(a.agent_name ?? ''),
+      String(a.client_id ?? ''),
+      String(a.connected_at ?? ''),
+      String((callers?.length ?? 0) === 0),
+      callers?.join(',') ?? '',
+    ];
+  });
+  return renderTable(
+    ['AGENT_ID', 'AGENT_NAME', 'CLIENT_ID', 'CONNECTED_AT', 'IS_PUBLIC', 'CALLERS'],
+    tableRows,
+  );
 }
 
-export async function runAddCaller(args: AddCallerArgs): Promise<number> {
+// ----- New agent-* handlers --------------------------------------------------
+
+export async function runAgentList(args: AgentListArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: '/admin-api/clients',
+  });
+  // status 0 / 4xx / 5xx: surface as-is via emit's error branch.
+  if (result.status === 0 || result.status >= 400) {
+    return emit(result, args.json, () => '');
+  }
+  const filtered: ApiResult = args.connected
+    ? { status: result.status, body: filterConnected(result.body) }
+    : result;
+  return emit(filtered, args.json, (b) => renderAgentRegistrationList(b, args.connected));
+}
+
+export async function runAgentRevoke(args: AgentRevokeArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  // The server-side resolver accepts agent_id, legacy client_id, or the
+  // registration name (admin-api.ts resolveClient), so we can keep the
+  // same endpoint and let the operator pass any of those.
+  const result = await callApi({
+    session,
+    method: 'DELETE',
+    path: `/admin-api/clients/${encodeURIComponent(args.target)}`,
+  });
+  return emit(result, args.json, renderRevokeResult);
+}
+
+interface CallerCommonArgs {
+  bridge?: string;
+  token?: string;
+  json: boolean;
+  agentId: string;
+}
+
+async function execListCallers(args: CallerCommonArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/callers`,
+  });
+  return emit(result, args.json, renderCallerList);
+}
+
+async function execAddCaller(args: CallerCommonArgs & { principal: string }): Promise<number> {
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
@@ -307,7 +517,7 @@ export async function runAddCaller(args: AddCallerArgs): Promise<number> {
   return emit(result, args.json, renderCallerMutation);
 }
 
-export async function runRemoveCaller(args: RemoveCallerArgs): Promise<number> {
+async function execRemoveCaller(args: CallerCommonArgs & { principal: string }): Promise<number> {
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
@@ -321,21 +531,47 @@ export async function runRemoveCaller(args: RemoveCallerArgs): Promise<number> {
   return emit(result, args.json, renderCallerMutation);
 }
 
+export async function runAgentCallersList(args: AgentCallersListArgs): Promise<number> {
+  return execListCallers(args);
+}
+
+export async function runAgentCallersAdd(args: AgentCallersAddArgs): Promise<number> {
+  return execAddCaller(args);
+}
+
+export async function runAgentCallersRemove(args: AgentCallersRemoveArgs): Promise<number> {
+  return execRemoveCaller(args);
+}
+
+// ----- Deprecated flat handlers ---------------------------------------------
+// Each emits a one-line stderr warning suggesting the new form and then
+// dispatches to the same implementation.
+
+function warnDeprecated(oldForm: string, newForm: string): void {
+  process.stderr.write(
+    `[warning] \`vicoop-client ${oldForm}\` is deprecated; ` +
+      `use \`vicoop-client ${newForm}\` instead. ` +
+      'The deprecated form will be removed in a future release.\n',
+  );
+}
+
+export async function runAddCaller(args: AddCallerArgs): Promise<number> {
+  warnDeprecated('add-caller', 'agent callers add');
+  return execAddCaller(args);
+}
+
+export async function runRemoveCaller(args: RemoveCallerArgs): Promise<number> {
+  warnDeprecated('remove-caller', 'agent callers remove');
+  return execRemoveCaller(args);
+}
+
 export async function runListCallers(args: ListCallersArgs): Promise<number> {
-  const session = resolveSession(args);
-  if ('error' in session) {
-    process.stderr.write(`${session.error}\n`);
-    return 1;
-  }
-  const result = await callApi({
-    session,
-    method: 'GET',
-    path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/callers`,
-  });
-  return emit(result, args.json, renderCallerList);
+  warnDeprecated('list-callers', 'agent callers list');
+  return execListCallers(args);
 }
 
 export async function runListClients(args: ListClientsArgs): Promise<number> {
+  warnDeprecated('list-clients', 'agent list');
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
@@ -350,6 +586,7 @@ export async function runListClients(args: ListClientsArgs): Promise<number> {
 }
 
 export async function runRevokeClient(args: RevokeClientArgs): Promise<number> {
+  warnDeprecated('revoke-client', 'agent revoke');
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
@@ -364,6 +601,7 @@ export async function runRevokeClient(args: RevokeClientArgs): Promise<number> {
 }
 
 export async function runListAgents(args: ListAgentsArgs): Promise<number> {
+  warnDeprecated('list-agents', 'agent list --connected');
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -20,11 +20,11 @@ import { agentRegisterCmd } from './setup.js';
 // All six admin subcommands share the same auth/output flags. Define them
 // once and splice into each command's parser to keep the surface uniform.
 const sharedFlags = {
-  bridge: optional(option('--bridge', string({ metavar: 'URL' }), {
+  server: optional(option('--server', string({ metavar: 'URL' }), {
     description: message`Override the bridge URL from the saved owner-session. Pair with --token.`,
   })),
   token: optional(option('--token', string({ metavar: 'TOKEN' }), {
-    description: message`Override the owner-session token from disk. Pair with --bridge.`,
+    description: message`Override the owner-session token from disk. Pair with --server.`,
   })),
   json: withDefault(flag('--json', {
     description: message`Emit a machine-readable JSON response.`,
@@ -220,26 +220,28 @@ interface Session {
   token: string;
 }
 
-// Auth resolution shared by every admin handler. Explicit --bridge/--token
-// wins; otherwise we fall back to the file `vicoop-client login` wrote (or
-// VICOOP_BRIDGE / VICOOP_OWNER_TOKEN if the operator prefers env, which is
-// owner-session-bootstrap, *not* daemon runtime config — see #189 §5
-// rationale).
+// Auth resolution shared by every admin handler. Explicit --server/--token
+// wins; otherwise we fall back to the file `vicoop-client auth login` wrote
+// (or VICOOP_BRIDGE / VICOOP_OWNER_TOKEN if the operator prefers env, which
+// is owner-session-bootstrap, *not* daemon runtime config — see #189 §5
+// rationale). The on-disk owner-session schema still names the field
+// `bridge`; only the args / flag layer was renamed to `server` for parity
+// with the daemon flag (#225-style rename folded into #218 / #224).
 function resolveSession(args: {
-  bridge?: string;
+  server?: string;
   token?: string;
 }): Session | { error: string } {
-  if (args.bridge && args.token) {
-    return { bridge: args.bridge.replace(/\/$/, ''), token: args.token };
+  if (args.server && args.token) {
+    return { bridge: args.server.replace(/\/$/, ''), token: args.token };
   }
   const stored = resolveOwnerSession();
-  const bridge = args.bridge ?? stored?.bridge;
+  const bridge = args.server ?? stored?.bridge;
   const token = args.token ?? stored?.token;
   if (!bridge || !token) {
     return {
       error:
-        'No owner-session bearer found. Run `vicoop-client login --bridge <URL>` first, ' +
-        'or pass --bridge and --token explicitly (or set VICOOP_BRIDGE / VICOOP_OWNER_TOKEN).',
+        'No owner-session bearer found. Run `vicoop-client auth login --server <URL>` first, ' +
+        'or pass --server and --token explicitly (or set VICOOP_BRIDGE / VICOOP_OWNER_TOKEN).',
     };
   }
   return { bridge: bridge.replace(/\/$/, ''), token };

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -24,9 +24,10 @@ import { loginCmd, runLogin } from './login.js';
 import { logoutCmd, runLogout } from './logout.js';
 import { setupCmd, runSetup } from './setup.js';
 import {
-  addCallerCmd, listAgentsCmd, listCallersCmd, listClientsCmd,
+  addCallerCmd, agentCmd, listAgentsCmd, listCallersCmd, listClientsCmd,
   removeCallerCmd, revokeClientCmd,
-  runAddCaller, runListAgents, runListCallers, runListClients,
+  runAddCaller, runAgentCallersAdd, runAgentCallersList, runAgentCallersRemove,
+  runAgentList, runAgentRevoke, runListAgents, runListCallers, runListClients,
   runRemoveCaller, runRevokeClient,
 } from './admin-cli.js';
 import { whoamiCmd, runWhoami } from './whoami.js';
@@ -101,6 +102,7 @@ const cli = longestMatch(
   logoutCmd,
   setupCmd,
   upgradeCmd,
+  agentCmd,
   addCallerCmd,
   removeCallerCmd,
   listCallersCmd,
@@ -339,6 +341,21 @@ async function main(): Promise<void> {
       break;
     case 'upgrade':
       process.exit(await runUpgradeCmd(parsed));
+      break;
+    case 'agent-list':
+      process.exit(await runAgentList(parsed));
+      break;
+    case 'agent-revoke':
+      process.exit(await runAgentRevoke(parsed));
+      break;
+    case 'agent-callers-list':
+      process.exit(await runAgentCallersList(parsed));
+      break;
+    case 'agent-callers-add':
+      process.exit(await runAgentCallersAdd(parsed));
+      break;
+    case 'agent-callers-remove':
+      process.exit(await runAgentCallersRemove(parsed));
       break;
     case 'add-caller':
       process.exit(await runAddCaller(parsed));

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -22,7 +22,7 @@ import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
 import { loginCmd, runLogin } from './login.js';
 import { logoutCmd, runLogout } from './logout.js';
-import { setupCmd, runSetup } from './setup.js';
+import { setupCmd, runAgentRegister, runSetup } from './setup.js';
 import {
   addCallerCmd, agentCmd, listAgentsCmd, listCallersCmd, listClientsCmd,
   removeCallerCmd, revokeClientCmd,
@@ -341,6 +341,9 @@ async function main(): Promise<void> {
       break;
     case 'upgrade':
       process.exit(await runUpgradeCmd(parsed));
+      break;
+    case 'agent-register':
+      process.exit(await runAgentRegister(parsed));
       break;
     case 'agent-list':
       process.exit(await runAgentList(parsed));

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -20,8 +20,8 @@ import { createVicoopCodexBackend } from './backends/vicoop-codex.js';
 import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
-import { loginCmd, runLogin } from './login.js';
-import { logoutCmd, runLogout } from './logout.js';
+import { authLoginCmd, loginCmd, runAuthLogin, runLogin } from './login.js';
+import { authLogoutCmd, logoutCmd, runAuthLogout, runLogout } from './logout.js';
 import { setupCmd, runAgentRegister, runSetup } from './setup.js';
 import {
   addCallerCmd, agentCmd, listAgentsCmd, listCallersCmd, listClientsCmd,
@@ -30,7 +30,7 @@ import {
   runAgentList, runAgentRevoke, runListAgents, runListCallers, runListClients,
   runRemoveCaller, runRevokeClient,
 } from './admin-cli.js';
-import { whoamiCmd, runWhoami } from './whoami.js';
+import { authWhoamiCmd, whoamiCmd, runAuthWhoami, runWhoami } from './whoami.js';
 import { deriveIdentity } from './identity.js';
 import {
   type ClientConfig,
@@ -97,7 +97,20 @@ const daemonCmd = object({
 // daemonCmd structurally matches. With longestMatch, subcommand branches
 // win whenever their keyword is present (longer match), and daemonCmd
 // wins otherwise.
+// Owner-session umbrella. Mirrors the `agent` umbrella from #218: both new
+// subcommands sit under their topic, the flat versions stay as deprecated
+// aliases.
+const authCmd = command(
+  'auth',
+  longestMatch(authLoginCmd, authLogoutCmd, authWhoamiCmd),
+  {
+    brief: message`Manage owner-session and identity (sign in / out / whoami).`,
+    description: message`Operator-facing umbrella for owner-session and agent-identity. Subcommands: \`login\`, \`logout\`, \`whoami\`. Replaces the older flat \`login\` / \`logout\` / \`whoami\` commands, which remain as deprecated aliases.`,
+  },
+);
+
 const cli = longestMatch(
+  authCmd,
   loginCmd,
   logoutCmd,
   setupCmd,
@@ -330,6 +343,15 @@ async function main(): Promise<void> {
   });
 
   switch (parsed.action) {
+    case 'auth-login':
+      process.exit(await runAuthLogin(parsed));
+      break;
+    case 'auth-logout':
+      process.exit(await runAuthLogout(parsed));
+      break;
+    case 'auth-whoami':
+      process.exit(await runAuthWhoami(parsed));
+      break;
     case 'login':
       process.exit(await runLogin(parsed));
       break;

--- a/packages/client/src/login.test.ts
+++ b/packages/client/src/login.test.ts
@@ -10,11 +10,11 @@ import { runAuthLogin, runLogin } from './login.js';
 // construct that shape directly — argv-level parsing is owned by optique
 // and exercised at the integration level in cli.test (top-level `run()`).
 function loginArgs(p: Partial<Omit<LoginArgs, 'action'>> = {}): LoginArgs {
-  return { action: 'login', bridge: undefined, json: false, pollOnce: false, ...p };
+  return { action: 'login', server: undefined, json: false, pollOnce: false, ...p };
 }
 
 function authLoginArgs(p: Partial<Omit<AuthLoginArgs, 'action'>> = {}): AuthLoginArgs {
-  return { action: 'auth-login', bridge: undefined, json: false, pollOnce: false, ...p };
+  return { action: 'auth-login', server: undefined, json: false, pollOnce: false, ...p };
 }
 
 test('login saves owner-session bearer without registering a client', async (t) => {
@@ -79,7 +79,7 @@ test('login saves owner-session bearer without registering a client', async (t) 
     return true;
   });
 
-  const code = await runLogin(loginArgs({ bridge: 'https://bridge.test' }));
+  const code = await runLogin(loginArgs({ server: 'https://bridge.test' }));
 
   assert.equal(code, 0);
   assert.equal(calls.length, 2);
@@ -202,7 +202,7 @@ test('auth login dispatches to the same flow without emitting a deprecation warn
     return true;
   });
 
-  const code = await runAuthLogin(authLoginArgs({ bridge: 'https://bridge.test' }));
+  const code = await runAuthLogin(authLoginArgs({ server: 'https://bridge.test' }));
   assert.equal(code, 0);
   // Same handler body as runLogin (verified by the post-login hint), without
   // the deprecation banner the legacy `login` entry point emits.
@@ -248,7 +248,7 @@ test('legacy login prints a deprecation warning pointing at auth login', async (
     return true;
   });
 
-  const code = await runLogin(loginArgs({ bridge: 'https://bridge.test' }));
+  const code = await runLogin(loginArgs({ server: 'https://bridge.test' }));
   assert.equal(code, 0);
   assert.match(stderr, /vicoop-client login.*deprecated.*vicoop-client auth login/s);
 });

--- a/packages/client/src/login.test.ts
+++ b/packages/client/src/login.test.ts
@@ -3,14 +3,18 @@ import test from 'node:test';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { LoginArgs } from './login.js';
-import { runLogin } from './login.js';
+import type { AuthLoginArgs, LoginArgs } from './login.js';
+import { runAuthLogin, runLogin } from './login.js';
 
 // `runLogin` now takes the parser's discriminated-union output. Tests
 // construct that shape directly — argv-level parsing is owned by optique
 // and exercised at the integration level in cli.test (top-level `run()`).
 function loginArgs(p: Partial<Omit<LoginArgs, 'action'>> = {}): LoginArgs {
   return { action: 'login', bridge: undefined, json: false, pollOnce: false, ...p };
+}
+
+function authLoginArgs(p: Partial<Omit<AuthLoginArgs, 'action'>> = {}): AuthLoginArgs {
+  return { action: 'auth-login', bridge: undefined, json: false, pollOnce: false, ...p };
 }
 
 test('login saves owner-session bearer without registering a client', async (t) => {
@@ -87,7 +91,7 @@ test('login saves owner-session bearer without registering a client', async (t) 
   assert.equal(saved.bridge, 'https://bridge.test');
   assert.equal(saved.token, 'vbc_owner_test');
   assert.equal(saved.principal_id, 'google:123');
-  assert.match(stderr, /Run `vicoop-client setup`/);
+  assert.match(stderr, /Run `vicoop-client agent register`/);
 });
 
 test('login falls back to DEFAULT_BRIDGE_HTTPS_URL when --bridge is omitted', async (t) => {
@@ -157,4 +161,94 @@ test('login falls back to DEFAULT_BRIDGE_HTTPS_URL when --bridge is omitted', as
     seen.every((u) => u.startsWith('https://vicoop-bridge-server.fly.dev/')),
     `expected every fetch to hit the default bridge URL; got ${JSON.stringify(seen)}`,
   );
+});
+
+// ---- New `auth login` surface ----------------------------------------------
+
+test('auth login dispatches to the same flow without emitting a deprecation warning', async (t) => {
+  const previousHome = process.env.HOME;
+  const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-auth-login-'));
+  process.env.HOME = tmpHome;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  t.after(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    delete process.env.VICOOP_HOME;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  const originalFetch = globalThis.fetch;
+  let call = 0;
+  globalThis.fetch = (async () => {
+    call++;
+    if (call === 1) {
+      return new Response(JSON.stringify({
+        device_code: 'D', user_code: 'AB-CD',
+        verification_uri: 'https://bridge.test/oauth/device',
+        verification_uri_complete: 'https://bridge.test/oauth/device?user_code=AB-CD',
+        expires_in: 600, interval: 1,
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      access_token: 'vbc_owner_x', token_type: 'Bearer', expires_in: 3600,
+      principal_id: 'google:123', email: 'op@example.com',
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  const code = await runAuthLogin(authLoginArgs({ bridge: 'https://bridge.test' }));
+  assert.equal(code, 0);
+  // Same handler body as runLogin (verified by the post-login hint), without
+  // the deprecation banner the legacy `login` entry point emits.
+  assert.doesNotMatch(stderr, /deprecated/i);
+  assert.match(stderr, /Saved owner-session bearer/);
+  assert.match(stderr, /Run `vicoop-client agent register`/);
+});
+
+test('legacy login prints a deprecation warning pointing at auth login', async (t) => {
+  const previousHome = process.env.HOME;
+  const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-legacy-login-'));
+  process.env.HOME = tmpHome;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  t.after(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    delete process.env.VICOOP_HOME;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  const originalFetch = globalThis.fetch;
+  let call = 0;
+  globalThis.fetch = (async () => {
+    call++;
+    if (call === 1) {
+      return new Response(JSON.stringify({
+        device_code: 'D', user_code: 'AB-CD',
+        verification_uri: 'https://bridge.test/oauth/device',
+        verification_uri_complete: 'https://bridge.test/oauth/device?user_code=AB-CD',
+        expires_in: 600, interval: 1,
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response(JSON.stringify({
+      access_token: 'vbc_owner_x', token_type: 'Bearer', expires_in: 3600,
+      principal_id: 'google:123', email: null,
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  const code = await runLogin(loginArgs({ bridge: 'https://bridge.test' }));
+  assert.equal(code, 0);
+  assert.match(stderr, /vicoop-client login.*deprecated.*vicoop-client auth login/s);
 });

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -1,7 +1,9 @@
-// `vicoop-client login` — authenticate the operator and persist an
-// owner-session bearer. Client creation is deliberately handled by
-// `vicoop-client setup` so login has no server-side client-registration
-// side effects.
+// `vicoop-client auth login` — authenticate the operator and persist an
+// owner-session bearer. Agent registration is deliberately handled by
+// `vicoop-client agent register` so login has no server-side side effects.
+//
+// The legacy flat `vicoop-client login` parser stays exported as a
+// deprecated alias; both surfaces dispatch to the same handler.
 
 import { object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
@@ -15,32 +17,54 @@ import {
   saveOwnerSession,
 } from './owner-session.js';
 
-// `login` is one branch of the top-level `or(...)` parser in cli.ts.
-// `action: constant("login")` is the discriminator the dispatch switch
-// reads after `run()` returns.
+// Shared field shape for both the new `auth login` and the legacy `login`
+// command. Defined once so the two parsers stay in lockstep — adding a
+// flag in one place automatically surfaces in the other.
+const loginFields = {
+  bridge: optional(
+    option('--bridge', string({ metavar: 'URL' }), {
+      description: message`Bridge HTTPS URL (defaults to ${DEFAULT_BRIDGE_HTTPS_URL}; override only when running your own bridge).`,
+    }),
+  ),
+  json: withDefault(
+    flag('--json', {
+      description: message`Print the token-endpoint response as JSON to stdout without persisting ~/.vicoop/owner-session.json.`,
+    }),
+    false,
+  ),
+  // Undocumented test/CI smoke flag — exits after the first poll cycle
+  // so login.test.ts can drive a deterministic fixture without sleeping
+  // through the real device-flow polling interval.
+  pollOnce: withDefault(flag('--poll-once'), false),
+};
+
+// New agent-first surface: `vicoop-client auth login`. Wired into
+// `authCmd` over in cli.ts (longestMatch with auth logout). The
+// `action: constant('auth-login')` discriminator drives dispatch.
+export const authLoginCmd = command(
+  'login',
+  object({
+    action: constant('auth-login' as const),
+    ...loginFields,
+  }),
+  {
+    brief: message`Sign in as the agent owner and save an owner-session bearer.`,
+    description: message`Drives Google OAuth device flow and issues an owner-session bearer used by \`agent register\`, \`agent list/revoke/callers\`. By default the token is saved to ~/.vicoop/owner-session.json (chmod 600) so admin subcommands pick it up automatically; pass --json to print the raw token-endpoint response to stdout instead (that mode does NOT persist the session).`,
+  },
+);
+
+export type AuthLoginArgs = InferValue<typeof authLoginCmd>;
+
+// Legacy flat `vicoop-client login`. Kept as a deprecated alias.
 export const loginCmd = command(
   'login',
   object({
     action: constant('login' as const),
-    bridge: optional(
-      option('--bridge', string({ metavar: 'URL' }), {
-        description: message`Bridge HTTPS URL (defaults to ${DEFAULT_BRIDGE_HTTPS_URL}; override only when running your own bridge).`,
-      }),
-    ),
-    json: withDefault(
-      flag('--json', {
-        description: message`Print the token-endpoint response as JSON to stdout without persisting ~/.vicoop/owner-session.json.`,
-      }),
-      false,
-    ),
-    // Undocumented test/CI smoke flag — exits after the first poll cycle
-    // so login.test.ts can drive a deterministic fixture without sleeping
-    // through the real device-flow polling interval.
-    pollOnce: withDefault(flag('--poll-once'), false),
+    ...loginFields,
   }),
   {
-    brief: message`Sign in as the client owner and save an owner-session bearer.`,
-    description: message`Drives Google OAuth device flow and issues an owner-session bearer used by setup / add-caller / list-callers / list-agents / remove-caller. By default the token is saved to ~/.vicoop/owner-session.json (chmod 600) so admin subcommands pick it up automatically; pass --json to print the raw token-endpoint response to stdout instead (that mode does NOT persist the session).`,
+    brief: message`[deprecated] Use \`auth login\`.`,
+    description: message`Deprecated alias for \`vicoop-client auth login\`. Will be removed in a future release.`,
   },
 );
 
@@ -143,7 +167,29 @@ function saveOwnerSessionBearer(bridgeUrl: string, success: OwnerSessionSuccess)
   return path;
 }
 
+// Common shape both LoginArgs and AuthLoginArgs satisfy — `executeLogin`
+// accepts this so the handler body is written once and the two thin entry
+// points only differ in whether they emit a deprecation warning.
+interface LoginCommonArgs {
+  bridge?: string;
+  json: boolean;
+  pollOnce: boolean;
+}
+
+export async function runAuthLogin(args: AuthLoginArgs): Promise<number> {
+  return executeLogin(args);
+}
+
 export async function runLogin(args: LoginArgs): Promise<number> {
+  process.stderr.write(
+    '[warning] `vicoop-client login` is deprecated; ' +
+      'use `vicoop-client auth login` instead. ' +
+      'The deprecated form will be removed in a future release.\n',
+  );
+  return executeLogin(args);
+}
+
+async function executeLogin(args: LoginCommonArgs): Promise<number> {
   // No --bridge → public default (#189 §6). Self-hosters pass
   // `--bridge https://bridge.example.com`.
   const bridge = args.bridge ?? DEFAULT_BRIDGE_HTTPS_URL;
@@ -190,13 +236,13 @@ export async function runLogin(args: LoginArgs): Promise<number> {
         const path = saveOwnerSessionBearer(bridge, success);
         process.stderr.write(
           `Saved owner-session bearer to ${path} (mode 600).\n` +
-            'Run `vicoop-client setup` to create a bridge client token.\n',
+            'Run `vicoop-client agent register` to register an agent and mint an agent token.\n',
         );
       }
       return 0;
     }
     if (result.kind === 'expired') {
-      process.stderr.write('\nDevice session expired. Re-run `vicoop-client login`.\n');
+      process.stderr.write('\nDevice session expired. Re-run `vicoop-client auth login`.\n');
       return 1;
     }
     if (result.kind === 'error') {

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -21,8 +21,8 @@ import {
 // command. Defined once so the two parsers stay in lockstep — adding a
 // flag in one place automatically surfaces in the other.
 const loginFields = {
-  bridge: optional(
-    option('--bridge', string({ metavar: 'URL' }), {
+  server: optional(
+    option('--server', string({ metavar: 'URL' }), {
       description: message`Bridge HTTPS URL (defaults to ${DEFAULT_BRIDGE_HTTPS_URL}; override only when running your own bridge).`,
     }),
   ),
@@ -171,7 +171,7 @@ function saveOwnerSessionBearer(bridgeUrl: string, success: OwnerSessionSuccess)
 // accepts this so the handler body is written once and the two thin entry
 // points only differ in whether they emit a deprecation warning.
 interface LoginCommonArgs {
-  bridge?: string;
+  server?: string;
   json: boolean;
   pollOnce: boolean;
 }
@@ -190,9 +190,9 @@ export async function runLogin(args: LoginArgs): Promise<number> {
 }
 
 async function executeLogin(args: LoginCommonArgs): Promise<number> {
-  // No --bridge → public default (#189 §6). Self-hosters pass
-  // `--bridge https://bridge.example.com`.
-  const bridge = args.bridge ?? DEFAULT_BRIDGE_HTTPS_URL;
+  // No --server → public default (#189 §6). Self-hosters pass
+  // `--server https://bridge.example.com`.
+  const bridge = args.server ?? DEFAULT_BRIDGE_HTTPS_URL;
 
   let device: DeviceCodeResponse;
   try {

--- a/packages/client/src/logout.test.ts
+++ b/packages/client/src/logout.test.ts
@@ -3,11 +3,15 @@ import test from 'node:test';
 import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { LogoutArgs } from './logout.js';
-import { runLogout } from './logout.js';
+import type { AuthLogoutArgs, LogoutArgs } from './logout.js';
+import { runAuthLogout, runLogout } from './logout.js';
 
 function logoutArgs(p: Partial<Omit<LogoutArgs, 'action'>> = {}): LogoutArgs {
   return { action: 'logout', localOnly: false, keepLocal: false, ...p };
+}
+
+function authLogoutArgs(p: Partial<Omit<AuthLogoutArgs, 'action'>> = {}): AuthLogoutArgs {
+  return { action: 'auth-logout', localOnly: false, keepLocal: false, ...p };
 }
 
 // Pins $VICOOP_HOME so loadOwnerSession / defaultStorePath route into the
@@ -187,4 +191,37 @@ test('logout --keep-local revokes server-side but leaves the file in place', asy
   assert.equal(calls.length, 1);
   assert.match(stderr, /--keep-local/);
   assert.equal(existsSync(sessionPath), true);
+});
+
+// ---- New `auth logout` surface --------------------------------------------
+
+test('auth logout does NOT emit a deprecation warning', async (t) => {
+  const { sessionPath, writeSession } = pinVicoopHome(t);
+  writeSession();
+  // No bridge fetch needed for --local-only; keep it offline.
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  const code = await runAuthLogout(authLogoutArgs({ localOnly: true }));
+  assert.equal(code, 0);
+  assert.equal(existsSync(sessionPath), false);
+  assert.doesNotMatch(stderr, /deprecated/i);
+});
+
+test('legacy logout prints a deprecation warning pointing at auth logout', async (t) => {
+  const { sessionPath, writeSession } = pinVicoopHome(t);
+  writeSession();
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  const code = await runLogout(logoutArgs({ localOnly: true }));
+  assert.equal(code, 0);
+  assert.equal(existsSync(sessionPath), false);
+  assert.match(stderr, /vicoop-client logout.*deprecated.*vicoop-client auth logout/s);
 });

--- a/packages/client/src/logout.ts
+++ b/packages/client/src/logout.ts
@@ -31,26 +31,47 @@ import {
   loadOwnerSession,
 } from './owner-session.js';
 
-export const logoutCmd = command(
+// Shared field shape for both the new `auth logout` and the legacy `logout`
+// command. Adding a flag in one place automatically surfaces in the other.
+const logoutFields = {
+  localOnly: withDefault(
+    flag('--local-only', {
+      description: message`Skip the server-side revoke; just delete the local owner-session file.`,
+    }),
+    false,
+  ),
+  keepLocal: withDefault(
+    flag('--keep-local', {
+      description: message`Revoke server-side but leave ~/.vicoop/owner-session.json in place.`,
+    }),
+    false,
+  ),
+};
+
+export const authLogoutCmd = command(
   'logout',
   object({
-    action: constant('logout' as const),
-    localOnly: withDefault(
-      flag('--local-only', {
-        description: message`Skip the server-side revoke; just delete the local owner-session file.`,
-      }),
-      false,
-    ),
-    keepLocal: withDefault(
-      flag('--keep-local', {
-        description: message`Revoke server-side but leave ~/.vicoop/owner-session.json in place.`,
-      }),
-      false,
-    ),
+    action: constant('auth-logout' as const),
+    ...logoutFields,
   }),
   {
     brief: message`Invalidate the owner-session bearer and clear the local copy.`,
     description: message`Calls the bridge's RFC 7009 /oauth/revoke endpoint with the stored owner-session bearer, then deletes ~/.vicoop/owner-session.json. Use --local-only when the bridge is unreachable, or --keep-local to revoke server-side without removing the file. A missing local session is reported but not an error.`,
+  },
+);
+
+export type AuthLogoutArgs = InferValue<typeof authLogoutCmd>;
+
+// Legacy flat `vicoop-client logout`. Kept as a deprecated alias.
+export const logoutCmd = command(
+  'logout',
+  object({
+    action: constant('logout' as const),
+    ...logoutFields,
+  }),
+  {
+    brief: message`[deprecated] Use \`auth logout\`.`,
+    description: message`Deprecated alias for \`vicoop-client auth logout\`. Will be removed in a future release.`,
   },
 );
 
@@ -74,7 +95,25 @@ async function revokeOnServer(bridge: string, token: string): Promise<{ ok: bool
   }
 }
 
+interface LogoutCommonArgs {
+  localOnly: boolean;
+  keepLocal: boolean;
+}
+
+export async function runAuthLogout(args: AuthLogoutArgs): Promise<number> {
+  return executeLogout(args);
+}
+
 export async function runLogout(args: LogoutArgs): Promise<number> {
+  process.stderr.write(
+    '[warning] `vicoop-client logout` is deprecated; ' +
+      'use `vicoop-client auth logout` instead. ' +
+      'The deprecated form will be removed in a future release.\n',
+  );
+  return executeLogout(args);
+}
+
+async function executeLogout(args: LogoutCommonArgs): Promise<number> {
   const path = defaultStorePath();
   const session = loadOwnerSession(path);
 

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -930,11 +930,24 @@ function installAgentRegisterFixture(t: TestContext): {
   const envFile = join(tmpHome, 'vicoop-client.env');
   t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
 
+  // Pin both `VICOOP_HOME` and `HOME` so `resolveConfigDir()` lands inside the
+  // tmp dir on every host. Clearing `XDG_CONFIG_HOME` matters on CI runners
+  // (Linux) where it is exported by default — otherwise the config write goes
+  // to `$XDG_CONFIG_HOME/vicoop/config.json` while the assertion reads
+  // `${tmpHome}/.vicoop/config.json` and sees `null`.
   const prevHome = process.env.HOME;
+  const prevVicoop = process.env.VICOOP_HOME;
+  const prevXdg = process.env.XDG_CONFIG_HOME;
   process.env.HOME = tmpHome;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  delete process.env.XDG_CONFIG_HOME;
   t.after(() => {
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;
+    if (prevVicoop === undefined) delete process.env.VICOOP_HOME;
+    else process.env.VICOOP_HOME = prevVicoop;
+    if (prevXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = prevXdg;
   });
 
   saveOwnerSession({

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { saveOwnerSession } from './owner-session.js';
-import { runSetup, type SetupArgs } from './setup.js';
+import { runAgentRegister, runSetup, type AgentRegisterArgs, type SetupArgs } from './setup.js';
 import { readConfig } from './config.js';
 
 // `runSetup` now takes the parser's discriminated-union output. Tests
@@ -891,4 +891,202 @@ test('setup quotes env values so shell metacharacters cannot trigger expansion',
   // Anything else (a bare letter, `$`, backtick) means the value escaped the
   // quoted literal and would be evaluated on `. vicoop-client.env`.
   assert.doesNotMatch(body, /^export AGENT_ID=[^']/m);
+});
+
+// ---- New `agent register` surface (#224) -----------------------------------
+
+function agentRegisterArgs(
+  p: { name: string; agentId: string }
+    & Partial<Omit<AgentRegisterArgs, 'action' | 'name' | 'agentId'>>,
+): AgentRegisterArgs {
+  const {
+    name, agentId,
+    callers = [], envFile, envFileAlias, bridge, token, json = false,
+  } = p;
+  return {
+    action: 'agent-register',
+    name,
+    agentId,
+    callers,
+    envFile,
+    envFileAlias,
+    bridge,
+    token,
+    json,
+  };
+}
+
+function installAgentRegisterFixture(t: {
+  after: (fn: () => void) => void;
+  mock: { method: (...args: unknown[]) => unknown };
+}): {
+  tmpHome: string;
+  envFile: string;
+  calls: Array<{ url: string; method?: string; body: string }>;
+  stderr: () => string;
+} {
+  const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-agent-register-'));
+  const envFile = join(tmpHome, 'vicoop-client.env');
+  t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
+
+  const prevHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  t.after(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+  });
+
+  saveOwnerSession({
+    bridge: 'https://bridge.test',
+    token: 'vbc_owner_test',
+    principal_id: 'google:123',
+    email: 'owner@example.com',
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    saved_at: new Date().toISOString(),
+  });
+
+  const calls: Array<{ url: string; method?: string; body: string }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({
+      url,
+      method: init?.method,
+      body: typeof init?.body === 'string' ? init.body : '',
+    });
+    if (url.endsWith('/graphql')) {
+      return new Response(JSON.stringify({
+        data: {
+          registerClient: {
+            clientWithToken: {
+              id: 'reg-uuid-1',
+              token: 'agent-token-1',
+              ownerPrincipal: 'google:123',
+              allowedAgentIds: ['codex-Mac'],
+            },
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    // caller add success
+    return new Response(JSON.stringify({
+      agent_id: 'codex-Mac', principal: 'eth:0xabc', allowed_callers: ['eth:0xabc'],
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+  return { tmpHome, envFile, calls, stderr: () => stderr };
+}
+
+test('agent register calls registerClient with a 1-element allowedAgentIds and writes config', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    name: 'codex on Mac', agentId: 'codex-Mac', envFile: fix.envFile,
+  }));
+
+  assert.equal(code, 0);
+  assert.equal(fix.calls.length, 1);
+  assert.equal(fix.calls[0].url, 'https://bridge.test/graphql');
+  // Server-side 1:1 enforcement (#219) means the array must contain exactly
+  // one id; the new flag is singular so this is the natural shape.
+  // GraphQL mutation body is JSON-encoded, so inner double quotes appear
+  // escaped as \" — accept either form.
+  assert.match(fix.calls[0].body, /allowedAgentIds:\[\\"codex-Mac\\"\]/);
+  assert.match(fix.calls[0].body, /clientName:\\"codex on Mac\\"/);
+
+  const config = readConfig(join(fix.tmpHome, '.vicoop', 'config.json'));
+  assert.deepEqual(config, {
+    server_url: 'wss://bridge.test',
+    server_token: 'agent-token-1',
+    agent_id: 'codex-Mac',
+  });
+});
+
+test('agent register stderr surfaces agent-first labels (agent_id, name, AGENT_TOKEN)', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    name: 'codex on Mac', agentId: 'codex-Mac',
+  }));
+
+  assert.equal(code, 0);
+  const out = fix.stderr();
+  // Operator-supplied agent_id (not the server's registration UUID) is the
+  // primary identifier in the success block.
+  assert.match(out, /agent_id\s+codex-Mac/);
+  assert.match(out, /name\s+codex on Mac/);
+  assert.match(out, /The AGENT_TOKEN is one-time/);
+  assert.match(out, /agent register persists it to the canonical config/);
+  // Recovery hint and "add caller" pointer also use the new vocabulary.
+  assert.match(out, /vicoop-client agent callers add/);
+  // The legacy CLIENT_TOKEN label should not appear on this surface.
+  assert.doesNotMatch(out, /CLIENT_TOKEN/);
+  assert.doesNotMatch(out, /client_id\b/);
+});
+
+test('agent register --json prints the registerClient response shape unchanged for back-compat', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+  let stdout = '';
+  t.mock.method(process.stdout, 'write', (chunk: string | Uint8Array) => {
+    stdout += String(chunk);
+    return true;
+  });
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    name: 'codex on Mac', agentId: 'codex-Mac', json: true,
+  }));
+
+  assert.equal(code, 0);
+  const parsed = JSON.parse(stdout) as Record<string, unknown>;
+  // Existing scripts depend on these field names; #224 explicitly keeps the
+  // JSON shape stable across the rename.
+  assert.equal(parsed.intent, 'client_register');
+  assert.equal(parsed.client_token, 'agent-token-1');
+  assert.equal(parsed.client_id, 'reg-uuid-1');
+  assert.deepEqual(parsed.allowed_agent_ids, ['codex-Mac']);
+});
+
+test('agent register configures callers when --caller is passed', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    name: 'codex on Mac', agentId: 'codex-Mac',
+    callers: ['eth:0xabc'],
+  }));
+
+  assert.equal(code, 0);
+  assert.equal(fix.calls.length, 2);
+  assert.equal(fix.calls[1].method, 'POST');
+  assert.equal(
+    fix.calls[1].url,
+    'https://bridge.test/admin-api/agents/codex-Mac/callers',
+  );
+});
+
+// ---- Legacy `setup` alias: deprecation warning -----------------------------
+
+test('legacy setup prints a stderr deprecation warning pointing at agent register', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  const code = await runSetup(setupArgs({
+    clientName: 'codex on Mac', allowedAgentIds: ['codex-Mac'],
+  }));
+
+  assert.equal(code, 0);
+  assert.match(
+    fix.stderr(),
+    /vicoop-client setup.*deprecated.*vicoop-client agent register --name NAME --agent-id ID/s,
+  );
+  // Old vocabulary stays present on the legacy surface (back-compat for scripts
+  // that parse stderr) — only the new path uses agent-first labels.
+  assert.match(fix.stderr(), /client_id\s+reg-uuid-1/);
+  assert.match(fix.stderr(), /The CLIENT_TOKEN is one-time/);
 });

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import test, { type TestContext } from 'node:test';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,7 +16,7 @@ function setupArgs(
 ): SetupArgs {
   const {
     clientName, allowedAgentIds,
-    callers = [], envFile, envFileAlias, bridge, token, json = false,
+    callers = [], envFile, envFileAlias, server, token, json = false,
   } = p;
   return {
     action: 'setup',
@@ -25,7 +25,7 @@ function setupArgs(
     callers,
     envFile,
     envFileAlias,
-    bridge,
+    server,
     token,
     json,
   };
@@ -296,9 +296,9 @@ test('setup requires explicit bridge and token to be passed together', async (t)
   assert.equal(await runSetup(setupArgs({
     clientName: 'test client',
     allowedAgentIds: ['agent-1'],
-    bridge: 'https://other-bridge.test',
+    server: 'https://other-bridge.test',
   })), 1);
-  assert.match(stderr, /Pass --bridge and --token together/);
+  assert.match(stderr, /Pass --server and --token together/);
 
   stderr = '';
   assert.equal(await runSetup(setupArgs({
@@ -306,7 +306,7 @@ test('setup requires explicit bridge and token to be passed together', async (t)
     allowedAgentIds: ['agent-1'],
     token: 'vbc_owner_other',
   })), 1);
-  assert.match(stderr, /Pass --bridge and --token together/);
+  assert.match(stderr, /Pass --server and --token together/);
 });
 
 test('setup prompts for login when no owner-session is available', async (t) => {
@@ -352,7 +352,7 @@ test('setup prompts for login when no owner-session is available', async (t) => 
   const code = await runSetup(setupArgs({ clientName: 'test client', allowedAgentIds: ['agent-1'] }));
 
   assert.equal(code, 1);
-  assert.match(stderr, /vicoop-client login --bridge/);
+  assert.match(stderr, /vicoop-client auth login --server/);
 });
 
 test('setup writes config.json by default and preserves operator-edited fields', async (t) => {
@@ -901,7 +901,7 @@ function agentRegisterArgs(
 ): AgentRegisterArgs {
   const {
     name, agentId,
-    callers = [], envFile, envFileAlias, bridge, token, json = false,
+    callers = [], envFile, envFileAlias, server, token, json = false,
   } = p;
   return {
     action: 'agent-register',
@@ -910,16 +910,17 @@ function agentRegisterArgs(
     callers,
     envFile,
     envFileAlias,
-    bridge,
+    server,
     token,
     json,
   };
 }
 
-function installAgentRegisterFixture(t: {
-  after: (fn: () => void) => void;
-  mock: { method: (...args: unknown[]) => unknown };
-}): {
+// The test-context fixture type is intentionally permissive — node:test's
+// real TestContext.mock.method signature is heavily overloaded and not
+// portable across versions, so the fixture just relies on the runtime
+// shape it actually uses.
+function installAgentRegisterFixture(t: TestContext): {
   tmpHome: string;
   envFile: string;
   calls: Array<{ url: string; method?: string; body: string }>;

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -1,7 +1,7 @@
-// `vicoop-client setup` — create a bridge client token using an existing
-// owner-session bearer, then persist the daemon credentials to the canonical
-// `config.json`. `--write-env-file` remains as an opt-in for operators who
-// want a shell-sourceable env file alongside the canonical config — see #137.
+// Agent registration command surface: the new `vicoop-client agent register`
+// (agent-first; see #224) and the legacy `vicoop-client setup` alias, both
+// backed by `executeRegistration`. `setup` keeps working but prints a
+// deprecation hint to stderr.
 
 import { existsSync } from 'node:fs';
 import { object } from '@optique/core/constructs';
@@ -27,7 +27,8 @@ export const setupCmd = command(
     // We accept comma-separated IDs in a single occurrence and explode
     // them post-parse. `map()` does the split so the handler always sees
     // a clean array — no callers need to remember the historical
-    // semicolon-or-comma trivia.
+    // semicolon-or-comma trivia. After #219 the server enforces a single
+    // id; we keep the comma-list shape here only for backward-compat.
     allowedAgentIds: map(option('--agent-ids', string({ metavar: 'ID1,ID2' }), {
       description: message`Comma-separated agent ids this client is allowed to run as.`,
     }), (raw) => raw.split(',').map((s) => s.trim()).filter(Boolean)),
@@ -53,12 +54,47 @@ export const setupCmd = command(
     }), false),
   }),
   {
-    brief: message`Register a bridge client and persist daemon credentials.`,
-    description: message`Calls the bridge's \`registerClient\` GraphQL mutation using the owner-session bearer (saved by \`vicoop-client login\`, or supplied via --bridge/--token), receives a one-time CLIENT_TOKEN, and writes the daemon credentials into the canonical \`~/.vicoop/config.json\` (mode 600). The token is unrecoverable after this single output; back up config.json before rotating hosts. \`--json\` skips disk persistence and prints the raw response instead.`,
+    brief: message`[deprecated] Use \`agent register\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent register\` (#224). Calls the bridge's \`registerClient\` GraphQL mutation, persists daemon credentials to \`~/.vicoop/config.json\`, and supports \`--write-env-file\` for an optional shell-sourceable env file. Will be removed in a future release.`,
   },
 );
 
 export type SetupArgs = InferValue<typeof setupCmd>;
+
+export const agentRegisterCmd = command(
+  'register',
+  object({
+    action: constant('agent-register' as const),
+    name: option('--name', string({ metavar: 'NAME' }), {
+      description: message`Human-readable label saved with this agent registration.`,
+    }),
+    agentId: option('--agent-id', string({ metavar: 'ID' }), {
+      description: message`Agent id (routing key external A2A callers will use). After #219 the server enforces a single agent per registration.`,
+    }),
+    callers: multiple(option('--caller', string({ metavar: 'PRINCIPAL' }), {
+      description: message`Principal allowed to call this agent. Repeatable; comma-separated lists also accepted within a single occurrence.`,
+    })),
+    envFile: optional(option('--write-env-file', string({ metavar: 'PATH' }), {
+      description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars (#189 §5); the file is purely an operator-side credentials backup / scripting hook.`,
+    })),
+    envFileAlias: optional(option('--env-file', string({ metavar: 'PATH' }))),
+    bridge: optional(option('--bridge', string({ metavar: 'URL' }), {
+      description: message`Override the bridge URL from the saved owner-session. Pair with --token.`,
+    })),
+    token: optional(option('--token', string({ metavar: 'TOKEN' }), {
+      description: message`Override the owner-session token from disk. Pair with --bridge.`,
+    })),
+    json: withDefault(flag('--json', {
+      description: message`Print the registration response as JSON to stdout instead of persisting to config.json.`,
+    }), false),
+  }),
+  {
+    brief: message`Register an agent and persist daemon credentials.`,
+    description: message`Calls the bridge's \`registerClient\` GraphQL mutation (compat name; the unified server model from #219 is agent-first) using the owner-session bearer saved by \`vicoop-client login\`, receives a one-time AGENT_TOKEN, and writes the daemon credentials into the canonical \`~/.vicoop/config.json\` (mode 600). The token is unrecoverable after this single output; back up config.json before rotating hosts. \`--json\` skips disk persistence and prints the raw response instead.`,
+  },
+);
+
+export type AgentRegisterArgs = InferValue<typeof agentRegisterCmd>;
 
 interface RegisterClientGraphQLResponse {
   data?: {
@@ -299,28 +335,53 @@ async function configureCallers(
   }
 }
 
-export async function runSetup(args: SetupArgs): Promise<number> {
-  if (args.allowedAgentIds.length === 0) {
-    process.stderr.write('--agent-ids is required\n');
+// Label set for human-output text. The new `agent register` and the
+// deprecated `setup` share the same wire path (and identical --json shape so
+// scripts on either entry point keep working) but diverge in their stderr
+// vocabulary. `renderSuccessBlock` picks the right identifier (agent_id is
+// the operator-supplied routing key; client_id is the legacy registration
+// UUID returned by registerClient) per surface.
+interface RegistrationLabels {
+  cmdName: string;        // 'agent register' or 'setup'
+  agentsFlag: string;     // '--agent-id' or '--agent-ids'
+  tokenLabel: string;     // 'AGENT_TOKEN' or 'CLIENT_TOKEN'
+  addCallerHint: string;  // 'vicoop-client agent callers add' or 'vicoop-client add-caller'
+  renderSuccessBlock: (s: ClientRegisterSuccess) => string;
+  renderRecoveryBlock: (s: ClientRegisterSuccess, serverUrl: string) => string;
+}
+
+interface ExecuteRegistrationOpts {
+  name: string;
+  allowedAgentIds: string[];
+  callers: string[];
+  envFile: string | null;
+  bridge: string | null;
+  token: string | null;
+  json: boolean;
+  labels: RegistrationLabels;
+}
+
+// Shared registration flow used by both `agent register` and the legacy
+// `setup` alias. Label strings are injected so callers can use the
+// vocabulary appropriate to their command surface; everything else
+// (preflight, GraphQL call, persistence, env-file write, caller
+// configuration, recovery hatches) is identical.
+async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<number> {
+  if (opts.allowedAgentIds.length === 0) {
+    process.stderr.write(`${opts.labels.agentsFlag} is required\n`);
     return 1;
   }
-  // `--caller` is repeatable AND accepts comma-separated values within each
-  // occurrence — explode both into a flat list.
-  const callers = args.callers.flatMap((c) =>
-    c.split(',').map((s) => s.trim()).filter(Boolean),
-  );
-  const envFile = args.envFile ?? args.envFileAlias ?? null;
 
   const stored = resolveOwnerSession();
-  if ((args.bridge && !args.token) || (!args.bridge && args.token)) {
+  if ((opts.bridge && !opts.token) || (!opts.bridge && opts.token)) {
     process.stderr.write(
       'Pass --bridge and --token together. Owner-session credentials are tied to their bridge URL.\n',
     );
     return 1;
   }
 
-  const session = args.bridge && args.token
-    ? { bridge: args.bridge, token: args.token }
+  const session = opts.bridge && opts.token
+    ? { bridge: opts.bridge, token: opts.token }
     : stored;
   const bridge = session?.bridge;
   const token = session?.token;
@@ -337,17 +398,16 @@ export async function runSetup(args: SetupArgs): Promise<number> {
   // client token. Otherwise `registerClient` succeeds, the token comes back
   // exactly once from the bridge, and `writeConfigForSetup` then throws the
   // same "refusing to overwrite" error — leaving the operator with no token
-  // and no record of it. Only `--json` is exempt (it skips
-  // `writeClientSetupOutput` entirely and prints the token to stdout);
-  // `--bridge/--token` overrides change *where* the owner session comes
-  // from, not *where* the client credentials get persisted, so they still
-  // write canonical config.json and need the same preflight.
-  if (!args.json) {
+  // and no record of it. Only `--json` is exempt (it skips persistence and
+  // prints the token to stdout); `--bridge/--token` overrides change *where*
+  // the owner session comes from, not *where* the credentials get persisted,
+  // so they still write canonical config.json and need the same preflight.
+  if (!opts.json) {
     const configPath = defaultConfigPath();
     if (existsSync(configPath) && readConfigRaw(configPath) === null) {
       process.stderr.write(
         `${configPath} exists but is unreadable / not a JSON object — ` +
-          'fix or move it aside before rerunning setup (refusing to mint a token we cannot save).\n',
+          `fix or move it aside before rerunning ${opts.labels.cmdName} (refusing to mint a token we cannot save).\n`,
       );
       return 1;
     }
@@ -357,7 +417,7 @@ export async function runSetup(args: SetupArgs): Promise<number> {
   try {
     success = await registerClient(
       { bridge, token },
-      { clientName: args.clientName, allowedAgentIds: args.allowedAgentIds },
+      { clientName: opts.name, allowedAgentIds: opts.allowedAgentIds },
     );
   } catch (e) {
     process.stderr.write(`${(e as Error).message}\n`);
@@ -365,16 +425,13 @@ export async function runSetup(args: SetupArgs): Promise<number> {
   }
 
   process.stderr.write(
-    `  client_id        ${success.client_id}\n` +
-      `  owner_principal  ${success.owner_principal}\n` +
-      `  client_name      ${success.client_name}\n` +
-      `  allowed_agents   ${success.allowed_agent_ids.join(', ')}\n\n` +
-      'The CLIENT_TOKEN is one-time — the bridge cannot reissue it.\n' +
-      '  setup persists it to the canonical config below; --json prints it to\n' +
+    `${opts.labels.renderSuccessBlock(success)}\n\n` +
+      `The ${opts.labels.tokenLabel} is one-time — the bridge cannot reissue it.\n` +
+      `  ${opts.labels.cmdName} persists it to the canonical config below; --json prints it to\n` +
       '  stdout instead. Back up that file before rotating hosts.\n' +
       '  To also stash it in a shell-sourceable env file, pass --write-env-file\n' +
-      '  on this same setup invocation — rerunning setup later would call\n' +
-      '  registerClient again and mint a NEW CLIENT_TOKEN, invalidating this\n' +
+      `  on this same ${opts.labels.cmdName} invocation — rerunning ${opts.labels.cmdName} later would call\n` +
+      `  registerClient again and mint a NEW ${opts.labels.tokenLabel}, invalidating this\n` +
       '  one. To populate an env file from an already-issued token, copy\n' +
       '  SERVER_URL / SERVER_TOKEN / AGENT_ID out of config.json by hand.\n\n',
   );
@@ -384,53 +441,41 @@ export async function runSetup(args: SetupArgs): Promise<number> {
   // recovery hatch.
   let canonicalPath: string | null;
   try {
-    canonicalPath = persistCanonical({ json: args.json }, success, bridge);
+    canonicalPath = persistCanonical({ json: opts.json }, success, bridge);
   } catch (e) {
     process.stderr.write(`${(e as Error).message}\n`);
-    // The preflight above catches the common "existing config is malformed"
-    // case before minting, but a disk-full / EPERM failure during the
-    // write itself can still strand the token. Surface it on stderr so
-    // the operator can save it manually instead of being left with an
-    // unrecoverable bridge registration. The token still goes to stderr
-    // (not stdout) so `--json`-style pipelines aren't affected — they
-    // would have taken the --json branch inside persistCanonical.
     process.stderr.write(
-      '\n[recovery] canonical persistence failed AFTER registerClient succeeded. The bridge has issued this CLIENT_TOKEN exactly once:\n' +
-        `\n  CLIENT_ID:      ${success.client_id}\n` +
-        `  CLIENT_TOKEN:   ${success.client_token}\n` +
-        `  SERVER_URL:     ${wsUrlFromBridge(bridge)}\n` +
-        `  AGENT_ID:       ${success.allowed_agent_ids[0] ?? ''}\n\n` +
+      `\n[recovery] canonical persistence failed AFTER registerClient succeeded. ` +
+        `The bridge has issued this ${opts.labels.tokenLabel} exactly once:\n\n` +
+        `${opts.labels.renderRecoveryBlock(success, wsUrlFromBridge(bridge))}\n\n` +
         '  Save these values now; they cannot be retrieved later. Rotate via ' +
         '`rotateClientToken` GraphQL mutation if you suspect leakage.\n',
     );
     return 1;
   }
 
-  // Optional env-file emission (shell-sourceable). Errors here
-  // are NOT recovery situations: the token is already safe in canonical
-  // config.json. Surface a targeted warning that tells the operator how
-  // to populate the env file by hand without rotating the token (rerunning
-  // `setup --write-env-file` would mint a new CLIENT_TOKEN). Exit
-  // non-zero so CI / scripts catch the partial failure, but with a
-  // distinct message — not the "token was not persisted" recovery block.
-  if (envFile && !args.json) {
+  // Optional env-file emission (shell-sourceable). Errors here are NOT
+  // recovery situations: the token is already safe in canonical config.json.
+  // Surface a targeted warning instead of the "token was not persisted"
+  // recovery block; exit non-zero so CI / scripts catch the partial failure.
+  if (opts.envFile && !opts.json) {
     try {
-      writeClientEnvFile(envFile, success, bridge);
-      process.stderr.write(`Wrote env block to ${envFile} (mode 600).\n`);
+      writeClientEnvFile(opts.envFile, success, bridge);
+      process.stderr.write(`Wrote env block to ${opts.envFile} (mode 600).\n`);
     } catch (e) {
       process.stderr.write(
-        `\nWARNING: --write-env-file ${envFile} failed: ${(e as Error).message}\n` +
-          `  The CLIENT_TOKEN was persisted to ${canonicalPath ?? '(canonical config)'} — the daemon can start without the env file.\n` +
+        `\nWARNING: --write-env-file ${opts.envFile} failed: ${(e as Error).message}\n` +
+          `  The ${opts.labels.tokenLabel} was persisted to ${canonicalPath ?? '(canonical config)'} — the daemon can start without the env file.\n` +
           '  To populate the env file without rotating the token, copy SERVER_URL / SERVER_TOKEN / AGENT_ID out of config.json by hand.\n' +
-          '  Re-running `setup --write-env-file ...` would mint a NEW CLIENT_TOKEN and invalidate the one just written.\n',
+          `  Re-running \`${opts.labels.cmdName} --write-env-file ...\` would mint a NEW ${opts.labels.tokenLabel} and invalidate the one just written.\n`,
       );
       return 1;
     }
   }
 
-  if (callers.length > 0) {
+  if (opts.callers.length > 0) {
     try {
-      await configureCallers({ bridge, token }, [...success.allowed_agent_ids], callers);
+      await configureCallers({ bridge, token }, [...success.allowed_agent_ids], opts.callers);
     } catch (e) {
       process.stderr.write(`${(e as Error).message}\n`);
       return 1;
@@ -438,10 +483,106 @@ export async function runSetup(args: SetupArgs): Promise<number> {
     process.stderr.write('\n');
   } else {
     process.stderr.write(
-      'WARNING: no callers configured. The agent is public until you run ' +
-        '`vicoop-client add-caller <agent_id> <principal>`.\n\n',
+      `WARNING: no callers configured. The agent is public until you run ` +
+        `\`${opts.labels.addCallerHint} <agent_id> <principal>\`.\n\n`,
     );
   }
 
   return 0;
+}
+
+// Renderers for `setup`'s client-first stderr vocabulary. Kept here so the
+// legacy alias surfaces unchanged for operators (and scripts) still parsing
+// stderr; `success.client_id` is the legacy registration UUID returned by
+// registerClient, not the operator-supplied agent id.
+function renderSetupSuccessBlock(success: ClientRegisterSuccess): string {
+  return [
+    `  client_id        ${success.client_id}`,
+    `  owner_principal  ${success.owner_principal}`,
+    `  client_name      ${success.client_name}`,
+    `  allowed_agents   ${success.allowed_agent_ids.join(', ')}`,
+  ].join('\n');
+}
+
+function renderSetupRecoveryBlock(success: ClientRegisterSuccess, serverUrl: string): string {
+  return [
+    `  CLIENT_ID:      ${success.client_id}`,
+    `  CLIENT_TOKEN:   ${success.client_token}`,
+    `  SERVER_URL:     ${serverUrl}`,
+    `  AGENT_ID:       ${success.allowed_agent_ids[0] ?? ''}`,
+  ].join('\n');
+}
+
+// Renderers for `agent register`. Surfaces the operator-supplied agent_id
+// (= `allowed_agent_ids[0]`) as the primary identifier. The legacy
+// registration UUID is exposed only on the recovery path, where the operator
+// may need it for an out-of-band revoke / audit.
+function renderAgentRegisterSuccessBlock(success: ClientRegisterSuccess): string {
+  return [
+    `  agent_id         ${success.allowed_agent_ids[0] ?? ''}`,
+    `  owner_principal  ${success.owner_principal}`,
+    `  name             ${success.client_name}`,
+  ].join('\n');
+}
+
+function renderAgentRegisterRecoveryBlock(success: ClientRegisterSuccess, serverUrl: string): string {
+  return [
+    `  AGENT_ID:        ${success.allowed_agent_ids[0] ?? ''}`,
+    `  AGENT_TOKEN:     ${success.client_token}`,
+    `  SERVER_URL:      ${serverUrl}`,
+    `  registration_id: ${success.client_id}`,
+  ].join('\n');
+}
+
+export async function runSetup(args: SetupArgs): Promise<number> {
+  process.stderr.write(
+    '[warning] `vicoop-client setup` is deprecated; ' +
+      'use `vicoop-client agent register --name NAME --agent-id ID` instead. ' +
+      'The deprecated form will be removed in a future release.\n',
+  );
+  // `--caller` is repeatable AND accepts comma-separated values within each
+  // occurrence — explode both into a flat list.
+  const callers = args.callers.flatMap((c) =>
+    c.split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  return executeRegistration({
+    name: args.clientName,
+    allowedAgentIds: args.allowedAgentIds,
+    callers,
+    envFile: args.envFile ?? args.envFileAlias ?? null,
+    bridge: args.bridge ?? null,
+    token: args.token ?? null,
+    json: args.json,
+    labels: {
+      cmdName: 'setup',
+      agentsFlag: '--agent-ids',
+      tokenLabel: 'CLIENT_TOKEN',
+      addCallerHint: 'vicoop-client add-caller',
+      renderSuccessBlock: renderSetupSuccessBlock,
+      renderRecoveryBlock: renderSetupRecoveryBlock,
+    },
+  });
+}
+
+export async function runAgentRegister(args: AgentRegisterArgs): Promise<number> {
+  const callers = args.callers.flatMap((c) =>
+    c.split(',').map((s) => s.trim()).filter(Boolean),
+  );
+  return executeRegistration({
+    name: args.name,
+    allowedAgentIds: [args.agentId],
+    callers,
+    envFile: args.envFile ?? args.envFileAlias ?? null,
+    bridge: args.bridge ?? null,
+    token: args.token ?? null,
+    json: args.json,
+    labels: {
+      cmdName: 'agent register',
+      agentsFlag: '--agent-id',
+      tokenLabel: 'AGENT_TOKEN',
+      addCallerHint: 'vicoop-client agent callers add',
+      renderSuccessBlock: renderAgentRegisterSuccessBlock,
+      renderRecoveryBlock: renderAgentRegisterRecoveryBlock,
+    },
+  });
 }

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -43,11 +43,11 @@ export const setupCmd = command(
     })),
     // `--env-file` is an alias for `--write-env-file` (older docs used it).
     envFileAlias: optional(option('--env-file', string({ metavar: 'PATH' }))),
-    bridge: optional(option('--bridge', string({ metavar: 'URL' }), {
+    server: optional(option('--server', string({ metavar: 'URL' }), {
       description: message`Override the bridge URL from the saved owner-session. Pair with --token.`,
     })),
     token: optional(option('--token', string({ metavar: 'TOKEN' }), {
-      description: message`Override the owner-session token from disk. Pair with --bridge.`,
+      description: message`Override the owner-session token from disk. Pair with --server.`,
     })),
     json: withDefault(flag('--json', {
       description: message`Print the registerClient response as JSON to stdout instead of persisting to config.json.`,
@@ -78,11 +78,11 @@ export const agentRegisterCmd = command(
       description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars (#189 §5); the file is purely an operator-side credentials backup / scripting hook.`,
     })),
     envFileAlias: optional(option('--env-file', string({ metavar: 'PATH' }))),
-    bridge: optional(option('--bridge', string({ metavar: 'URL' }), {
+    server: optional(option('--server', string({ metavar: 'URL' }), {
       description: message`Override the bridge URL from the saved owner-session. Pair with --token.`,
     })),
     token: optional(option('--token', string({ metavar: 'TOKEN' }), {
-      description: message`Override the owner-session token from disk. Pair with --bridge.`,
+      description: message`Override the owner-session token from disk. Pair with --server.`,
     })),
     json: withDefault(flag('--json', {
       description: message`Print the registration response as JSON to stdout instead of persisting to config.json.`,
@@ -355,7 +355,10 @@ interface ExecuteRegistrationOpts {
   allowedAgentIds: string[];
   callers: string[];
   envFile: string | null;
-  bridge: string | null;
+  // Override URL for the bridge (was `--bridge` pre-rename). Surfaced as
+  // `--server` on the CLI for parity with the daemon flag (#225-style
+  // rename); kept as `server` here to match the args field name.
+  server: string | null;
   token: string | null;
   json: boolean;
   labels: RegistrationLabels;
@@ -373,22 +376,22 @@ async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<numbe
   }
 
   const stored = resolveOwnerSession();
-  if ((opts.bridge && !opts.token) || (!opts.bridge && opts.token)) {
+  if ((opts.server && !opts.token) || (!opts.server && opts.token)) {
     process.stderr.write(
-      'Pass --bridge and --token together. Owner-session credentials are tied to their bridge URL.\n',
+      'Pass --server and --token together. Owner-session credentials are tied to their bridge URL.\n',
     );
     return 1;
   }
 
-  const session = opts.bridge && opts.token
-    ? { bridge: opts.bridge, token: opts.token }
+  const session = opts.server && opts.token
+    ? { bridge: opts.server, token: opts.token }
     : stored;
   const bridge = session?.bridge;
   const token = session?.token;
   if (!bridge || !token) {
     process.stderr.write(
-      'No owner-session bearer found. Run `vicoop-client login --bridge <URL>` first, ' +
-        'or pass --bridge and --token explicitly (or set VICOOP_BRIDGE / VICOOP_OWNER_TOKEN).\n',
+      'No owner-session bearer found. Run `vicoop-client auth login --server <URL>` first, ' +
+        'or pass --server and --token explicitly (or set VICOOP_BRIDGE / VICOOP_OWNER_TOKEN).\n',
     );
     return 1;
   }
@@ -399,7 +402,7 @@ async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<numbe
   // exactly once from the bridge, and `writeConfigForSetup` then throws the
   // same "refusing to overwrite" error — leaving the operator with no token
   // and no record of it. Only `--json` is exempt (it skips persistence and
-  // prints the token to stdout); `--bridge/--token` overrides change *where*
+  // prints the token to stdout); `--server/--token` overrides change *where*
   // the owner session comes from, not *where* the credentials get persisted,
   // so they still write canonical config.json and need the same preflight.
   if (!opts.json) {
@@ -550,7 +553,7 @@ export async function runSetup(args: SetupArgs): Promise<number> {
     allowedAgentIds: args.allowedAgentIds,
     callers,
     envFile: args.envFile ?? args.envFileAlias ?? null,
-    bridge: args.bridge ?? null,
+    server: args.server ?? null,
     token: args.token ?? null,
     json: args.json,
     labels: {
@@ -573,7 +576,7 @@ export async function runAgentRegister(args: AgentRegisterArgs): Promise<number>
     allowedAgentIds: [args.agentId],
     callers,
     envFile: args.envFile ?? args.envFileAlias ?? null,
-    bridge: args.bridge ?? null,
+    server: args.server ?? null,
     token: args.token ?? null,
     json: args.json,
     labels: {

--- a/packages/client/src/whoami.test.ts
+++ b/packages/client/src/whoami.test.ts
@@ -1,13 +1,24 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
-import { runWhoami, type WhoamiArgs, type WhoamiIO } from './whoami.js';
+import { runAuthWhoami, runWhoami, type AuthWhoamiArgs, type WhoamiArgs, type WhoamiIO } from './whoami.js';
 
 // `runWhoami` now takes the parser's discriminated-union output. Tests
 // construct that shape directly.
 function whoamiArgs(p: Partial<Omit<WhoamiArgs, 'action'>> = {}): WhoamiArgs {
   return {
     action: 'whoami',
+    agentId: undefined,
+    server: undefined,
+    json: false,
+    verify: false,
+    ...p,
+  };
+}
+
+function authWhoamiArgs(p: Partial<Omit<AuthWhoamiArgs, 'action'>> = {}): AuthWhoamiArgs {
+  return {
+    action: 'auth-whoami',
     agentId: undefined,
     server: undefined,
     json: false,
@@ -298,4 +309,27 @@ test('whoami --verify still surfaces a bare status when the body is not JSON', a
       }
     });
   });
+});
+
+// ---- New `auth whoami` surface --------------------------------------------
+
+test('auth whoami emits the agent identity without a deprecation warning', async () => {
+  const io = makeIO();
+  const code = await runAuthWhoami(
+    authWhoamiArgs({ agentId: 'my-agent', server: 'wss://bridge.example.com' }),
+    io,
+  );
+  assert.equal(code, 0);
+  assert.doesNotMatch(io.readStderr(), /deprecated/i);
+  assert.match(io.readStdout(), /mention:\s*@my-agent@bridge\.example\.com/);
+});
+
+test('legacy whoami prints a deprecation warning pointing at auth whoami', async () => {
+  const io = makeIO();
+  const code = await runWhoami(
+    whoamiArgs({ agentId: 'my-agent', server: 'wss://bridge.example.com' }),
+    io,
+  );
+  assert.equal(code, 0);
+  assert.match(io.readStderr(), /vicoop-client whoami.*deprecated.*vicoop-client auth whoami/s);
 });

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -25,34 +25,58 @@ import {
   type AgentIdentity,
 } from './identity.js';
 
-export const whoamiCmd = command(
+// Shared parser fields so the new `auth whoami` and the legacy flat
+// `whoami` stay in lockstep.
+const whoamiFields = {
+  agentId: optional(
+    option('--agentId', string({ metavar: 'ID' }), {
+      description: message`Agent id. Falls back to the canonical config.json (\`agent_id\`).`,
+    }),
+  ),
+  server: optional(
+    option('--server', string({ metavar: 'WS_URL' }), {
+      description: message`Bridge WS URL. Falls back to the canonical config.json (\`server_url\`).`,
+    }),
+  ),
+  json: withDefault(
+    flag('--json', { description: message`Emit a machine-readable JSON record.` }),
+    false,
+  ),
+  verify: withDefault(
+    flag('--verify', {
+      description: message`Probe WebFinger to confirm the bridge resolves this agent's acct.`,
+    }),
+    false,
+  ),
+};
+
+// New `vicoop-client auth whoami` surface (#218 / #224). Sits under the
+// `auth` umbrella alongside `auth login` / `auth logout`. Identity surfaces
+// are owner-session-adjacent — the `auth` topic is the natural home.
+export const authWhoamiCmd = command(
   'whoami',
   object({
-    action: constant('whoami' as const),
-    agentId: optional(
-      option('--agentId', string({ metavar: 'ID' }), {
-        description: message`Agent id. Falls back to the canonical config.json (\`agent_id\`).`,
-      }),
-    ),
-    server: optional(
-      option('--server', string({ metavar: 'WS_URL' }), {
-        description: message`Bridge WS URL. Falls back to the canonical config.json (\`server_url\`).`,
-      }),
-    ),
-    json: withDefault(
-      flag('--json', { description: message`Emit a machine-readable JSON record.` }),
-      false,
-    ),
-    verify: withDefault(
-      flag('--verify', {
-        description: message`Probe WebFinger to confirm the bridge resolves this agent's acct.`,
-      }),
-      false,
-    ),
+    action: constant('auth-whoami' as const),
+    ...whoamiFields,
   }),
   {
     brief: message`Print the agent's A2A identity (mention / acct / WebFinger URL).`,
     description: message`Surfaces the identifiers external callers will see for this agent. Use the output to populate other agents' \`allowed_callers\` or the OpenClaw gateway persona for self-reference recognition. With \`--verify\`, additionally fetches WebFinger to confirm the bridge resolves the agent's acct under the derived host.`,
+  },
+);
+
+export type AuthWhoamiArgs = InferValue<typeof authWhoamiCmd>;
+
+// Legacy flat `vicoop-client whoami`. Kept as a deprecated alias.
+export const whoamiCmd = command(
+  'whoami',
+  object({
+    action: constant('whoami' as const),
+    ...whoamiFields,
+  }),
+  {
+    brief: message`[deprecated] Use \`auth whoami\`.`,
+    description: message`Deprecated alias for \`vicoop-client auth whoami\`. Will be removed in a future release.`,
   },
 );
 
@@ -206,7 +230,30 @@ function buildResult(id: AgentIdentity): WhoamiResult {
   };
 }
 
+interface WhoamiCommonArgs {
+  agentId?: string;
+  server?: string;
+  json: boolean;
+  verify: boolean;
+}
+
+export async function runAuthWhoami(
+  args: AuthWhoamiArgs,
+  io: WhoamiIO = defaultIO,
+): Promise<number> {
+  return executeWhoami(args, io);
+}
+
 export async function runWhoami(args: WhoamiArgs, io: WhoamiIO = defaultIO): Promise<number> {
+  io.stderr(
+    '[warning] `vicoop-client whoami` is deprecated; ' +
+      'use `vicoop-client auth whoami` instead. ' +
+      'The deprecated form will be removed in a future release.\n',
+  );
+  return executeWhoami(args, io);
+}
+
+async function executeWhoami(args: WhoamiCommonArgs, io: WhoamiIO): Promise<number> {
   // Fallback to canonical config.json (#189 §5 — env removed from daemon
   // config chain, and whoami reuses the same source so the two surfaces
   // can't drift). The file is optional: a fresh install with no `setup`


### PR DESCRIPTION
## Summary

Two issues land together, restructuring the operator-facing CLI under two umbrellas. Wire contracts and `--json` shapes are unchanged; legacy flat commands keep working as deprecated aliases.

- **#218 / admin commands → `agent` umbrella.** `agent register`, `agent list`, `agent revoke`, `agent callers {list,add,remove}`. Demotes `setup`, `list-agents`, `list-clients`, `revoke-client`, `add-caller`, `remove-caller`, `list-callers`.
- **#224 / vocabulary alignment.** Same PR also moves `login`, `logout`, `whoami` under a new **`auth`** umbrella so the read/write/auth surfaces are all topic-grouped. The flat `login` / `logout` / `whoami` become deprecated aliases too.

Server-side persistence already moved to `agents`-as-primary in `deb7555` (#219); this PR brings the CLI in line. No server changes ship here.

## Commands now

```
vicoop-client auth login              # was: login
vicoop-client auth logout             # was: logout
vicoop-client auth whoami             # was: whoami
vicoop-client agent register          # was: setup
vicoop-client agent list              # was: list-agents / list-clients
vicoop-client agent revoke            # was: revoke-client
vicoop-client agent callers list|add|remove   # was: list-caller / add-caller / remove-caller
```

Every flat command listed above (`login`, `logout`, `whoami`, `setup`, `list-agents`, `list-clients`, `revoke-client`, `add-caller`, `remove-caller`, `list-callers`) still works but prints a one-line stderr deprecation hint pointing at its new form. `setup` additionally retains its old `--client-name` / `--agent-ids` flags and `CLIENT_TOKEN` / `client_id` / `client_name` stderr vocabulary so scripts that parse it aren't affected.

## Changes

### `agent` group (#218)

- `agent register --name NAME --agent-id ID [--caller PRINCIPAL ...] [--write-env-file PATH]` — calls `registerClient` GraphQL mutation, persists `~/.vicoop/config.json` (mode 600), prints a stderr success block with agent-first labels (`agent_id`, `name`, `AGENT_TOKEN`). The agent id surfaced is the operator-supplied routing key, not the server's registration UUID.
- `agent list [--connected]` — whitespace-padded table: `AGENT_ID NAME CONNECTED REVOKED REGISTERED_AT`. `--json` still carries the legacy `client_id` for back-compat scripts.
- `agent revoke AGENT_ID` — `DELETE /admin-api/clients/<target>`; resolves agent_id, legacy client_id, or unique registration name (server-side resolver in `admin-api.ts`).
- `agent callers {list,add,remove}` — thin wrappers around `/admin-api/agents/:id/callers`.

### `auth` group (#224)

- `auth login` — Google OAuth device flow; same `--bridge` / `--json` / `--poll-once` flags as the legacy `login`.
- `auth logout` — RFC 7009 revoke + local file delete; `--local-only` / `--keep-local` to split the two effects.
- `auth whoami` — agent identity (mention / acct / WebFinger URL); `--verify` probes WebFinger.

### Renderers

- New `renderTable(headers, rows)` helper — minimal whitespace-padded, no box-drawing chars, columns auto-sized from data.
- `renderAgentRegistrationList`, `renderClientList`, `renderAgentList` all moved from block-per-row to single table.
- Single-record outputs (`agent revoke`, `agent callers list`, mutation results) stay as key/value blocks.

### Docs

- `docs/install-client.md` updated end-to-end: Step 4 example, scripting example, "Inspecting and revoking your agents" section, "What login and agent register do", "Self-hosting the bridge" tip, troubleshooting section.
- Single consolidated deprecation note lists all flat aliases and their replacements.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client test` — 441/441 pass (430 existing + 5 from #218 + 5 from #224 register/setup + 6 from auth login/logout/whoami).
- [x] `pnpm --filter @vicoop-bridge/client typecheck` — no errors in touched files.
- [x] `pnpm --filter @vicoop-bridge/client build` — clean.
- [x] Smoke: `vicoop-client --help`, `vicoop-client agent --help`, `vicoop-client agent callers --help`, `vicoop-client auth --help`. Bare `agent` / `agent callers` / `auth` prints usage.
- [x] Smoke: `agent register` and legacy `setup` end-to-end against a stub bridge — outputs verified side by side; deprecation banners appear only on legacy paths.
- [ ] Manual run against a staging bridge: `auth login` → `agent register` → `agent list` / `agent revoke` round-trip on that registration.
- [ ] Verify a legacy command (e.g. `setup --client-name ... --agent-ids ...`) still mints a working token on staging (script-compat check).

## Commits

- `afee038` — #218 admin surface (`agent list/revoke/callers`, table renderer, deprecation on flat aliases)
- `88dfaf9` — #224 registration surface (`agent register`, `setup` demotion)
- `34126c7` — docs sweep for narrative consistency
- `a46c3ce` — `auth` umbrella (`auth login/logout/whoami`, flat deprecations)

## Related

- Design: #218
- Server-side unification: #219 (merged as `deb7555`)
- Registration vocabulary alignment: #224
- Origin CLI cleanup: #217
- Follow-up multi-agent config: #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)