### PR TITLE
feat(client): drop `--name` from `agent register`

### DIFF
--- a/.changeset/agent-register-drop-name.md
+++ b/.changeset/agent-register-drop-name.md
@@ -1,0 +1,17 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Remove `--name` from `vicoop-client agent register`. The flag was a
+display-only label with no authz, routing, or lookup logic tied to it
+(admin UI does not render it; active-agent listings pull from the
+runtime `AgentCard`, not the registration row). The CLI now sends the
+operator-supplied `--agent-id` as `clientName` so the server's
+`register_client()` NOT NULL contract on `agents.name` /
+`clients.client_name` stays satisfied without a schema migration. The
+redundant `name` line in the `agent register` stderr success block is
+dropped for the same reason — it used to just echo the flag back.
+
+Migration: drop `--name "$CLIENT_NAME"` from your `agent register`
+invocation. The legacy `setup` alias still accepts `--client-name` for
+back-compat (it's already deprecated and slated for removal).

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -173,13 +173,9 @@ saved owner-session to call `registerClient` and mint a one-time
 `AGENT_TOKEN`. No wallet or SIWE required.
 
 ```sh
-HOSTNAME=$(hostname)
-CLIENT_NAME="openclaw on ${HOSTNAME%%.*}"
-
 "$INSTALL_DIR/vicoop-client" auth login
 
 "$INSTALL_DIR/vicoop-client" agent register \
-  --name "$CLIENT_NAME" \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
 ```
@@ -198,7 +194,6 @@ consolidated config layout. The success output looks like:
 ```text
   agent_id         openclaw-my-host
   owner_principal  google:sub:<sub>
-  name             openclaw on my-host
 
 The AGENT_TOKEN is one-time — the bridge cannot reissue it.
   agent register persists it to the canonical config below; --json prints it to
@@ -324,7 +319,6 @@ compose with shell tooling (no disk side effects, raw response on stdout):
 
 ```sh
 "$INSTALL_DIR/vicoop-client" agent register \
-  --name "$CLIENT_NAME" \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>" --json \
   | tee /tmp/vicoop-agent.json
@@ -692,7 +686,6 @@ published release:
 ```sh
 # Step 4 login saves the owner-session bearer, so these work without re-authenticating:
 "$INSTALL_DIR/vicoop-client" agent register \
-  --name "$CLIENT_NAME" \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
 "$INSTALL_DIR/vicoop-client" agent list --connected

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -896,16 +896,15 @@ test('setup quotes env values so shell metacharacters cannot trigger expansion',
 // ---- New `agent register` surface (#224) -----------------------------------
 
 function agentRegisterArgs(
-  p: { name: string; agentId: string }
-    & Partial<Omit<AgentRegisterArgs, 'action' | 'name' | 'agentId'>>,
+  p: { agentId: string }
+    & Partial<Omit<AgentRegisterArgs, 'action' | 'agentId'>>,
 ): AgentRegisterArgs {
   const {
-    name, agentId,
+    agentId,
     callers = [], envFile, envFileAlias, server, token, json = false,
   } = p;
   return {
     action: 'agent-register',
-    name,
     agentId,
     callers,
     envFile,
@@ -1003,7 +1002,7 @@ test('agent register calls registerClient with a 1-element allowedAgentIds and w
   const fix = installAgentRegisterFixture(t);
 
   const code = await runAgentRegister(agentRegisterArgs({
-    name: 'codex on Mac', agentId: 'codex-Mac', envFile: fix.envFile,
+    agentId: 'codex-Mac', envFile: fix.envFile,
   }));
 
   assert.equal(code, 0);
@@ -1014,7 +1013,9 @@ test('agent register calls registerClient with a 1-element allowedAgentIds and w
   // GraphQL mutation body is JSON-encoded, so inner double quotes appear
   // escaped as \" — accept either form.
   assert.match(fix.calls[0].body, /allowedAgentIds:\[\\"codex-Mac\\"\]/);
-  assert.match(fix.calls[0].body, /clientName:\\"codex on Mac\\"/);
+  // `--name` was removed; the daemon defaults `clientName` to the agent id
+  // (server schema still requires a non-empty name). Asserts the fallback.
+  assert.match(fix.calls[0].body, /clientName:\\"codex-Mac\\"/);
 
   const config = readConfig(join(fix.tmpHome, '.vicoop', 'config.json'));
   assert.deepEqual(config, {
@@ -1024,11 +1025,11 @@ test('agent register calls registerClient with a 1-element allowedAgentIds and w
   });
 });
 
-test('agent register stderr surfaces agent-first labels (agent_id, name, AGENT_TOKEN)', async (t) => {
+test('agent register stderr surfaces agent-first labels (agent_id, AGENT_TOKEN)', async (t) => {
   const fix = installAgentRegisterFixture(t);
 
   const code = await runAgentRegister(agentRegisterArgs({
-    name: 'codex on Mac', agentId: 'codex-Mac',
+    agentId: 'codex-Mac',
   }));
 
   assert.equal(code, 0);
@@ -1036,7 +1037,9 @@ test('agent register stderr surfaces agent-first labels (agent_id, name, AGENT_T
   // Operator-supplied agent_id (not the server's registration UUID) is the
   // primary identifier in the success block.
   assert.match(out, /agent_id\s+codex-Mac/);
-  assert.match(out, /name\s+codex on Mac/);
+  // The `name` line was removed alongside `--name`; the field would have just
+  // echoed the agent id back, so dropping it kills the redundancy.
+  assert.doesNotMatch(out, /^\s*name\s/m);
   assert.match(out, /The AGENT_TOKEN is one-time/);
   assert.match(out, /agent register persists it to the canonical config/);
   // Recovery hint and "add caller" pointer also use the new vocabulary.
@@ -1055,7 +1058,7 @@ test('agent register --json prints the registerClient response shape unchanged f
   });
 
   const code = await runAgentRegister(agentRegisterArgs({
-    name: 'codex on Mac', agentId: 'codex-Mac', json: true,
+    agentId: 'codex-Mac', json: true,
   }));
 
   assert.equal(code, 0);
@@ -1072,7 +1075,7 @@ test('agent register configures callers when --caller is passed', async (t) => {
   const fix = installAgentRegisterFixture(t);
 
   const code = await runAgentRegister(agentRegisterArgs({
-    name: 'codex on Mac', agentId: 'codex-Mac',
+    agentId: 'codex-Mac',
     callers: ['eth:0xabc'],
   }));
 
@@ -1097,7 +1100,7 @@ test('legacy setup prints a stderr deprecation warning pointing at agent registe
   assert.equal(code, 0);
   assert.match(
     fix.stderr(),
-    /vicoop-client setup.*deprecated.*vicoop-client agent register --name NAME --agent-id ID/s,
+    /vicoop-client setup.*deprecated.*vicoop-client agent register --agent-id ID/s,
   );
   // Old vocabulary stays present on the legacy surface (back-compat for scripts
   // that parse stderr) — only the new path uses agent-first labels.

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -65,9 +65,6 @@ export const agentRegisterCmd = command(
   'register',
   object({
     action: constant('agent-register' as const),
-    name: option('--name', string({ metavar: 'NAME' }), {
-      description: message`Human-readable label saved with this agent registration.`,
-    }),
     agentId: option('--agent-id', string({ metavar: 'ID' }), {
       description: message`Agent id (routing key external A2A callers will use). After #219 the server enforces a single agent per registration.`,
     }),
