### PR TITLE
chore: backfill missing changesets for #221 and #225

### DIFF
--- a/.changeset/claude-ask-user-question.md
+++ b/.changeset/claude-ask-user-question.md
@@ -1,0 +1,28 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+claude backend: surface `AskUserQuestion` calls as A2A
+`input-required` instead of silently looping (#221).
+
+When the spawned `claude` invokes the built-in `AskUserQuestion` tool the
+backend now:
+
+- closes the task with `task.complete state=input-required` carrying the
+  tool call as a `DataPart` on `status.message.parts[0]`
+  (`{ kind: 'tool_call', toolName, toolUseId, input }`) so downstream
+  clients (e.g. slack-connector) can reconstruct the question via
+  `toolCallPartFromLegacyRecord` and render it as interactive UI (Slack
+  Block Kit, etc.).
+- writes a placeholder `tool_result` back to claude's stdin and closes
+  the stream so the session terminates cleanly and the next turn can
+  `--resume` against the same `contextId`.
+- sets an `emittedAskUserQuestion` flag that suppresses any further
+  assistant text / `tool_use` events from claude, preventing the retry
+  loop where claude re-invokes `AskUserQuestion` upon receiving the
+  placeholder.
+
+No A2A `ask-user-question` artifact is emitted — the terminal
+`input-required` frame is the single source of truth for the multi-turn
+contract. Plain claude tasks that never hit `AskUserQuestion` are
+unaffected.

--- a/.changeset/vicoop-codex-backend.md
+++ b/.changeset/vicoop-codex-backend.md
@@ -1,0 +1,51 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add a new `vicoop-codex` bridge client backend that delegates each A2A
+task to the local `vicoop-codex call` CLI (#225).
+
+`--backend vicoop-codex` (or `"backend": "vicoop-codex"` in
+`config.json`) is now a first-class backend kind alongside `echo`,
+`openclaw`, `claude`, and `codex`. The backend reuses the existing
+4-field openai-compat A2A extension schema
+(`system` / `tools` / `tool_choice` / `tool_call_history`) — no new
+metadata keys, CLI flags, or config knobs are introduced. The
+canonical agent card is published on both the server and the client
+(`packages/{server,client}/cards/vicoop-codex.json`) and the server
+maps the new `backendKind` to it via `card-resolver.ts`.
+
+Request mapping:
+
+| A2A metadata (`OPENAI_COMPAT_EXTENSION_URI`) | `vicoop-codex call` body |
+|---|---|
+| `system`                | first entry of `messages` (role `system`) |
+| `tool_call_history`     | replayed as `assistant` + `tool` messages in order |
+| `message.parts` (text / data) | last entry of `messages` (role `user`) |
+| `tools`                 | `tools` (verbatim) |
+| `tool_choice`           | `tool_choice` (verbatim) |
+
+Response mapping:
+
+- `choices[0].message.content` → `task.artifact` (`text` part)
+- `choices[0].message.tool_calls` → `task.artifact` (`data` part:
+  `{ tool_calls: [...] }`, `extensions: [OPENAI_COMPAT_EXTENSION_URI]`)
+- `task.complete.status.message.metadata[OPENAI_COMPAT_EXTENSION_URI]`
+  carries `usage` (with `total = prompt + completion` enforced) plus a
+  `chat_completion` echo (`id`, `object`, `created`, `model`,
+  `choices`, `usage`).
+
+Exit code → A2A error code:
+
+| `vicoop-codex` exit | `task.fail.error.code` |
+|---|---|
+| `2` | `invalid_input` |
+| `3` | `login_required` |
+| `4` | `upstream_error` |
+| `5` | `network_error` |
+| other | `vicoop_codex_failed` |
+
+Plus backend-internal codes: `empty_prompt`, `serialize_failed`,
+`spawn_failed`, `parse_failed`.
+
+The other backends are unchanged.


### PR DESCRIPTION
## Summary

Two recent merges landed on main without an accompanying changeset, so they would have been omitted from the upcoming `@vicoop-bridge/client@0.18.0` CHANGELOG entry that the auto-generated #214 release PR produces:

- **#221** (\`77086f6\`) — \`feat(claude): emit AskUserQuestion as A2A artifact and suppress CC retry\`
- **#225** (\`5edbee9\`) — \`feat: add vicoop-codex backend\`

Both are user-visible client changes (one alters claude backend behavior, one adds a new \`--backend vicoop-codex\` option), so they warrant a minor bump and a CHANGELOG paragraph. This PR adds the two missing changeset files; no source code changes.

Once merged, the changesets bot will regenerate #214 to roll these in alongside the three already-present changesets (\`agent-subcommand\`, \`claude-native-tool-dispatch\`, \`codex-native-tool-dispatch\`).

## Test plan

- [x] \`pnpm changeset status\` recognises both files (verified locally — changeset format passes)
- [ ] #214 (\`chore: version packages\`) refreshes its body to include the two new entries after this PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)