### PR TITLE
chore(client/claude): namespace internal MCP registration keys under `_vb-`

### DIFF
--- a/.changeset/claude-namespace-internal-mcp.md
+++ b/.changeset/claude-namespace-internal-mcp.md
@@ -1,0 +1,26 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: namespace internal MCP server registration keys under a
+`_vb-` ("vicoop-bridge") prefix so they cannot collide with
+operator-supplied servers under the same `--mcp-config` map.
+
+The previous keys were generic enough to clash with operator names —
+`caller-tools` in particular looks like something an operator might
+name their own MCP server, and claude's `--mcp-config` JSON resolves
+collisions last-wins, silently overwriting the bridge's entry.
+
+Renames:
+
+- `vicoop-bridge` → `_vb-send-file`
+- `caller-tools` → `_vb-caller-tools`
+
+Resulting model-visible tool ids change accordingly
+(`mcp___vb-send-file__send_file`, `mcp___vb-caller-tools__<tool>`); the
+bridge's own `--allowedTools` argv is generated from the same map so it
+tracks automatically. No A2A wire change.
+
+The merger of the two servers under a single namespace is tracked
+separately and naturally lands at `_vb` once #216 (long-lived listener
+for caller-tools) ships.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1728,8 +1728,8 @@ test('send_file MCP: server is registered on first task and a registered handle 
   const cfg = JSON.parse(String(child.args[cfgIdx + 1])) as {
     mcpServers: Record<string, { type: string; url: string }>;
   };
-  assert.equal(cfg.mcpServers['vicoop-bridge'].type, 'http');
-  assert.equal(cfg.mcpServers['vicoop-bridge'].url, server.url);
+  assert.equal(cfg.mcpServers['_vb-send-file'].type, 'http');
+  assert.equal(cfg.mcpServers['_vb-send-file'].url, server.url);
 
   // argv must also pre-approve the send_file MCP server's tools so the
   // model's `send_file` invocation survives a default permission policy
@@ -1737,7 +1737,7 @@ test('send_file MCP: server is registered on first task and a registered handle 
   // would auto-deny in -p mode since there's no TTY to answer the prompt.
   const allowedIdx = child.args.indexOf('--allowedTools');
   assert.notEqual(allowedIdx, -1, '--allowedTools required when an MCP server is registered (#235)');
-  assert.equal(child.args[allowedIdx + 1], 'mcp__vicoop-bridge');
+  assert.equal(child.args[allowedIdx + 1], 'mcp___vb-send-file');
 
   // Re-register a synthetic handle to check the routing reaches the handle's
   // emit (the lifecycle inside handle() already ran and released).
@@ -2820,14 +2820,14 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   assert.ok(child);
   const args = child!.args;
 
-  // (a) --mcp-config carries a `caller-tools` server entry.
+  // (a) --mcp-config carries a `_vb-caller-tools` server entry.
   const cfgIdx = args.indexOf('--mcp-config');
   assert.notEqual(cfgIdx, -1, 'expected --mcp-config in argv');
   const cfg = JSON.parse(args[cfgIdx + 1] as string) as {
     mcpServers?: Record<string, { type?: string; url?: string }>;
   };
-  assert.ok(cfg.mcpServers?.['caller-tools'], 'caller-tools MCP server registered');
-  assert.equal(cfg.mcpServers?.['caller-tools']?.type, 'http');
+  assert.ok(cfg.mcpServers?.['_vb-caller-tools'], '_vb-caller-tools MCP server registered');
+  assert.equal(cfg.mcpServers?.['_vb-caller-tools']?.type, 'http');
 
   // (b) --append-system-prompt carries the native variant — the envelope
   // contract block (the literal `{"tool_calls"` substring the legacy
@@ -2853,13 +2853,14 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   // `permission_denials` in the result event (issue #235).
   const allowedIdx = args.indexOf('--allowedTools');
   assert.notEqual(allowedIdx, -1, '--allowedTools required for caller-tools MCP (#235)');
-  assert.equal(args[allowedIdx + 1], 'mcp__caller-tools');
+  assert.equal(args[allowedIdx + 1], 'mcp___vb-caller-tools');
 });
 
 // Regression for #235: --allowedTools must cover every MCP server the
 // bridge registers, not just caller-tools. When both `send_file`
