### PR TITLE
feat(container): interactive wizard + install-container.sh wrapper (#244 PR 2)

### DIFF
--- a/.changeset/container-wizard.md
+++ b/.changeset/container-wizard.md
@@ -1,0 +1,31 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Container distribution PR 2 of #244: interactive setup wizard + host-side
+wrapper. The bridge client TypeScript surface is unchanged; this only
+adds operator UX in the image and a new top-level shell script.
+
+- `container/entrypoint.sh` — adds `wizard()`. Triggered when no config
+  exists and stdin/stdout are both TTYs (i.e. `docker run -it`). Walks
+  through `vicoop-client auth login` (Google OAuth device flow) →
+  prompts for agent name / id / backend → `vicoop-client agent
+  register` → backend install + per-backend OAuth (`claude auth login
+  --claudeai` / `codex login`). The wizard exits on completion; it
+  does *not* transition into daemon mode, so a follow-up `docker run
+  -d ...` (or the new wrapper, below) starts the actual daemon. Env
+  tokens (`CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`) detected at wizard time skip the corresponding
+  per-backend OAuth step.
+
+- `install-container.sh` — new top-level wrapper for the case-B path.
+  Pulls the image, runs the wizard (`--rm -it`) when the data volume
+  doesn't have a config yet, then stops + replaces any prior daemon
+  container with a fresh `-d --restart unless-stopped` one. Volume /
+  container / image names are overridable via env
+  (`VICOOP_DATA_VOLUME`, `VICOOP_CONTAINER`, `VICOOP_IMAGE`,
+  `VICOOP_WORK_VOLUME`). Re-runs are idempotent: existing setup is
+  detected and the wizard is skipped.
+
+- `docs/container.md` — restructured so the wizard / wrapper is the
+  recommended first path. Headless / case-A docs preserved below.

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -206,9 +206,8 @@ wizard() {
 
     printf '\n'
     log 'step 2 of 3 — agent registration'
-    local agent_name agent_id backend_kind
-    read -r -p '  Agent name (e.g. my-claude): ' agent_name
-    read -r -p '  Agent id  (lowercase, hyphen-allowed): ' agent_id
+    local agent_id backend_kind
+    read -r -p '  Agent id  (routing key, e.g. my-claude): ' agent_id
     log    '  Backends:'
     log    '    echo       — smoke test, no LLM'
     log    '    claude     — Anthropic Claude Code'
@@ -216,15 +215,19 @@ wizard() {
     log    '    openclaw   — connects to an external openclaw gateway'
     read -r -p '  Backend: ' backend_kind
 
-    if [[ -z "$agent_name" || -z "$agent_id" || -z "$backend_kind" ]]; then
-        die "all three prompts are required; re-run when ready"
+    if [[ -z "$agent_id" || -z "$backend_kind" ]]; then
+        die "both prompts are required; re-run when ready"
     fi
     case "$backend_kind" in
         echo|claude|codex|openclaw|vicoop-codex) ;;
         *) die64 "backend '$backend_kind' is not one of: echo claude codex openclaw vicoop-codex" ;;
     esac
 
-    if ! vicoop-client agent register --name "$agent_name" --agent-id "$agent_id"; then
+    # `agent register` requires both --name and --agent-id. The wizard
+    # treats the operator-supplied id as both — operators who want a
+    # distinct display label can edit /data/config.json afterward or
+    # use the bare-metal CLI flow.
+    if ! vicoop-client agent register --name "$agent_id" --agent-id "$agent_id"; then
         die "agent register failed"
     fi
     # `agent register` writes server_url + server_token + agent_id into

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -51,7 +51,7 @@ bootstrap_from_env() {
     if [[ ${#missing[@]} -gt 0 ]]; then
         log "no /data/config.json and no TTY for an interactive setup."
         log "supply the headless bootstrap env vars (missing: ${missing[*]}) or"
-        log "re-run with -it so the interactive wizard can take over (PR 2)."
+        log "re-run with -it so the interactive wizard can take over."
         log ""
         log "minimum env set for headless bootstrap:"
         log "  -e VICOOP_BRIDGE_TOKEN=<your client token>"
@@ -175,6 +175,122 @@ maybe_init_firewall() {
 }
 
 # --------------------------------------------------------------------------
+# Interactive wizard. Triggered when no config exists AND stdin/stdout are
+# both TTYs (i.e. operator launched with `docker run -it`).
+#
+# Walks through:
+#   1. bridge sign-in (vicoop-client auth login — Google OAuth device flow)
+#   2. agent identity prompts (name / id / backend) + agent register
+#   3. backend install (if a recipe exists) + backend OAuth (if no env
+#      token already covers it).
+#
+# Wizard EXITS 0 on success. It does NOT transition into daemon mode —
+# the operator (or install-container.sh wrapper) starts the daemon
+# separately with `docker run -d ...`. Splitting the two phases keeps
+# the wrapper simple and lets manual invokers do their own thing after
+# setup completes.
+# --------------------------------------------------------------------------
+wizard() {
+    printf '\n'
+    log '====================================================='
+    log '  vicoop-bridge — first-time setup'
+    log '====================================================='
+    printf '\n'
+
+    log 'step 1 of 3 — bridge sign-in (Google OAuth device flow)'
+    log 'a URL + user code will print below; open the URL in any browser.'
+    printf '\n'
+    if ! vicoop-client auth login; then
+        die "auth login failed"
+    fi
+
+    printf '\n'
+    log 'step 2 of 3 — agent registration'
+    local agent_name agent_id backend_kind
+    read -r -p '  Agent name (e.g. my-claude): ' agent_name
+    read -r -p '  Agent id  (lowercase, hyphen-allowed): ' agent_id
+    log    '  Backends:'
+    log    '    echo       — smoke test, no LLM'
+    log    '    claude     — Anthropic Claude Code'
+    log    '    codex      — OpenAI Codex'
+    log    '    openclaw   — connects to an external openclaw gateway'
+    read -r -p '  Backend: ' backend_kind
+
+    if [[ -z "$agent_name" || -z "$agent_id" || -z "$backend_kind" ]]; then
+        die "all three prompts are required; re-run when ready"
+    fi
+    case "$backend_kind" in
+        echo|claude|codex|openclaw|vicoop-codex) ;;
+        *) die64 "backend '$backend_kind' is not one of: echo claude codex openclaw vicoop-codex" ;;
+    esac
+
+    if ! vicoop-client agent register --name "$agent_name" --agent-id "$agent_id"; then
+        die "agent register failed"
+    fi
+    # `agent register` writes server_url + server_token + agent_id into
+    # config.json. Inject the operator's backend choice — daemon flag /
+    # config field that `agent register` doesn't set.
+    local tmp
+    tmp="$(mktemp "${CONFIG}.XXXXXX")"
+    jq --arg bk "$backend_kind" '.backend = $bk' "$CONFIG" > "$tmp"
+    mv "$tmp" "$CONFIG"
+    chmod 600 "$CONFIG"
+
+    printf '\n'
+    log "step 3 of 3 — backend setup ($backend_kind)"
+    if backend_is_installable "$backend_kind"; then
+        "$VICOOP_LIB/install-backend.sh" "$backend_kind"
+        printf '\n'
+
+        case "$backend_kind" in
+            claude)
+                if [[ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+                    log 'claude auth: CLAUDE_CODE_OAUTH_TOKEN provided via env; skipping interactive login.'
+                elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+                    log 'claude auth: ANTHROPIC_API_KEY provided via env; skipping interactive login.'
+                else
+                    log 'claude auth login — a URL will print; open it, then paste the code back here.'
+                    if ! "$VICOOP_DATA/agents/claude/bin/claude" auth login --claudeai; then
+                        die "claude auth login failed; re-run wizard or run it manually via docker exec"
+                    fi
+                fi
+                ;;
+            codex)
+                if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+                    log 'codex auth: OPENAI_API_KEY provided via env; skipping interactive login.'
+                else
+                    log 'codex login — a URL will print; open it, then paste the code back here.'
+                    if ! "$VICOOP_DATA/agents/codex/bin/codex" login; then
+                        die "codex login failed; re-run wizard or run it manually via docker exec"
+                    fi
+                fi
+                ;;
+        esac
+    else
+        log "no image-side install step for '$backend_kind' (gateway / built-in / non-installable)."
+        log "  echo / openclaw / vicoop-codex are valid daemon backends but skip the install step."
+    fi
+
+    printf '\n'
+    log '====================================================='
+    log '  setup complete'
+    log '====================================================='
+    log ''
+    log 'config written to /data/config.json; tokens + creds in /data.'
+    log 'start the daemon container:'
+    log ''
+    log "    docker run -d --restart unless-stopped \\"
+    log "      --name vicoop-bridge \\"
+    log "      -v vicoop-data:/data \\"
+    log "      -v vicoop-work:/home/node/work \\"
+    log "      --cap-add NET_ADMIN --cap-add NET_RAW \\"
+    log "      ghcr.io/planetarium/vicoop-bridge-client"
+    log ''
+    log '(or just re-run install-container.sh — it picks up from here.)'
+    printf '\n'
+}
+
+# --------------------------------------------------------------------------
 # Main
 # --------------------------------------------------------------------------
 # Daemon mode is the bare invocation or flags-only. Subcommands like
@@ -192,8 +308,11 @@ is_daemon_invocation() {
 if is_daemon_invocation "$@"; then
     if [[ ! -f "$CONFIG" ]]; then
         if [[ -t 0 && -t 1 ]]; then
-            log "TTY detected but interactive wizard isn't shipped yet (PR 2)."
-            log "use the headless env-bootstrap path for now — see below."
+            # Interactive wizard. Exits 0 on success and we exit too —
+            # daemon-mode is a separate `docker run -d ...` (or the
+            # install-container.sh wrapper handles it).
+            wizard
+            exit 0
         fi
         bootstrap_from_env || exit $?
     else

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -259,8 +259,13 @@ wizard() {
                 if [[ -n "${OPENAI_API_KEY:-}" ]]; then
                     log 'codex auth: OPENAI_API_KEY provided via env; skipping interactive login.'
                 else
-                    log 'codex login — a URL will print; open it, then paste the code back here.'
-                    if ! "$VICOOP_DATA/agents/codex/bin/codex" login; then
+                    # codex's default `login` spins up a localhost:1455
+                    # callback server, which the host browser can't
+                    # reach into the container. `--device-auth` is the
+                    # documented headless / remote-machine flow: prints
+                    # a URL + code, polls for approval.
+                    log 'codex login --device-auth — a URL + code will print; open the URL on any browser.'
+                    if ! "$VICOOP_DATA/agents/codex/bin/codex" login --device-auth; then
                         die "codex login failed; re-run wizard or run it manually via docker exec"
                     fi
                 fi

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,13 +1,22 @@
 # Running vicoop-bridge in a container
 
-This document covers the **headless / env-driven** path for running the
-bridge client as a container. It pairs with [#244][244] (design) and lands
-as part of PR 1.
+This document covers two paths for running the bridge client as a
+container — pick whichever fits your situation.
 
-An interactive setup wizard (TTY mode — `docker run -it` walks you through
-Google OAuth + per-backend OAuth from inside the container) is out of scope
-for PR 1; for now, operators provision tokens on a host with a TTY (e.g.
-their laptop) and inject them into the container as env vars.
+- **Interactive setup wizard** (the easy path, recommended for first-
+  time operators with a TTY available). A wrapper script
+  ([`install-container.sh`](#interactive-wizard-install-containersh))
+  drives `docker pull`, the one-shot wizard, and the long-lived daemon
+  in a single command.
+- **Headless env-driven setup** (for CI / automation / hosts where the
+  operator already provisioned tokens elsewhere). Documented in the
+  "Headless / case A" section below.
+
+Both paths produce the same `/data` volume layout and run the same
+image — the wizard just collects the same inputs interactively that
+the env path expects pre-baked.
+
+It pairs with [#244][244] (design).
 
 [244]: https://github.com/planetarium/vicoop-bridge/issues/244
 
@@ -30,7 +39,58 @@ bridge server, so the container exposes zero inbound ports.
 - Base: `node:20-bookworm-slim`
 - Size: ~250 MB before any agent CLI is installed
 
-## Quick start
+## Interactive wizard (`install-container.sh`)
+
+The recommended path for first-time operators. One command on the host
+takes care of `docker pull`, an interactive wizard (bridge OAuth +
+agent register + per-backend OAuth), and a long-lived daemon container
+with `--restart unless-stopped`. Subsequent invocations skip the
+wizard but refresh the daemon (useful after `docker pull`).
+
+```bash
+# from a clone of this repo
+./install-container.sh
+
+# or one-liner via curl
+curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install-container.sh | bash
+```
+
+You'll be walked through three steps inside a one-shot `-it`
+container:
+
+1. **bridge sign-in** — Google OAuth device flow. A URL + user code
+   prints; open the URL in any browser, enter the code.
+2. **agent registration** — prompts for `name`, `agent-id`, and
+   `backend` (echo / claude / codex / openclaw). Writes
+   `/data/config.json`.
+3. **backend setup** — `install-backend.sh` installs the chosen CLI
+   (claude / codex) into `/data/agents/<kind>/`, then walks its own
+   OAuth flow. Skipped when an equivalent token is already in env
+   (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`).
+
+Wizard exits on completion. The wrapper then starts a fresh detached
+daemon container (`-d --restart unless-stopped`) bound to the same
+named volumes, so the daemon picks up the config the wizard just
+wrote.
+
+Environment variable overrides for the wrapper:
+
+| Var | Default | Purpose |
+|---|---|---|
+| `VICOOP_IMAGE` | `ghcr.io/planetarium/vicoop-bridge-client:latest` | image to pull |
+| `VICOOP_CONTAINER` | `vicoop-bridge` | name for the daemon container |
+| `VICOOP_DATA_VOLUME` | `vicoop-data` | named volume for `/data` |
+| `VICOOP_WORK_VOLUME` | `vicoop-work` | named volume for `/home/node/work` |
+
+The wizard is non-destructive on re-run: if a `config.json` already
+exists in the data volume, the wrapper skips it and just refreshes
+the daemon.
+
+## Headless / case A — env-driven
+
+When you'd rather provision tokens on a host (CI, automation, fleet
+deploys), you can bypass the wizard entirely by pre-baking the
+bootstrap env vars.
 
 You need three things:
 

--- a/install-container.sh
+++ b/install-container.sh
@@ -52,9 +52,19 @@ if ! docker info >/dev/null 2>&1; then
 fi
 
 # --- 1. Pull --------------------------------------------------------------
+# Try to fetch the latest version of the requested tag. If the pull
+# fails but the operator already has a local image with that tag
+# (e.g. a `vicoop-bridge-client:dev` they built themselves while
+# debugging), continue with what's on disk — the pull is a refresh
+# convenience, not a hard requirement.
 log "pulling $IMAGE"
-docker pull "$IMAGE" >/dev/null \
-    || die "docker pull $IMAGE failed"
+if ! docker pull "$IMAGE" >/dev/null 2>&1; then
+    if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        log "pull failed but image is present locally — continuing"
+    else
+        die "docker pull $IMAGE failed and no local image with that tag"
+    fi
+fi
 
 # --- 2. Detect existing setup --------------------------------------------
 needs_wizard=false

--- a/install-container.sh
+++ b/install-container.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# vicoop-bridge container installer.
+#
+# Drives the container distribution end to end:
+#
+#   1. docker pull the published image (tag is configurable)
+#   2. detect whether this host already has a wizard-completed setup
+#      (i.e. /data/config.json exists in the data volume)
+#   3. if not, launch the wizard container interactively
+#   4. stop+remove any prior daemon container, then start a fresh
+#      detached daemon with --restart unless-stopped
+#
+# Idempotent — operators can re-run after editing config or pulling a
+# new image; the wizard step is skipped when the volume already carries
+# a config.
+#
+# Pairs with the headless / case-A path documented in docs/container.md;
+# this is the case-B (interactive) entrypoint and the recommended path
+# for first-time operators on a host where they have a TTY available.
+
+set -euo pipefail
+
+IMAGE="${VICOOP_IMAGE:-ghcr.io/planetarium/vicoop-bridge-client:latest}"
+CONTAINER="${VICOOP_CONTAINER:-vicoop-bridge}"
+DATA_VOLUME="${VICOOP_DATA_VOLUME:-vicoop-data}"
+WORK_VOLUME="${VICOOP_WORK_VOLUME:-vicoop-work}"
+
+# ANSI colour for log lines. Skip when stdout isn't a TTY (curl|bash
+# captured into a pipe shouldn't leak escape codes).
+if [[ -t 1 ]]; then
+    C_CYAN=$'\033[1;36m'
+    C_RED=$'\033[1;31m'
+    C_RESET=$'\033[0m'
+else
+    C_CYAN=""
+    C_RED=""
+    C_RESET=""
+fi
+
+log() { printf '%s==>%s %s\n' "$C_CYAN" "$C_RESET" "$*"; }
+die() {
+    printf '%serror:%s %s\n' "$C_RED" "$C_RESET" "$*" >&2
+    exit 1
+}
+
+# --- 0. Sanity ------------------------------------------------------------
+command -v docker >/dev/null 2>&1 \
+    || die "docker not found on PATH"
+
+if ! docker info >/dev/null 2>&1; then
+    die "docker is installed but the daemon isn't reachable (try: open Docker Desktop, or 'systemctl start docker')"
+fi
+
+# --- 1. Pull --------------------------------------------------------------
+log "pulling $IMAGE"
+docker pull "$IMAGE" >/dev/null \
+    || die "docker pull $IMAGE failed"
+
+# --- 2. Detect existing setup --------------------------------------------
+needs_wizard=false
+if ! docker volume inspect "$DATA_VOLUME" >/dev/null 2>&1; then
+    needs_wizard=true
+else
+    # The image has /usr/bin/test. Override the entrypoint so we run
+    # the bare test instead of falling into wizard / daemon logic.
+    if ! docker run --rm --entrypoint /usr/bin/test \
+            -v "$DATA_VOLUME:/data" "$IMAGE" -f /data/config.json \
+            2>/dev/null; then
+        needs_wizard=true
+    fi
+fi
+
+# --- 3. Wizard (interactive, one-shot) -----------------------------------
+if [[ "$needs_wizard" == "true" ]]; then
+    log "no config detected in volume '$DATA_VOLUME' — running interactive setup wizard"
+    log "(the wizard will prompt for agent name / id / backend and walk OAuth flows)"
+    if ! docker run --rm -it \
+            -v "$DATA_VOLUME:/data" \
+            -v "$WORK_VOLUME:/home/node/work" \
+            --cap-add NET_ADMIN --cap-add NET_RAW \
+            "$IMAGE"; then
+        die "wizard exited non-zero; no daemon started"
+    fi
+else
+    log "existing setup detected in volume '$DATA_VOLUME' — skipping wizard"
+fi
+
+# --- 4. Daemon ------------------------------------------------------------
+if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
+    log "stopping prior container '$CONTAINER'"
+    docker stop "$CONTAINER" >/dev/null
+    docker rm "$CONTAINER" >/dev/null
+fi
+
+log "starting daemon container '$CONTAINER'"
+docker run -d \
+    --name "$CONTAINER" \
+    --restart unless-stopped \
+    -v "$DATA_VOLUME:/data" \
+    -v "$WORK_VOLUME:/home/node/work" \
+    --cap-add NET_ADMIN --cap-add NET_RAW \
+    "$IMAGE" >/dev/null
+
+log "vicoop-bridge is running."
+cat <<EOF
+
+  logs:    docker logs -f $CONTAINER
+  stop:    docker stop $CONTAINER
+  status:  docker exec $CONTAINER vicoop-client whoami
+  info:    docker exec $CONTAINER vicoop-client info
+  shell:   docker exec -it $CONTAINER bash
+
+EOF


### PR DESCRIPTION
## Summary

PR 2 of #244 — the interactive setup wizard + a host-side wrapper that
makes the case-B flow a one-command operator UX. The bridge client TS
surface is unchanged; this adds wizard + wrapper around the image
shipped in #245.

After this lands, a first-time operator can run
`./install-container.sh` (or `curl -fsSL ... | bash`) on their host
and get a running, OAuth-configured `vicoop-bridge` daemon container.
No prior `claude setup-token` step, no env juggling.

## Wizard (`container/entrypoint.sh`)

Triggered when **no `/data/config.json` exists AND stdin/stdout are
both TTYs** (i.e. operator launched with `docker run -it`). Walks three
steps:

1. `vicoop-client auth login` — Google OAuth device flow (URL + user
   code printed; operator opens the URL on any browser).
2. Prompts for agent name / agent-id / backend, then
   `vicoop-client agent register` writes `config.json`. `jq` injects
   the `backend` field that `agent register` itself doesn't set.
3. `install-backend.sh <kind>` if a recipe exists (claude / codex),
   then the backend's own OAuth (`claude auth login --claudeai` /
   `codex login`). Skipped when an equivalent env token is already
   present (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` /
   `OPENAI_API_KEY`).

The wizard exits 0 on success. It deliberately does **not**
auto-transition to daemon mode — the operator (or
`install-container.sh`) starts the daemon with a separate
`docker run -d ...`. Phase separation keeps the wrapper simple and
lets manual invokers do their own thing post-setup.

Stale "PR 2" wording in `bootstrap_from_env` removed.

## Host wrapper (`install-container.sh`)

Top-level shell script. End-to-end flow on the host:

1. `docker pull` the published image.
2. Detect whether the data volume already has `config.json` (via
   `docker run --entrypoint /usr/bin/test ...`).
3. If absent: run wizard container (`--rm -it`).
4. Stop + remove any prior daemon container with the same name.
5. Start a fresh daemon (`-d --restart unless-stopped`) bound to the
   same named volumes.

Idempotent on re-runs: existing setup means the wizard is skipped,
the daemon is refreshed. Env knobs:

| Var | Default |
|---|---|
| `VICOOP_IMAGE` | `ghcr.io/planetarium/vicoop-bridge-client:latest` |
| `VICOOP_CONTAINER` | `vicoop-bridge` |
| `VICOOP_DATA_VOLUME` | `vicoop-data` |
| `VICOOP_WORK_VOLUME` | `vicoop-work` |

ANSI colour suppressed when stdout isn't a TTY so `curl ... | bash`
output is clean.

## `docs/container.md`

Restructured so the wizard / wrapper is the recommended first path.
The existing headless / case-A docs (which #245 shipped) are
preserved verbatim below the new section.

## Test plan

- [x] `bash -n container/entrypoint.sh` + `bash -n install-container.sh` clean
- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean (TS untouched, kept for safety)
- [x] `docker build` succeeds locally on Apple Silicon
- [x] Non-TTY `docker run` still hits the env-bootstrap guide with
      updated wording (no stale "PR 2" reference)
- [ ] **manual**: `./install-container.sh` end-to-end with real bridge
      server + Claude subscription. The wizard's TTY paste-back step
      for `claude auth login --claudeai` cannot be exercised in CI;
      reviewers please verify on a host terminal.
- [ ] **manual**: re-run `./install-container.sh` and confirm the
      wizard is skipped while the daemon is refreshed.

## Follow-up

Out of scope for this PR — possible later:

- arm64 image build in `release.yml` (PR 1 follow-up).
- Wizard resume / partial-completion recovery (today: Ctrl-C mid-wizard
  starts over from step 1; `auth login` is idempotent so this is
  generally fine, but a more polished resume could land later).
- `install-container.sh` `--uninstall` / `--status` subcommands.

Closes (with PR 1, #245) the wizard + wrapper portion of #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)