### PR TITLE
ci: release-bundled workflow — restart bundled image publish (#244)

### DIFF
--- a/.changeset/release-bundled-image.md
+++ b/.changeset/release-bundled-image.md
@@ -1,0 +1,26 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Restart the bundled-direct image publish (#244). Adds
+`.github/workflows/release-bundled.yml` so `container/bundled/`'s
+Dockerfile rebuilds and pushes to
+`ghcr.io/planetarium/vicoop-bridge-client` whenever its inputs
+change — paths filter covers `container/bundled/**`, the shared
+`container/` scripts, and the bridge-client source (the image
+embeds the bun-compiled `vicoop-client` binary).
+
+Companion to PR A's `release-runtime.yml` (#249); the two image
+families now have their own workflows so the changesets/action
+release for the npm artifact stays independent of either image's
+publish schedule. PR #250 removed the in-line bundled push from
+`release.yml` precisely so a separate workflow could own it.
+
+No bridge-client behavior change — the image artifact was the only
+missing piece between the bundled code on disk (landed in #245,
+reorganized in #250) and operators being able to
+`docker pull ghcr.io/planetarium/vicoop-bridge-client` again.
+
+`VICOOP_BRIDGE_IMAGE` build-arg is stamped with `<tag>-<full-sha>`
+so `vicoop-client info` / `vicoop-client upgrade`'s in-container
+fingerprint reads more diagnostic than just `latest`.

--- a/.github/workflows/release-bundled.yml
+++ b/.github/workflows/release-bundled.yml
@@ -1,0 +1,94 @@
+name: Release bundled image
+
+# Restarts the bundled-direct image publish that #250 removed from
+# release.yml. Separate from release.yml (the changesets/action
+# pipeline for the @vicoop-bridge/client binary release) and from
+# release-runtime.yml (#249's agent-agnostic vicoop-runtime image).
+#
+# The bundled-direct image (#244) is the "docker run -d
+# ghcr.io/.../vicoop-bridge-client" one-shot deployment shape — it
+# ships the vicoop-client binary plus the same install-backend.sh
+# / init-firewall.sh / backends recipes the external-runtime image
+# ships, so its paths-filter includes the bridge-client source as
+# well as the shared container/ scripts.
+#
+# Tags are `latest` + `sha-<short>` while the profile iterates;
+# wiring a semver flow alongside the client Version PR is a
+# follow-up.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - container/bundled/**
+      - container/init-firewall.sh
+      - container/install-backend.sh
+      - container/backends/**
+      - packages/client/src/**
+      - packages/client/package.json
+      - packages/protocol/src/**
+      - packages/protocol/package.json
+      - pnpm-lock.yaml
+      - .github/workflows/release-bundled.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release-bundled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      # buildx + qemu enable cross-arch builds (linux/amd64 +
+      # linux/arm64) from the ubuntu-latest x86_64 runner. The bundled
+      # image is heavier than the runtime image (it embeds the
+      # bun-compiled vicoop-client binary on top of the same base +
+      # deps), so emulated arm64 build time is noticeable; if it
+      # becomes a CI bottleneck, move to a native-arm64 runner for
+      # the arm64 leg.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vicoop-bridge-client
+          tags: |
+            type=raw,value=latest
+            type=sha,format=short
+
+      - name: Build and push bundled image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: container/bundled/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # bundled Dockerfile's runtime stage stamps VICOOP_BRIDGE_IMAGE
+          # into ENV so `vicoop-client info` / `upgrade` can fingerprint
+          # the image. metadata-action's `version` is whatever tag
+          # logic picked (`latest` here); SHORT_SHA gets stitched into
+          # the same value so operators see something more diagnostic
+          # than just "latest".
+          build-args: |
+            VICOOP_BRIDGE_IMAGE=${{ steps.meta.outputs.version }}-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/container/bundled/Dockerfile
+++ b/container/bundled/Dockerfile
@@ -115,7 +115,12 @@ RUN apt-get update \
 
 # Node's `semver` is bundled with npm; we install it as a global lib here
 # so entrypoint.sh can `node -e "require('semver')..."` for compat checks.
+# NODE_PATH points at the global modules dir so `node -e` invocations
+# (which don't have a local `package.json` to anchor resolution) can
+# actually find the install — without it the require fails with
+# MODULE_NOT_FOUND even though `npm install -g semver` succeeded.
 RUN npm install -g semver
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 # Canonical data root for all persistent state. Mounted as a named volume
 # in operator-side compose. Per backend creds get redirected here via

--- a/container/bundled/entrypoint.sh
+++ b/container/bundled/entrypoint.sh
@@ -136,9 +136,18 @@ compat_check() {
         range="$(jq -r --arg k "$kind" '.backends[$k].supportedRange // empty' <<< "$info")"
         [[ -z "$range" || "$range" == "*" ]] && continue
 
-        # Take the first whitespace-separated token from `<bin> --version`
-        # as the semver. Recipes that don't print a semver get skipped.
-        actual="$("$bin" --version 2>/dev/null | awk '{print $1; exit}' || true)"
+        # Pull the first semver-shaped token out of `<bin> --version`.
+        # Naive "first whitespace token" gets fooled by codex, which
+        # prints `codex-cli 0.132.0` (program-name first, semver
+        # second); claude prints `2.1.146 (Claude Code)` (semver
+        # leads) and works either way. The pattern also tolerates
+        # pre-release / build suffixes (`X.Y.Z-rc.1`, `X.Y.Z+sha`).
+        # Recipes that don't print a semver-shaped token at all get
+        # skipped.
+        actual="$("$bin" --version 2>/dev/null \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+([-+][[:alnum:].-]+)?' \
+            | head -n1 \
+            || true)"
         [[ -z "$actual" ]] && continue
 
         if ! node -e "


### PR DESCRIPTION
## Summary

- Re-enables the `ghcr.io/planetarium/vicoop-bridge-client` (bundled-
  direct) image publish that PR #250 removed from `release.yml` as
  part of clearing the deck for #249's PR A/B/C. With #249 shipped,
  the bundled-direct profile (#244) is the only operator surface
  still missing an actual image artifact — the code under
  `container/bundled/` from PR #245 / PR #250 is otherwise complete.
- New standalone workflow `.github/workflows/release-bundled.yml`,
  mirroring `release-runtime.yml` (#249 PR A). Paths-filter covers
  the bundled Dockerfile, the shared `container/` scripts the image
  COPYs in, and the bridge-client source (the bundled image embeds
  the bun-compiled `vicoop-client` binary), so the build kicks off
  whenever any input drifts.
- Multi-arch (`linux/amd64` + `linux/arm64`) via buildx + qemu.
  Tags: `latest` + `sha-<short>` while the bundled profile keeps
  iterating; semver tag flow alongside the client Version PR is a
  separate follow-up.
- `VICOOP_BRIDGE_IMAGE` build-arg stamps `<tag>-<full-sha>` rather
  than just the tag, so `vicoop-client info` / `vicoop-client
  upgrade` inside the bundled image reads a more diagnostic
  fingerprint.

## Why a separate workflow

- `release.yml` is the changesets/action pipeline for the npm
  artifact — gating image publish on Version-PR merges would tie
  the image release cadence to the binary release cadence
  unnecessarily.
- `release-runtime.yml` is its own thing (#249 PR A's vicoop-runtime
  image, a different artifact).
- Following that pattern, each image family owns its publish
  workflow.

## Test plan

- [x] Workflow is `workflow_dispatch:`-capable, so it can be invoked
      from the Actions tab once merged to validate the first build
      without waiting on a `container/**` push.
- [ ] CI run: first push to main triggers a clean `latest` +
      `sha-<short>` push of `ghcr.io/planetarium/vicoop-bridge-client`.
- [ ] Operator smoke: `docker pull ghcr.io/planetarium/vicoop-bridge-client:latest`
      + the case-A env-token incantation from #244's issue body
      ("docker run -d -e VICOOP_BRIDGE_TOKEN=... …") boots a
      bridge-client daemon.
- [ ] (Out of scope, gated on interactive-wizard PR) case-B `docker run -it`
      flow once the wizard land — same image, just `-it` vs `-d`.

## Related

- #244 — bundled-direct profile design (this PR closes the artifact
  gap; interactive wizard is the next dormant piece, tracked
  separately after #247 was closed for fresh start)
- #245 — bundled foundation (merged; provided container/bundled/)
- #250 — bundled cleanup (merged; removed the in-line image push that
  this workflow restores)
- #249 — external-runtime profile (merged; parallel image,
  release-runtime.yml is this workflow's sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)