### PR TITLE
fix(client): route win32 child_process.spawn through shell for .cmd shims

### DIFF
--- a/packages/client/src/backends/codex-rpc.ts
+++ b/packages/client/src/backends/codex-rpc.ts
@@ -28,8 +28,16 @@ export type AppServerSpawnFn = (
 ) => AppServerChildHandle;
 
 // Default spawn — node:child_process.spawn cast to our minimal surface.
+// On Windows the `codex` bin lands as a `.cmd` shim; bare `spawn` without
+// `shell:true` fails with ENOENT on the shim. Route through the shell on
+// win32. `command`/`args` are module-internal — no operator-supplied
+// tokens enter the argv.
 export const defaultAppServerSpawn: AppServerSpawnFn = (command, args, options) =>
-  nodeSpawn(command, args, { cwd: options.cwd, stdio: ['pipe', 'pipe', 'pipe'] }) as unknown as AppServerChildHandle;
+  nodeSpawn(command, args, {
+    cwd: options.cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
+  }) as unknown as AppServerChildHandle;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Narrow typed views of the app-server protocol. We do NOT pull in the 81

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -326,8 +326,14 @@ function defaultSpawn(
   args: readonly string[],
   options: VicoopCodexSpawnOptions,
 ): VicoopCodexChildHandle {
+  // On Windows npm installs the `vicoop-codex` bin as a `.cmd` shim; bare
+  // `spawn('vicoop-codex', …)` without `shell:true` doesn't pick up the
+  // extension and fails with ENOENT. Route through the shell on win32 so
+  // the shim resolves. Safe here because `command` and `args` are fully
+  // determined by this module — no user-supplied tokens enter the argv.
   return nodeSpawn(command, Array.from(args), {
     stdio: ['pipe', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
     ...(options.cwd ? { cwd: options.cwd } : {}),
   }) as ChildProcess;
 }


### PR DESCRIPTION
## Summary

- `node:child_process.spawn('vicoop-codex', …)` and `spawn('codex', …)` fail with `ENOENT` on Windows because npm installs those bins as `.cmd` shims that Node cannot resolve directly.
- Set `shell: process.platform === 'win32'` in both `defaultSpawn` (vicoop-codex backend) and `defaultAppServerSpawn` (codex app-server RPC). POSIX hosts keep `shell: false`.

## Repro (Windows host, prior behavior)

```text
backend.start taskId=… backend=vicoop-codex
…
task.fail code=spawn_failed message="failed to spawn vicoop-codex: spawn vicoop-codex ENOENT"
```

After the patch the same daemon completes the task end-to-end against the published `@vicoop-bridge/client@0.19.1` Windows install (Node 22).

## Safety

`command` and `args` are fully module-internal (`'vicoop-codex' / ['call']` and `'codex' / ['app-server']`); no operator-supplied tokens enter the argv, so the well-known `shell:true` argument-escaping warning is a non-issue here.

## Test plan

- [x] Manual e2e on Windows: `vicoop-client --backend vicoop-codex` daemon receives an A2A task, spawns `vicoop-codex call`, returns a valid Chat Completions response (verified via `apps/web-vicoop-test` → a2x-internal-router → bridge → daemon).
- [ ] CI (existing unit tests cover the spawn injection seam via `spawn?` test override; behavior unchanged on POSIX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)