### PR TITLE
fix(client/claude): allowlist registered MCP servers via --allowedTools (#235)

### DIFF
--- a/.changeset/claude-mcp-allowedtools.md
+++ b/.changeset/claude-mcp-allowedtools.md
@@ -1,0 +1,24 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: pre-approve registered MCP servers via `--allowedTools`
+so the model's tool calls survive operator environments that leave
+claude's permission system at its built-in default (#235).
+
+claude's permission system runs even in `-p` (non-interactive) mode. With
+the built-in `defaultMode: "default"` and no TTY there's nothing to
+answer a permission prompt, so an MCP tool invocation auto-denies, the
+model never reaches the bridge's `caller-tools-mcp` handler, and the run
+dies at `--max-turns 1` with `permission_denials` in the result event —
+the exact failure path in #235.
+
+The fix is surgical: for every MCP server the bridge itself registers
+(`caller-tools` for openai-compat caller tools, `vicoop-bridge` for
+`send_file`), append a server-level `--allowedTools mcp__<server>` rule
+to the spawn argv. Built-ins are already off via `--tools ""`, so this
+allowlist only opens the surface we stood up — and operator settings
+retain veto power because claude resolves `deny` rules before `allow`.
+
+Behaviour without an active MCP server (plain claude tasks) is
+unchanged: `--allowedTools` is only appended when `--mcp-config` is.

--- a/.changeset/claude-namespace-internal-mcp.md
+++ b/.changeset/claude-namespace-internal-mcp.md
@@ -1,0 +1,26 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: namespace internal MCP server registration keys under a
+`_vb-` ("vicoop-bridge") prefix so they cannot collide with
+operator-supplied servers under the same `--mcp-config` map.
+
+The previous keys were generic enough to clash with operator names —
+`caller-tools` in particular looks like something an operator might
+name their own MCP server, and claude's `--mcp-config` JSON resolves
+collisions last-wins, silently overwriting the bridge's entry.
+
+Renames:
+
+- `vicoop-bridge` → `_vb-send-file`
+- `caller-tools` → `_vb-caller-tools`
+
+Resulting model-visible tool ids change accordingly
+(`mcp___vb-send-file__send_file`, `mcp___vb-caller-tools__<tool>`); the
+bridge's own `--allowedTools` argv is generated from the same map so it
+tracks automatically. No A2A wire change.
+
+The merger of the two servers under a single namespace is tracked
+separately and naturally lands at `_vb` once #216 (long-lived listener
+for caller-tools) ships.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1728,8 +1728,8 @@ test('send_file MCP: server is registered on first task and a registered handle 
   const cfg = JSON.parse(String(child.args[cfgIdx + 1])) as {
     mcpServers: Record<string, { type: string; url: string }>;
   };
-  assert.equal(cfg.mcpServers['vicoop-bridge'].type, 'http');
-  assert.equal(cfg.mcpServers['vicoop-bridge'].url, server.url);
+  assert.equal(cfg.mcpServers['_vb-send-file'].type, 'http');
+  assert.equal(cfg.mcpServers['_vb-send-file'].url, server.url);
 
   // argv must also pre-approve the send_file MCP server's tools so the
   // model's `send_file` invocation survives a default permission policy
@@ -1737,7 +1737,7 @@ test('send_file MCP: server is registered on first task and a registered handle 
   // would auto-deny in -p mode since there's no TTY to answer the prompt.
   const allowedIdx = child.args.indexOf('--allowedTools');
   assert.notEqual(allowedIdx, -1, '--allowedTools required when an MCP server is registered (#235)');
-  assert.equal(child.args[allowedIdx + 1], 'mcp__vicoop-bridge');
+  assert.equal(child.args[allowedIdx + 1], 'mcp___vb-send-file');
 
   // Re-register a synthetic handle to check the routing reaches the handle's
   // emit (the lifecycle inside handle() already ran and released).
@@ -2820,14 +2820,14 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   assert.ok(child);
   const args = child!.args;
 
-  // (a) --mcp-config carries a `caller-tools` server entry.
+  // (a) --mcp-config carries a `_vb-caller-tools` server entry.
   const cfgIdx = args.indexOf('--mcp-config');
   assert.notEqual(cfgIdx, -1, 'expected --mcp-config in argv');
   const cfg = JSON.parse(args[cfgIdx + 1] as string) as {
     mcpServers?: Record<string, { type?: string; url?: string }>;
   };
-  assert.ok(cfg.mcpServers?.['caller-tools'], 'caller-tools MCP server registered');
-  assert.equal(cfg.mcpServers?.['caller-tools']?.type, 'http');
+  assert.ok(cfg.mcpServers?.['_vb-caller-tools'], '_vb-caller-tools MCP server registered');
+  assert.equal(cfg.mcpServers?.['_vb-caller-tools']?.type, 'http');
 
   // (b) --append-system-prompt carries the native variant — the envelope
   // contract block (the literal `{"tool_calls"` substring the legacy
@@ -2853,13 +2853,14 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   // `permission_denials` in the result event (issue #235).
   const allowedIdx = args.indexOf('--allowedTools');
   assert.notEqual(allowedIdx, -1, '--allowedTools required for caller-tools MCP (#235)');
-  assert.equal(args[allowedIdx + 1], 'mcp__caller-tools');
+  assert.equal(args[allowedIdx + 1], 'mcp___vb-caller-tools');
 });
 
 // Regression for #235: --allowedTools must cover every MCP server the
 // bridge registers, not just caller-tools. When both `send_file`
