### PR TITLE
feat(client/claude): reuse session + diff-inject new tool results on openai-compat continuation (#241)

### DIFF
--- a/.changeset/claude-openai-compat-session-reuse-241.md
+++ b/.changeset/claude-openai-compat-session-reuse-241.md
@@ -1,0 +1,93 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+feat(client/claude): reuse the claude session across openai-compat
+continuation turns and prepend only newly-arrived `role:"tool"` results
+(#241).
+
+Before this change, every A2A task carrying the openai-compat extension
+spawned a fresh `--session-id` and the bridge re-fed the entire
+`tool_call_history` JSON block on every turn. That made the per-turn
+prompt cost grow linearly in the number of prior round-trips and the
+cumulative cost grow quadratically; it also discarded the prior
+reasoning continuity that `--resume` would otherwise carry in claude's
+own session memory. The fresh-spawn gate (`sessionReuseEligible =
+openaiCompat === null && sessionTtlMs > 0` at `claude.ts:1149`) was the
+emergency workaround for #175 — when session reuse was on AND the
+gateway also re-sent the full history, the model saw every prior round
+twice and looped.
+
+The redesign keeps the contextId-keyed session alive across openai-compat
+A2A tasks and reconciles the two sources of truth instead of avoiding
+the conflict. Each `SessionEntry` now carries an `ackSet:
+Set<string>` of `tool_call_id` values whose `role:"tool"` result has
+already been delivered to this claude session. A continuation turn:
+
+1. Resumes the prior session via `--resume <sid>` (`isResume = true`).
+2. Filters the inbound `tool_call_history` to `role:"tool"` entries
+   whose `tool_call_id` isn't in the cached `ackSet`. The matching
+   `assistant.tool_calls` entries are *not* re-fed — they're already in
+   claude's own session memory from the prior turn, and re-feeding them
+   is precisely the #233 / #175 failure mode.
+3. Renders the filtered list through the existing `formatToolCallHistory`
+   wrapper and prepends it to the user content.
+4. On a successful terminal frame (`task.complete` with state
+   `completed` or `input-required`), adds every `role:"tool"`
+   `tool_call_id` from this turn's history to the ackSet so the next
+   continuation turn doesn't replay them. Failure leaves the ackSet
+   unchanged so the retry sees the same diff.
+
+First turns and fresh-fallback paths (no cached entry, TTL-evicted, or
+in-process restart) render the full history exactly as before, so a
+caller's first sight of any given conversation is identical.
+
+What was deliberately NOT added, after weighing the implementation cost
+against the failure modes:
+
+- **`callerPrincipal`-keyed cache.** A2A's `contextId` is UUID v4 in
+  practice (122-bit entropy); blind-guess hijack collisions are
+  negligible and the remaining leak vectors (caller-internal storage,
+  TLS-broken transport, server log access) aren't the bridge's
+  responsibility. See the closed PR #242 for the discussion that
+  arrived at this decision.
+- **`(system, tools)` fingerprint check.** If a caller changes their
+  system prompt or tools array mid-conversation, the cached claude
+  session has stale dispatch surface in its system prompt because
+  `--resume` can't reissue `--append-system-prompt`. Acceptable
+  trade-off: callers that change tools should also change contextId
+  (the natural "new conversation" boundary). If this turns into a
+  real failure mode in production, the fingerprint check is a small
+  follow-up — keep `system` + canonicalised `tools` sorted by
+  `function.name`, hash to 16 hex, mismatch → fresh fallback.
+- **Fork detection (incoming history prefix vs cached `historyPrefix`).**
+  A caller cutting their conversation history mid-flight is a malformed
+  use of the extension. The ackSet's "drop already-delivered ids"
+  semantics is safe even under this scenario — the worst that happens
+  is the model has a stale view of an earlier turn that the caller is
+  now claiming didn't happen.
+
+Operational requirement: same-`contextId` continuation turns must land
+on the same bridge instance for the optimisation to apply. Round-robin
+across multiple bridge processes correctly falls back to fresh every
+turn (no regression) but realises none of the savings — sticky routing
+on `contextId` is required to hit the acceptance-criteria benchmark in
+#241.
+
+Tests added:
+
+- `openai-compat continuation: second turn with same contextId resumes
+  via --resume (#241)` — argv-level proof that `--resume <sid>` carries
+  the first turn's minted session id and `--session-id` is absent on
+  the second spawn. Replaces the prior `#213`-era invariant assertion
+  ("openai-compat ALWAYS spawns fresh `--session-id`") that the
+  emergency workaround had to lock in.
+- `openai-compat continuation: prepended history contains only new
+  role:"tool" results since the prior turn (#241)` — three-turn
+  scenario verifying that the prepended block contains only the
+  newly-acked tool results, never the matching `assistant.tool_calls`
+  and never a `role:"tool"` entry whose id was already acked on a
+  prior turn.
+- `openai-compat continuation: regression guard against #175
+  double-feeding` — structural invariant: across both turns' stdin
+  payloads combined, any given `tool_call_id` appears at most once.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -3231,19 +3231,17 @@ test('no openai-compat tools → no native dispatch argv (#213)', async () => {
 // conflicting sources of truth on the same `tool_call_id`. Force fresh
 // `--session-id` instead. Plain claude tasks (no openai-compat metadata)
 // keep their existing session-reuse behaviour.
-test('openai-compat: same contextId still spawns a fresh --session-id (no --resume) (#213)', async () => {
-  const fake = scriptedSpawn({
-    lines: [
-      JSON.stringify({ type: 'system', subtype: 'init', session_id: 's' }),
-      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
-    ],
-    exitCode: 0,
-  });
-  const backend = createClaudeBackend({
-    spawn: fake.spawn,
-    onCallerToolsMcpReady: () => {},
-  });
-  const { emit } = collect();
+test('openai-compat continuation: second turn with same contextId resumes via --resume (#241)', async () => {
+  // The body of #241: under the openai-compat extension, follow-up A2A
+  // turns on the same contextId resume the prior claude session via
+  // `--resume <sid>` instead of spawning a fresh `--session-id`. Without
+  // this, every continuation turn re-fed the full `tool_call_history`
+  // from scratch and the cumulative token cost grew O(N²) in the number
+  // of round-trips. Replaces the #213-era assertion that openai-compat
+  // ALWAYS spawned with `--session-id` — that invariant was the
+  // emergency workaround for #175 (double-feeding when session reuse
+  // was on and the gateway also replayed history), now replaced by the
+  // diff-based replay verified in the test below.
   const meta = {
     [OPENAI_COMPAT_EXTENSION_URI]: {
       tools: [
@@ -3251,10 +3249,21 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
       ],
     },
   };
+  const sid = 'sid-shared-241';
 
-  // Two turns sharing the same contextId — without the openai-compat gate
-  // the second one would carry `--resume <sessionId-from-turn-1>`.
-  await backend.handle(
+  const fake1 = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: sid }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend1 = createClaudeBackend({
+    spawn: fake1.spawn,
+    onCallerToolsMcpReady: () => {},
+  });
+  const { emit } = collect();
+  await backend1.handle(
     {
       type: 'task.assign',
       taskId: 'oai-t1',
@@ -3264,7 +3273,20 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
     emit,
     NEVER,
   );
-  await backend.handle(
+  const child1 = fake1.lastChild()!;
+  const sidIdx1 = child1.args.indexOf('--session-id');
+  assert.notEqual(sidIdx1, -1, 'first turn must spawn with --session-id');
+  assert.equal(child1.args.indexOf('--resume'), -1, 'first turn must NOT --resume');
+  // Capture the sessionId the backend minted on turn 1 so the second
+  // turn's assertion can name it explicitly. The fake claude echoes
+  // whatever id the backend supplied via the `system/init` line above —
+  // here we only care that argv carries the same value.
+  const mintedSid = child1.args[sidIdx1 + 1]!;
+
+  // Second turn on the same contextId reuses the entry minted above.
+  // The same backend instance carries the in-memory session map across
+  // tasks, so we keep using `backend1`.
+  await backend1.handle(
     {
       type: 'task.assign',
       taskId: 'oai-t2',
@@ -3274,11 +3296,215 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
     emit,
     NEVER,
   );
+  const child2 = fake1.lastChild()!;
+  const resumeIdx = child2.args.indexOf('--resume');
+  assert.notEqual(resumeIdx, -1, 'second turn must --resume the prior session');
+  assert.equal(child2.args[resumeIdx + 1], mintedSid, '--resume must name the sid minted on turn 1');
+  assert.equal(child2.args.indexOf('--session-id'), -1, 'second turn must NOT also pass --session-id');
+});
 
-  const child = fake.lastChild()!;
-  // Every openai-compat spawn must use `--session-id`, never `--resume`.
-  assert.notEqual(child.args.indexOf('--session-id'), -1, 'second turn uses --session-id');
-  assert.equal(child.args.indexOf('--resume'), -1, 'second turn must NOT --resume');
+test('openai-compat continuation: prepended history contains only new role:"tool" results since the prior turn (#241)', async () => {
+  // The token-cost half of #241: a continuation turn on a resumed
+  // session prepends ONLY the `role:"tool"` entries whose `tool_call_id`
+  // isn't already in the session's ackSet. The matching
+  // `assistant.tool_calls` are in claude's session memory from the prior
+  // turn — re-feeding them is precisely the #233 / #175 failure mode the
+  // emergency workaround disabled session reuse to avoid.
+  const meta = (history?: unknown[]): Record<string, unknown> => ({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [
+        { type: 'function', function: { name: 'fetch', parameters: { type: 'object' } } },
+      ],
+      ...(history ? { tool_call_history: history } : {}),
+    },
+  });
+
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid-diff' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    onCallerToolsMcpReady: () => {},
+  });
+  const { emit } = collect();
+
+  // Turn 1: no history yet. The fresh-spawn path renders nothing.
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 't1',
+      contextId: 'ctx-diff',
+      message: { role: 'user', messageId: 'm1', parts: [{ kind: 'text', text: 'hi' }], metadata: meta() },
+    },
+    emit,
+    NEVER,
+  );
+  const stdin1 = fake.lastChild()!.stdinPayload;
+  assert.equal(stdin1.includes('<tool_call_history>'), false, 'turn 1 has no history to prepend');
+
+  // Turn 2: history has one resolved round-trip (assistant call_a + its
+  // tool result) and a fresh assistant call_b that hasn't been resolved
+  // yet. Only the resolved-result entry (`role:"tool"` for call_a) is
+  // new — call_b's `assistant.tool_calls` lives in claude's session
+  // memory from turn 1, and there's no tool result for call_b yet.
+  const history2 = [
+    { role: 'assistant', tool_calls: [{ id: 'call_a', type: 'function', function: { name: 'fetch', arguments: '{}' } }] },
+    { role: 'tool', tool_call_id: 'call_a', name: 'fetch', content: 'A' },
+    { role: 'assistant', tool_calls: [{ id: 'call_b', type: 'function', function: { name: 'fetch', arguments: '{}' } }] },
+  ];
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 't2',
+      contextId: 'ctx-diff',
+      message: { role: 'user', messageId: 'm2', parts: [{ kind: 'text', text: 'continue' }], metadata: meta(history2) },
+    },
+    emit,
+    NEVER,
+  );
+  // stdin is JSON-encoded so the inner history block's quotes are escaped
+  // when matched against the raw payload — parse out the envelope and
+  // inspect the prepended text block directly.
+  const histText2 = extractPrependedHistoryBlock(fake.lastChild()!.stdinPayload);
+  assert.ok(histText2, 'turn 2 prepends a history block');
+  assert.ok(histText2.includes('"tool_call_id": "call_a"'), 'turn 2 history contains the new role:"tool" entry');
+  assert.equal(
+    histText2.includes('"id": "call_a"'),
+    false,
+    'turn 2 history must NOT re-feed the assistant.tool_calls entry (claude has it in session memory)',
+  );
+  assert.equal(
+    histText2.includes('"id": "call_b"'),
+    false,
+    'turn 2 history must NOT re-feed the unresolved assistant call either',
+  );
+
+  // Turn 3: caller delivers the result for call_b. call_a is already in
+  // the ackSet from turn 2, so the prepended block must contain only
+  // call_b's result.
+  const history3 = [
+    ...history2,
+    { role: 'tool', tool_call_id: 'call_b', name: 'fetch', content: 'B' },
+  ];
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 't3',
+      contextId: 'ctx-diff',
+      message: { role: 'user', messageId: 'm3', parts: [{ kind: 'text', text: 'continue' }], metadata: meta(history3) },
+    },
+    emit,
+    NEVER,
+  );
+  const histText3 = extractPrependedHistoryBlock(fake.lastChild()!.stdinPayload);
+  assert.ok(histText3, 'turn 3 prepends a history block');
+  assert.ok(histText3.includes('"tool_call_id": "call_b"'), 'turn 3 history contains the newly-acked tool result');
+  assert.equal(
+    histText3.includes('"tool_call_id": "call_a"'),
+    false,
+    'turn 3 must NOT re-feed call_a — already acked on turn 2',
+  );
+});
+
+// Extract the prepended `<tool_call_history>...</tool_call_history>` block
+// from a turn's stdin payload, returning the inner block's raw text (with
+// the wrapper tags) for substring assertions. Returns null when no block
+// was prepended. claude's stdin is one JSON line per message (`{type:"user",
+// message:{role,content}}`); we walk the first envelope's `content` for the
+// text part whose body starts with the wrapper tag.
+function extractPrependedHistoryBlock(stdin: string): string | null {
+  const firstLine = stdin.trim().split('\n')[0];
+  if (!firstLine) return null;
+  let env: unknown;
+  try {
+    env = JSON.parse(firstLine);
+  } catch {
+    return null;
+  }
+  const e = env as {
+    message?: { content?: Array<{ type?: string; text?: string }> };
+  };
+  for (const c of e.message?.content ?? []) {
+    if (c?.type === 'text' && typeof c.text === 'string' && c.text.includes('<tool_call_history>')) {
+      return c.text;
+    }
+  }
+  return null;
+}
+
+test('openai-compat continuation: regression guard against #175 double-feeding', async () => {
+  // Structural guarantee against #175: across the two A2A turns of a
+  // single openai-compat round-trip, no `tool_call_id` ever appears in
+  // the stdin envelope more than once. The previous emergency workaround
+  // (disable session reuse on openai-compat) achieved this by always
+  // feeding the full history every turn but with the model starting
+  // from a fresh session. The #241 redesign keeps the session alive and
+  // ALSO drops already-acked entries from the next turn's prepend, so
+  // we now have the strict "appears in stdin at most once" invariant
+  // that the prior workaround couldn't promise (it fed the full history
+  // every turn, just into a fresh session).
+  const meta = (history?: unknown[]): Record<string, unknown> => ({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      tools: [
+        { type: 'function', function: { name: 'fetch', parameters: { type: 'object' } } },
+      ],
+      ...(history ? { tool_call_history: history } : {}),
+    },
+  });
+
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid-175' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    onCallerToolsMcpReady: () => {},
+  });
+  const { emit } = collect();
+
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 'r1',
+      contextId: 'ctx-175',
+      message: { role: 'user', messageId: 'm1', parts: [{ kind: 'text', text: 'hi' }], metadata: meta() },
+    },
+    emit,
+    NEVER,
+  );
+  const stdin1 = fake.lastChild()!.stdinPayload;
+
+  const history = [
+    { role: 'assistant', tool_calls: [{ id: 'call_x', type: 'function', function: { name: 'fetch', arguments: '{}' } }] },
+    { role: 'tool', tool_call_id: 'call_x', name: 'fetch', content: 'result-of-x' },
+  ];
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 'r2',
+      contextId: 'ctx-175',
+      message: { role: 'user', messageId: 'm2', parts: [{ kind: 'text', text: 'continue' }], metadata: meta(history) },
+    },
+    emit,
+    NEVER,
+  );
+  const stdin2 = fake.lastChild()!.stdinPayload;
+
+  // Count call_x occurrences across BOTH turns' stdin. The id should
+  // appear exactly once — turn 2's prepended `role:"tool"` block. Turn
+  // 1 had no history and the model emitted `call_x` to its stdout
+  // (artifact), which doesn't flow through stdin.
+  const occurrences = (haystack: string, needle: string): number =>
+    haystack.split(needle).length - 1;
+  const totalCallX = occurrences(stdin1, 'call_x') + occurrences(stdin2, 'call_x');
+  assert.equal(totalCallX, 1, `expected call_x exactly once across both stdin payloads, saw ${totalCallX}`);
 });
 
 test('AskUserQuestion: terminal frame uses state=input-required with DataPart payload (A2A spec §9.4)', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -143,6 +143,16 @@ interface SessionEntry {
   // second concurrent task on the same contextId that has since refreshed
   // the binding (and bumped writeId) is not robbed of its session id.
   writeId: number;
+  // `tool_call_id` values whose `role:"tool"` result has already been
+  // injected into this claude session on a prior turn. On a continuation
+  // turn the bridge prepends ONLY the new `role:"tool"` entries — entries
+  // whose id is in this set are dropped, since the model already saw the
+  // result on the earlier turn and re-feeding it triggers the #233 / #175
+  // re-call loop. Empty on the non-openai-compat path (no history to diff
+  // against) — the Set object is shared across refreshes of the same
+  // entry so a concurrent task on the same contextId accumulates into the
+  // same set without losing prior acks.
+  ackSet: Set<string>;
 }
 
 // claude --output-format stream-json writes one JSON object per line.
@@ -697,10 +707,13 @@ export function openaiToolsToCallerToolDefs(
 //     emit parallel `tool_use` blocks within one assistant message (which
 //     is fine per OpenAI semantics), but it cannot proceed to a second
 //     model turn within the same task.
-//   - A "session memory vs history block" disambiguation — openai-compat
-//     tasks always spawn with a fresh `--session-id` (see the session
-//     reuse gate in `handle()`), so there's no prior session memory to
-//     conflict with the history block.
+//   - A "session memory vs history block" disambiguation. On a
+//     continuation turn (`--resume`) the prior `assistant.tool_calls`
+//     live in claude's own session memory and the prepended history
+//     block contains ONLY the `role:"tool"` results that haven't been
+//     delivered to this session yet (see the ackSet-driven filter in
+//     `handle()`). The two sources never overlap, so there's nothing to
+//     disambiguate from the model's side.
 export function buildOpenAICompatNativeSystemPrompt(meta: OpenAICompatMetadata): string {
   const sections: string[] = [];
   if (meta.system) sections.push(meta.system);
@@ -1113,19 +1126,6 @@ export function createClaudeBackend(
 
       const mapped = await mapPartsToContentBlocks(task.message.parts, opts.fetchUriPolicy, signal);
       recorder.mark('map');
-      if (mapped.ok && openaiCompat?.tool_call_history) {
-        // Spec contract: bridges MUST replay the entire `tool_call_history`
-        // in order. We render it as a text block and prepend it to the user
-        // content so the model reads the prior round BEFORE the current
-        // user turn. Any internal optimisation (e.g. claude `--resume`
-        // already holds the prior `assistant.tool_calls` in session
-        // memory) is invisible to the wire and does not change replay
-        // semantics — the redundancy is the price of cross-bridge interop.
-        mapped.blocks.unshift({
-          type: 'text',
-          text: formatToolCallHistory(openaiCompat.tool_call_history),
-        });
-      }
       if (!mapped.ok) {
         emit({
           type: 'task.fail',
@@ -1135,31 +1135,75 @@ export function createClaudeBackend(
         return;
       }
 
-      // Session reuse is for A2A callers that want conversation continuity
-      // across tasks sharing a contextId. The openai-compat extension is
-      // stateless by design — every OpenAI Chat Completions request carries
-      // its own full message history, so resuming a prior claude session
-      // would risk feeding the model two sources of truth (claude's own
-      // session memory containing the sentinel "captured by bridge" result
-      // we returned from the MCP `onInvoke` handler, AND the user message's
-      // prepended `tool_call_history` JSON carrying the caller's real tool
-      // results). Skip the session map entirely for openai-compat tasks so
-      // every spawn starts on a clean `--session-id`; the history block in
-      // the user message is then the unambiguous source of truth.
-      const sessionReuseEligible = openaiCompat === null && sessionTtlMs > 0;
+      // Session reuse on a recurring contextId. The non-openai-compat path
+      // uses it to give the caller conversation continuity across A2A
+      // tasks; the openai-compat path uses it to avoid the quadratic-token
+      // cost of re-feeding the full `tool_call_history` on every
+      // continuation turn (#241). On the latter path, the model's prior
+      // `assistant.tool_calls` already live in claude's own session memory
+      // — only the *new* `role:"tool"` results since the last turn need to
+      // be injected via the in-prompt history block. `ackSet` tracks the
+      // `tool_call_id`s already delivered to this session so a duplicate
+      // can be filtered.
+      const sessionReuseEligible = sessionTtlMs > 0;
       const tNow = now();
       if (sessionReuseEligible) evictExpired(tNow - sessionTtlMs);
       const existing = sessionReuseEligible ? sessions.get(task.contextId) : undefined;
       const sessionId = existing?.sessionId ?? randomUUID();
       const isResume = existing !== undefined;
+      // Share the Set object across refreshes of the same entry so a
+      // concurrent task on the same contextId accumulates acks into the
+      // same set rather than racing to overwrite.
+      const entryAckSet = existing?.ackSet ?? new Set<string>();
       let writeId = 0;
       if (sessionReuseEligible) {
         // Refresh lastUsedAt eagerly: a concurrent second task on the same
         // contextId arriving before this one finishes also resumes the same
         // session id (rather than racing to mint a new one).
         writeId = ++writeCounter;
-        sessions.set(task.contextId, { sessionId, lastUsedAt: tNow, writeId });
+        sessions.set(task.contextId, {
+          sessionId,
+          lastUsedAt: tNow,
+          writeId,
+          ackSet: entryAckSet,
+        });
       }
+
+      if (openaiCompat?.tool_call_history) {
+        // Continuation turns under the openai-compat extension prepend only
+        // the `role:"tool"` entries that aren't in `ackSet` — the matching
+        // `assistant.tool_calls` are in claude's session memory and the
+        // prior tool results are already acked. First-turn / fresh-fallback
+        // (no cached session) renders the full history so the model sees
+        // its prior round-trips for the first time. See `formatToolCallHistory`
+        // for the block wrapper that both paths share.
+        const renderable = isResume
+          ? openaiCompat.tool_call_history.filter(
+              (e) => e.role === 'tool' && !entryAckSet.has(e.tool_call_id),
+            )
+          : openaiCompat.tool_call_history;
+        if (renderable.length > 0) {
+          mapped.blocks.unshift({
+            type: 'text',
+            text: formatToolCallHistory(renderable),
+          });
+        }
+      }
+
+      // Add the `role:"tool"` `tool_call_id`s the model just consumed to
+      // the entry's ackSet so a future continuation turn doesn't replay
+      // the same results. Only called from the success exit paths — a
+      // failed turn leaves the invariant unchanged so the retry sees the
+      // same diff. Closes over `entryAckSet`, which is the same Set
+      // reference held by whatever entry currently lives in `sessions`
+      // (preserved across refreshes), so a concurrent task on the same
+      // contextId observes our additions.
+      const commitAckSet = (): void => {
+        if (!openaiCompat?.tool_call_history) return;
+        for (const e of openaiCompat.tool_call_history) {
+          if (e.role === 'tool') entryAckSet.add(e.tool_call_id);
+        }
+      };
 
       // Drop the freshly-minted (contextId → sessionId) binding when the
       // run never reached a successful state, so the next task on this
@@ -1832,6 +1876,7 @@ export function createClaudeBackend(
       }
 
       if (pendingInputRequest !== null) {
+        commitAckSet();
         emit({
           type: 'task.complete',
           taskId: task.taskId,
@@ -1886,6 +1931,7 @@ export function createClaudeBackend(
       const messageMetadata = finalUsage
         ? makeOpenAICompatUsageMetadata(finalUsage)
         : undefined;
+      commitAckSet();
       emit({
         type: 'task.complete',
         taskId: task.taskId,


### PR DESCRIPTION
## Summary

Implements the diff-based openai-compat session reuse described in #241, for the claude backend.

- Drop the `openaiCompat === null && sessionTtlMs > 0` gate at `claude.ts:1149` so openai-compat continuation turns also resume via `--resume <sid>` instead of spawning fresh every time.
- Add an `ackSet: Set<string>` to each cached `SessionEntry`. Continuation turns prepend only `role:"tool"` history entries whose `tool_call_id` isn't already in the ackSet — the matching `assistant.tool_calls` are in claude's own session memory from the earlier turn, and re-feeding them is precisely the #233 / #175 failure mode.
- Update the ackSet only on a successful terminal frame (state `completed` or `input-required`), so a failed turn leaves the invariant unchanged and the retry sees the same diff.

First turns and fresh-fallback paths (no cached entry, TTL-evicted, in-process restart) render the full history exactly as before — a caller's first sight of any given conversation is unchanged.

## What's deliberately NOT in this PR

Surfaced during the review thread on #241 (see [the strategy comment](https://github.com/planetarium/vicoop-bridge/issues/241#issuecomment-4497744271) and the closed [PR #242](https://github.com/planetarium/vicoop-bridge/pull/242)). All three were on the original plan and dropped as YAGNI / unjustified complexity once we walked through the failure modes:

- **`callerPrincipal`-keyed cache.** A2A's `contextId` is UUID v4 in practice (122-bit entropy); blind-guess hijack collisions are negligible and the remaining leak vectors (caller-internal storage, TLS-broken transport, server log access) aren't the bridge's responsibility.
- **`(system, tools)` fingerprint check.** If a caller changes their system prompt or tools array mid-conversation, the cached claude session has stale dispatch surface because `--resume` can't reissue `--append-system-prompt`. Trade-off accepted: callers that change tools should also change contextId (the natural "new conversation" boundary). Add later if production measurement shows real stale-dispatch incidents — it's a 16-hex hash and a mismatch branch, easy to bolt on.
- **Fork detection (incoming history prefix vs cached `historyPrefix`).** A caller cutting their conversation history mid-flight is malformed use of the extension. The ackSet's "drop already-delivered ids" semantics is safe even under this scenario — the worst case is the model has a stale view of an earlier turn that the caller is now claiming didn't happen.

## Operational requirement

Same-`contextId` continuation turns must land on the same bridge instance for the optimisation to apply. Round-robin across multiple bridge processes correctly falls back to fresh every turn (no regression) but realises none of the savings — sticky routing on `contextId` is required to hit the acceptance-criteria benchmark in #241.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 469/469 pass, including the three new tests + the existing `#213`-era invariant replaced inline:
  - `openai-compat continuation: second turn with same contextId resumes via --resume (#241)` — argv-level proof: `--resume <sid>` carries the first turn's minted session id, `--session-id` absent on the second spawn.
  - `openai-compat continuation: prepended history contains only new role:"tool" results since the prior turn (#241)` — three-turn scenario verifying the prepended block contains only newly-acked tool results, never the matching `assistant.tool_calls` and never an entry whose id was already acked on a prior turn.
  - `openai-compat continuation: regression guard against #175 double-feeding` — structural invariant: across both turns' stdin payloads combined, any given `tool_call_id` appears at most once.

## Follow-up

- **PR for `codex.ts`** mirrors this pattern (#241's codex deliverable). Tracking that as the next PR — it also gets to revert the #240 session-reuse opt-out (`codex.ts:815`).
- **#216** (caller-tools MCP listener lifecycle) is unaffected by this PR — MCPs remain per-task even on a resumed session, per the issue's "out of scope" call.

## Related

- #241 — the redesign this implements
- #233, #175 — earlier symptoms of the underlying invariant violation
- #240 — codex-side counterpart workaround (this PR's pattern unblocks reverting it)
- closed PR #242 — the `callerPrincipal` protocol prerequisite that turned out to be unnecessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)