@@ -524,7 +521,6 @@ function renderAgentRegisterSuccessBlock(success: ClientRegisterSuccess): string
   return [
     `  agent_id         ${success.allowed_agent_ids[0] ?? ''}`,
     `  owner_principal  ${success.owner_principal}`,
-    `  name             ${success.client_name}`,
   ].join('\n');
 }
 
@@ -540,7 +536,7 @@ function renderAgentRegisterRecoveryBlock(success: ClientRegisterSuccess, server
 export async function runSetup(args: SetupArgs): Promise<number> {
   process.stderr.write(
     '[warning] `vicoop-client setup` is deprecated; ' +
-      'use `vicoop-client agent register --name NAME --agent-id ID` instead. ' +
+      'use `vicoop-client agent register --agent-id ID` instead. ' +
       'The deprecated form will be removed in a future release.\n',
   );
   // `--caller` is repeatable AND accepts comma-separated values within each
@@ -571,8 +567,13 @@ export async function runAgentRegister(args: AgentRegisterArgs): Promise<number>
   const callers = args.callers.flatMap((c) =>
     c.split(',').map((s) => s.trim()).filter(Boolean),
   );
+  // `clientName` is required by the server's `register_client` SQL function
+  // (NOT NULL on `agents.name` / `clients.client_name`) but is no longer
+  // operator-supplied — it's pure display metadata that no authz / lookup
+  // path depends on. Default to the agent id so the field stays populated
+  // without surfacing a redundant flag in the CLI.
   return executeRegistration({
-    name: args.name,
+    name: args.agentId,
     allowedAgentIds: [args.agentId],
     callers,
     envFile: args.envFile ?? args.envFileAlias ?? null,


### PR DESCRIPTION
## Summary

- Remove `--name` from `vicoop-client agent register`. The flag was display-only metadata — no authz, routing, or lookup logic was tied to it (admin UI doesn't render it; active-agent listings pull from the runtime `AgentCard`, not the registration row).
- The CLI now sends the operator-supplied `--agent-id` as `clientName` so the server's NOT NULL contract on `agents.name` / `clients.client_name` stays satisfied without a schema migration or GraphQL-schema change.
- Drop the redundant `name` line from the `agent register` stderr success block — with the fallback in place it would just echo the agent id back.
- Legacy `setup --client-name` is left alone (already deprecated; tracked separately for removal).

## Migration

Drop `--name "$CLIENT_NAME"` from your `agent register` invocation. No other changes needed.

## Test plan

- [x] `pnpm typecheck` (client)
- [x] `pnpm test` (client) — 470/470 pass, including the four `agent register` / `legacy setup` deprecation cases that were updated
- [ ] Manual: run `vicoop-client agent register --agent-id foo` against a dev bridge and confirm `agents.name = 'foo'` on the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)