-// (vicoop-bridge) and `caller-tools` are active, both server-level
-// rules must appear in a single space-separated `--allowedTools` value.
+// (_vb-send-file) and caller-tools (_vb-caller-tools) are active, both
+// server-level rules must appear in a single space-separated
+// `--allowedTools` value.
 test('argv: --allowedTools covers all registered MCP servers (#235)', async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-235-allowed-'));
   const realRoot = await fs.realpath(root);
@@ -2909,9 +2910,9 @@ test('argv: --allowedTools covers all registered MCP servers (#235)', async () =
     assert.notEqual(allowedIdx, -1);
     const tokens = String(args[allowedIdx + 1]).split(/\s+/).filter(Boolean);
     // Order is insertion-order of `Object.keys(mcpServers)`:
-    // vicoop-bridge first (added when sendFileMcp is enabled), then
-    // caller-tools (added when openai-compat tools are present).
-    assert.deepEqual(tokens.sort(), ['mcp__caller-tools', 'mcp__vicoop-bridge']);
+    // _vb-send-file first (added when sendFileMcp is enabled), then
+    // _vb-caller-tools (added when openai-compat tools are present).
+    assert.deepEqual(tokens.sort(), ['mcp___vb-caller-tools', 'mcp___vb-send-file']);
 
     const closer = backend.getSendFileMcpServer();
     if (closer) await closer.close();
@@ -3210,7 +3211,7 @@ test('no openai-compat tools → no native dispatch argv (#213)', async () => {
     const cfg = JSON.parse(child.args[cfgIdx + 1] as string) as {
       mcpServers?: Record<string, unknown>;
     };
-    assert.equal(cfg.mcpServers?.['caller-tools'], undefined);
+    assert.equal(cfg.mcpServers?.['_vb-caller-tools'], undefined);
   }
   assert.equal(child.args.indexOf('--max-turns'), -1);
   // Built-in tools stay enabled (no `--tools ""`) so claude can operate

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1351,11 +1351,20 @@ export function createClaudeBackend(
       // depending on opts; an entirely empty `mcpServers` map skips
       // both `--mcp-config` and the matching `--allowedTools` below.
       const mcpServers: Record<string, { type: string; url: string }> = {};
+      // Registration keys use a `_vb-` ("vicoop-bridge") prefix so they
+      // can't collide with operator-supplied MCP server names under the
+      // same `--mcp-config` map. The previous keys (`vicoop-bridge`,
+      // `caller-tools`) were generic enough that an operator naming
+      // their own MCP server identically would last-wins overwrite the
+      // bridge's entry. The leading underscore marks these as internal
+      // and the short brand prefix keeps the resulting tool ids
+      // (`mcp___vb-<server>__<tool>`) readable. A future merge of these
+      // two servers under #216 would naturally land at a single `_vb`.
       if (mcpServerForTask) {
-        mcpServers['vicoop-bridge'] = { type: 'http', url: mcpServerForTask.url };
+        mcpServers['_vb-send-file'] = { type: 'http', url: mcpServerForTask.url };
       }
       if (callerToolsMcp) {
-        mcpServers['caller-tools'] = { type: 'http', url: callerToolsMcp.url };
+        mcpServers['_vb-caller-tools'] = { type: 'http', url: callerToolsMcp.url };
       }
       const mcpServerNames = Object.keys(mcpServers);
       const mcpConfigArgs: readonly string[] =


### PR DESCRIPTION
## Summary

- Move both bridge-internal MCP server keys under a `_vb-` ("vicoop-bridge") prefix so an operator-supplied MCP named the same generic word doesn't last-wins clobber the bridge's entry under `--mcp-config`.
- `vicoop-bridge` → `_vb-send-file`
- `caller-tools` → `_vb-caller-tools`
- `--allowedTools` (from #236) is generated from the same `mcpServers` map, so the allowlist tracks the rename automatically — model-visible tool ids become `mcp___vb-send-file__send_file` / `mcp___vb-caller-tools__<tool>` and the matching allow rules update with no extra wiring.
- Internal `McpProtocolServer({ name })` identity strings are intentionally left as-is — they don't participate in claude's namespacing and changing them could break external observers matching on those names.

Merging the two servers into one `_vb` namespace remains a follow-up tied to #216 (long-lived listener refactor for caller-tools-mcp); filing a separate issue to track that.

## Base

Branched off `fix/claude-mcp-allowedtools-235` (#236). Merge order matters — this PR's tests assume the `--allowedTools` argv from that PR. If #236 lands first this rebases cleanly onto `main`; if reordered, switch base to `main`.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 462/462 pass
- [x] All assertions on the prior `vicoop-bridge` / `caller-tools` keys updated to the new namespaced forms
- [x] `--allowedTools` regression tests (`#235`) assert the new `mcp___vb-*` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)