-// (vicoop-bridge) and `caller-tools` are active, both server-level
-// rules must appear in a single space-separated `--allowedTools` value.
+// (_vb-send-file) and caller-tools (_vb-caller-tools) are active, both
+// server-level rules must appear in a single space-separated
+// `--allowedTools` value.
 test('argv: --allowedTools covers all registered MCP servers (#235)', async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-235-allowed-'));
   const realRoot = await fs.realpath(root);
@@ -2909,9 +2910,9 @@ test('argv: --allowedTools covers all registered MCP servers (#235)', async () =
     assert.notEqual(allowedIdx, -1);
     const tokens = String(args[allowedIdx + 1]).split(/\s+/).filter(Boolean);
     // Order is insertion-order of `Object.keys(mcpServers)`:
-    // vicoop-bridge first (added when sendFileMcp is enabled), then
-    // caller-tools (added when openai-compat tools are present).
-    assert.deepEqual(tokens.sort(), ['mcp__caller-tools', 'mcp__vicoop-bridge']);
+    // _vb-send-file first (added when sendFileMcp is enabled), then
+    // _vb-caller-tools (added when openai-compat tools are present).
+    assert.deepEqual(tokens.sort(), ['mcp___vb-caller-tools', 'mcp___vb-send-file']);
 
     const closer = backend.getSendFileMcpServer();
     if (closer) await closer.close();
@@ -3210,7 +3211,7 @@ test('no openai-compat tools → no native dispatch argv (#213)', async () => {
     const cfg = JSON.parse(child.args[cfgIdx + 1] as string) as {
       mcpServers?: Record<string, unknown>;
     };
-    assert.equal(cfg.mcpServers?.['caller-tools'], undefined);
+    assert.equal(cfg.mcpServers?.['_vb-caller-tools'], undefined);
   }
   assert.equal(child.args.indexOf('--max-turns'), -1);
   // Built-in tools stay enabled (no `--tools ""`) so claude can operate

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1731,6 +1731,14 @@ test('send_file MCP: server is registered on first task and a registered handle 
   assert.equal(cfg.mcpServers['vicoop-bridge'].type, 'http');
   assert.equal(cfg.mcpServers['vicoop-bridge'].url, server.url);
 
+  // argv must also pre-approve the send_file MCP server's tools so the
+  // model's `send_file` invocation survives a default permission policy
+  // (#235). Without --allowedTools, claude's `defaultMode: "default"`
+  // would auto-deny in -p mode since there's no TTY to answer the prompt.
+  const allowedIdx = child.args.indexOf('--allowedTools');
+  assert.notEqual(allowedIdx, -1, '--allowedTools required when an MCP server is registered (#235)');
+  assert.equal(child.args[allowedIdx + 1], 'mcp__vicoop-bridge');
+
   // Re-register a synthetic handle to check the routing reaches the handle's
   // emit (the lifecycle inside handle() already ran and released).
   const captured: Array<{ artifactId: string; name: string }> = [];
@@ -2836,6 +2844,80 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   const toolsIdx = args.indexOf('--tools');
   assert.notEqual(toolsIdx, -1);
   assert.equal(args[toolsIdx + 1], '');
+
+  // (d) --allowedTools pre-approves the caller-tools MCP server so the
+  // model's tool_use survives operator environments that leave claude's
+  // permission system in `defaultMode: "default"`. In `-p` mode there's
+  // no TTY to answer a permission prompt, so an un-allowlisted MCP
+  // tool auto-denies and the run dies at --max-turns 1 with
+  // `permission_denials` in the result event (issue #235).
+  const allowedIdx = args.indexOf('--allowedTools');
+  assert.notEqual(allowedIdx, -1, '--allowedTools required for caller-tools MCP (#235)');
+  assert.equal(args[allowedIdx + 1], 'mcp__caller-tools');
+});
+
+// Regression for #235: --allowedTools must cover every MCP server the
+// bridge registers, not just caller-tools. When both `send_file`
+// (vicoop-bridge) and `caller-tools` are active, both server-level
+// rules must appear in a single space-separated `--allowedTools` value.
+test('argv: --allowedTools covers all registered MCP servers (#235)', async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-235-allowed-'));
+  const realRoot = await fs.realpath(root);
+  try {
+    const fake = scriptedSpawn({
+      lines: [
+        JSON.stringify({ type: 'system', subtype: 'init', session_id: 's' }),
+        JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+      ],
+      exitCode: 0,
+    });
+    const backend = createClaudeBackend({
+      spawn: fake.spawn,
+      sendFileMcp: { allowedRoots: [realRoot], skipHttp: true },
+    });
+    await backend.handle(
+      {
+        ...assign('do a fetch'),
+        message: {
+          role: 'user',
+          messageId: 'm',
+          parts: [{ kind: 'text', text: 'do a fetch' }],
+          metadata: {
+            [OPENAI_COMPAT_EXTENSION_URI]: {
+              system: 'be terse',
+              tools: [
+                {
+                  type: 'function',
+                  function: {
+                    name: 'fetch',
+                    description: 'Fetch a URL',
+                    parameters: { type: 'object', properties: {} },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+      collect().emit,
+      NEVER,
+    );
+    const child = fake.lastChild();
+    assert.ok(child);
+    const args = child!.args;
+    const allowedIdx = args.indexOf('--allowedTools');
+    assert.notEqual(allowedIdx, -1);
+    const tokens = String(args[allowedIdx + 1]).split(/\s+/).filter(Boolean);
+    // Order is insertion-order of `Object.keys(mcpServers)`:
+    // vicoop-bridge first (added when sendFileMcp is enabled), then
+    // caller-tools (added when openai-compat tools are present).
+    assert.deepEqual(tokens.sort(), ['mcp__caller-tools', 'mcp__vicoop-bridge']);
+
+    const closer = backend.getSendFileMcpServer();
+    if (closer) await closer.close();
+  } finally {
+    await fs.rm(realRoot, { recursive: true, force: true });
+  }
 });
 
 // End-to-end (with test seam): the model "invokes" the caller tool via

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1351,11 +1351,20 @@ export function createClaudeBackend(
       // depending on opts; an entirely empty `mcpServers` map skips
       // both `--mcp-config` and the matching `--allowedTools` below.
       const mcpServers: Record<string, { type: string; url: string }> = {};
+      // Registration keys use a `_vb-` ("vicoop-bridge") prefix so they
+      // can't collide with operator-supplied MCP server names under the
+      // same `--mcp-config` map. The previous keys (`vicoop-bridge`,
+      // `caller-tools`) were generic enough that an operator naming
+      // their own MCP server identically would last-wins overwrite the
+      // bridge's entry. The leading underscore marks these as internal
+      // and the short brand prefix keeps the resulting tool ids
+      // (`mcp___vb-<server>__<tool>`) readable. A future merge of these
+      // two servers under #216 would naturally land at a single `_vb`.
       if (mcpServerForTask) {
-        mcpServers['vicoop-bridge'] = { type: 'http', url: mcpServerForTask.url };
+        mcpServers['_vb-send-file'] = { type: 'http', url: mcpServerForTask.url };
       }
       if (callerToolsMcp) {
-        mcpServers['caller-tools'] = { type: 'http', url: callerToolsMcp.url };
+        mcpServers['_vb-caller-tools'] = { type: 'http', url: callerToolsMcp.url };
       }
       const mcpServerNames = Object.keys(mcpServers);
       const mcpConfigArgs: readonly string[] =

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1344,6 +1344,39 @@ export function createClaudeBackend(
         ? ['--max-turns', '1']
         : [];
 
+      // Both MCP servers ride on a single `--mcp-config` argv with one
+      // JSON blob. Keys are the MCP server names claude exposes the
+      // tools under (`mcp__<name>__<tool>` is the resulting tool-id
+      // pattern in the model's view). Either or both can be absent
+      // depending on opts; an entirely empty `mcpServers` map skips
+      // both `--mcp-config` and the matching `--allowedTools` below.
+      const mcpServers: Record<string, { type: string; url: string }> = {};
+      if (mcpServerForTask) {
+        mcpServers['vicoop-bridge'] = { type: 'http', url: mcpServerForTask.url };
+      }
+      if (callerToolsMcp) {
+        mcpServers['caller-tools'] = { type: 'http', url: callerToolsMcp.url };
+      }
+      const mcpServerNames = Object.keys(mcpServers);
+      const mcpConfigArgs: readonly string[] =
+        mcpServerNames.length === 0
+          ? []
+          : ['--mcp-config', JSON.stringify({ mcpServers })];
+      // Pre-approve the MCP servers we register. claude's permission system
+      // runs even in `-p` mode, and with the built-in `defaultMode: "default"`
+      // there's no TTY to answer a permission prompt — the request silently
+      // auto-denies, the model's tool call never executes, and the run dies
+      // at `--max-turns 1` with `permission_denials` in the result event
+      // (see #235). Built-ins are already off via `--tools ""` so this
+      // allowlist only opens tools the bridge itself stood up; operator
+      // settings retain veto power because claude's `deny` rules beat
+      // `allow`. Server-level rule (`mcp__<server>`) covers every tool
+      // exposed by that server without naming them individually.
+      const mcpAllowedToolsArgs: readonly string[] =
+        mcpServerNames.length === 0
+          ? []
+          : ['--allowedTools', mcpServerNames.map((s) => `mcp__${s}`).join(' ')];
+
       const args: string[] = [
         '-p',
         '--input-format',
@@ -1354,29 +1387,8 @@ export function createClaudeBackend(
         // prints a banner and exits instead of streaming.
         '--verbose',
         ...(isResume ? ['--resume', sessionId] : ['--session-id', sessionId]),
-        // Both MCP servers ride on a single `--mcp-config` argv with one
-        // JSON blob. Keys are the MCP server names claude exposes the
-        // tools under (`mcp__<name>__<tool>` is the resulting tool-id
-        // pattern in the model's view). Either or both can be absent
-        // depending on opts; an entirely empty `mcpServers` map is
-        // skipped entirely so we don't pass an unused argv to claude.
-        ...((): readonly string[] => {
-          const mcpServers: Record<string, unknown> = {};
-          if (mcpServerForTask) {
-            mcpServers['vicoop-bridge'] = {
-              type: 'http',
-              url: mcpServerForTask.url,
-            };
-          }
-          if (callerToolsMcp) {
-            mcpServers['caller-tools'] = {
-              type: 'http',
-              url: callerToolsMcp.url,
-            };
-          }
-          if (Object.keys(mcpServers).length === 0) return [];
-          return ['--mcp-config', JSON.stringify({ mcpServers })];
-        })(),
+        ...mcpConfigArgs,
+        ...mcpAllowedToolsArgs,
         ...identityArgs,
         ...openaiCompatArgs,
         ...disableBuiltinToolArgs,


### PR DESCRIPTION
## Summary

Two commits on the same MCP-server-registration surface:

### 1. `--allowedTools` for registered MCP servers (closes #235)

- claude's permission system runs even in `-p` mode; the built-in `defaultMode: "default"` auto-denies tool prompts (no TTY to answer) → MCP tool calls die at `--max-turns 1` with `permission_denials` in the result event.
- Append a server-level `--allowedTools mcp__<server>` rule to the spawn argv for every MCP server the bridge itself registers. Built-ins stay off via the existing `--tools ""`, so the allowlist only opens what we stood up; operator `deny` rules still win.
- No behavior change for plain claude tasks: `--allowedTools` is appended only when `--mcp-config` is.

### 2. `_vb-` namespace prefix on internal MCP registration keys (previously #237, folded in)

- The prior keys (`vicoop-bridge` for send_file, `caller-tools` for the openai-compat caller dispatch surface) were generic enough that an operator naming their own MCP server with one of those keys would last-wins overwrite the bridge's entry under the same `--mcp-config` map.
- Renames:
  - `vicoop-bridge` → `_vb-send-file`
  - `caller-tools` → `_vb-caller-tools`
- Model-visible tool ids become `mcp___vb-send-file__send_file` / `mcp___vb-caller-tools__<tool>`. `--allowedTools` is generated from the same map so the allowlist tracks the rename automatically.
- Internal `McpProtocolServer({ name })` identity strings left as-is — they don't participate in claude's namespacing and changing them risks breaking external observers matching on them.
- Merging the two servers into a single `_vb` namespace is tracked separately as #238 (depends on #216).

## Reproduction (#235)

claude 2.1.145, forced `defaultMode: "default"` via `--settings` to bypass operator-specific masking:

| | `permission_denials` | `caller-tools.onInvoke` |
|---|---|---|
| without `--allowedTools` | `[{tool_name: "mcp__caller-tools__get_weather", ...}]` | not called |
| with `--allowedTools "mcp___vb-caller-tools"` | `[]` | called with `{city: "Seoul", unit: "celsius"}` |

Matches the trace in issue #235 exactly.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client test` — 462/462 pass
- [x] `pnpm --filter @vicoop-bridge/client typecheck` — clean
- [x] Regression tests in `claude.test.ts`:
  - `argv: openai-compat caller tools wire caller-tools MCP + native prompt + --tools "" (#213)` — extended to assert `--allowedTools mcp___vb-caller-tools`
  - `send_file MCP: server is registered on first task ...` — extended to assert `--allowedTools mcp___vb-send-file`
  - `argv: --allowedTools covers all registered MCP servers (#235)` — both servers active, asserts both server-level rules appear
- [x] E2E driver run locally against a real `claude` binary (claude 2.1.145) with `defaultMode: "default"` forced — without fix: `task.fail code=claude_exit_nonzero` + `permission_denials`; with fix: `task.complete` + `tool_calls` artifact

Closes #235. Supersedes #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)