### PR TITLE
feat: vicoop-runtime image foundation (#249 PR A)

### DIFF
--- a/.changeset/external-runtime-image.md
+++ b/.changeset/external-runtime-image.md
@@ -1,0 +1,34 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Add the external-runtime container image (#249, PR A). Lands the
+agent-agnostic `vicoop-runtime` image alongside the bundled-direct
+profile (#244, `container/bundled/`) so the two profiles can coexist:
+
+```
+execution=direct
+  - host direct                          (existing bare-metal)
+  - bundled bridge container direct      (#244 — container/bundled/)
+
+execution=container
+  - external runtime container           (#249 — container/runtime/)
+```
+
+The image is intentionally agent-agnostic: agent CLIs (claude / codex)
+are NOT baked in. The host-resident bridge client provisions them into
+a named volume at backend init time via
+`docker exec <c> install-backend.sh <kind>` (the shared install
+machinery under `container/` works inside either profile's container).
+Container body is `sleep infinity` after firewall init; per-task work
+flows through `docker exec` from the host.
+
+Published to `ghcr.io/planetarium/vicoop-runtime` from a new
+`.github/workflows/release-runtime.yml` that builds linux/amd64 +
+linux/arm64 on main pushes that touch image inputs (`container/runtime/**`,
+shared scripts under `container/`).
+
+Bridge client wiring (a `SpawnAdapter` + `runtime: host | container`
+config) lands in PR B of #249. This PR only ships the image so the
+runtime artifact exists by the time the host-side code starts
+exec'ing into it.

--- a/.github/workflows/release-runtime.yml
+++ b/.github/workflows/release-runtime.yml
@@ -1,0 +1,75 @@
+name: Release runtime image
+
+# Separate from release.yml — that workflow is the changesets/action
+# pipeline for the @vicoop-bridge/client package binaries. This one
+# rebuilds the agent-agnostic vicoop-runtime image (#249) only when
+# something the image actually depends on changes. The bundled-direct
+# image (#244, container/bundled/) is intentionally not published from
+# CI right now (see #250).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - container/runtime/**
+      - container/init-firewall.sh
+      - container/install-backend.sh
+      - container/backends/**
+      - .github/workflows/release-runtime.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      # buildx + qemu enable cross-arch builds (linux/amd64 + linux/arm64)
+      # from the ubuntu-latest x86_64 runner. The runtime image is small
+      # enough that emulated arm64 builds are tolerable; revisit a
+      # native-arm64 runner if cold-build times become a problem.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `latest` + `sha-<short>` is enough for the external-runtime
+      # profile while we iterate. Once the image stabilizes we can wire
+      # a semver tag flow (either piggybacked on the client Version PR
+      # merge in release.yml, or its own changeset-equivalent).
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vicoop-runtime
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Build and push runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: container/runtime/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VICOOP_RUNTIME_IMAGE=${{ steps.meta.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/container/runtime/Dockerfile
+++ b/container/runtime/Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1.6
+#
+# vicoop-runtime — external-runtime container profile (#249).
+#
+# Agent-agnostic thin sandbox. Provides:
+#   - base + system tools (git/curl/jq/openssh + iptables/ipset/dnsutils …)
+#   - tini PID 1
+#   - shared install machinery (install-backend.sh + backends/*.sh)
+#   - init-firewall.sh outbound allowlist
+#
+# Agent CLIs themselves (claude / codex / …) are NOT baked in. The host-
+# resident bridge client provisions them into a named volume mounted at
+# /data/agents/<kind> by `docker exec <c> install-backend.sh <kind>` at
+# backend init time. The container body is `sleep infinity`; every task
+# is driven from outside via `docker exec`.
+#
+# Companion bundled-direct profile (#244) Dockerfile is at
+# container/bundled/Dockerfile — same shared scripts under container/,
+# different deployment shape.
+
+ARG NODE_BASE=node:20-bookworm-slim
+FROM ${NODE_BASE}
+
+# Identifies the image at runtime so the host bridge client can probe
+# (`docker exec <c> printenv VICOOP_RUNTIME_IMAGE`) which runtime
+# version is mounted. Release workflow wires the real value via
+# build-arg; local builds default to a dev marker.
+ARG VICOOP_RUNTIME_IMAGE=0.0.0-dev
+ENV VICOOP_RUNTIME_IMAGE=$VICOOP_RUNTIME_IMAGE
+
+# System dependencies. Mirrors container/bundled/Dockerfile's runtime
+# stage minus the bridge-client-specific bits (vicoop-client binary,
+# semver lib). Each justified:
+#   - ca-certificates, curl: TLS + ad-hoc fetches in install recipes
+#   - git, openssh-client: agent CLIs clone repos, sometimes via ssh
+#   - jq: shell-side JSON manipulation in install-backend
+#   - tini: PID-1 reaper. agent CLI subprocesses spawn other children
+#     (e.g. claude code -> bash); without tini we leak zombies.
+#   - iptables, ipset, dnsutils, iproute2: init-firewall.sh
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates curl git jq openssh-client tini \
+      iptables ipset dnsutils iproute2 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Persistent state root. The host bridge client mounts named volumes
+# under /data (agents/, creds/, sessions/) when starting the runtime
+# container for a backend. CLAUDE_CONFIG_DIR / CODEX_HOME redirect each
+# agent CLI's creds into /data/creds/<kind> so the whole stateful
+# surface lives in one place — and stays inside the container-scoped
+# named volume, never touching the host operator's ~/.claude.
+ENV VICOOP_DATA=/data
+ENV VICOOP_HOME=/data
+ENV CLAUDE_CONFIG_DIR=/data/creds/claude
+ENV CODEX_HOME=/data/creds/codex
+ENV PATH=/data/agents/claude/bin:/data/agents/codex/bin:/data/agents/claude/.npm-global/bin:/data/agents/codex/.npm-global/bin:$PATH
+
+# Disable agent CLI self-updaters. The host bridge client drives
+# upgrades explicitly via `docker exec <c> install-backend.sh <kind>`.
+ENV DISABLE_AUTOUPDATER=1
+
+# Image scripts. /usr/local/lib/vicoop-bridge matches install-backend.sh's
+# $VICOOP_LIB default so `docker exec <c> install-backend.sh <kind>` works
+# without env overrides.
+COPY container/runtime/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY container/install-backend.sh    /usr/local/lib/vicoop-bridge/install-backend.sh
+COPY container/init-firewall.sh      /usr/local/lib/vicoop-bridge/init-firewall.sh
+COPY container/backends/             /usr/local/lib/vicoop-bridge/backends/
+RUN chmod 755 /usr/local/bin/entrypoint.sh \
+              /usr/local/lib/vicoop-bridge/install-backend.sh \
+              /usr/local/lib/vicoop-bridge/init-firewall.sh \
+              /usr/local/lib/vicoop-bridge/backends/*.sh
+
+# Pre-seed /data with the directory tree install-backend.sh expects,
+# owned by the unprivileged `node` user the runtime drops to. A volume
+# mount on /data at runtime inherits these permissions.
+RUN mkdir -p /data/agents /data/creds/claude /data/creds/codex /data/sessions \
+ && chown -R node:node /data
+
+USER node
+WORKDIR /data
+
+# tini as PID 1 → entrypoint.sh → sleep infinity. All meaningful work
+# (install-backend, agent spawn, version probe) flows through
+# `docker exec` from the host bridge client.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
+LABEL org.opencontainers.image.source="https://github.com/planetarium/vicoop-bridge"
+LABEL org.opencontainers.image.description="vicoop-bridge external-runtime container (#249) — agent-agnostic sandbox for host-driven claude/codex spawn"
+LABEL org.opencontainers.image.licenses="Apache-2.0"

--- a/container/runtime/entrypoint.sh
+++ b/container/runtime/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# vicoop-runtime entrypoint — external-runtime profile (#249).
+#
+# Body: optional firewall init, then `sleep infinity`. The container is
+# an idle sandbox; every real action (install-backend, agent spawn,
+# version probe) is invoked from outside via `docker exec` by the host
+# bridge client.
+#
+# Contrast with container/bundled/entrypoint.sh, which runs the bridge
+# client daemon at the end. Here the bridge client is on the host.
+
+set -euo pipefail
+
+VICOOP_LIB="${VICOOP_LIB:-/usr/local/lib/vicoop-bridge}"
+
+log() { printf '[runtime] %s\n' "$*" >&2; }
+
+# Same graceful-degrade pattern as container/bundled/entrypoint.sh:
+# missing CAP_NET_ADMIN logs a warning and skips the firewall rather
+# than failing boot, so an operator can iterate locally without the
+# cap while still seeing a clear hint about how to enable isolation.
+maybe_init_firewall() {
+    if [[ "${VICOOP_SKIP_FIREWALL:-0}" == "1" ]]; then
+        log "VICOOP_SKIP_FIREWALL=1 — skipping init-firewall.sh"
+        return 0
+    fi
+    if ! command -v iptables >/dev/null 2>&1; then
+        log "WARN: iptables not present in PATH; skipping firewall"
+        return 0
+    fi
+    if ! iptables -L >/dev/null 2>&1; then
+        log "WARN: cannot read iptables (missing CAP_NET_ADMIN?); skipping firewall."
+        log "      add '--cap-add NET_ADMIN --cap-add NET_RAW' to your run command"
+        log "      to enable outbound-allowlist isolation."
+        return 0
+    fi
+    log "applying init-firewall.sh"
+    "$VICOOP_LIB/init-firewall.sh"
+}
+
+maybe_init_firewall
+
+log "sandbox ready — sleeping until docker stop"
+exec sleep infinity


### PR DESCRIPTION
## Summary

- First land of #249's external-runtime profile: an agent-agnostic
  `vicoop-runtime` image that sits next to the bundled-direct profile
  (#244, `container/bundled/`). Contains base + system tools + tini +
  the shared install machinery (`install-backend.sh`,
  `backends/*.sh`, `init-firewall.sh`); body is `sleep infinity` so
  the host bridge client drives every per-task action via
  `docker exec`.
- Agent CLIs are intentionally NOT baked into the image. They get
  provisioned into a named volume mounted at `/data/agents/<kind>` by
  the host via `docker exec <c> install-backend.sh <kind>` — the same
  recipe the bundled profile already uses on first boot.
- Published from a new `.github/workflows/release-runtime.yml` that
  builds `linux/amd64` + `linux/arm64` and pushes to
  `ghcr.io/planetarium/vicoop-runtime` on main pushes that touch
  image inputs (paths filter: `container/runtime/**` + the shared
  scripts under `container/`). bundled image publishing stays off,
  per #250.
- Bridge-client wiring (a `SpawnAdapter` + `runtime: host | container`
  config) is intentionally out of scope — it lands as PR B of #249.
  This PR only ships the image so the runtime artifact exists by the
  time the host-side code starts exec'ing into it.

## Test plan

- [x] `docker build -f container/runtime/Dockerfile -t vicoop-runtime:local .` succeeds locally
- [x] `docker run -d -e VICOOP_SKIP_FIREWALL=1 vicoop-runtime:local` boots and stays up under tini
- [x] `printenv VICOOP_RUNTIME_IMAGE VICOOP_DATA CLAUDE_CONFIG_DIR CODEX_HOME` inside the container returns the expected values
- [x] `docker exec <c> /usr/local/lib/vicoop-bridge/install-backend.sh codex` installs into `/data/agents/codex/` and `/data/agents/codex/bin/codex --version` reports a real version
- [x] firewall graceful-skip path logs the missing-CAP_NET_ADMIN hint instead of failing boot (matches `container/bundled/entrypoint.sh`)
- [ ] CI: `release-runtime` workflow builds + pushes both arches on first main run after merge
- [ ] (follow-up in PR B) host bridge client can `docker exec` into a long-lived runtime container and stream agent CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)