### PR TITLE
feat: add vicoop-codex backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "pnpm -r build",
     "typecheck": "pnpm -r typecheck",
+    "install:client": "pnpm --filter @vicoop-bridge/client... build && npm install -g ./packages/client",
+    "uninstall:client": "npm uninstall -g @vicoop-bridge/client",
     "dev:server": "pnpm --filter @vicoop-bridge/server dev",
     "dev:client": "pnpm --filter @vicoop-bridge/client dev",
     "dev:admin-ui": "pnpm --filter @vicoop-bridge/admin-ui dev",

--- a/packages/client/cards/vicoop-codex.json
+++ b/packages/client/cards/vicoop-codex.json
@@ -1,0 +1,31 @@
+{
+  "name": "vicoop-codex",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion echo on the final message metadata.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": false,
+    "extensions": [
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / tool_call_history) to assemble the call body; emits OpenAI Chat Completions tool_calls back as an A2A data part and the full response envelope on the final message metadata.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the vicoop-codex CLI responds with text. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks. File parts are not supported.",
+      "tags": ["chat", "assistant", "codex", "openai-compat"]
+    }
+  ]
+}

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -1,0 +1,628 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
+import {
+  buildCallBody,
+  buildMessages,
+  buildResponseMetadata,
+  createVicoopCodexBackend,
+  flattenA2AUserContent,
+  historyToChatCompletionMessages,
+  parseChatCompletionUsage,
+  type ChatCompletionResponse,
+  type VicoopCodexChildHandle,
+  type VicoopCodexSpawnFn,
+  type VicoopCodexSpawnOptions,
+} from './vicoop-codex.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fake `vicoop-codex` child — collects stdin, scripts stdout/stderr/exit-code
+// to drive integration tests through the backend's `handle()` path without a
+// real subprocess. Mirrors the codex.test.ts FakeChild shape.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FakeChild extends VicoopCodexChildHandle {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd?: string;
+  killed: boolean;
+  killSignal: NodeJS.Signals | null;
+  stdinPayload: () => string;
+  emitStdout(text: string): void;
+  emitStderr(text: string): void;
+  finish(code: number | null, sig?: NodeJS.Signals | null): void;
+}
+
+interface FakeSpawn {
+  spawn: VicoopCodexSpawnFn;
+  children: FakeChild[];
+  lastChild: () => FakeChild;
+}
+
+function makeFakeSpawn(): FakeSpawn {
+  const children: FakeChild[] = [];
+  const spawn: VicoopCodexSpawnFn = (
+    command,
+    args,
+    options: VicoopCodexSpawnOptions,
+  ) => {
+    const stdoutEmitter = new EventEmitter();
+    const stderrEmitter = new EventEmitter();
+    const closeListeners: Array<
+      (code: number | null, sig: NodeJS.Signals | null) => void
+    > = [];
+    let closed = false;
+
+    const mkReadable = (em: EventEmitter): NodeJS.ReadableStream =>
+      ({
+        on(event: string, cb: (...a: unknown[]) => void) {
+          em.on(event, cb);
+        },
+      }) as unknown as NodeJS.ReadableStream;
+
+    const stdinChunks: string[] = [];
+    const stdin: NodeJS.WritableStream = {
+      write(chunk: unknown): boolean {
+        const s =
+          typeof chunk === 'string'
+            ? chunk
+            : Buffer.from(chunk as Buffer).toString('utf8');
+        stdinChunks.push(s);
+        return true;
+      },
+      end(chunk?: unknown) {
+        if (chunk !== undefined) {
+          const s =
+            typeof chunk === 'string'
+              ? chunk
+              : Buffer.from(chunk as Buffer).toString('utf8');
+          stdinChunks.push(s);
+        }
+        return stdin;
+      },
+      on() {
+        return stdin;
+      },
+      once() {
+        return stdin;
+      },
+      emit() {
+        return false;
+      },
+    } as unknown as NodeJS.WritableStream;
+
+    const child: FakeChild = {
+      command,
+      args,
+      cwd: options.cwd,
+      stdin,
+      stdout: mkReadable(stdoutEmitter),
+      stderr: mkReadable(stderrEmitter),
+      killed: false,
+      killSignal: null,
+      stdinPayload: () => stdinChunks.join(''),
+      emitStdout(text) {
+        stdoutEmitter.emit('data', Buffer.from(text, 'utf8'));
+      },
+      emitStderr(text) {
+        stderrEmitter.emit('data', Buffer.from(text, 'utf8'));
+      },
+      kill(sig?: NodeJS.Signals) {
+        this.killed = true;
+        this.killSignal = sig ?? 'SIGTERM';
+        queueMicrotask(() => {
+          if (closed) return;
+          closed = true;
+          for (const l of closeListeners) l(null, this.killSignal);
+        });
+        return true;
+      },
+      on(
+        event: 'close' | 'error',
+        listener:
+          | ((code: number | null, signal: NodeJS.Signals | null) => void)
+          | ((err: Error) => void),
+      ) {
+        if (event === 'close') {
+          closeListeners.push(
+            listener as (
+              code: number | null,
+              signal: NodeJS.Signals | null,
+            ) => void,
+          );
+        }
+      },
+      finish(code, sig = null) {
+        if (closed) return;
+        closed = true;
+        // Schedule async so the backend has a chance to register its
+        // listeners before we synthesise the exit — mirrors real
+        // child_process semantics.
+        queueMicrotask(() => {
+          for (const l of closeListeners) l(code, sig);
+        });
+      },
+    };
+    children.push(child);
+    return child;
+  };
+  return {
+    spawn,
+    children,
+    lastChild: () => {
+      if (children.length === 0) throw new Error('no fake child spawned yet');
+      return children[children.length - 1];
+    },
+  };
+}
+
+function makeTask(
+  overrides: Partial<TaskAssignFrame> & { metadata?: Record<string, unknown> } = {},
+): TaskAssignFrame {
+  const { metadata, ...rest } = overrides;
+  return {
+    type: 'task.assign',
+    taskId: 'task-1',
+    contextId: 'ctx-1',
+    message: {
+      role: 'user',
+      messageId: 'msg-1',
+      parts: [{ kind: 'text', text: 'hello' }],
+      ...(metadata ? { metadata } : {}),
+    },
+    ...rest,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure-function unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('flattenA2AUserContent: text + data parts, drops files', () => {
+  const out = flattenA2AUserContent([
+    { kind: 'text', text: 'hello' },
+    { kind: 'data', data: { city: 'Seoul' } },
+    { kind: 'file', file: { mimeType: 'image/png', bytes: 'xx' } },
+    { kind: 'text', text: 'world' },
+  ]);
+  assert.ok(out);
+  assert.ok(out!.includes('hello'));
+  assert.ok(out!.includes('world'));
+  assert.ok(out!.includes('Seoul'));
+});
+
+test('flattenA2AUserContent: empty / file-only yields null', () => {
+  assert.equal(flattenA2AUserContent([]), null);
+  assert.equal(
+    flattenA2AUserContent([
+      { kind: 'file', file: { mimeType: 'image/png', bytes: 'xx' } },
+    ]),
+    null,
+  );
+});
+
+test('historyToChatCompletionMessages: assistant tool_calls + tool result round-trip', () => {
+  const msgs = historyToChatCompletionMessages([
+    {
+      role: 'assistant',
+      tool_calls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
+        },
+      ],
+    },
+    {
+      role: 'tool',
+      tool_call_id: 'call_1',
+      content: '{"temp":13}',
+      name: 'get_weather',
+    },
+  ]);
+  assert.equal(msgs.length, 2);
+  assert.equal(msgs[0].role, 'assistant');
+  assert.equal(msgs[0].content, null);
+  assert.equal((msgs[0].tool_calls as unknown[]).length, 1);
+  assert.equal(msgs[1].role, 'tool');
+  assert.equal(msgs[1].tool_call_id, 'call_1');
+  assert.equal(msgs[1].name, 'get_weather');
+  assert.equal(msgs[1].content, '{"temp":13}');
+});
+
+test('buildMessages: ordering — system → history → user', () => {
+  const msgs = buildMessages(
+    {
+      system: 'be concise',
+      tool_call_history: [
+        {
+          role: 'assistant',
+          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
+        },
+        { role: 'tool', tool_call_id: 'c1', content: 'result' },
+      ],
+    },
+    'current ask',
+  );
+  assert.deepEqual(
+    msgs.map((m) => m.role),
+    ['system', 'assistant', 'tool', 'user'],
+  );
+  assert.equal(msgs[0].content, 'be concise');
+  assert.equal(msgs[msgs.length - 1].content, 'current ask');
+});
+
+test('buildMessages: no metadata still emits a user message', () => {
+  const msgs = buildMessages(null, 'hi');
+  assert.deepEqual(msgs, [{ role: 'user', content: 'hi' }]);
+});
+
+test('buildCallBody: forwards only tools / tool_choice from the existing 4-field schema', () => {
+  const body = buildCallBody(
+    {
+      system: 'sys',
+      tools: [{ type: 'function', function: { name: 'x' } }],
+      tool_choice: 'auto',
+      tool_call_history: [
+        {
+          role: 'assistant',
+          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
+        },
+        { role: 'tool', tool_call_id: 'c1', content: 'r' },
+      ],
+    },
+    [{ role: 'user', content: 'q' }],
+  );
+  assert.deepEqual(body.tools, [{ type: 'function', function: { name: 'x' } }]);
+  assert.equal(body.tool_choice, 'auto');
+  assert.deepEqual(body.messages, [{ role: 'user', content: 'q' }]);
+  // Nothing else lands on the body — no model, no reasoning_effort, no
+  // Group B / Group C fields.
+  assert.equal(Object.keys(body).sort().join(','), 'messages,tool_choice,tools');
+});
+
+test('buildCallBody: no metadata yields messages-only body', () => {
+  const body = buildCallBody(null, [{ role: 'user', content: 'q' }]);
+  assert.deepEqual(body, { messages: [{ role: 'user', content: 'q' }] });
+});
+
+test('parseChatCompletionUsage: enforces total = prompt + completion', () => {
+  const u = parseChatCompletionUsage(
+    {
+      prompt_tokens: 17,
+      completion_tokens: 5,
+      total_tokens: 999,
+      prompt_tokens_details: { cached_tokens: 3 },
+      completion_tokens_details: { reasoning_tokens: 2 },
+    },
+    'gpt-5.4',
+  );
+  assert.ok(u);
+  assert.equal(u!.prompt_tokens, 17);
+  assert.equal(u!.completion_tokens, 5);
+  assert.equal(u!.total_tokens, 22);
+  assert.equal(u!.model, 'gpt-5.4');
+  assert.equal(u!.prompt_tokens_details?.cached_tokens, 3);
+  assert.equal(u!.completion_tokens_details?.reasoning_tokens, 2);
+});
+
+test('parseChatCompletionUsage: missing primary counts yields null', () => {
+  assert.equal(parseChatCompletionUsage(undefined, undefined), null);
+  assert.equal(parseChatCompletionUsage({ prompt_tokens: 1 }, undefined), null);
+});
+
+test('buildResponseMetadata: includes both usage and chat_completion echo', () => {
+  const response: ChatCompletionResponse = {
+    id: 'chatcmpl-abc',
+    object: 'chat.completion',
+    created: 1779177411,
+    model: 'gpt-5.4',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'ok' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+  const usage = parseChatCompletionUsage(response.usage, response.model);
+  const meta = buildResponseMetadata(response, usage) as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const ext = meta[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown>;
+  assert.ok(ext.usage);
+  const echo = ext.chat_completion as Record<string, unknown>;
+  assert.equal(echo.id, 'chatcmpl-abc');
+  assert.equal(echo.model, 'gpt-5.4');
+  assert.equal(echo.created, 1779177411);
+  assert.deepEqual(echo.usage, response.usage);
+  assert.ok(Array.isArray(echo.choices));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// End-to-end Backend.handle() tests via the fake spawn surface
+// ─────────────────────────────────────────────────────────────────────────────
+
+function runBackend(
+  task: TaskAssignFrame,
+  driveChild: (child: FakeChild) => void,
+): Promise<UpFrame[]> {
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const frames: UpFrame[] = [];
+  const ctrl = new AbortController();
+  const done = backend.handle(task, (f) => frames.push(f), ctrl.signal);
+  // Wait one microtask so the backend has spawned its child before we drive
+  // it. The fake spawn is synchronous, so a single queueMicrotask suffices.
+  return new Promise((resolve, reject) => {
+    queueMicrotask(() => {
+      try {
+        driveChild(fake.lastChild());
+      } catch (err) {
+        reject(err);
+        return;
+      }
+      done.then(() => resolve(frames), reject);
+    });
+  });
+}
+
+test('handle: success path — text response → artifact + complete with metadata', async () => {
+  const task = makeTask({
+    metadata: {
+      [OPENAI_COMPAT_EXTENSION_URI]: {
+        system: 'be concise',
+      },
+    },
+  });
+  const frames = await runBackend(task, (child) => {
+    const response: ChatCompletionResponse = {
+      id: 'chatcmpl-1',
+      object: 'chat.completion',
+      created: 1700000000,
+      model: 'gpt-5.4',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+    };
+    child.emitStdout(JSON.stringify(response));
+    child.finish(0);
+  });
+
+  const statuses = frames.filter((f) => f.type === 'task.status');
+  const artifacts = frames.filter((f) => f.type === 'task.artifact');
+  const completes = frames.filter((f) => f.type === 'task.complete');
+  assert.equal(statuses.length, 1);
+  assert.equal(statuses[0].status.state, 'working');
+  assert.equal(artifacts.length, 1);
+  const artifact = artifacts[0];
+  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
+  assert.equal(artifact.artifact.parts[0].kind, 'text');
+  if (artifact.artifact.parts[0].kind !== 'text') throw new Error('unreachable');
+  assert.equal(artifact.artifact.parts[0].text, 'ok');
+  assert.equal(completes.length, 1);
+  const completeFrame = completes[0];
+  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
+  assert.equal(completeFrame.status.state, 'completed');
+  const msg = completeFrame.status.message!;
+  assert.ok(msg.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+  const ext = (msg.metadata as Record<string, Record<string, unknown>>)[
+    OPENAI_COMPAT_EXTENSION_URI
+  ];
+  assert.ok(ext.usage);
+  const echo = ext.chat_completion as Record<string, unknown>;
+  assert.equal(echo.id, 'chatcmpl-1');
+  assert.equal(echo.model, 'gpt-5.4');
+});
+
+test('handle: tool_calls response → data artifact + no text in status message', async () => {
+  const task = makeTask({
+    metadata: {
+      [OPENAI_COMPAT_EXTENSION_URI]: {
+        tools: [{ type: 'function', function: { name: 'list_files' } }],
+      },
+    },
+  });
+  const frames = await runBackend(task, (child) => {
+    const response: ChatCompletionResponse = {
+      id: 'chatcmpl-2',
+      object: 'chat.completion',
+      created: 1700000001,
+      model: 'gpt-5.3-codex',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_xyz',
+                type: 'function',
+                function: { name: 'list_files', arguments: '{"path":"."}' },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+      usage: { prompt_tokens: 4, completion_tokens: 6, total_tokens: 10 },
+    };
+    child.emitStdout(JSON.stringify(response));
+    child.finish(0);
+  });
+  const artifacts = frames.filter((f) => f.type === 'task.artifact');
+  assert.equal(artifacts.length, 1);
+  const artifact = artifacts[0];
+  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
+  assert.equal(artifact.artifact.parts[0].kind, 'data');
+  if (artifact.artifact.parts[0].kind !== 'data') throw new Error('unreachable');
+  const data = artifact.artifact.parts[0].data as { tool_calls: unknown[] };
+  assert.equal(data.tool_calls.length, 1);
+  assert.ok(artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+  const completes = frames.filter((f) => f.type === 'task.complete');
+  assert.equal(completes.length, 1);
+  const completeFrame = completes[0];
+  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
+  // status.message exists but parts must be empty so we don't re-stamp the
+  // tool_calls envelope onto the message.
+  assert.deepEqual(completeFrame.status.message!.parts, []);
+});
+
+test('handle: stdin body carries only system/tools/tool_choice/history-derived messages', async () => {
+  const task = makeTask({
+    message: {
+      role: 'user',
+      messageId: 'msg',
+      parts: [{ kind: 'text', text: 'current question' }],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          // The 4-field schema only.
+          system: 'reply in korean',
+          tools: [{ type: 'function', function: { name: 'get_weather' } }],
+          tool_choice: { type: 'function', function: { name: 'get_weather' } },
+          tool_call_history: [
+            {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
+                },
+              ],
+            },
+            { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
+          ],
+          // Unknown extension keys must NOT reach the call body — they
+          // aren't part of the openai-compat 4-field schema.
+          model: 'gpt-5.5',
+          reasoning_effort: 'high',
+          temperature: 0.7,
+          max_tokens: 200,
+        },
+      },
+    },
+  });
+
+  await runBackend(task, (child) => {
+    const response: ChatCompletionResponse = {
+      id: 'chatcmpl-3',
+      object: 'chat.completion',
+      created: 1,
+      model: 'gpt-5.5',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    };
+    const payload = child.stdinPayload();
+    const body = JSON.parse(payload) as Record<string, unknown>;
+    // Messages: system → assistant(tool_calls) → tool → user
+    const messages = body.messages as Array<{ role: string }>;
+    assert.deepEqual(
+      messages.map((m) => m.role),
+      ['system', 'assistant', 'tool', 'user'],
+    );
+    // Only the existing 4-field schema's `tools` / `tool_choice` are
+    // forwarded; the spurious model/reasoning_effort/temperature/max_tokens
+    // entries are dropped at the metadata reader.
+    assert.deepEqual(body.tools, [
+      { type: 'function', function: { name: 'get_weather' } },
+    ]);
+    assert.deepEqual(body.tool_choice, {
+      type: 'function',
+      function: { name: 'get_weather' },
+    });
+    assert.equal(body.model, undefined);
+    assert.equal(body.reasoning_effort, undefined);
+    assert.equal(body.temperature, undefined);
+    assert.equal(body.max_tokens, undefined);
+    child.emitStdout(JSON.stringify(response));
+    child.finish(0);
+  });
+});
+
+test('handle: empty prompt → task.fail with empty_prompt code', async () => {
+  const task = makeTask({
+    message: {
+      role: 'user',
+      messageId: 'msg',
+      parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: 'xx' } }],
+    },
+  });
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const frames: UpFrame[] = [];
+  await backend.handle(task, (f) => frames.push(f), new AbortController().signal);
+  assert.equal(fake.children.length, 0);
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'empty_prompt');
+});
+
+test('handle: non-zero exit maps to documented exit-code error codes', async () => {
+  const exitCases: Array<{ code: number; expected: string }> = [
+    { code: 2, expected: 'invalid_input' },
+    { code: 3, expected: 'login_required' },
+    { code: 4, expected: 'upstream_error' },
+    { code: 5, expected: 'network_error' },
+    { code: 99, expected: 'vicoop_codex_failed' },
+  ];
+  for (const { code, expected } of exitCases) {
+    const frames = await runBackend(makeTask(), (child) => {
+      child.emitStderr('Error: simulated');
+      child.finish(code);
+    });
+    const fails = frames.filter((f) => f.type === 'task.fail');
+    assert.equal(fails.length, 1, `exit code ${code}`);
+    const failFrame = fails[0];
+    if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+    assert.equal(failFrame.error.code, expected, `exit code ${code} → ${expected}`);
+    assert.ok(failFrame.error.message.includes('simulated'));
+  }
+});
+
+test('handle: malformed JSON stdout → parse_failed', async () => {
+  const frames = await runBackend(makeTask(), (child) => {
+    child.emitStdout('not json at all');
+    child.finish(0);
+  });
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'parse_failed');
+});
+
+test('handle: cancel before spawn → task.complete with canceled', async () => {
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const frames: UpFrame[] = [];
+  const ctrl = new AbortController();
+  ctrl.abort();
+  await backend.handle(makeTask(), (f) => frames.push(f), ctrl.signal);
+  assert.equal(fake.children.length, 0);
+  assert.equal(frames.length, 1);
+  const frame = frames[0];
+  if (frame.type !== 'task.complete') throw new Error('unreachable');
+  assert.equal(frame.status.state, 'canceled');
+});

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -1,0 +1,701 @@
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  type Part,
+} from '@vicoop-bridge/protocol';
+import type { Backend } from '../backend.js';
+import { createLogger, type Logger } from '../logger.js';
+import {
+  parseOpenAICompatMetadata,
+  type OpenAICompatHistoryEntry,
+  type OpenAICompatMetadata,
+} from './claude.js';
+import {
+  buildOpenAICompatUsage,
+  type OpenAICompatUsage,
+} from './openai-compat-usage.js';
+
+// Slim subset of ChildProcess the backend actually uses. Tests inject a
+// fake that satisfies this without wiring up a real OS process.
+export interface VicoopCodexChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
+  readonly stdout: NodeJS.ReadableStream | null;
+  readonly stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface VicoopCodexSpawnOptions {
+  cwd?: string;
+}
+
+export type VicoopCodexSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: VicoopCodexSpawnOptions,
+) => VicoopCodexChildHandle;
+
+export interface VicoopCodexBackendOptions {
+  // Test seams only — the production CLI calls `createVicoopCodexBackend()`
+  // with no arguments. We don't expose operator-facing knobs here because
+  // anything an operator could set would have to ride through the existing
+  // CLI / config surface, and we are not extending that surface for this
+  // backend. Defaults below cover the production path; tests inject
+  // `spawn` / `logger` / timing overrides.
+  command?: string;
+  cwd?: string;
+  extraArgs?: readonly string[];
+  spawn?: VicoopCodexSpawnFn;
+  stderrCaptureBytes?: number;
+  callTimeoutMs?: number;
+  logger?: Logger;
+}
+
+// `vicoop-codex call` body shape — only the fields this backend actually
+// emits. The openai-compat A2A extension defines `system` / `tools` /
+// `tool_choice` / `tool_call_history`, of which `system` and
+// `tool_call_history` fold into `messages`; the remaining two ride out
+// verbatim. Everything else (model, reasoning_effort, parallel_tool_calls,
+// the Group B / Group C parameters from the call command's input doc) is
+// intentionally not on this shape because no input surface we currently
+// read carries them. The binary applies its own defaults.
+export interface VicoopCodexCallBody {
+  messages: ChatCompletionMessage[];
+  tools?: unknown[];
+  tool_choice?: unknown;
+}
+
+export interface ChatCompletionMessage {
+  role: 'system' | 'developer' | 'user' | 'assistant' | 'tool' | 'function';
+  // OpenAI permits string or content-parts. We emit a string for system /
+  // developer / user / tool messages and `null` for assistant tool-call-only
+  // messages, mirroring the doc's worked examples.
+  content?: string | null;
+  tool_calls?: unknown[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+// Parsed OpenAI Chat Completions non-streaming response (the shape
+// `vicoop-codex call` prints to stdout). All optional / nullable
+// per OpenAI — the binary always emits `id` / `object` / `model` / `choices`
+// but we tolerate missing fields rather than crash on a future schema bump.
+export interface ChatCompletionResponse {
+  id?: string;
+  object?: string;
+  created?: number;
+  model?: string;
+  choices?: Array<{
+    index?: number;
+    message?: {
+      role?: string;
+      content?: string | null;
+      tool_calls?: Array<{
+        id?: string;
+        type?: string;
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
+    completion_tokens_details?: {
+      reasoning_tokens?: number;
+    };
+  };
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === 'string') return e;
+  try {
+    return String(e);
+  } catch {
+    return '<unrepresentable>';
+  }
+}
+
+function serializeDataPart(data: Record<string, unknown>): string {
+  let body: string;
+  try {
+    body = JSON.stringify(data, null, 2);
+  } catch {
+    return '';
+  }
+  return `<context kind="application/json">\n${body}\n</context>`;
+}
+
+// Extract the user turn from A2A `Message.parts`. The vicoop-codex `call`
+// command's `messages[].content` is string-or-multimodal-parts, but the
+// binary only consumes text parts (image / audio are dropped per the doc's
+// "Known limitations" section); we therefore flatten everything to a single
+// string here. DataParts are folded in as `<context>`-tagged JSON so the
+// model sees them as auxiliary structured input — same convention the
+// codex / claude backends already use.
+//
+// Returns null when the message carries no text and no data, signalling the
+// caller to fail the task with `empty_prompt` rather than send an empty
+// user message upstream (which the binary would reject as
+// `'messages' is required and must be a non-empty array`).
+export function flattenA2AUserContent(parts: readonly Part[]): string | null {
+  const sections: string[] = [];
+  for (const p of parts) {
+    if (p.kind === 'text') {
+      if (p.text) sections.push(p.text);
+      continue;
+    }
+    if (p.kind === 'data') {
+      const serialized = serializeDataPart(p.data);
+      if (serialized) sections.push(serialized);
+      continue;
+    }
+    // FilePart: deliberately dropped. The doc states images/audio are not
+    // forwarded; surfacing a partial picture would be worse than a clear
+    // "this backend is text-only" contract on the artifact side. Operators
+    // that need vision/audio should use the `codex` or `claude` backends.
+  }
+  if (sections.length === 0) return null;
+  return sections.join('\n\n');
+}
+
+// Render `tool_call_history` entries as OpenAI Chat Completions messages
+// the way the doc's worked examples show: each `assistant.tool_calls[]`
+// entry maps to one assistant message with `content:null` and the full
+// `tool_calls` array, and each `role:"tool"` entry maps to one tool
+// message with `tool_call_id` + `content` (string).
+export function historyToChatCompletionMessages(
+  history: OpenAICompatHistoryEntry[],
+): ChatCompletionMessage[] {
+  const out: ChatCompletionMessage[] = [];
+  for (const entry of history) {
+    if (entry.role === 'assistant') {
+      out.push({
+        role: 'assistant',
+        content: null,
+        tool_calls: entry.tool_calls,
+      });
+      continue;
+    }
+    const tool: ChatCompletionMessage = {
+      role: 'tool',
+      tool_call_id: entry.tool_call_id,
+      content: entry.content,
+    };
+    if (entry.name) tool.name = entry.name;
+    out.push(tool);
+  }
+  return out;
+}
+
+// Assemble the full `messages` array for the call body. Order, per the
+// doc's "Per-role message JSON examples" section:
+//   1. system (from openai-compat.system; one entry)
+//   2. tool_call_history (assistant → tool round-trips)
+//   3. current user turn (flattened from A2A parts)
+//
+// The user turn comes last so the model sees prior tool results before the
+// new instruction — same convention as claude.ts's `formatToolCallHistory`
+// prepending the block to the user content.
+export function buildMessages(
+  meta: OpenAICompatMetadata | null,
+  userContent: string,
+): ChatCompletionMessage[] {
+  const messages: ChatCompletionMessage[] = [];
+  if (meta?.system) {
+    messages.push({ role: 'system', content: meta.system });
+  }
+  if (meta?.tool_call_history) {
+    for (const m of historyToChatCompletionMessages(meta.tool_call_history)) {
+      messages.push(m);
+    }
+  }
+  messages.push({ role: 'user', content: userContent });
+  return messages;
+}
+
+// Assemble the call body from the existing openai-compat A2A extension:
+//   - `tools` / `tool_choice` (read by the existing `parseOpenAICompatMetadata`)
+//   - the assembled `messages` array (from `system` + `tool_call_history`
+//     + current user turn — the other two fields of the extension)
+//
+// Nothing else is forwarded. The openai-compat A2A extension only defines
+// those four fields, and we read no other A2A or operator-side input on
+// behalf of this backend. `model`, `reasoning_effort`, `parallel_tool_calls`,
+// and every Group B / Group C parameter from the call command's input doc
+// are left unset — the vicoop-codex binary applies its own defaults.
+export function buildCallBody(
+  meta: OpenAICompatMetadata | null,
+  messages: ChatCompletionMessage[],
+): VicoopCodexCallBody {
+  const body: VicoopCodexCallBody = { messages };
+  if (meta?.tools) body.tools = meta.tools;
+  if (meta?.tool_choice !== undefined) body.tool_choice = meta.tool_choice;
+  return body;
+}
+
+// Map `vicoop-codex call` exit codes (doc's "Exit codes" section) to A2A
+// task.fail error codes. Anything outside the documented set surfaces as
+// `vicoop_codex_failed` so an operator can grep stderr without needing to
+// memorise the table.
+function exitCodeToA2ACode(code: number | null): string {
+  switch (code) {
+    case 2:
+      return 'invalid_input';
+    case 3:
+      return 'login_required';
+    case 4:
+      return 'upstream_error';
+    case 5:
+      return 'network_error';
+    default:
+      return 'vicoop_codex_failed';
+  }
+}
+
+// Convert the parsed `usage` block to a spec-compliant OpenAICompatUsage.
+// vicoop-codex prints the standard OpenAI shape so the mapping is direct;
+// total_tokens is recomputed by `buildOpenAICompatUsage` to enforce the
+// `total === prompt + completion` invariant regardless of what the binary
+// reported.
+export function parseChatCompletionUsage(
+  raw: ChatCompletionResponse['usage'],
+  model: string | undefined,
+): OpenAICompatUsage | null {
+  if (!raw) return null;
+  const prompt = typeof raw.prompt_tokens === 'number' ? raw.prompt_tokens : null;
+  const completion = typeof raw.completion_tokens === 'number' ? raw.completion_tokens : null;
+  if (prompt === null || completion === null) return null;
+  const cached =
+    typeof raw.prompt_tokens_details?.cached_tokens === 'number'
+      ? raw.prompt_tokens_details.cached_tokens
+      : undefined;
+  const reasoning =
+    typeof raw.completion_tokens_details?.reasoning_tokens === 'number'
+      ? raw.completion_tokens_details.reasoning_tokens
+      : undefined;
+  return buildOpenAICompatUsage({
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    cached_tokens: cached,
+    reasoning_tokens: reasoning,
+    model,
+  });
+}
+
+// Build the metadata payload spread onto the final A2A message under
+// `OPENAI_COMPAT_EXTENSION_URI`. Includes the spec's `usage` field plus a
+// `chat_completion` echo of the binary's response envelope (id / model /
+// created / choices / finish_reason) so callers that need the full OpenAI
+// response shape (e.g. an oai2a2a gateway) can recover it from a single
+// metadata block instead of reconstructing from the text artifact.
+export function buildResponseMetadata(
+  response: ChatCompletionResponse,
+  usage: OpenAICompatUsage | null,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  if (usage) payload.usage = usage;
+  // Echo the upstream response envelope so callers downstream get the
+  // complete OpenAI Chat Completions shape (id / object / created / model /
+  // choices) without having to round-trip through the text artifact. Empty
+  // `choices` arrays still ride along — a malformed-but-non-fatal upstream
+  // payload is more useful to surface than to silently drop.
+  const echo: Record<string, unknown> = {};
+  if (response.id) echo.id = response.id;
+  if (response.object) echo.object = response.object;
+  if (typeof response.created === 'number') echo.created = response.created;
+  if (response.model) echo.model = response.model;
+  if (Array.isArray(response.choices)) echo.choices = response.choices;
+  if (response.usage) echo.usage = response.usage;
+  if (Object.keys(echo).length > 0) payload.chat_completion = echo;
+  return { [OPENAI_COMPAT_EXTENSION_URI]: payload };
+}
+
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: VicoopCodexSpawnOptions,
+): VicoopCodexChildHandle {
+  return nodeSpawn(command, Array.from(args), {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  }) as ChildProcess;
+}
+
+// Internal record of the binary's exit + collected streams. Returned by
+// `runVicoopCodexCall` so `handle()` can branch on exit code without
+// re-parsing the stderr / stdout itself.
+interface CallResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+// Spawn `vicoop-codex call`, write the JSON body on stdin, and collect
+// the result. Honours abort/cancel via `signal` — on abort we SIGTERM the
+// child so the daemon doesn't wait on a stale subprocess after the
+// caller's A2A `tasks/cancel` lands. Stderr is captured in full (no cap)
+// because vicoop-codex's user-facing error guidance lives there and the
+// task.fail message is operator-visible.
+async function runVicoopCodexCall(
+  body: string,
+  opts: {
+    command: string;
+    args: readonly string[];
+    cwd?: string;
+    spawn: VicoopCodexSpawnFn;
+    timeoutMs: number;
+    signal: AbortSignal;
+    stderrCap: number;
+    logger?: Logger;
+  },
+): Promise<CallResult> {
+  return await new Promise<CallResult>((resolve, reject) => {
+    let child: VicoopCodexChildHandle;
+    try {
+      child = opts.spawn(opts.command, opts.args, { cwd: opts.cwd });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+    let timer: NodeJS.Timeout | null = null;
+    let aborted = false;
+    let settled = false;
+
+    const finish = (result: CallResult): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      opts.signal.removeEventListener('abort', onAbort);
+      resolve(result);
+    };
+
+    const fail = (err: Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      opts.signal.removeEventListener('abort', onAbort);
+      reject(err);
+    };
+
+    const onAbort = (): void => {
+      aborted = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // best-effort
+      }
+    };
+    if (opts.signal.aborted) {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // best-effort
+      }
+    } else {
+      opts.signal.addEventListener('abort', onAbort);
+    }
+
+    if (opts.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        if (settled) return;
+        try {
+          child.kill('SIGTERM');
+        } catch {
+          // best-effort
+        }
+        fail(new Error(`vicoop-codex call timed out after ${opts.timeoutMs}ms`));
+      }, opts.timeoutMs);
+    }
+
+    if (child.stdout) {
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        stdout += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      });
+    }
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        const piece = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+        if (stderr.length < opts.stderrCap) {
+          const remaining = opts.stderrCap - stderr.length;
+          stderr += piece.length > remaining ? piece.slice(0, remaining) : piece;
+        }
+      });
+    }
+
+    child.on('error', (err) => {
+      fail(err);
+    });
+    child.on('close', (code, signal) => {
+      finish({
+        code: aborted ? null : code,
+        signal,
+        stdout,
+        stderr,
+      });
+    });
+
+    if (child.stdin) {
+      child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+        // EPIPE on early exit is expected (e.g. exit code 2 before reading
+        // the body) — surface it as a normal close, not a hard error.
+        if (err.code !== 'EPIPE') {
+          opts.logger?.warn?.(`[vicoop-codex] stdin error: ${errorMessage(err)}`);
+        }
+      });
+      try {
+        child.stdin.write(body);
+        child.stdin.end();
+      } catch (err) {
+        opts.logger?.warn?.(`[vicoop-codex] failed to write stdin: ${errorMessage(err)}`);
+      }
+    }
+  });
+}
+
+// Construct the A2A Backend. The handler turns each task into a single
+// non-streaming `vicoop-codex call` invocation: read the existing
+// openai-compat extension metadata → assemble messages → invoke →
+// translate response to A2A artifacts + final message metadata.
+export function createVicoopCodexBackend(
+  opts: VicoopCodexBackendOptions = {},
+): Backend {
+  const command = opts.command ?? 'vicoop-codex';
+  const baseArgs: readonly string[] = ['call', ...(opts.extraArgs ?? [])];
+  const cwd = opts.cwd;
+  const spawnFn = opts.spawn ?? defaultSpawn;
+  const stderrCap = opts.stderrCaptureBytes ?? 16 * 1024;
+  const callTimeoutMs = opts.callTimeoutMs ?? 0;
+  const logger = opts.logger ?? createLogger();
+
+  return {
+    name: 'vicoop-codex',
+
+    async handle(task, emit, signal) {
+      if (signal.aborted) {
+        emit({
+          type: 'task.complete',
+          taskId: task.taskId,
+          status: { state: 'canceled', timestamp: new Date().toISOString() },
+        });
+        return;
+      }
+
+      // Use the existing openai-compat A2A extension reader (claude.ts).
+      // It returns the 4-field schema { system, tools, tool_choice,
+      // tool_call_history } — the canonical surface every backend in this
+      // package already speaks. We do NOT define additional reader fields
+      // here: extending the extension schema unilaterally would risk
+      // breaking the contract other backends rely on.
+      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+
+      const userContent = flattenA2AUserContent(task.message.parts);
+      if (userContent === null) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'empty_prompt',
+            message: 'vicoop-codex backend received no text or data content in the user message',
+          },
+        });
+        return;
+      }
+
+      const messages = buildMessages(openaiCompat, userContent);
+      const body = buildCallBody(openaiCompat, messages);
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(body);
+      } catch (err) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'serialize_failed',
+            message: `failed to serialize call body: ${errorMessage(err)}`,
+          },
+        });
+        return;
+      }
+
+      emit({
+        type: 'task.status',
+        taskId: task.taskId,
+        status: { state: 'working', timestamp: new Date().toISOString() },
+      });
+
+      let result: CallResult;
+      try {
+        result = await runVicoopCodexCall(serialized, {
+          command,
+          args: baseArgs,
+          cwd,
+          spawn: spawnFn,
+          timeoutMs: callTimeoutMs,
+          signal,
+          stderrCap,
+          logger,
+        });
+      } catch (err) {
+        if (signal.aborted) {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'spawn_failed',
+            message: `failed to spawn vicoop-codex: ${errorMessage(err)}`,
+          },
+        });
+        return;
+      }
+
+      // Aborted mid-flight — caller already pulled the plug, surface as
+      // canceled regardless of what the subprocess did before SIGTERM
+      // delivered.
+      if (signal.aborted) {
+        emit({
+          type: 'task.complete',
+          taskId: task.taskId,
+          status: { state: 'canceled', timestamp: new Date().toISOString() },
+        });
+        return;
+      }
+
+      if (result.code !== 0) {
+        const trimmedStderr = result.stderr.trim();
+        const message =
+          trimmedStderr.length > 0
+            ? trimmedStderr
+            : `vicoop-codex exited with code ${result.code}`;
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: exitCodeToA2ACode(result.code),
+            message,
+          },
+        });
+        return;
+      }
+
+      // Parse the stdout payload. A malformed (non-JSON) stdout shouldn't
+      // crash the backend — surface as `parse_failed` with the head of
+      // the output so the operator can diagnose without `--verbose`.
+      let response: ChatCompletionResponse;
+      try {
+        response = JSON.parse(result.stdout) as ChatCompletionResponse;
+      } catch (err) {
+        const head = result.stdout.slice(0, 256);
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'parse_failed',
+            message: `failed to parse vicoop-codex stdout as JSON: ${errorMessage(err)}; head: ${JSON.stringify(head)}`,
+          },
+        });
+        return;
+      }
+
+      // Doc invariants: `choices` is always length 1, n>1 is unsupported.
+      // Tolerate variants regardless (future schema bump) but always read
+      // index 0 — anything else would silently lose data.
+      const choice = response.choices?.[0];
+      const messagePayload = choice?.message;
+      const contentText =
+        typeof messagePayload?.content === 'string' ? messagePayload.content : '';
+      const toolCalls = Array.isArray(messagePayload?.tool_calls)
+        ? messagePayload.tool_calls
+        : [];
+      const finishReason = typeof choice?.finish_reason === 'string' ? choice.finish_reason : '';
+
+      // When the model emitted a `tool_calls` envelope we mirror codex.ts's
+      // native dispatch artifact shape: a `data` part carrying the
+      // `tool_calls` array under the OPENAI_COMPAT_EXTENSION_URI. Callers
+      // downstream (oai2a2a) special-case this artifact to recover the
+      // OpenAI Chat Completions wire shape on the way out.
+      if (toolCalls.length > 0) {
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'vicoop-codex-message',
+            parts: [{ kind: 'data', data: { tool_calls: toolCalls } }],
+            extensions: [OPENAI_COMPAT_EXTENSION_URI],
+          },
+          lastChunk: true,
+        });
+      } else if (contentText) {
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'vicoop-codex-message',
+            parts: [{ kind: 'text', text: contentText }],
+          },
+          lastChunk: true,
+        });
+      }
+
+      const usage = parseChatCompletionUsage(response.usage, response.model);
+      const responseMetadata = buildResponseMetadata(response, usage);
+
+      // The final `task.complete` message mirrors codex.ts's pattern:
+      //   - `parts`: the assistant's text content (omitted on the tool-call
+      //     path so we don't double-stamp the tool_calls envelope onto the
+      //     status message).
+      //   - `metadata[OPENAI_COMPAT_EXTENSION_URI]`: usage + the full
+      //     chat_completion echo. Always emitted so the caller has access
+      //     to id / model / created / choices / finish_reason without
+      //     parsing the artifact.
+      //   - `extensions`: the OPENAI_COMPAT_EXTENSION_URI marker.
+      const parts: Part[] =
+        toolCalls.length === 0 && contentText ? [{ kind: 'text', text: contentText }] : [];
+      emit({
+        type: 'task.complete',
+        taskId: task.taskId,
+        status: {
+          state: 'completed',
+          timestamp: new Date().toISOString(),
+          message: {
+            role: 'agent',
+            messageId: randomUUID(),
+            parts,
+            metadata: responseMetadata,
+            extensions: [OPENAI_COMPAT_EXTENSION_URI],
+          },
+        },
+      });
+      // finish_reason is informational; surfaced only via the metadata
+      // echo above. The A2A `task.complete` state is always `completed`
+      // (incl. `finish_reason: "tool_calls"`) because the tool-call round
+      // is a successful turn from the bridge's perspective — the next A2A
+      // turn brings back the tool result via `tool_call_history`.
+      void finishReason;
+    },
+  };
+}

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -28,7 +28,7 @@ export const DEFAULT_BRIDGE_HTTPS_URL = 'https://vicoop-bridge-server.fly.dev';
 const SANDBOX_MODES = ['read-only', 'workspace-write', 'danger-full-access'] as const;
 export type CodexSandboxMode = (typeof SANDBOX_MODES)[number];
 
