### PR TITLE
feat(client): backend runtime: container mode (#249 PR B)

### DIFF
--- a/.changeset/external-runtime-spawn.md
+++ b/.changeset/external-runtime-spawn.md
@@ -1,0 +1,53 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add `runtime: 'host' | 'container'` to the claude and codex backends
+(#249 PR B). This is the bridge-client side of the external-runtime
+profile landed in PR A (#251) — when an operator opts in, the agent
+CLI runs inside a long-lived `vicoop-runtime` container the bridge
+client orchestrates via `docker exec`, instead of being spawned as a
+host child process.
+
+New surface:
+
+- Config: `backends.claude.runtime` / `backends.codex.runtime` accept
+  `'host'` (default) or `'container'`.
+- CLI flags: `--claude-runtime host|container`, `--codex-runtime host|container`.
+  Standard precedence (flag > config) applies.
+- A `RuntimeContainer` module (`src/runtime-container.ts`) owns the
+  per-backend lifecycle: docker daemon ping, image pull, named-volume
+  provisioning (`vicoop-agents-<kind>`, `vicoop-creds-<kind>`,
+  `vicoop-sessions-<kind>`), container create with
+  `--restart unless-stopped` + `NET_ADMIN/NET_RAW`, reuse of an
+  existing container on bridge-client restart, and an explicit stop
+  on shutdown.
+- A `SpawnAdapter` module (`src/spawn-adapter.ts`) presents the
+  existing `ClaudeSpawnFn` / `AppServerSpawnFn` shape regardless of
+  mode. The host implementation is the same `node:child_process.spawn`
+  the backends use today; the container implementation runs the
+  command via `docker exec` inside the runtime container and bridges
+  stdin/stdout/stderr to PassThrough streams so backends see a normal
+  child-handle.
+- `dockerode` is a new runtime dependency (#249 Decision §1).
+
+Decisions reflected (#249 §Decisions):
+
+- §1 dockerode (programmatic API, not shell-out).
+- §2 `--restart unless-stopped` + bridge-client-side reuse on restart.
+- §3 Per-backend long-lived only; no per-context runtime.
+- §4 Creds in a container-only named volume — the host's `~/.claude`
+  never enters the container.
+- §5 Sessions volume mounted into the container so claude/codex
+  session resume survives container re-creation.
+- §6 No docker daemon → explicit error from `RuntimeContainer.start()`
+  with a "switch to runtime: 'host' or start docker" hint; no
+  fallback.
+- §8 The two backend kinds keep their identity; runtime mode is the
+  `runtime` field, and backend internals stay unaware of it.
+
+Out of scope (separate work):
+
+- Per-context workspace branching (today the host bind-mount is whole).
+- `vicoop-client backend init` operator-UX subcommand (PR C of #249).
+- Bundled-direct image publishing (still off per #250).

--- a/container/runtime/Dockerfile
+++ b/container/runtime/Dockerfile
@@ -37,10 +37,17 @@ ENV VICOOP_RUNTIME_IMAGE=$VICOOP_RUNTIME_IMAGE
 #   - tini: PID-1 reaper. agent CLI subprocesses spawn other children
 #     (e.g. claude code -> bash); without tini we leak zombies.
 #   - iptables, ipset, dnsutils, iproute2: init-firewall.sh
+#   - bubblewrap, socat: claude code's per-tool-call sandbox runtime;
+#     without them claude 2.1.x exits 1 with
+#     "sandbox.failIfUnavailable is set — refusing to start without a
+#     working sandbox" on first task. ~5MB combined; cheap insurance
+#     against an agent-CLI-specific landmine in an image whose entire
+#     point is to host claude / codex.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates curl git jq openssh-client tini \
       iptables ipset dnsutils iproute2 \
+      bubblewrap socat \
  && rm -rf /var/lib/apt/lists/*
 
 # Persistent state root. The host bridge client mounts named volumes

--- a/container/runtime/Dockerfile
+++ b/container/runtime/Dockerfile
@@ -37,17 +37,20 @@ ENV VICOOP_RUNTIME_IMAGE=$VICOOP_RUNTIME_IMAGE
 #   - tini: PID-1 reaper. agent CLI subprocesses spawn other children
 #     (e.g. claude code -> bash); without tini we leak zombies.
 #   - iptables, ipset, dnsutils, iproute2: init-firewall.sh
-#   - bubblewrap, socat: claude code's per-tool-call sandbox runtime;
-#     without them claude 2.1.x exits 1 with
-#     "sandbox.failIfUnavailable is set — refusing to start without a
-#     working sandbox" on first task. ~5MB combined; cheap insurance
-#     against an agent-CLI-specific landmine in an image whose entire
-#     point is to host claude / codex.
+#
+# Intentionally NOT installed: bubblewrap / socat. claude code uses
+# them to sandbox each tool call from the host. In the external-
+# runtime profile the outer container already provides isolation
+# (per-backend named volumes + init-firewall.sh egress allowlist),
+# so layering bwrap inside that container would double-isolate at
+# noticeable image cost without a security benefit. The bridge-client
+# side disables claude's sandbox guard via `sandbox.failIfUnavailable
+# = false` only when runtime === 'container'; host-mode claude keeps
+# its sandbox unchanged.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates curl git jq openssh-client tini \
       iptables ipset dnsutils iproute2 \
-      bubblewrap socat \
  && rm -rf /var/lib/apt/lists/*
 
 # Persistent state root. The host bridge client mounts named volumes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,10 +24,12 @@
     "@optique/core": "1.0.2",
     "@optique/run": "1.0.2",
     "@vicoop-bridge/protocol": "workspace:*",
+    "dockerode": "^5.0.0",
     "ws": "^8.18.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/dockerode": "^4.0.1",
     "@types/ws": "^8.5.13"
   }
 }

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -10,7 +10,7 @@ import { choice, integer, string } from '@optique/core/valueparser';
 import { parse } from '@optique/core/parser';
 import { formatMessage } from '@optique/core/message';
 import type { InferValue } from '@optique/core/parser';
-import type { ClientConfig, BackendConfigs } from './config.js';
+import type { ClientConfig, BackendConfigs, BackendRuntime } from './config.js';
 
 // Public bridge URL baked in so a fresh install on the public deployment
 // needs zero flags. Self-hosters override via --server / config.json. The
@@ -30,6 +30,8 @@ export type CodexSandboxMode = (typeof SANDBOX_MODES)[number];
 
 const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex', 'vicoop-codex'] as const;
 export type BackendKind = (typeof BACKEND_KINDS)[number];
+
+const BACKEND_RUNTIMES = ['host', 'container'] as const;
 
 // Optique daemon-mode grammar. Every operator-tunable knob is a flag here,
 // including the ones that used to be env-only (CLAUDE_CWD, CODEX_SANDBOX_MODE,
@@ -77,6 +79,9 @@ export const daemonFlagsFields = {
   claudeSettingsFile: optional(option('--claude-settings-file', string({ metavar: 'PATH' }), {
     description: message`Path to a JSON file used as Claude \`--settings\`.`,
   })),
+  claudeRuntime: optional(option('--claude-runtime', choice([...BACKEND_RUNTIMES]), {
+    description: message`Where to run \`claude\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates (#249).`,
+  })),
 
   // Backend-specific (Codex)
   codexCwd: optional(option('--codex-cwd', string({ metavar: 'PATH' }), {
@@ -84,6 +89,9 @@ export const daemonFlagsFields = {
   })),
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
     description: message`Codex sandbox mode.`,
+  })),
+  codexRuntime: optional(option('--codex-runtime', choice([...BACKEND_RUNTIMES]), {
+    description: message`Where to run \`codex\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates (#249).`,
   })),
 
   // Backend-specific (OpenClaw)
@@ -123,8 +131,10 @@ export interface DaemonArgs {
   // env when set; merge logic in cli.ts threads them into backend factories.
   claudeCwd?: string;
   claudeSettingsFile?: string;
+  claudeRuntime?: BackendRuntime;
   codexCwd?: string;
   codexSandbox?: CodexSandboxMode;
+  codexRuntime?: BackendRuntime;
   openclawGateway?: string;
   openclawGatewayToken?: string;
   openclawAgent?: string;
@@ -200,9 +210,11 @@ export function mergeClientArgs(
     backends: config.backends,
     claudeCwd: pick(flags.claudeCwd) || backends.claude?.cwd || undefined,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
+    claudeRuntime: flags.claudeRuntime ?? backends.claude?.runtime,
     codexCwd: pick(flags.codexCwd) || backends.codex?.cwd || undefined,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
+    codexRuntime: flags.codexRuntime ?? backends.codex?.runtime,
     openclawGateway:
       pick(flags.openclawGateway) || backends.openclaw?.gateway_url || undefined,
     openclawGatewayToken:

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -314,9 +314,22 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         cwd: args.codexCwd,
         bridgeUrl: args.server,
       });
+      // Container isolation supersedes codex's sandbox the same way
+      // it supersedes claude's bwrap one: the outer container caps
+      // what the agent can reach, so codex's host-process sandbox
+      // is double-duty. In host mode codex's own default ('read-only')
+      // is the right safety floor; in container mode we lift it to
+      // 'danger-full-access' so codex can actually write to
+      // /workspace and run bash — operator override (--codex-sandbox
+      // / config) still wins for the rare case where someone wants
+      // belt-and-suspenders.
+      const explicitSandbox = coerceCodexSandbox(args, backends.codex?.sandbox_mode);
+      const sandboxMode = runtime
+        ? (explicitSandbox ?? 'danger-full-access')
+        : explicitSandbox;
       const backend = createCodexBackend({
         cwd,
-        sandboxMode: coerceCodexSandbox(args, backends.codex?.sandbox_mode),
+        sandboxMode,
         approvalDecision: backends.codex?.approval_decision as ApprovalDecision | undefined,
         ...(spawn ? { spawn: spawn as AppServerSpawnFn } : {}),
       });

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -11,13 +11,16 @@ import { run } from '@optique/run';
 import { Client } from './client.js';
 import { echoBackend } from './backends/echo.js';
 import { createOpenclawBackend } from './backends/openclaw.js';
-import { createClaudeBackend } from './backends/claude.js';
+import { createClaudeBackend, type ClaudeSpawnFn } from './backends/claude.js';
 import {
   createCodexBackend,
   type ApprovalDecision,
 } from './backends/codex.js';
+import type { AppServerSpawnFn } from './backends/codex-rpc.js';
 import { createVicoopCodexBackend } from './backends/vicoop-codex.js';
 import type { Backend } from './backend.js';
+import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
+import { createDockerExecSpawn, type SpawnFn } from './spawn-adapter.js';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
 import { BACKENDS_MANIFEST } from './backends-manifest.js';
@@ -237,10 +240,12 @@ function coerceCodexSandbox(
   return undefined;
 }
 
-function pickBackend(name: string, args: Args): Backend {
+async function pickBackend(name: string, args: Args): Promise<Backend> {
   // All backend-specific knobs are now threaded through `args` (merged from
   // flag + config in mergeClientArgs). `pickBackend` just constructs
-  // the right factory with those values; no env reads here.
+  // the right factory with those values; no env reads here — except for
+  // VICOOP_RUNTIME_IMAGE, which is image-identity (mirrors how the
+  // bundled profile resolves VICOOP_BRIDGE_IMAGE).
   const backends = args.backends ?? {};
   switch (name) {
     case 'echo':
@@ -266,18 +271,35 @@ function pickBackend(name: string, args: Args): Backend {
       const settings = args.claudeSettingsFile
         ? readClaudeSettingsFile(args.claudeSettingsFile)
         : backends.claude?.settings;
-      return createClaudeBackend({
+      const { spawn, cwd, runtime } = await resolveRuntime({
+        kind: 'claude',
+        runtime: args.claudeRuntime,
         cwd: args.claudeCwd,
+        bridgeUrl: args.server,
+      });
+      const backend = createClaudeBackend({
+        cwd,
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         settings,
+        ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });
+      return runtime ? withRuntimeStop(backend, runtime) : backend;
     }
-    case 'codex':
-      return createCodexBackend({
+    case 'codex': {
+      const { spawn, cwd, runtime } = await resolveRuntime({
+        kind: 'codex',
+        runtime: args.codexRuntime,
         cwd: args.codexCwd,
+        bridgeUrl: args.server,
+      });
+      const backend = createCodexBackend({
+        cwd,
         sandboxMode: coerceCodexSandbox(args, backends.codex?.sandbox_mode),
         approvalDecision: backends.codex?.approval_decision as ApprovalDecision | undefined,
+        ...(spawn ? { spawn: spawn as AppServerSpawnFn } : {}),
       });
+      return runtime ? withRuntimeStop(backend, runtime) : backend;
+    }
     case 'vicoop-codex':
       return createVicoopCodexBackend();
     default:
@@ -287,7 +309,63 @@ function pickBackend(name: string, args: Args): Backend {
   }
 }
 
-function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): void {
+// Resolves the runtime mode for a claude/codex backend.
+//
+// - 'host' (default): nothing to do. The backend factory's built-in
+//   defaultSpawn handles host child_process.spawn unchanged.
+// - 'container': starts a long-lived vicoop-runtime container for this
+//   kind and returns a docker-exec SpawnFn the backend factory plugs
+//   into its spawn slot. cwd, if any, is rewritten to /workspace; the
+//   original host path becomes the bind-mount source.
+async function resolveRuntime(args: {
+  kind: 'claude' | 'codex';
+  runtime: 'host' | 'container' | undefined;
+  cwd: string | undefined;
+  bridgeUrl: string;
+}): Promise<{ spawn?: SpawnFn; cwd?: string; runtime?: RuntimeContainer }> {
+  if ((args.runtime ?? 'host') !== 'container') {
+    return { cwd: args.cwd };
+  }
+  const runtime = new RuntimeContainer({
+    backendKind: args.kind,
+    image: process.env.VICOOP_RUNTIME_IMAGE || DEFAULT_RUNTIME_IMAGE,
+    workspaceDir: args.cwd,
+    bridgeUrl: args.bridgeUrl,
+  });
+  await runtime.start();
+  return {
+    runtime,
+    spawn: createDockerExecSpawn(runtime),
+    // Inside the container the workspace is always /workspace (when
+    // bind-mounted) — backends pass this through to claude/codex as
+    // their --cwd, so the host path the operator typed must not leak
+    // into the container's argv.
+    cwd: args.cwd ? '/workspace' : undefined,
+  };
+}
+
+// Wraps a backend so its stop() also stops the runtime container. The
+// Backend interface's stop() is synchronous and best-effort; we honor
+// that here by fire-and-forgetting runtime.stop(). The
+// `--restart unless-stopped` policy plus this explicit stop means an
+// orderly shutdown ends with no live runtime container, while a hard
+// crash leaves the container alive for the next bridge-client process
+// to reuse (see RuntimeContainer.start() reuse path).
+function withRuntimeStop(backend: Backend, runtime: RuntimeContainer): Backend {
+  return {
+    name: backend.name,
+    handle: backend.handle.bind(backend),
+    ...(backend.resolveCapabilities
+      ? { resolveCapabilities: backend.resolveCapabilities.bind(backend) }
+      : {}),
+    stop: () => {
+      backend.stop?.();
+      void runtime.stop();
+    },
+  };
+}
+
+async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
   const args = resolveDaemonArgs(parsed);
   const agentCard = args.card
     ? AgentCard.parse(JSON.parse(readFileSync(args.card, 'utf8')))
@@ -300,13 +378,17 @@ function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): void {
   // tell whether parsing landed where they expected.
   console.log(`[client] backend: ${args.backend}`);
 
+  // pickBackend is async because container-mode backends boot a
+  // long-lived runtime container before construction (#249).
+  const backend = await pickBackend(args.backend, args);
+
   const client = new Client({
     serverUrl: args.server,
     token: args.token,
     agentId: args.agentId,
     agentCard,
     backendKind: args.backend,
-    backend: pickBackend(args.backend, args),
+    backend,
     // Daemon entrypoint: a fatal terminal close (currently 4014 "client
     // revoked") should drop the process with a non-zero exit so
     // systemd / a parent supervisor sees the revocation as a hard
@@ -437,7 +519,10 @@ async function main(): Promise<void> {
     case 'daemon':
       // Long-running. Do not exit — client.start() keeps the event loop
       // alive and signal handlers will call process.exit on shutdown.
-      runDaemon(parsed);
+      // We await runDaemon's setup phase (which now boots a runtime
+      // container in container-mode) so startup errors surface through
+      // main's catch instead of unhandled rejections.
+      await runDaemon(parsed);
       break;
   }
 }

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -283,7 +283,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
     case 'claude': {
       // settings precedence: --claude-settings-file (flag, path on disk) >
       // backends.claude.settings (config). No env layer (#189 §5).
-      const settings = args.claudeSettingsFile
+      const baseSettings = args.claudeSettingsFile
         ? readClaudeSettingsFile(args.claudeSettingsFile)
         : backends.claude?.settings;
       const { spawn, cwd, runtime } = await resolveRuntime({
@@ -292,6 +292,13 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         cwd: args.claudeCwd,
         bridgeUrl: args.server,
       });
+      // Container mode supersedes claude's bwrap sandbox with the
+      // outer container's own isolation, so the runtime image
+      // deliberately doesn't ship bwrap / socat. Without this
+      // override claude 2.1.x exits 1 on first task with
+      // "sandbox.failIfUnavailable is set" because its default
+      // setting refuses unsandboxed execution.
+      const settings = runtime ? disableClaudeSandboxGuard(baseSettings) : baseSettings;
       const backend = createClaudeBackend({
         cwd,
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
@@ -357,6 +364,26 @@ async function resolveRuntime(args: {
     // into the container's argv.
     cwd: args.cwd ? '/workspace' : undefined,
   };
+}
+
+// Container-mode override for claude's sandbox guard. Returns a new
+// settings object with `sandbox.failIfUnavailable: false` merged on
+// top of whatever the operator already had. Other sandbox keys —
+// including any future addition from claude-code — are preserved.
+// Exported for unit-testability; daemon-only usage doesn't need to
+// import it from outside cli.ts.
+export function disableClaudeSandboxGuard(
+  base: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...(base ?? {}) };
+  const existing = out.sandbox;
+  const sandbox: Record<string, unknown> =
+    existing && typeof existing === 'object' && !Array.isArray(existing)
+      ? { ...(existing as Record<string, unknown>) }
+      : {};
+  sandbox.failIfUnavailable = false;
+  out.sandbox = sandbox;
+  return out;
 }
 
 // Race a shutdown promise against a timeout. Container stop normally

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -240,7 +240,20 @@ function coerceCodexSandbox(
   return undefined;
 }
 
-async function pickBackend(name: string, args: Args): Promise<Backend> {
+// What pickBackend returns. The optional `shutdown` is an async
+// cleanup hook the daemon awaits **before** process.exit — Backend's
+// own `stop()` is documented as synchronous best-effort, which works
+// for kill-a-subprocess but not for "ask docker daemon to stop a
+// container and wait for the SIGTERM grace period to elapse." When
+// shutdown is set, the SIGINT/SIGTERM handler in runDaemon awaits it
+// (under a timeout) so an orderly exit really does end with the
+// runtime container stopped.
+interface PickedBackend {
+  backend: Backend;
+  shutdown?: () => Promise<void>;
+}
+
+async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
   // All backend-specific knobs are now threaded through `args` (merged from
   // flag + config in mergeClientArgs). `pickBackend` just constructs
   // the right factory with those values; no env reads here — except for
@@ -249,21 +262,23 @@ async function pickBackend(name: string, args: Args): Promise<Backend> {
   const backends = args.backends ?? {};
   switch (name) {
     case 'echo':
-      return echoBackend;
+      return { backend: echoBackend };
     case 'openclaw': {
       // openclaw's persona / system prompt lives in the gateway-side config
       // (`/data/openclaw.json`), not in a per-message field on `chat.send`.
       // Self-identity is surfaced via `vicoop-client whoami` so operators
       // can paste it into their gateway persona; the bridge has no
       // wire-protocol hook to inject it from here.
-      return createOpenclawBackend({
-        url: args.openclawGateway ?? backends.openclaw?.gateway_url,
-        token: args.openclawGatewayToken ?? backends.openclaw?.gateway_token,
-        agent: args.openclawAgent ?? backends.openclaw?.agent,
-        openaiCompatAgent:
-          args.openclawOpenaiCompatAgent ?? backends.openclaw?.openai_compat_agent,
-        taskTimeoutMs: args.openclawTaskTimeoutMs,
-      });
+      return {
+        backend: createOpenclawBackend({
+          url: args.openclawGateway ?? backends.openclaw?.gateway_url,
+          token: args.openclawGatewayToken ?? backends.openclaw?.gateway_token,
+          agent: args.openclawAgent ?? backends.openclaw?.agent,
+          openaiCompatAgent:
+            args.openclawOpenaiCompatAgent ?? backends.openclaw?.openai_compat_agent,
+          taskTimeoutMs: args.openclawTaskTimeoutMs,
+        }),
+      };
     }
     case 'claude': {
       // settings precedence: --claude-settings-file (flag, path on disk) >
@@ -283,7 +298,7 @@ async function pickBackend(name: string, args: Args): Promise<Backend> {
         settings,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });
-      return runtime ? withRuntimeStop(backend, runtime) : backend;
+      return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };
     }
     case 'codex': {
       const { spawn, cwd, runtime } = await resolveRuntime({
@@ -298,10 +313,10 @@ async function pickBackend(name: string, args: Args): Promise<Backend> {
         approvalDecision: backends.codex?.approval_decision as ApprovalDecision | undefined,
         ...(spawn ? { spawn: spawn as AppServerSpawnFn } : {}),
       });
-      return runtime ? withRuntimeStop(backend, runtime) : backend;
+      return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };
     }
     case 'vicoop-codex':
-      return createVicoopCodexBackend();
+      return { backend: createVicoopCodexBackend() };
     default:
       throw new Error(
         `unknown backend: ${name} (supported: echo, openclaw, claude, codex, vicoop-codex)`,
@@ -344,25 +359,30 @@ async function resolveRuntime(args: {
   };
 }
 
-// Wraps a backend so its stop() also stops the runtime container. The
-// Backend interface's stop() is synchronous and best-effort; we honor
-// that here by fire-and-forgetting runtime.stop(). The
-// `--restart unless-stopped` policy plus this explicit stop means an
-// orderly shutdown ends with no live runtime container, while a hard
-// crash leaves the container alive for the next bridge-client process
-// to reuse (see RuntimeContainer.start() reuse path).
-function withRuntimeStop(backend: Backend, runtime: RuntimeContainer): Backend {
-  return {
-    name: backend.name,
-    handle: backend.handle.bind(backend),
-    ...(backend.resolveCapabilities
-      ? { resolveCapabilities: backend.resolveCapabilities.bind(backend) }
-      : {}),
-    stop: () => {
-      backend.stop?.();
-      void runtime.stop();
-    },
-  };
+// Race a shutdown promise against a timeout. Container stop normally
+// completes within docker's grace period (RuntimeContainer.stop()
+// passes t: 10s) but we don't want a wedged daemon socket to hold
+// SIGINT hostage indefinitely — operators expect ctrl-c to actually
+// exit. Resolves either way; the caller decides whether to surface
+// the timeout in logs.
+const SHUTDOWN_TIMEOUT_MS = 15_000;
+async function runWithShutdownTimeout(shutdown: () => Promise<void>): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      shutdown(),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+          console.warn(
+            `[client] runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; exiting anyway`,
+          );
+          resolve();
+        }, SHUTDOWN_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
@@ -380,7 +400,7 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
 
   // pickBackend is async because container-mode backends boot a
   // long-lived runtime container before construction (#249).
-  const backend = await pickBackend(args.backend, args);
+  const { backend, shutdown: backendShutdown } = await pickBackend(args.backend, args);
 
   const client = new Client({
     serverUrl: args.server,
@@ -400,13 +420,33 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
 
   client.start();
 
-  const shutdown = () => {
-    console.log('\n[client] shutting down');
-    client.stop();
-    process.exit(0);
+  // Async shutdown so the container-mode `runtime.stop()` actually
+  // completes before process.exit. Re-entry guarded: a second
+  // signal (e.g. impatient operator pressing ctrl-c twice) drops to
+  // an immediate exit so the daemon can't get pinned by a wedged
+  // docker socket.
+  let shuttingDown = false;
+  const onSignal = (signal: NodeJS.Signals) => {
+    if (shuttingDown) {
+      console.log(`[client] received second ${signal}; forcing exit`);
+      process.exit(130);
+    }
+    shuttingDown = true;
+    void (async () => {
+      console.log(`\n[client] shutting down (${signal})`);
+      client.stop();
+      if (backendShutdown) {
+        try {
+          await runWithShutdownTimeout(backendShutdown);
+        } catch (err) {
+          console.error('[client] shutdown error:', (err as Error).message);
+        }
+      }
+      process.exit(0);
+    })();
   };
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
 }
 
 async function runUpgradeCmd(args: Extract<CliArgs, { action: 'upgrade' }>): Promise<number> {

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -99,9 +99,17 @@ export function defaultOwnerSessionPath(): string {
   return join(resolveConfigDir(), OWNER_SESSION_FILENAME);
 }
 
+// Where the agent CLI actually runs.
+//   - 'host'      : node:child_process.spawn on the bridge-client host
+//                   (today's behavior; default).
+//   - 'container' : `docker exec` into a long-lived vicoop-runtime
+//                   container the bridge client orchestrates (#249).
+export type BackendRuntime = 'host' | 'container';
+
 export interface ClaudeBackendConfig {
   cwd?: string;
   settings?: Record<string, unknown>;
+  runtime?: BackendRuntime;
 }
 
 export interface CodexBackendConfig {
@@ -109,6 +117,7 @@ export interface CodexBackendConfig {
   sandbox_mode?: string;
   /** What to answer when codex requests user approval. Default `decline`. */
   approval_decision?: 'accept' | 'acceptForSession' | 'decline';
+  runtime?: BackendRuntime;
 }
 
 export interface OpenclawBackendConfig {
@@ -186,6 +195,15 @@ const KNOWN_CODEX_SANDBOX_MODES = new Set([
   'workspace-write',
   'danger-full-access',
 ]);
+const KNOWN_BACKEND_RUNTIMES = new Set<BackendRuntime>(['host', 'container']);
+
+function pickBackendRuntime(v: unknown): BackendRuntime | undefined {
+  if (typeof v !== 'string') return undefined;
+  const trimmed = v.trim();
+  return KNOWN_BACKEND_RUNTIMES.has(trimmed as BackendRuntime)
+    ? (trimmed as BackendRuntime)
+    : undefined;
+}
 
 // Hand-edited config files reliably ship malformed entries (typos, wrong
 // types, accidental nesting). Be permissive: drop bad fields silently and
@@ -212,10 +230,12 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
     if (claudeRaw) {
       const cwd = asString(claudeRaw.cwd);
       const settings = asRecord(claudeRaw.settings);
-      if (cwd || settings) {
+      const runtime = pickBackendRuntime(claudeRaw.runtime);
+      if (cwd || settings || runtime) {
         out.claude = {};
         if (cwd) out.claude.cwd = cwd;
         if (settings) out.claude.settings = settings;
+        if (runtime) out.claude.runtime = runtime;
       }
     }
     const codexRaw = asRecord(backends.codex);
@@ -229,11 +249,13 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
         approvalRaw && KNOWN_APPROVAL_DECISIONS.has(approvalRaw)
           ? (approvalRaw as 'accept' | 'acceptForSession' | 'decline')
           : undefined;
-      if (cwd || validSandbox || validApproval) {
+      const runtime = pickBackendRuntime(codexRaw.runtime);
+      if (cwd || validSandbox || validApproval || runtime) {
         out.codex = {};
         if (cwd) out.codex.cwd = cwd;
         if (validSandbox) out.codex.sandbox_mode = validSandbox;
         if (validApproval) out.codex.approval_decision = validApproval;
+        if (runtime) out.codex.runtime = runtime;
       }
     }
     const ocRaw = asRecord(backends.openclaw);

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { RuntimeContainer } from './runtime-container.js';
+
+// Minimal dockerode-compatible stub. Records what was called so the
+// tests can assert lifecycle behavior (volumes ensured, container
+// created, restart policy / mounts set) without a live daemon.
+function makeDockerStub(opts: {
+  ping?: () => Promise<void>;
+  // Initial set of pre-existing container names (no leading `/`).
+  containers?: string[];
+  // Initial set of pre-existing image names.
+  images?: string[];
+  // Whether the existing container is reported as Running. Used by
+  // start() to decide between start vs reuse-as-is.
+  containerRunning?: boolean;
+}) {
+  const created: Array<Record<string, unknown>> = [];
+  const startedContainers: string[] = [];
+  const stoppedContainers: string[] = [];
+  const ensuredVolumes: string[] = [];
+  const pulledImages: string[] = [];
+  const images = new Set(opts.images ?? []);
+  const containers = new Map<string, { name: string; running: boolean }>();
+  for (const name of opts.containers ?? []) {
+    containers.set(name, { name, running: opts.containerRunning ?? false });
+  }
+
+  const modem = {
+    followProgress(_stream: unknown, done: (err: Error | null) => void): void {
+      // We never feed real layer events into stream; tests don't care
+      // about progress reporting, only that the pull resolves.
+      done(null);
+    },
+  };
+
+  const docker = {
+    modem,
+    ping: opts.ping ?? (async () => {}),
+    getImage(name: string) {
+      return {
+        inspect: async () => {
+          if (!images.has(name)) {
+            const err = new Error(`no such image: ${name}`) as Error & {
+              statusCode: number;
+            };
+            err.statusCode = 404;
+            throw err;
+          }
+          return {};
+        },
+      };
+    },
+    pull(name: string, cb: (err: Error | null, stream: NodeJS.ReadableStream) => void) {
+      pulledImages.push(name);
+      images.add(name);
+      const stream = new PassThrough();
+      cb(null, stream);
+      stream.end();
+    },
+    getVolume(name: string) {
+      return {
+        inspect: async () => {
+          if (!ensuredVolumes.includes(name)) {
+            const err = new Error(`no such volume: ${name}`) as Error & {
+              statusCode: number;
+            };
+            err.statusCode = 404;
+            throw err;
+          }
+          return { Name: name };
+        },
+      };
+    },
+    async createVolume(opts: { Name: string }) {
+      ensuredVolumes.push(opts.Name);
+      return { Name: opts.Name };
+    },
+    async listContainers(_opts: unknown): Promise<Array<{ Id: string; Names: string[] }>> {
+      return Array.from(containers.values()).map((c) => ({
+        Id: c.name,
+        Names: [`/${c.name}`],
+      }));
+    },
+    async createContainer(spec: Record<string, unknown> & { name: string }) {
+      created.push(spec);
+      containers.set(spec.name, { name: spec.name, running: false });
+      return makeContainerStub(spec.name);
+    },
+    getContainer(id: string) {
+      return makeContainerStub(id);
+    },
+  };
+
+  function makeContainerStub(id: string) {
+    return {
+      id,
+      async inspect() {
+        const entry = containers.get(id);
+        return { State: { Running: entry?.running ?? false, Status: entry?.running ? 'running' : 'created' } };
+      },
+      async start() {
+        startedContainers.push(id);
+        const entry = containers.get(id);
+        if (entry) entry.running = true;
+      },
+      async stop(_opts?: { t?: number }) {
+        stoppedContainers.push(id);
+        const entry = containers.get(id);
+        if (entry) entry.running = false;
+      },
+      async exec(_spec: unknown) {
+        return new EventEmitter();
+      },
+    };
+  }
+
+  return { docker, created, startedContainers, stoppedContainers, ensuredVolumes, pulledImages };
+}
+
+test('start: pulls image, ensures volumes, creates+starts a fresh container', async () => {
+  const stub = makeDockerStub({});
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    image: 'test/runtime:latest',
+    workspaceDir: '/host/workspace',
+    bridgeUrl: 'wss://bridge.example',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await rc.start();
+  assert.deepEqual(stub.pulledImages, ['test/runtime:latest']);
+  assert.deepEqual(
+    stub.ensuredVolumes.sort(),
+    ['vicoop-agents-claude', 'vicoop-creds-claude', 'vicoop-sessions-claude'].sort(),
+  );
+  assert.equal(stub.created.length, 1);
+  assert.equal(stub.created[0].name, 'vicoop-runtime-claude');
+  const hostConfig = stub.created[0].HostConfig as {
+    Binds: string[];
+    RestartPolicy: { Name: string };
+    CapAdd: string[];
+  };
+  assert.equal(hostConfig.RestartPolicy.Name, 'unless-stopped');
+  assert.deepEqual(hostConfig.CapAdd, ['NET_ADMIN', 'NET_RAW']);
+  assert.ok(hostConfig.Binds.some((b) => b === '/host/workspace:/workspace'));
+  assert.ok(hostConfig.Binds.some((b) => b === 'vicoop-creds-claude:/data/creds/claude'));
+  assert.ok(hostConfig.Binds.some((b) => b === 'vicoop-sessions-claude:/data/sessions/claude'));
+  assert.deepEqual(stub.startedContainers, ['vicoop-runtime-claude']);
+});
+
+test('start: reuses an existing running container (no create, no start)', async () => {
+  const stub = makeDockerStub({
+    containers: ['vicoop-runtime-claude'],
+    containerRunning: true,
+    images: ['test/runtime:latest'],
+  });
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    image: 'test/runtime:latest',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await rc.start();
+  assert.equal(stub.created.length, 0);
+  assert.equal(stub.startedContainers.length, 0);
+});
+
+test('start: starts an existing stopped container', async () => {
+  const stub = makeDockerStub({
+    containers: ['vicoop-runtime-codex'],
+    containerRunning: false,
+    images: ['test/runtime:latest'],
+  });
+  const rc = new RuntimeContainer({
+    backendKind: 'codex',
+    image: 'test/runtime:latest',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await rc.start();
+  assert.equal(stub.created.length, 0);
+  assert.deepEqual(stub.startedContainers, ['vicoop-runtime-codex']);
+});
+
+test('start: docker ping failure surfaces an actionable error', async () => {
+  const stub = makeDockerStub({
+    ping: async () => {
+      throw new Error('connect ENOENT /var/run/docker.sock');
+    },
+  });
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await assert.rejects(rc.start(), /docker daemon is not reachable/);
+});
+
+test('stop: calls container.stop and tolerates 304 already-stopped', async () => {
+  const stub = makeDockerStub({
+    containers: ['vicoop-runtime-claude'],
+    containerRunning: true,
+    images: ['test/runtime:latest'],
+  });
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    image: 'test/runtime:latest',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await rc.start();
+  await rc.stop();
+  assert.deepEqual(stub.stoppedContainers, ['vicoop-runtime-claude']);
+});
+
+test('Env carries VICOOP_BRIDGE_URL and optional skip-firewall toggle', async () => {
+  const stub = makeDockerStub({});
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    image: 'test/runtime:latest',
+    bridgeUrl: 'wss://bridge.example',
+    skipFirewall: true,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    docker: stub.docker as any,
+  });
+  await rc.start();
+  const env = (stub.created[0].Env ?? []) as string[];
+  assert.ok(env.includes('VICOOP_BRIDGE_URL=wss://bridge.example'));
+  assert.ok(env.includes('VICOOP_SKIP_FIREWALL=1'));
+});

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
-import { RuntimeContainer } from './runtime-container.js';
+import { RuntimeContainer, resolveDockerOptions } from './runtime-container.js';
 
 // Minimal dockerode-compatible stub. Records what was called so the
 // tests can assert lifecycle behavior (volumes ensured, container
@@ -214,6 +214,14 @@ test('stop: calls container.stop and tolerates 304 already-stopped', async () =>
   await rc.start();
   await rc.stop();
   assert.deepEqual(stub.stoppedContainers, ['vicoop-runtime-claude']);
+});
+
+test('resolveDockerOptions: defers to dockerode when DOCKER_HOST is set', () => {
+  // When the operator (or systemd unit) already exports DOCKER_HOST,
+  // returning undefined lets dockerode parse it itself — we don't
+  // want our context-file resolver to fight a fully-explicit env.
+  const opts = resolveDockerOptions({ DOCKER_HOST: 'tcp://example:2375' });
+  assert.equal(opts, undefined);
 });
 
 test('Env carries VICOOP_BRIDGE_URL and optional skip-firewall toggle', async () => {

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -24,8 +24,12 @@
 // `vicoop-runtime-<kind>` shape keeps it human-readable and easy to
 // `docker exec` / `docker logs` into from the host.
 
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import Docker from 'dockerode';
-import type { Container, ContainerInspectInfo, Exec } from 'dockerode';
+import type { Container, ContainerInspectInfo, DockerOptions, Exec } from 'dockerode';
 import { createLogger, type Logger } from './logger.js';
 
 export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest';
@@ -83,7 +87,7 @@ export class RuntimeContainer {
     // (unix:///var/run/docker.sock on linux/mac). We don't pass an
     // explicit socket path so DOCKER_HOST env still wins for operators
     // running rootless / podman-with-docker-shim.
-    this.docker = opts.docker ?? new Docker();
+    this.docker = opts.docker ?? new Docker(resolveDockerOptions());
     this.log = opts.logger ?? createLogger();
   }
 
@@ -304,4 +308,74 @@ function sleep(ms: number): Promise<void> {
 
 function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
+}
+
+// Pick the socket / TCP host dockerode should connect to.
+//
+// dockerode's zero-arg constructor honors $DOCKER_HOST and otherwise
+// falls back to `/var/run/docker.sock`. That misses the common macOS
+// reality where colima / orbstack / rancher-desktop publish their
+// socket somewhere under $HOME and rely on `docker context` to wire
+// the CLI. dockerode doesn't read docker contexts itself, so without
+// this resolver every container-mode bridge client on those setups
+// would fail with `ENOENT /var/run/docker.sock`.
+//
+// Precedence:
+//   1. $DOCKER_HOST  -> return undefined; dockerode parses it.
+//   2. `currentContext` from ~/.docker/config.json -> read its
+//      meta.json's Endpoints.docker.Host (unix:// or tcp://).
+//   3. anything we don't recognize -> return undefined and let
+//      dockerode use its default.
+//
+// Exported so unit tests can exercise it without spinning up a real
+// daemon connection.
+export function resolveDockerOptions(env: NodeJS.ProcessEnv = process.env): DockerOptions | undefined {
+  if (env.DOCKER_HOST) return undefined;
+
+  const home = homedir();
+  const configPath = join(home, '.docker', 'config.json');
+  if (!existsSync(configPath)) return undefined;
+
+  let currentContext: string;
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    currentContext = typeof config.currentContext === 'string' ? config.currentContext : 'default';
+  } catch {
+    return undefined;
+  }
+  if (!currentContext || currentContext === 'default') return undefined;
+
+  // docker stores per-context metadata under a sha256-of-context-name
+  // directory. The format is stable enough to lean on directly; the
+  // alternative (shelling out to `docker context inspect`) would
+  // defeat the point of using a programmatic API.
+  const hash = createHash('sha256').update(currentContext).digest('hex');
+  const metaPath = join(home, '.docker', 'contexts', 'meta', hash, 'meta.json');
+  if (!existsSync(metaPath)) return undefined;
+
+  let host: unknown;
+  try {
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
+    host = meta?.Endpoints?.docker?.Host;
+  } catch {
+    return undefined;
+  }
+  if (typeof host !== 'string') return undefined;
+
+  if (host.startsWith('unix://')) {
+    return { socketPath: host.slice('unix://'.length) };
+  }
+  if (host.startsWith('tcp://')) {
+    try {
+      const url = new URL(host);
+      return {
+        host: url.hostname,
+        port: Number(url.port) || 2375,
+        protocol: url.protocol === 'https:' ? 'https' : 'http',
+      };
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
 }

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -1,0 +1,307 @@
+// Lifecycle wrapper around the external-runtime container (#249).
+//
+// One RuntimeContainer instance owns one long-lived Docker container —
+// per-backend (claude / codex / …), per-bridge-client process. Wiring:
+//
+//   bridge client startup
+//     → pickBackend (cli.ts) decides runtime = 'container'
+//       → new RuntimeContainer({ backendKind, ... }).start()
+//         - pings docker daemon (Decision §6)
+//         - ensures named volumes exist (creds, sessions)
+//         - looks for an existing container by canonical name; reuses
+//           if found, otherwise pulls the image and creates a new one
+//         - starts the container (firewall + sleep infinity from
+//           container/runtime/entrypoint.sh in PR A)
+//       → wires a docker-exec SpawnAdapter (spawn-adapter.ts) into the
+//         backend factory; backend sees a normal SpawnFn signature
+//   bridge client shutdown
+//     → backend.stop() → runtime.stop() fire-and-forget
+//       (docker --restart unless-stopped will not auto-restart after
+//       an explicit `docker stop`, matching expected operator UX)
+//
+// Containers are intentionally named so a daemon restart finds the
+// previous container instead of leaving orphans behind. The
+// `vicoop-runtime-<kind>` shape keeps it human-readable and easy to
+// `docker exec` / `docker logs` into from the host.
+
+import Docker from 'dockerode';
+import type { Container, ContainerInspectInfo, Exec } from 'dockerode';
+import { createLogger, type Logger } from './logger.js';
+
+export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest';
+
+export interface RuntimeContainerOptions {
+  // Which backend this container hosts. Used in the canonical
+  // container/volume names so claude and codex get isolated runtimes.
+  backendKind: string;
+  // OCI image to run. Defaults to DEFAULT_RUNTIME_IMAGE; env override
+  // `VICOOP_RUNTIME_IMAGE` is resolved by the caller (cli.ts) so this
+  // module stays env-clean.
+  image?: string;
+  // Host directory bind-mounted as the agent's workspace at /workspace.
+  // Optional — `claude --cwd` and `codex --cwd` can also point inside
+  // the container's /workspace once we land per-context branching
+  // (separate issue).
+  workspaceDir?: string;
+  // Bridge WS URL forwarded into the container so init-firewall.sh's
+  // outbound allowlist resolves the same host the bridge client speaks
+  // to.
+  bridgeUrl?: string;
+  // Skip the in-container firewall init. Mostly a dev / CI escape
+  // hatch; production runs should leave this off and pass NET_ADMIN.
+  skipFirewall?: boolean;
+  logger?: Logger;
+  // Test seam — inject a stub Docker client so unit tests don't need
+  // a live daemon.
+  docker?: Docker;
+}
+
+function containerName(kind: string): string {
+  return `vicoop-runtime-${kind}`;
+}
+function credsVolumeName(kind: string): string {
+  return `vicoop-creds-${kind}`;
+}
+function sessionsVolumeName(kind: string): string {
+  return `vicoop-sessions-${kind}`;
+}
+
+export class RuntimeContainer {
+  private readonly docker: Docker;
+  private readonly opts: Required<Pick<RuntimeContainerOptions, 'backendKind' | 'image'>> &
+    RuntimeContainerOptions;
+  private readonly log: Logger;
+  private container?: Container;
+  private started = false;
+
+  constructor(opts: RuntimeContainerOptions) {
+    this.opts = {
+      ...opts,
+      image: opts.image ?? DEFAULT_RUNTIME_IMAGE,
+    };
+    // dockerode's zero-arg constructor picks the platform default
+    // (unix:///var/run/docker.sock on linux/mac). We don't pass an
+    // explicit socket path so DOCKER_HOST env still wins for operators
+    // running rootless / podman-with-docker-shim.
+    this.docker = opts.docker ?? new Docker();
+    this.log = opts.logger ?? createLogger();
+  }
+
+  // Boots the runtime container, blocking until it's running. Resolves
+  // with no value; on any failure throws — callers should let the
+  // exception propagate so the daemon exits with a clear error rather
+  // than degrade silently.
+  async start(): Promise<void> {
+    await this.ensureDaemonReachable();
+    await this.ensureImage();
+    await this.ensureVolumes();
+
+    const name = containerName(this.opts.backendKind);
+    const existing = await this.findContainerByName(name);
+    if (existing) {
+      // Reuse path: a previous bridge-client process (or a manual
+      // operator run) left a container with the same canonical name.
+      // We inspect first to decide whether to just start it or
+      // re-create — re-create only when something runtime-affecting
+      // (image, mounts) drifted, which we keep out of scope for PR B.
+      // Today: reuse and start if stopped.
+      this.container = this.docker.getContainer(existing.Id);
+      const info = await this.container.inspect();
+      if (!info.State.Running) {
+        this.log.info(`runtime container '${name}' exists but stopped — starting`);
+        await this.container.start();
+      } else {
+        this.log.info(`runtime container '${name}' already running — reusing`);
+      }
+    } else {
+      this.container = await this.createContainer(name);
+      await this.container.start();
+      this.log.info(`runtime container '${name}' created and started`);
+    }
+
+    await this.waitUntilRunning();
+    this.started = true;
+  }
+
+  // Run a one-shot command inside the long-lived runtime container.
+  // Returns the dockerode Exec handle; the caller (spawn-adapter)
+  // wires its stream into the ChildHandle the backends consume.
+  async exec(opts: {
+    command: string;
+    args: readonly string[];
+    cwd?: string;
+    env?: readonly string[];
+  }): Promise<Exec> {
+    if (!this.started || !this.container) {
+      throw new Error('runtime container not started');
+    }
+    return this.container.exec({
+      Cmd: [opts.command, ...opts.args],
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: false,
+      ...(opts.cwd ? { WorkingDir: opts.cwd } : {}),
+      ...(opts.env && opts.env.length > 0 ? { Env: [...opts.env] } : {}),
+    });
+  }
+
+  // Best-effort container stop. Fire-and-forget from backend.stop()
+  // (which is sync); errors are logged but do not propagate so a
+  // mid-shutdown daemon never blocks on docker.
+  async stop(): Promise<void> {
+    if (!this.container) return;
+    try {
+      await this.container.stop({ t: 10 });
+      this.log.info(`runtime container '${containerName(this.opts.backendKind)}' stopped`);
+    } catch (err) {
+      // 304 = already stopped; not an error
+      const status = (err as { statusCode?: number }).statusCode;
+      if (status !== 304) {
+        this.log.warn(`runtime container stop failed: ${errorMessage(err)}`);
+      }
+    }
+  }
+
+  // Expose the underlying dockerode handles so spawn-adapter can call
+  // exec / inspect without re-implementing them. Internal use only.
+  getDocker(): Docker {
+    return this.docker;
+  }
+  getContainer(): Container {
+    if (!this.container) throw new Error('runtime container not started');
+    return this.container;
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  private async ensureDaemonReachable(): Promise<void> {
+    try {
+      await this.docker.ping();
+    } catch (err) {
+      throw new Error(
+        `docker daemon is not reachable (${errorMessage(err)}). ` +
+          `The container runtime profile (#249) requires a local docker daemon. ` +
+          `Switch to runtime: 'host' for this backend, or start docker and retry.`,
+      );
+    }
+  }
+
+  private async ensureImage(): Promise<void> {
+    const image = this.opts.image;
+    try {
+      await this.docker.getImage(image).inspect();
+      return;
+    } catch (err) {
+      const status = (err as { statusCode?: number }).statusCode;
+      if (status !== 404) throw err;
+    }
+    this.log.info(`pulling runtime image ${image}`);
+    await new Promise<void>((resolve, reject) => {
+      this.docker.pull(image, (err: Error | null, stream: NodeJS.ReadableStream) => {
+        if (err) return reject(err);
+        // followProgress drains the pull stream; we don't surface
+        // layer-level progress (would spam logs for a 200MB image).
+        this.docker.modem.followProgress(stream, (finishErr: Error | null) => {
+          if (finishErr) reject(finishErr);
+          else resolve();
+        });
+      });
+    });
+  }
+
+  private async ensureVolumes(): Promise<void> {
+    const names = [
+      credsVolumeName(this.opts.backendKind),
+      sessionsVolumeName(this.opts.backendKind),
+      // The agents/<kind> tree lives in its own named volume too so
+      // install-backend.sh's installs survive container re-creation.
+      `vicoop-agents-${this.opts.backendKind}`,
+    ];
+    for (const name of names) {
+      try {
+        await this.docker.getVolume(name).inspect();
+      } catch (err) {
+        const status = (err as { statusCode?: number }).statusCode;
+        if (status !== 404) throw err;
+        await this.docker.createVolume({ Name: name, Labels: { 'vicoop.kind': this.opts.backendKind } });
+        this.log.info(`created named volume '${name}'`);
+      }
+    }
+  }
+
+  private async findContainerByName(name: string): Promise<{ Id: string } | undefined> {
+    const list = await this.docker.listContainers({
+      all: true,
+      filters: { name: [name] },
+    });
+    // listContainers returns names prefixed with "/" — match the bare
+    // name to avoid false positives on substrings.
+    const hit = list.find((c) => c.Names.some((n) => n === `/${name}` || n === name));
+    return hit ? { Id: hit.Id } : undefined;
+  }
+
+  private async createContainer(name: string): Promise<Container> {
+    const kind = this.opts.backendKind;
+    const env: string[] = [];
+    if (this.opts.bridgeUrl) env.push(`VICOOP_BRIDGE_URL=${this.opts.bridgeUrl}`);
+    if (this.opts.skipFirewall) env.push('VICOOP_SKIP_FIREWALL=1');
+
+    const binds: string[] = [
+      // Per-kind named volumes — keeps the bridge-client-driven
+      // /data/agents/<kind>, /data/creds/<kind>, /data/sessions/<kind>
+      // persistent across container re-creation. Decisions §4, §5.
+      `vicoop-agents-${kind}:/data/agents/${kind}`,
+      `${credsVolumeName(kind)}:/data/creds/${kind}`,
+      `${sessionsVolumeName(kind)}:/data/sessions/${kind}`,
+    ];
+    if (this.opts.workspaceDir) {
+      // Workspace as a host bind-mount. Per-context branching
+      // (a different workspace per task) is intentionally out of
+      // scope for this PR — see #249's non-goals.
+      binds.push(`${this.opts.workspaceDir}:/workspace`);
+    }
+
+    return this.docker.createContainer({
+      name,
+      Image: this.opts.image,
+      Env: env,
+      Labels: { 'vicoop.kind': kind },
+      HostConfig: {
+        Binds: binds,
+        // Decision §2 — daemon-side belt to the bridge-client's
+        // health-check braces.
+        RestartPolicy: { Name: 'unless-stopped' },
+        // NET_ADMIN / NET_RAW let init-firewall.sh program iptables
+        // inside the container. Without them the entrypoint logs a
+        // warning and skips the allowlist; we add them by default so
+        // outbound isolation is on out of the box.
+        CapAdd: ['NET_ADMIN', 'NET_RAW'],
+      },
+    });
+  }
+
+  private async waitUntilRunning(): Promise<void> {
+    if (!this.container) throw new Error('runtime container not started');
+    const start = Date.now();
+    const timeoutMs = 10_000;
+    while (Date.now() - start < timeoutMs) {
+      const info: ContainerInspectInfo = await this.container.inspect();
+      if (info.State.Running) return;
+      if (info.State.Status === 'exited' || info.State.Status === 'dead') {
+        throw new Error(
+          `runtime container entered terminal state '${info.State.Status}' before becoming ready`,
+        );
+      }
+      await sleep(200);
+    }
+    throw new Error(`runtime container did not become ready within ${timeoutMs}ms`);
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/packages/client/src/spawn-adapter.test.ts
+++ b/packages/client/src/spawn-adapter.test.ts
@@ -1,0 +1,99 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { createDockerExecSpawn } from './spawn-adapter.js';
+
+// Stub RuntimeContainer surface that spawn-adapter consumes:
+// only `exec()` (returns an Exec-like) and `getDocker()` (whose
+// `modem.demuxStream` splits the duplex stream into stdout/stderr).
+function makeRuntimeStub(opts: {
+  execScript?: (stream: PassThrough) => void;
+  exitCode?: number | null;
+  execStartShouldThrow?: boolean;
+}) {
+  const stream = new PassThrough();
+  const execEvents = new EventEmitter();
+  const exec = {
+    async start(_opts: { hijack: boolean; stdin: boolean }) {
+      if (opts.execStartShouldThrow) throw new Error('exec failed to start');
+      // Schedule the script to run after the consumer wires
+      // listeners (microtask boundary). Simulates the real docker
+      // hijack stream pushing data after start resolves.
+      queueMicrotask(() => opts.execScript?.(stream));
+      return stream;
+    },
+    async inspect() {
+      return { ExitCode: opts.exitCode ?? 0 };
+    },
+  };
+  const recordedCmds: Array<{ command: string; args: readonly string[] }> = [];
+  const runtime = {
+    async exec(spec: { command: string; args: readonly string[]; cwd?: string }) {
+      recordedCmds.push({ command: spec.command, args: spec.args });
+      return exec;
+    },
+    getDocker() {
+      return {
+        modem: {
+          demuxStream(src: PassThrough, stdout: PassThrough, stderr: PassThrough) {
+            // Trivial demux: forward all data to stdout. Tests that
+            // care about stderr can write a multiplex-like marker
+            // themselves; the real dockerode protocol's framing is
+            // out of scope for unit tests.
+            src.on('data', (chunk) => stdout.write(chunk));
+            src.on('end', () => {
+              stdout.end();
+              stderr.end();
+            });
+          },
+        },
+      };
+    },
+  };
+  return { runtime, stream, exec, execEvents, recordedCmds };
+}
+
+test('docker-exec spawn: emits close with the exec exit code after stream ends', async () => {
+  const stub = makeRuntimeStub({
+    execScript: (stream) => {
+      stream.write('hello\n');
+      stream.end();
+    },
+    exitCode: 0,
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spawn = createDockerExecSpawn(stub.runtime as any);
+  const child = spawn('claude', ['--version'], {});
+
+  const collected: Buffer[] = [];
+  child.stdout?.on('data', (chunk: Buffer) => collected.push(chunk));
+
+  const exit = await new Promise<{ code: number | null }>((resolve) => {
+    child.on('close', (code) => resolve({ code }));
+  });
+  assert.equal(exit.code, 0);
+  assert.equal(Buffer.concat(collected).toString(), 'hello\n');
+  assert.deepEqual(stub.recordedCmds, [{ command: 'claude', args: ['--version'] }]);
+});
+
+test('docker-exec spawn: surfaces start failures as the child error event', async () => {
+  const stub = makeRuntimeStub({ execStartShouldThrow: true });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spawn = createDockerExecSpawn(stub.runtime as any);
+  const child = spawn('claude', [], {});
+  const err = await new Promise<Error>((resolve) => {
+    child.on('error', (e) => resolve(e));
+  });
+  assert.match(err.message, /exec failed to start/);
+});
+
+test('docker-exec spawn: kill() ends stdin and is idempotent', async () => {
+  const stub = makeRuntimeStub({ execScript: () => {}, exitCode: 137 });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spawn = createDockerExecSpawn(stub.runtime as any);
+  const child = spawn('codex', ['app-server'], {});
+  // First kill returns true, second returns false (already killed).
+  assert.equal(child.kill('SIGTERM'), true);
+  assert.equal(child.kill('SIGTERM'), false);
+});

--- a/packages/client/src/spawn-adapter.ts
+++ b/packages/client/src/spawn-adapter.ts
@@ -1,0 +1,173 @@
+// Spawn-time indirection for the external-runtime profile (#249).
+//
+// Both ClaudeSpawnFn (backends/claude.ts) and AppServerSpawnFn
+// (backends/codex-rpc.ts) share the same structural shape:
+//
+//   (command, args, { cwd? }) => ChildHandle
+//
+// where ChildHandle is the slim subset of child_process.ChildProcess
+// that the backends actually consume (stdin / stdout / stderr / kill /
+// on('close'|'error', ...)). Because the two ChildHandle interfaces
+// are structurally identical, a single SpawnFn satisfies both — we
+// don't need two parallel adapter trees.
+//
+// Two implementations:
+//
+//   - createHostSpawn(): the existing behavior (node:child_process.spawn).
+//     Used when `backends.<kind>.runtime === 'host'` (the default).
+//   - createDockerExecSpawn(runtime): runs the same command inside a
+//     long-lived RuntimeContainer via `docker exec`. Returns a
+//     ChildHandle that bridges PassThrough streams to the dockerode
+//     exec stream — close / error events fire when the remote exec
+//     finishes, mirroring what backends expect from a real subprocess.
+
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { spawn as nodeSpawn } from 'node:child_process';
+import type { Duplex } from 'node:stream';
+import type { Exec } from 'dockerode';
+import type { RuntimeContainer } from './runtime-container.js';
+
+// Same shape as ClaudeChildHandle / AppServerChildHandle. We keep the
+// definition here (instead of importing one of them) so spawn-adapter
+// doesn't introduce a circular dependency back into backends/, and so
+// it's obvious from the file alone what the contract is.
+export interface ChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
+  readonly stdout: NodeJS.ReadableStream | null;
+  readonly stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface SpawnOptions {
+  cwd?: string;
+}
+
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildHandle;
+
+// Host implementation. Identical to the per-backend defaultSpawn
+// today, exposed here so call sites can always go through the adapter
+// indirection regardless of mode.
+export function createHostSpawn(): SpawnFn {
+  return (command, args, options) =>
+    nodeSpawn(command, Array.from(args), {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+    }) as unknown as ChildHandle;
+}
+
+// docker-exec implementation. Each call starts a fresh `docker exec`
+// inside the long-lived runtime container; the returned ChildHandle's
+// streams are wired to the demuxed exec stream and close events fire
+// when the remote process exits (inspect.ExitCode then propagates as
+// the `close` listener's `code`).
+//
+// `kill` is best-effort: dockerode exec has no direct signal channel.
+// We close stdin and unpipe streams; if the agent process honors EOF
+// on stdin (claude / codex both do for app-server-style protocols)
+// it exits promptly. Hard kill via `container.exec(['kill', '-9', pid])`
+// is out of scope for this PR — a separate issue if cancel-during-task
+// proves laggy in practice.
+export function createDockerExecSpawn(runtime: RuntimeContainer): SpawnFn {
+  return (command, args, options) => makeDockerExecHandle(runtime, command, args, options);
+}
+
+function makeDockerExecHandle(
+  runtime: RuntimeContainer,
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+): ChildHandle {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const events = new EventEmitter();
+  let killed = false;
+  let execHandle: Exec | undefined;
+  let stream: Duplex | undefined;
+
+  // Async setup: build the exec, then wire the stream. Any failure
+  // surfaces as a synthetic 'error' event so the backend's existing
+  // child.on('error', ...) handler runs unchanged.
+  void (async () => {
+    try {
+      execHandle = await runtime.exec({
+        command,
+        args,
+        cwd: options.cwd,
+      });
+      // hijack + stdin: returns a duplex stream we can write stdin to
+      // and read multiplexed stdout/stderr from.
+      stream = (await execHandle.start({
+        hijack: true,
+        stdin: true,
+      })) as unknown as Duplex;
+
+      // demuxStream splits the multiplexed docker stream into stdout
+      // and stderr targets. We pass our PassThroughs so consumers (the
+      // backends) see independent stdout / stderr like real child
+      // processes do.
+      runtime.getDocker().modem.demuxStream(stream, stdout, stderr);
+
+      // Forward host-side stdin into the container.
+      stdin.pipe(stream);
+
+      stream.on('end', () => {
+        // Resolve the exit code via inspect once the stream closes.
+        // `inspect()` after end is reliable in dockerode; before it,
+        // ExitCode is null.
+        void (async () => {
+          let code: number | null = null;
+          try {
+            const info = await execHandle?.inspect();
+            code = info?.ExitCode ?? null;
+          } catch {
+            // Ignore — we still need to emit close so the backend's
+            // close handler runs and the task settles.
+          }
+          stdout.end();
+          stderr.end();
+          events.emit('close', code, null);
+        })();
+      });
+      stream.on('error', (err) => events.emit('error', err));
+    } catch (err) {
+      stdout.end();
+      stderr.end();
+      events.emit('error', err instanceof Error ? err : new Error(String(err)));
+    }
+  })();
+
+  return {
+    stdin,
+    stdout,
+    stderr,
+    kill(_signal) {
+      if (killed) return false;
+      killed = true;
+      // Best-effort: close stdin so an EOF-aware agent shuts down,
+      // and forcibly close the docker stream. No signal channel
+      // available through dockerode exec.
+      try {
+        stdin.end();
+      } catch {
+        // ignore
+      }
+      try {
+        stream?.destroy();
+      } catch {
+        // ignore
+      }
+      return true;
+    },
+    on(event, listener) {
+      events.on(event, listener as (...a: unknown[]) => void);
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
+      dockerode:
+        specifier: ^5.0.0
+        version: 5.0.0
       ws:
         specifier: ^8.18.0
         version: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -100,6 +103,9 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
+      '@types/dockerode':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/ws':
         specifier: ^8.5.13
         version: 8.18.1
@@ -314,6 +320,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@base-org/account@2.4.0':
     resolution: {integrity: sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==}
@@ -728,6 +737,20 @@ packages:
     resolution: {integrity: sha512-Fakuk190EAKxWSa9YQyr/87g8mvAv8HBvk6yPCPuIoA3bYXF7n6kl0XSqKjSd5VfjEqhtnzQ6zJGzDf1Gv/tJg==}
     engines: {node: '>=8.6'}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -758,6 +781,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
@@ -942,6 +968,36 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rainbow-me/rainbowkit@2.2.10':
     resolution: {integrity: sha512-8+E4die1A2ovN9t3lWxWnwqTGEdFqThXDQRj+E4eDKuUKyymYD+66Gzm6S9yfg8E95c6hmGlavGUfYPtl1EagA==}
@@ -1667,6 +1723,12 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1703,6 +1765,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -1731,6 +1796,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1995,6 +2063,9 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
 
@@ -2034,6 +2105,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2043,6 +2117,9 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -2073,12 +2150,19 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2136,8 +2220,15 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -2202,6 +2293,10 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -2367,6 +2462,14 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@5.0.0:
+    resolution: {integrity: sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==}
+    engines: {node: '>= 14.17'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2618,6 +2721,9 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -3063,6 +3169,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -3089,6 +3198,9 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3303,6 +3415,9 @@ packages:
       typescript:
         optional: true
 
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
@@ -3321,6 +3436,9 @@ packages:
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
+  nan@2.27.0:
+    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3660,6 +3778,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  protobufjs@7.6.0:
+    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -3954,6 +4076,9 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
@@ -3964,6 +4089,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -4032,6 +4161,13 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -4075,6 +4211,9 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -4104,6 +4243,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -4382,6 +4524,10 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4459,6 +4605,10 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
@@ -4469,9 +4619,17 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4699,6 +4857,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -5114,6 +5274,25 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.0
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.0
+      yargs: 17.7.2
+
   '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -5143,6 +5322,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
@@ -5432,6 +5613,28 @@ snapshots:
       '@optique/core': 1.0.2
 
   '@paulmillr/qr@0.2.1': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
@@ -6657,6 +6860,17 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 22.19.17
+      '@types/ssh2': 1.15.5
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6699,6 +6913,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -6733,6 +6951,10 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.17
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/trusted-types@2.0.7': {}
 
@@ -7580,6 +7802,10 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   async-mutex@0.2.6:
     dependencies:
       tslib: 2.7.0
@@ -7615,6 +7841,10 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -7622,6 +7852,12 @@ snapshots:
   big.js@6.2.2: {}
 
   bignumber.js@9.3.1: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   bn.js@5.2.3: {}
 
@@ -7676,6 +7912,11 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -7684,6 +7925,9 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
+
+  buildcheck@0.0.7:
+    optional: true
 
   bytes@3.1.2: {}
 
@@ -7734,11 +7978,19 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chownr@1.1.4: {}
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@1.2.1: {}
 
@@ -7784,6 +8036,12 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.27.0
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -7904,6 +8162,26 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@5.0.0:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.0
+      tar-fs: 2.1.4
+    transitivePeerDependencies:
+      - supports-color
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8250,6 +8528,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -8725,6 +9005,8 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -8742,6 +9024,8 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.18.1: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -9155,6 +9439,8 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  mkdirp-classic@0.5.3: {}
+
   modern-ahocorasick@1.1.0: {}
 
   mri@1.2.0: {}
@@ -9166,6 +9452,9 @@ snapshots:
   ms@2.1.3: {}
 
   multiformats@9.9.0: {}
+
+  nan@2.27.0:
+    optional: true
 
   nanoid@3.3.11: {}
 
@@ -9544,6 +9833,21 @@ snapshots:
   process-warning@1.0.0: {}
 
   property-information@7.1.0: {}
+
+  protobufjs@7.6.0:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -9930,11 +10234,21 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split-ca@1.0.1: {}
+
   split-on-first@1.1.0: {}
 
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.27.0
 
   statuses@1.5.0: {}
 
@@ -10001,6 +10315,21 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   term-size@2.2.1: {}
 
   thread-stream@0.15.2:
@@ -10041,6 +10370,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tweetnacl@0.14.5: {}
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -10069,6 +10400,8 @@ snapshots:
       multiformats: 9.9.0
 
   uncrypto@0.1.3: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
 
@@ -10397,6 +10730,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
@@ -10537,6 +10876,8 @@ snapshots:
 
   y18n@4.0.3: {}
 
+  y18n@5.0.8: {}
+
   yallist@2.1.2: {}
 
   yallist@3.1.1: {}
@@ -10545,6 +10886,8 @@ snapshots:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
+
+  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -10559,6 +10902,16 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

- Bridge-client side of the external-runtime profile that PR #251
  (#249 PR A) seeded the image for. `claude` and `codex` backends gain
  a `runtime: 'host' | 'container'` option — config field and matching
  `--claude-runtime` / `--codex-runtime` flags. Default stays `'host'`,
  so existing installs are unaffected.
- `RuntimeContainer` (`packages/client/src/runtime-container.ts`)
  owns per-backend lifecycle: docker daemon ping (no-fallback per
  Decision §6), image pull from `ghcr.io/planetarium/vicoop-runtime`
  (override via `VICOOP_RUNTIME_IMAGE`), named-volume provisioning for
  agents / creds / sessions (Decisions §4 + §5), container create with
  `--restart unless-stopped` + `NET_ADMIN`/`NET_RAW`, reuse of an
  existing container on bridge-client restart, explicit stop on
  shutdown.
- `SpawnAdapter` (`packages/client/src/spawn-adapter.ts`) wraps a host
  `child_process.spawn` implementation and a docker-exec
  implementation in a single `SpawnFn` signature that structurally
  satisfies the existing `ClaudeSpawnFn` / `AppServerSpawnFn`. Backend
  internals stay unaware of which mode they're running in.
- `pickBackend()` is now async and routes `claude` / `codex` through
  `resolveRuntime()`, which boots a `RuntimeContainer` in container
  mode and injects a docker-exec spawn into the factory. Backend
  `stop()` is wrapped so an orderly shutdown also stops the runtime
  container.
- `dockerode` (+ `@types/dockerode`) are new client deps (Decision §1).

## Decisions reflected from #249

- §1 dockerode (programmatic API, not shell-out).
- §2 `--restart unless-stopped` + bridge-client reuse on restart.
- §3 Per-backend long-lived only; no per-context runtime.
- §4 Creds isolated in a container-only named volume — the host's
  `~/.claude` is never bind-mounted in.
- §5 Sessions volume mounted into the container so claude/codex
  session resume survives container re-creation.
- §6 No docker daemon → explicit error from `RuntimeContainer.start()`
  with an actionable hint, no fallback.
- §8 Backend kind stays the externally-visible capability identifier;
  runtime mode is its own field, and backend implementations don't
  observe it.

## Out of scope (separate work, called out in #249)

- Per-context workspace branching (current host bind-mount is whole).
- `vicoop-client backend init` operator-UX subcommand (PR C of #249).
- Bundled-direct image publishing (still off per #250).

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 479 → 488 (9 new),
      no regressions across the existing claude / codex / openclaw
      / client suites
- [x] New `runtime-container.test.ts` covers: fresh-start (pull +
      volumes + create + start), reuse of an existing running
      container, restart of an existing stopped container, daemon
      ping failure, stop with 304 tolerance, env propagation
      (`VICOOP_BRIDGE_URL`, `VICOOP_SKIP_FIREWALL`)
- [x] New `spawn-adapter.test.ts` covers: docker-exec stream + close
      with exit code, error surfaced as the child's `error` event when
      exec.start fails, idempotent `kill()`
- [ ] Manual: against a real docker daemon, `--claude-runtime
      container` boots a `vicoop-runtime-claude` container, runs a
      task, and the container survives a bridge-client crash (reused
      on restart). Will exercise once #251's image lands on GHCR.
- [ ] (Follow-up in PR C) `vicoop-client backend init` operator UX
      wrapping the container-mode bootstrap (`docker exec
      install-backend.sh` + OAuth) end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)