### PR TITLE
feat(protocol,server): forward callerPrincipal on task.assign (#241 prereq)

### DIFF
--- a/.changeset/task-assign-caller-principal-241.md
+++ b/.changeset/task-assign-caller-principal-241.md
@@ -1,0 +1,36 @@
+---
+'@vicoop-bridge/protocol': minor
+'@vicoop-bridge/server': minor
+---
+
+Forward the server-verified caller principal to the connected client as
+`TaskAssignFrame.callerPrincipal`. Prerequisite for the diff-based
+openai-compat session reuse redesign in #241: the client backends will key
+their per-conversation session cache on `(callerPrincipal, contextId)`
+plus a `(system, tools)` fingerprint so one caller cannot resume another's
+backend session by guessing or sharing a `contextId`.
+
+Scope is the bridge-internal server↔client WebSocket frame only. No change
+to the A2A wire shape, the openai-compat extension contract, or any
+externally-visible API. `_principalId` continues to be stripped from
+`message.metadata` before the frame leaves the bridge — the new field
+carries the same value as a typed sibling so the client never has to
+parse the internal-metadata convention.
+
+Backwards compatibility:
+
+- `callerPrincipal` is optional and omitted on the wire when the binding
+  has no principalId (public-agent path; no auth middleware ran).
+- `PROTOCOL_VERSION` is unchanged — `HelloFrame.version` literal stays at
+  `'0.1'`, so the hello handshake remains compatible in both directions.
+- zod's default unknown-key strip on `z.object` means an older client
+  parsing a newer server's frame silently drops the new field and behaves
+  exactly as before.
+- A newer client parsing an older server's frame sees
+  `callerPrincipal === undefined` and treats the task as anonymous (never
+  resumable across turns), which is the same fail-safe path used for the
+  public-agent flow.
+
+No behaviour change in this release — `@vicoop-bridge/client` does not yet
+read the new field. The follow-up PRs for the claude and codex backends
+(#241) consume it.

--- a/.changeset/task-assign-caller-principal-241.md
+++ b/.changeset/task-assign-caller-principal-241.md
@@ -26,10 +26,11 @@ Backwards compatibility:
 - zod's default unknown-key strip on `z.object` means an older client
   parsing a newer server's frame silently drops the new field and behaves
   exactly as before.
-- A newer client parsing an older server's frame sees
-  `callerPrincipal === undefined` and treats the task as anonymous (never
-  resumable across turns), which is the same fail-safe path used for the
-  public-agent flow.
+- Deployment is server-first; older-server + newer-client isn't a
+  supported configuration. The only remaining trigger for
+  `callerPrincipal === undefined` at the client is public-agent traffic,
+  where the server intentionally omits the field; the follow-up PRs treat
+  that case as anonymous (never resumable across turns).
 
 No behaviour change in this release — `@vicoop-bridge/client` does not yet
 read the new field. The follow-up PRs for the claude and codex backends

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -175,6 +175,14 @@ export const TaskAssignFrame = z.object({
   contextId: z.string(),
   message: Message,
   requestedExtensions: z.array(z.string()).optional(),
+  // The server-verified caller identity, forwarded to the client backend so
+  // it can key per-conversation state (e.g. the openai-compat session cache
+  // in #241) on the (callerPrincipal, contextId) pair rather than on the
+  // caller-supplied contextId alone. Absent on the public-agent path where
+  // no auth middleware ran. Optional + zod's default unknown-key strip on
+  // `z.object` keeps older clients forward-compatible with newer servers;
+  // PROTOCOL_VERSION is intentionally unchanged.
+  callerPrincipal: z.string().optional(),
 });
 
 export const TaskCancelFrame = z.object({

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -158,6 +158,10 @@ test('executor records principalId in binding and strips _principalId from outgo
       '_principalId must be stripped before the WS frame leaves the bridge',
     );
     assert.equal((md as Record<string, unknown>).userField, 'keep');
+    // PR #241 prerequisite: the verified principal is forwarded to the
+    // client as a sibling field on the frame (NOT inside message.metadata,
+    // where it could leak to downstream handlers that forward metadata).
+    assert.equal(frame.callerPrincipal, 'eth:0xabc');
   }
 
   // Push a terminal status so the generator returns without hanging.
@@ -208,6 +212,7 @@ test('executor omits message.metadata entirely when the only entry was _principa
   assert.equal(frame.type, 'task.assign');
   if (frame.type === 'task.assign') {
     assert.equal(frame.message.metadata, undefined);
+    assert.equal(frame.callerPrincipal, 'eth:0xabc');
   }
 
   const binding = registry.getBinding('t-2')!;
@@ -262,6 +267,14 @@ test('executor binding has no principalId when message metadata is absent', asyn
   assert.equal(frame.type, 'task.assign');
   if (frame.type === 'task.assign') {
     assert.equal(frame.message.metadata, undefined);
+    // Public-agent path: no principal recorded, frame omits the field
+    // entirely (rather than emitting `callerPrincipal: undefined`).
+    assert.equal(frame.callerPrincipal, undefined);
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(frame, 'callerPrincipal'),
+      false,
+      'callerPrincipal must be absent on the wire, not present-but-undefined',
+    );
   }
 
   binding.sink.pushStatus({

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -152,6 +152,7 @@ export class WSForwardingExecutor extends AgentExecutor {
         ...(message.extensions !== undefined ? { extensions: message.extensions } : {}),
       },
       ...(message.extensions !== undefined ? { requestedExtensions: message.extensions } : {}),
+      ...(principalId !== undefined ? { callerPrincipal: principalId } : {}),
     });
 
     if (!sent) {


### PR DESCRIPTION
## Summary

- Add optional `callerPrincipal` field to `TaskAssignFrame` (`packages/protocol/src/index.ts`) and populate it from the binding's verified `principalId` in the WS-forwarding executor (`packages/server/src/executor.ts`).
- Prerequisite for the diff-based openai-compat session reuse in #241: client backends will key per-conversation state on `(callerPrincipal, contextId)` plus a `(system, tools)` fingerprint so one caller can't resume another's backend session by guessing or sharing a `contextId`.
- **No behaviour change in this PR.** `@vicoop-bridge/client` doesn't read the field yet — that lands in the follow-up claude / codex PRs.

## Why a sibling field, not `message.metadata._principalId`?

`stripInternalMetadata` already drops `_`-prefixed keys before the frame leaves the bridge (`executor.ts:49-59`, `executor.test.ts:110-158`), so the client never sees `_principalId` today. Re-introducing it via the same channel would either reverse that strip (leaking server-internal context to downstream handlers that forward metadata) or require an exception. A typed sibling field on the frame is the cleanest path: it carries the same value to exactly one consumer (the client backend) without polluting application-facing metadata.

## Backwards compatibility

- **`PROTOCOL_VERSION` is unchanged.** `HelloFrame.version: z.literal('0.1')` still validates in both directions.
- **zod's default `z.object` strips unknown keys.** An older client parsing a newer server's frame silently drops `callerPrincipal` and behaves exactly as before.
- **Deployment is server-first**: older-server + newer-client isn't a supported configuration. The only remaining trigger for `callerPrincipal === undefined` at the client is public-agent traffic where the server intentionally omits the field; the follow-up PRs treat that case as anonymous (never resumable across turns).
- **Public-agent path**: the field is omitted entirely on the wire (not `present-but-undefined`) — explicit `hasOwnProperty === false` assertion locks this in (`executor.test.ts:268-277`).

## Test plan

- [x] `pnpm --filter @vicoop-bridge/protocol typecheck`
- [x] `pnpm --filter @vicoop-bridge/server typecheck`
- [x] `pnpm --filter @vicoop-bridge/client typecheck` (sanity — client doesn't consume the field yet but the published types must still resolve)
- [x] `pnpm --filter @vicoop-bridge/server test` — all 182 tests pass, including the three executor tests with new frame-level assertions:
  - `executor records principalId in binding and strips _principalId from outgoing WS frame` — also asserts `frame.callerPrincipal === 'eth:0xabc'`
  - `executor omits message.metadata entirely when the only entry was _principalId` — same plus `frame.callerPrincipal === 'eth:0xabc'` (proves the field rides as a sibling, not in metadata)
  - `executor binding has no principalId when message metadata is absent` — asserts both `frame.callerPrincipal === undefined` AND `hasOwnProperty === false` (public-agent path)

## Out of scope

- The (callerPrincipal, contextId) keyed cache + (system, tools) fingerprint + diff-based tool-result injection on the openai-compat path. Those land in the follow-up PRs for `claude.ts` and `codex.ts` per the review notes on #241.

## Related

- #241 — the redesign this is a prerequisite for. See [the review notes comment](https://github.com/planetarium/vicoop-bridge/issues/241#issuecomment-4497744271) for the broader strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)