-const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex'] as const;
+const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex', 'vicoop-codex'] as const;
 export type BackendKind = (typeof BACKEND_KINDS)[number];
 
 // Optique daemon-mode grammar. Every operator-tunable knob is a flag here,

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -16,6 +16,7 @@ import {
   createCodexBackend,
   type ApprovalDecision,
 } from './backends/codex.js';
+import { createVicoopCodexBackend } from './backends/vicoop-codex.js';
 import type { Backend } from './backend.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
@@ -242,9 +243,11 @@ function pickBackend(name: string, args: Args): Backend {
         sandboxMode: coerceCodexSandbox(args, backends.codex?.sandbox_mode),
         approvalDecision: backends.codex?.approval_decision as ApprovalDecision | undefined,
       });
+    case 'vicoop-codex':
+      return createVicoopCodexBackend();
     default:
       throw new Error(
-        `unknown backend: ${name} (supported: echo, openclaw, claude, codex)`,
+        `unknown backend: ${name} (supported: echo, openclaw, claude, codex, vicoop-codex)`,
       );
   }
 }

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -174,6 +174,7 @@ const KNOWN_BACKENDS = new Set([
   'openclaw',
   'claude',
   'codex',
+  'vicoop-codex',
 ]);
 const KNOWN_APPROVAL_DECISIONS = new Set([
   'accept',

--- a/packages/server/src/card-resolver.ts
+++ b/packages/server/src/card-resolver.ts
@@ -16,6 +16,7 @@ const canonicalCards = new Map<string, AgentCardType>(
     codex: readCanonicalCard('codex'),
     echo: readCanonicalCard('echo'),
     openclaw: readCanonicalCard('openclaw'),
+    'vicoop-codex': readCanonicalCard('vicoop-codex'),
   }),
 );
 

