### PR TITLE
[codex] Add Claude spawn debug logs

### DIFF
--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1024,11 +1024,12 @@ test('debug log records claude spawn shape and spawn errors', async () => {
       /claude\.spawn\.start/.test(line) &&
       /command=claude/.test(line) &&
       /argv=.*--settings/.test(line) &&
-      /<settings chars=/.test(line) &&
-      /<system-prompt chars=/.test(line) &&
-      !line.includes('operator secret-ish prompt')
+      line.includes('sandbox') &&
+      line.includes('enabled') &&
+      line.includes('true') &&
+      line.includes('operator secret-ish prompt')
     ),
-    `expected redacted spawn start debug log, got:\n${logs.join('\n')}`,
+    `expected raw spawn start debug log, got:\n${logs.join('\n')}`,
   );
   assert.ok(
     logs.some((line) =>

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -995,6 +995,50 @@ test('rolls back the session binding when spawn throws', async () => {
   assert.ok(child.args.indexOf('--session-id') !== -1);
 });
 
+test('debug log records claude spawn shape and spawn errors', async () => {
+  const oldLevel = process.env.VICOOP_CLIENT_LOG_LEVEL;
+  const oldLog = console.log;
+  const logs: string[] = [];
+  process.env.VICOOP_CLIENT_LOG_LEVEL = 'debug';
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  };
+  try {
+    const backend = createClaudeBackend({
+      spawn: () => {
+        throw new Error('ENOENT: claude missing');
+      },
+      settings: { sandbox: { enabled: true } },
+      extraArgs: ['--append-system-prompt', 'operator secret-ish prompt'],
+    });
+
+    await backend.handle(assign('one'), collect().emit, NEVER);
+  } finally {
+    console.log = oldLog;
+    if (oldLevel === undefined) delete process.env.VICOOP_CLIENT_LOG_LEVEL;
+    else process.env.VICOOP_CLIENT_LOG_LEVEL = oldLevel;
+  }
+
+  assert.ok(
+    logs.some((line) =>
+      /claude\.spawn\.start/.test(line) &&
+      /command=claude/.test(line) &&
+      /argv=.*--settings/.test(line) &&
+      /<settings chars=/.test(line) &&
+      /<system-prompt chars=/.test(line) &&
+      !line.includes('operator secret-ish prompt')
+    ),
+    `expected redacted spawn start debug log, got:\n${logs.join('\n')}`,
+  );
+  assert.ok(
+    logs.some((line) =>
+      /claude\.spawn\.error/.test(line) &&
+      /error=ENOENT: claude missing/.test(line)
+    ),
+    `expected spawn error debug log, got:\n${logs.join('\n')}`,
+  );
+});
+
 test('rolls back the session binding when claude exits non-zero on a fresh session', async () => {
   // First task: claude exits with a stderr message but no result. The
   // freshly-minted sessionId was never persisted on disk, so a follow-up
@@ -1027,6 +1071,24 @@ test('rolls back the session binding when claude exits non-zero on a fresh sessi
   const child = fakeOk.lastChild()!;
   assert.equal(child.args.indexOf('--resume'), -1, 'must not resume an aborted session');
   assert.ok(child.args.indexOf('--session-id') !== -1, 'must mint a fresh session id');
+});
+
+test('non-zero claude exit includes stdout tail when stderr is empty', async () => {
+  const fake = scriptedSpawn({
+    lines: ['fatal: stream-json setup failed before stderr'],
+    exitCode: 1,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('fail with stdout only'), emit, NEVER);
+
+  const terminal = frames.at(-1);
+  assert.ok(terminal && terminal.type === 'task.fail');
+  if (terminal.type === 'task.fail') {
+    assert.equal(terminal.error.code, 'claude_exit_nonzero');
+    assert.match(terminal.error.message, /\[stdout: fatal: stream-json setup failed before stderr\]/);
+  }
 });
 
 test('rollback does not delete a binding a concurrent task has refreshed', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -30,7 +30,7 @@ import {
   INPUT_IMAGE_MIME,
   type FetchUriPolicy,
 } from './fetch-uri-file.js';
-import { createLogger } from '../logger.js';
+import { createLogger, safeToken } from '../logger.js';
 import { createTimingRecorder } from './timing.js';
 
 // Slim subset of ChildProcess that the backend actually uses. Tests inject a
@@ -277,6 +277,46 @@ function errorMessage(e: unknown): string {
   } catch {
     return '<unrepresentable>';
   }
+}
+
+const SPAWN_ARG_VALUE_FLAGS = new Set([
+  '--append-system-prompt',
+  '--mcp-config',
+  '--settings',
+]);
+
+function summarizeSpawnArgValue(flag: string, value: string): string {
+  if (flag === '--mcp-config') {
+    try {
+      const parsed = JSON.parse(value) as { mcpServers?: unknown };
+      const servers = parsed.mcpServers && typeof parsed.mcpServers === 'object'
+        ? Object.keys(parsed.mcpServers as Record<string, unknown>).join(',')
+        : 'unknown';
+      return `<mcp-config servers=${servers || 'none'} chars=${value.length}>`;
+    } catch {
+      return `<mcp-config chars=${value.length}>`;
+    }
+  }
+  if (flag === '--append-system-prompt') {
+    return `<system-prompt chars=${value.length}>`;
+  }
+  if (flag === '--settings') {
+    return `<settings chars=${value.length}>`;
+  }
+  return value;
+}
+
+function summarizeSpawnArgs(args: readonly string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i] ?? '';
+    out.push(arg);
+    if (SPAWN_ARG_VALUE_FLAGS.has(arg) && i + 1 < args.length) {
+      out.push(summarizeSpawnArgValue(arg, args[i + 1] ?? ''));
+      i += 1;
+    }
+  }
+  return out;
 }
 
 function decodedBase64Size(b64: string): number {
@@ -1393,11 +1433,17 @@ export function createClaudeBackend(
 
       let child: ClaudeChildHandle;
       try {
+        timingLogger.debug(
+          `claude.spawn.start taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(summarizeSpawnArgs(args)), 4000)}`,
+        );
         child = spawnFn(command, args, { cwd });
         recorder.mark('spawn');
       } catch (err) {
         rollbackFreshSession();
         await closeCallerToolsMcp();
+        timingLogger.debug(
+          `claude.spawn.error taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(summarizeSpawnArgs(args)), 4000)} error=${safeToken(errorMessage(err), 1000)}`,
+        );
         emit({
           type: 'task.fail',
           taskId: task.taskId,
@@ -1462,6 +1508,7 @@ export function createClaudeBackend(
       } | null = null;
       let finalText: string | null = null;
       let finalUsage: OpenAICompatUsage | null = null;
+      let stdoutTail = '';
       let stderrTail = '';
       let aborted = false;
       let settled = false;
@@ -1657,7 +1704,10 @@ export function createClaudeBackend(
       let stdoutBuf = '';
       child.stdout?.on('data', (chunk: Buffer | string) => {
         recorder.mark('firstOut');
-        stdoutBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+        stdoutTail += text;
+        if (stdoutTail.length > stderrCap) stdoutTail = stdoutTail.slice(-stderrCap);
+        stdoutBuf += text;
         let nl: number;
         while ((nl = stdoutBuf.indexOf('\n')) !== -1) {
           const line = stdoutBuf.slice(0, nl).trim();
@@ -1714,6 +1764,9 @@ export function createClaudeBackend(
         child.on('close', (code, sig) => resolve({ code, signal: sig }));
       });
       recorder.mark('closed');
+      timingLogger.debug(
+        `claude.spawn.close taskId=${safeToken(task.taskId)} command=${safeToken(command)} code=${exit.code === null ? 'null' : String(exit.code)} signal=${exit.signal ? safeToken(exit.signal) : 'null'} stdoutTailChars=${stdoutTail.length} stderrTailChars=${stderrTail.length}${exit.error ? ` error=${safeToken(errorMessage(exit.error), 1000)}` : ''}`,
+      );
 
       signal.removeEventListener('abort', onAbort);
       settled = true;
@@ -1779,8 +1832,10 @@ export function createClaudeBackend(
       if (exit.code !== 0 && !treatExitAsSuccess) {
         rollbackFreshSession();
         const detail = stderrTail.trim();
+        const stdoutDetail = stdoutTail.trim();
         const sigPart = exit.signal ? ` (signal ${exit.signal})` : '';
         const detailPart = detail ? `: ${detail.slice(-500)}` : '';
+        const stdoutPart = stdoutDetail ? ` [stdout: ${stdoutDetail.slice(-500)}]` : '';
         // If stdin write blew up and the process exited non-zero, surface
         // both: the stdin error is usually the proximate cause.
         const stdinPart = stdinError ? ` [stdin: ${errorMessage(stdinError)}]` : '';
@@ -1789,7 +1844,7 @@ export function createClaudeBackend(
           taskId: task.taskId,
           error: {
             code: 'claude_exit_nonzero',
-            message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdinPart}`,
+            message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdoutPart}${stdinPart}`,
           },
         });
         return;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -279,46 +279,6 @@ function errorMessage(e: unknown): string {
   }
 }
 
-const SPAWN_ARG_VALUE_FLAGS = new Set([
-  '--append-system-prompt',
-  '--mcp-config',
-  '--settings',
-]);
-
-function summarizeSpawnArgValue(flag: string, value: string): string {
-  if (flag === '--mcp-config') {
-    try {
-      const parsed = JSON.parse(value) as { mcpServers?: unknown };
-      const servers = parsed.mcpServers && typeof parsed.mcpServers === 'object'
-        ? Object.keys(parsed.mcpServers as Record<string, unknown>).join(',')
-        : 'unknown';
-      return `<mcp-config servers=${servers || 'none'} chars=${value.length}>`;
-    } catch {
-      return `<mcp-config chars=${value.length}>`;
-    }
-  }
-  if (flag === '--append-system-prompt') {
-    return `<system-prompt chars=${value.length}>`;
-  }
-  if (flag === '--settings') {
-    return `<settings chars=${value.length}>`;
-  }
-  return value;
-}
-
-function summarizeSpawnArgs(args: readonly string[]): string[] {
-  const out: string[] = [];
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i] ?? '';
-    out.push(arg);
-    if (SPAWN_ARG_VALUE_FLAGS.has(arg) && i + 1 < args.length) {
-      out.push(summarizeSpawnArgValue(arg, args[i + 1] ?? ''));
-      i += 1;
-    }
-  }
-  return out;
-}
-
 function decodedBase64Size(b64: string): number {
   if (b64.length === 0) return 0;
   let pad = 0;
@@ -1434,7 +1394,7 @@ export function createClaudeBackend(
       let child: ClaudeChildHandle;
       try {
         timingLogger.debug(
-          `claude.spawn.start taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(summarizeSpawnArgs(args)), 4000)}`,
+          `claude.spawn.start taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)}`,
         );
         child = spawnFn(command, args, { cwd });
         recorder.mark('spawn');
@@ -1442,7 +1402,7 @@ export function createClaudeBackend(
         rollbackFreshSession();
         await closeCallerToolsMcp();
         timingLogger.debug(
-          `claude.spawn.error taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(summarizeSpawnArgs(args)), 4000)} error=${safeToken(errorMessage(err), 1000)}`,
+          `claude.spawn.error taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)} error=${safeToken(errorMessage(err), 1000)}`,
         );
         emit({
           type: 'task.fail',


### PR DESCRIPTION
## Summary

Add debug-level diagnostics around Claude backend process startup and failure handling.

## What changed

- Log `claude.spawn.start`, `claude.spawn.error`, and `claude.spawn.close` when `VICOOP_CLIENT_LOG_LEVEL=debug`.
- Log the raw Claude spawn argv at debug level so failures can be reproduced from the exact command shape. Values are still escaped/truncated as a single log token to avoid line injection and unbounded log volume.
- Capture stdout tail alongside stderr tail for `claude_exit_nonzero`, so failures with empty stderr can still surface useful CLI output.
- Add regression coverage for spawn debug logs and stdout-only non-zero exits.

## Why

When Claude Code exited non-zero during tool calls with empty stderr, the existing logs only showed `claude exited with code 1`. That made it hard to tell how the process was spawned or whether Claude wrote diagnostics to stdout instead.

## Validation

- `pnpm --filter @vicoop-bridge/client test -- src/backends/claude.test.ts`
- `pnpm --filter @vicoop-bridge/client typecheck`