--- a/packages/server/src/cards/vicoop-codex.json
+++ b/packages/server/src/cards/vicoop-codex.json
@@ -1,0 +1,31 @@
+{
+  "name": "vicoop-codex",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion echo on the final message metadata.",
+  "version": "0.0.1",
+  "protocolVersion": "0.3.0",
+  "capabilities": {
+    "streaming": false,
+    "extensions": [
+      {
+        "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
+        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / tool_call_history) to assemble the call body; emits OpenAI Chat Completions tool_calls back as an A2A data part and the full response envelope on the final message metadata.",
+        "required": false
+      }
+    ]
+  },
+  "defaultInputModes": [
+    "text/plain",
+    "application/json"
+  ],
+  "defaultOutputModes": [
+    "text/plain"
+  ],
+  "skills": [
+    {
+      "id": "chat",
+      "name": "chat",
+      "description": "Ask a question or give an instruction in natural language; the vicoop-codex CLI responds with text. Auxiliary structured context can be attached as A2A `data` parts; they are serialized into the prompt as tagged JSON blocks. File parts are not supported.",
+      "tags": ["chat", "assistant", "codex", "openai-compat"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a new bridge client backend (`--backend vicoop-codex`) that delegates each A2A task to the local `vicoop-codex call` CLI.
- The backend reuses the existing 4-field openai-compat A2A extension schema (`system` / `tools` / `tool_choice` / `tool_call_history`) — no new metadata keys, CLI flags, or config knobs are introduced. Anything not on that schema (e.g. `model`, `reasoning_effort`, Group B / Group C parameters) is left for the binary's own defaults so the existing extension contract shared with `claude` / `codex` / `openclaw` stays untouched.
- Translates the binary's OpenAI Chat Completions response back to A2A: assistant text becomes a `text` artifact; `tool_calls` become a `data` artifact carrying the OpenAI envelope; the final `task.complete.status.message.metadata` echoes the full response (`usage` + `chat_completion`) under the openai-compat extension URI so downstream gateways (e.g. oai2a2a) can recover the OpenAI shape from a single block.
- Registers a canonical agent card on both the server and the client so the bridge accepts the new `backendKind`.

## Changes
- `packages/client/src/backends/vicoop-codex.ts` — new backend.
- `packages/client/src/backends/vicoop-codex.test.ts` — pure-function and end-to-end (fake `vicoop-codex` subprocess) tests.
- `packages/client/src/{cli.ts,cli-args.ts,config.ts}` — one-line additions to register `'vicoop-codex'` as a known backend kind and wire `pickBackend()`.
- `packages/{server,client}/{src/,}cards/vicoop-codex.json` — canonical agent card.
- `packages/server/src/card-resolver.ts` — one-line addition so the bridge maps the new `backendKind` to its canonical card.
- `package.json` — root `install:client` script for local end-to-end testing.

## Request → call body mapping
| A2A metadata (under `OPENAI_COMPAT_EXTENSION_URI`) | `vicoop-codex call` body |
|---|---|
| `system` | first entry of `messages` (role `system`) |
| `tool_call_history` | replayed as `assistant` + `tool` messages in order |
| current `message.parts` (text / data) | last entry of `messages` (role `user`) |
| `tools` | `tools` (verbatim) |
| `tool_choice` | `tool_choice` (verbatim) |

Everything else from the call command's input doc (`model`, `parallel_tool_calls`, `reasoning_effort`, `store`, `stream`, `include`, `max_tokens`, `temperature`, etc.) is intentionally not read — adding readers would unilaterally extend the openai-compat extension schema that other backends rely on.

## Response → A2A mapping
- `choices[0].message.content` → `task.artifact` (`text` part).
- `choices[0].message.tool_calls` → `task.artifact` (`data` part: `{ tool_calls: [...] }`, `extensions: [OPENAI_COMPAT_EXTENSION_URI]`).
- `task.complete.status.message.metadata[OPENAI_COMPAT_EXTENSION_URI]` carries `usage` (with `total = prompt + completion` enforced) plus a `chat_completion` echo (`id`, `object`, `created`, `model`, `choices`, `usage`).

## Exit code → A2A error code
| `vicoop-codex` exit | A2A `task.fail.error.code` |
|---|---|
| `2` | `invalid_input` |
| `3` | `login_required` |
| `4` | `upstream_error` |
| `5` | `network_error` |
| other | `vicoop_codex_failed` |

Plus backend-internal codes: `empty_prompt`, `serialize_failed`, `spawn_failed`, `parse_failed`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm -r test` (new tests pass, no regressions in the other 400+ tests)
- [ ] `pnpm build` (server `dist/cards/vicoop-codex.json` is produced)
- [ ] After server redeploy: `vicoop-client --backend vicoop-codex` against the deployed bridge no longer disconnects with `4013 unknown backend kind`.
- [ ] End-to-end smoke against a real `vicoop-codex` install: simple text question, system prompt, tool round-trip via `tool_call_history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)