### PR TITLE
refactor(client/runtime): drop dockerode, route lifecycle through docker CLI

### DIFF
--- a/.changeset/container-init-subcommand.md
+++ b/.changeset/container-init-subcommand.md
@@ -54,16 +54,16 @@ Also threads a `user` option through `RuntimeContainer.exec()` so
 the chown step can run as root inside an image whose default user
 is unprivileged.
 
-Bun compatibility: the docker-exec steps inside `container init`
-and the spawn-adapter's `createDockerExecSpawn` both shell out to
-the `docker` CLI rather than using dockerode's
-`exec.start({ hijack: true })`. bun's node:http client doesn't yet
-implement the HTTP 101 'upgrade' event docker's hijack protocol
-relies on (oven-sh/bun#22412 is the in-flight fix); under a
-bun-compiled vicoop-client the hijack stream deadlocks. dockerode's
-non-hijacked lifecycle calls (pull / volume / create / start /
-stop / inspect) stay on the programmatic API where they work
-cleanly under bun.
+Every docker interaction (the per-step `docker exec` inside
+`container init`, the spawn-adapter's per-task `docker exec`,
+and the runtime container lifecycle calls) goes through the
+`docker` CLI as a child process. The operator-side `docker`
+install is already a hard requirement (Decision §6), so this
+adds no new dependency surface — and it sidesteps oven-sh/bun#22412
+(bun's node:http client doesn't yet emit the HTTP 101 'upgrade'
+event docker's hijack protocol relies on), which would otherwise
+deadlock a bun-compiled vicoop-client the first time it tried to
+stream stdio through a programmatic Docker client.
 
 Out of scope (still PR C-shaped follow-ups if motivated by ops
 feedback):

--- a/.changeset/external-runtime-spawn.md
+++ b/.changeset/external-runtime-spawn.md
@@ -26,14 +26,17 @@ New surface:
   existing `ClaudeSpawnFn` / `AppServerSpawnFn` shape regardless of
   mode. The host implementation is the same `node:child_process.spawn`
   the backends use today; the container implementation runs the
-  command via `docker exec` inside the runtime container and bridges
-  stdin/stdout/stderr to PassThrough streams so backends see a normal
-  child-handle.
-- `dockerode` is a new runtime dependency (#249 Decision §1).
+  command via `docker exec` (shelled out as a child process) so the
+  backend sees a normal child-handle either way.
+- All docker interactions go through the `docker` CLI as child
+  processes — image pull, volume / container lifecycle, and the
+  per-task `docker exec` for agent spawn. No programmatic Docker
+  client library; the operator-side `docker` install we already
+  require (Decision §6) is the dependency surface.
 
 Decisions reflected (#249 §Decisions):
 
-- §1 dockerode (programmatic API, not shell-out).
+- §1 docker CLI as the daemon-interaction surface.
 - §2 `--restart unless-stopped` + bridge-client-side reuse on restart.
 - §3 Per-backend long-lived only; no per-context runtime.
 - §4 Creds in a container-only named volume — the host's `~/.claude`

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,13 +24,11 @@
     "@optique/core": "1.0.2",
     "@optique/run": "1.0.2",
     "@vicoop-bridge/protocol": "workspace:*",
-    "dockerode": "^5.0.0",
     "semver": "^7.8.0",
     "ws": "^8.18.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/dockerode": "^4.0.1",
     "@types/semver": "^7.7.1",
     "@types/ws": "^8.5.13"
   }

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -1,241 +1,215 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { EventEmitter } from 'node:events';
-import { PassThrough } from 'node:stream';
-import { RuntimeContainer, resolveDockerOptions } from './runtime-container.js';
+import { RuntimeContainer, type DockerResult } from './runtime-container.js';
 
-// Minimal dockerode-compatible stub. Records what was called so the
-// tests can assert lifecycle behavior (volumes ensured, container
-// created, restart policy / mounts set) without a live daemon.
-function makeDockerStub(opts: {
-  ping?: () => Promise<void>;
-  // Initial set of pre-existing container names (no leading `/`).
-  containers?: string[];
-  // Initial set of pre-existing image names.
-  images?: string[];
-  // Whether the existing container is reported as Running. Used by
-  // start() to decide between start vs reuse-as-is.
-  containerRunning?: boolean;
-}) {
-  const created: Array<Record<string, unknown>> = [];
-  const startedContainers: string[] = [];
-  const stoppedContainers: string[] = [];
-  const ensuredVolumes: string[] = [];
-  const pulledImages: string[] = [];
-  const images = new Set(opts.images ?? []);
-  const containers = new Map<string, { name: string; running: boolean }>();
-  for (const name of opts.containers ?? []) {
-    containers.set(name, { name, running: opts.containerRunning ?? false });
-  }
+// Test seam fixture. Each `dockerRun` call is matched against the
+// next response in the queue and pushed onto `calls` for assertion.
+// Missing fixtures fall back to a successful zero-output result so
+// the harness can ignore steps it doesn't care about (e.g. the
+// `waitUntilRunning` poll after a successful start).
+type RunResponse =
+  | DockerResult
+  | ((args: readonly string[]) => DockerResult);
 
-  const modem = {
-    followProgress(_stream: unknown, done: (err: Error | null) => void): void {
-      // We never feed real layer events into stream; tests don't care
-      // about progress reporting, only that the pull resolves.
-      done(null);
-    },
+function makeDockerFixture(responses: RunResponse[]) {
+  const calls: Array<readonly string[]> = [];
+  let i = 0;
+  const run = (args: readonly string[]): DockerResult => {
+    calls.push(args);
+    const r = responses[i++] ?? ok();
+    return typeof r === 'function' ? r(args) : r;
   };
-
-  const docker = {
-    modem,
-    ping: opts.ping ?? (async () => {}),
-    getImage(name: string) {
-      return {
-        inspect: async () => {
-          if (!images.has(name)) {
-            const err = new Error(`no such image: ${name}`) as Error & {
-              statusCode: number;
-            };
-            err.statusCode = 404;
-            throw err;
-          }
-          return {};
-        },
-      };
-    },
-    pull(name: string, cb: (err: Error | null, stream: NodeJS.ReadableStream) => void) {
-      pulledImages.push(name);
-      images.add(name);
-      const stream = new PassThrough();
-      cb(null, stream);
-      stream.end();
-    },
-    getVolume(name: string) {
-      return {
-        inspect: async () => {
-          if (!ensuredVolumes.includes(name)) {
-            const err = new Error(`no such volume: ${name}`) as Error & {
-              statusCode: number;
-            };
-            err.statusCode = 404;
-            throw err;
-          }
-          return { Name: name };
-        },
-      };
-    },
-    async createVolume(opts: { Name: string }) {
-      ensuredVolumes.push(opts.Name);
-      return { Name: opts.Name };
-    },
-    async listContainers(_opts: unknown): Promise<Array<{ Id: string; Names: string[] }>> {
-      return Array.from(containers.values()).map((c) => ({
-        Id: c.name,
-        Names: [`/${c.name}`],
-      }));
-    },
-    async createContainer(spec: Record<string, unknown> & { name: string }) {
-      created.push(spec);
-      containers.set(spec.name, { name: spec.name, running: false });
-      return makeContainerStub(spec.name);
-    },
-    getContainer(id: string) {
-      return makeContainerStub(id);
-    },
-  };
-
-  function makeContainerStub(id: string) {
-    return {
-      id,
-      async inspect() {
-        const entry = containers.get(id);
-        return { State: { Running: entry?.running ?? false, Status: entry?.running ? 'running' : 'created' } };
-      },
-      async start() {
-        startedContainers.push(id);
-        const entry = containers.get(id);
-        if (entry) entry.running = true;
-      },
-      async stop(_opts?: { t?: number }) {
-        stoppedContainers.push(id);
-        const entry = containers.get(id);
-        if (entry) entry.running = false;
-      },
-      async exec(_spec: unknown) {
-        return new EventEmitter();
-      },
-    };
-  }
-
-  return { docker, created, startedContainers, stoppedContainers, ensuredVolumes, pulledImages };
+  return { run, calls };
 }
 
-test('start: pulls image, ensures volumes, creates+starts a fresh container', async () => {
-  const stub = makeDockerStub({});
+function ok(stdout = ''): DockerResult {
+  return { stdout, stderr: '', exitCode: 0 };
+}
+function fail(stderr: string, exitCode = 1): DockerResult {
+  return { stdout: '', stderr, exitCode };
+}
+
+// Helper for the "happy start" sequence shape. The image pull path
+// is bypassed (ensureImage finds the image on the first inspect),
+// the three volumes are inspected → created, then the container is
+// inspected (absent) → created → started, then waitUntilRunning's
+// first poll sees `running`. That's what most tests need; the
+// negative tests override the relevant entries to inject failures.
+function happyStartResponses(): RunResponse[] {
+  return [
+    ok('28.0.0'), // version (ensureDaemonReachable)
+    ok(), // image inspect — found
+    fail('volume not found', 1), // volume inspect agents
+    ok(), // volume create agents
+    fail('volume not found', 1), // volume inspect creds
+    ok(), // volume create creds
+    fail('volume not found', 1), // volume inspect sessions
+    ok(), // volume create sessions
+    ok(''), // ps -a --filter (no existing container)
+    ok(), // create container
+    ok(), // start container
+    ok('running'), // waitUntilRunning poll
+  ];
+}
+
+test('start: pulls nothing when image is cached, creates+starts a fresh container', async () => {
+  const { run, calls } = makeDockerFixture(happyStartResponses());
   const rc = new RuntimeContainer({
     backendKind: 'claude',
     image: 'test/runtime:latest',
     workspaceDir: '/host/workspace',
     bridgeUrl: 'wss://bridge.example',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    dockerRun: run,
   });
   await rc.start();
-  assert.deepEqual(stub.pulledImages, ['test/runtime:latest']);
+
+  // version → image inspect → 3×volume(inspect|create) → ps → create → start → inspect-running
+  assert.equal(calls.length, 12);
+  assert.deepEqual(calls[0].slice(0, 2), ['version', '--format']);
+  assert.deepEqual(calls[1], ['image', 'inspect', 'test/runtime:latest']);
+
+  // Volumes created with the expected labels
+  const volumeCreates = calls.filter((c) => c[0] === 'volume' && c[1] === 'create');
   assert.deepEqual(
-    stub.ensuredVolumes.sort(),
+    volumeCreates.map((c) => c[c.length - 1]).sort(),
     ['vicoop-agents-claude', 'vicoop-creds-claude', 'vicoop-sessions-claude'].sort(),
   );
-  assert.equal(stub.created.length, 1);
-  assert.equal(stub.created[0].name, 'vicoop-runtime-claude');
-  const hostConfig = stub.created[0].HostConfig as {
-    Binds: string[];
-    RestartPolicy: { Name: string };
-    CapAdd: string[];
-  };
-  assert.equal(hostConfig.RestartPolicy.Name, 'unless-stopped');
-  assert.deepEqual(hostConfig.CapAdd, ['NET_ADMIN', 'NET_RAW']);
-  assert.ok(hostConfig.Binds.some((b) => b === '/host/workspace:/workspace'));
-  assert.ok(hostConfig.Binds.some((b) => b === 'vicoop-creds-claude:/data/creds/claude'));
-  assert.ok(hostConfig.Binds.some((b) => b === 'vicoop-sessions-claude:/data/sessions/claude'));
-  assert.deepEqual(stub.startedContainers, ['vicoop-runtime-claude']);
+  for (const v of volumeCreates) {
+    assert.ok(v.includes('vicoop.kind=claude'), `label on ${v.join(' ')}`);
+  }
+
+  // Container create argv: --name, --restart unless-stopped, NET_ADMIN+RAW,
+  // mounts, env, image last.
+  const createCmd = calls.find((c) => c[0] === 'create');
+  assert.ok(createCmd, 'create call present');
+  const argv = createCmd as readonly string[];
+  assert.ok(argv.includes('vicoop-runtime-claude'), 'container name');
+  assert.equal(argv[argv.length - 1], 'test/runtime:latest', 'image last');
+  const restartIdx = argv.indexOf('--restart');
+  assert.equal(argv[restartIdx + 1], 'unless-stopped');
+  assert.ok(argv.includes('NET_ADMIN'));
+  assert.ok(argv.includes('NET_RAW'));
+  assert.ok(
+    argv.some((a) => a === 'type=bind,source=/host/workspace,target=/workspace'),
+    'host workspace mounted',
+  );
+  assert.ok(
+    argv.some((a) => a === 'type=volume,source=vicoop-creds-claude,target=/data/creds/claude'),
+    'creds volume mounted',
+  );
+  assert.ok(
+    argv.some((a) => a === 'VICOOP_BRIDGE_URL=wss://bridge.example'),
+    'bridge URL forwarded',
+  );
+
+  // Start sequence
+  assert.deepEqual(calls[calls.length - 2], ['start', 'vicoop-runtime-claude']);
+  assert.deepEqual(calls[calls.length - 1], [
+    'inspect',
+    '--format',
+    '{{.State.Status}}',
+    'vicoop-runtime-claude',
+  ]);
 });
 
 test('start: reuses an existing running container (no create, no start)', async () => {
-  const stub = makeDockerStub({
-    containers: ['vicoop-runtime-claude'],
-    containerRunning: true,
-    images: ['test/runtime:latest'],
-  });
+  const { run, calls } = makeDockerFixture([
+    ok('28.0.0'),
+    ok(), // image inspect
+    ok(), // volume inspect agents — present
+    ok(), // volume inspect creds
+    ok(), // volume inspect sessions
+    ok('abc123'), // ps -a — match
+    ok('true'), // inspect Running
+    ok('running'), // wait poll
+  ]);
   const rc = new RuntimeContainer({
     backendKind: 'claude',
     image: 'test/runtime:latest',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    dockerRun: run,
   });
   await rc.start();
-  assert.equal(stub.created.length, 0);
-  assert.equal(stub.startedContainers.length, 0);
+
+  assert.equal(
+    calls.filter((c) => c[0] === 'create').length,
+    0,
+    'no create call',
+  );
+  assert.equal(
+    calls.filter((c) => c[0] === 'start').length,
+    0,
+    'no start call',
+  );
 });
 
 test('start: starts an existing stopped container', async () => {
-  const stub = makeDockerStub({
-    containers: ['vicoop-runtime-codex'],
-    containerRunning: false,
-    images: ['test/runtime:latest'],
-  });
+  const { run, calls } = makeDockerFixture([
+    ok('28.0.0'),
+    ok(),
+    ok(),
+    ok(),
+    ok(),
+    ok('abc123'), // ps -a — found
+    ok('false'), // inspect Running — stopped
+    ok(), // start
+    ok('running'), // wait
+  ]);
   const rc = new RuntimeContainer({
     backendKind: 'codex',
     image: 'test/runtime:latest',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    dockerRun: run,
   });
   await rc.start();
-  assert.equal(stub.created.length, 0);
-  assert.deepEqual(stub.startedContainers, ['vicoop-runtime-codex']);
+  assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
+  assert.deepEqual(
+    calls.filter((c) => c[0] === 'start'),
+    [['start', 'vicoop-runtime-codex']],
+  );
 });
 
-test('start: docker ping failure surfaces an actionable error', async () => {
-  const stub = makeDockerStub({
-    ping: async () => {
-      throw new Error('connect ENOENT /var/run/docker.sock');
-    },
-  });
+test('start: docker daemon unreachable surfaces an actionable error', async () => {
+  const { run } = makeDockerFixture([
+    fail('Cannot connect to the Docker daemon at unix:///var/run/docker.sock', 1),
+  ]);
   const rc = new RuntimeContainer({
     backendKind: 'claude',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    image: 'test/runtime:latest',
+    dockerRun: run,
   });
   await assert.rejects(rc.start(), /docker daemon is not reachable/);
 });
 
-test('stop: calls container.stop and tolerates 304 already-stopped', async () => {
-  const stub = makeDockerStub({
-    containers: ['vicoop-runtime-claude'],
-    containerRunning: true,
-    images: ['test/runtime:latest'],
-  });
+test('stop: tolerates already-stopped containers', async () => {
+  const { run } = makeDockerFixture([
+    fail('Error: No such container: vicoop-runtime-claude', 1),
+  ]);
   const rc = new RuntimeContainer({
     backendKind: 'claude',
-    image: 'test/runtime:latest',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    dockerRun: run,
   });
-  await rc.start();
+  // Should not throw despite docker stop's non-zero exit.
   await rc.stop();
-  assert.deepEqual(stub.stoppedContainers, ['vicoop-runtime-claude']);
-});
-
-test('resolveDockerOptions: defers to dockerode when DOCKER_HOST is set', () => {
-  // When the operator (or systemd unit) already exports DOCKER_HOST,
-  // returning undefined lets dockerode parse it itself — we don't
-  // want our context-file resolver to fight a fully-explicit env.
-  const opts = resolveDockerOptions({ DOCKER_HOST: 'tcp://example:2375' });
-  assert.equal(opts, undefined);
 });
 
 test('Env carries VICOOP_BRIDGE_URL and optional skip-firewall toggle', async () => {
-  const stub = makeDockerStub({});
+  const { run, calls } = makeDockerFixture(happyStartResponses());
   const rc = new RuntimeContainer({
     backendKind: 'claude',
     image: 'test/runtime:latest',
     bridgeUrl: 'wss://bridge.example',
     skipFirewall: true,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    docker: stub.docker as any,
+    dockerRun: run,
   });
   await rc.start();
-  const env = (stub.created[0].Env ?? []) as string[];
-  assert.ok(env.includes('VICOOP_BRIDGE_URL=wss://bridge.example'));
-  assert.ok(env.includes('VICOOP_SKIP_FIREWALL=1'));
+  const createCmd = calls.find((c) => c[0] === 'create') as readonly string[];
+  assert.ok(createCmd.includes('VICOOP_BRIDGE_URL=wss://bridge.example'));
+  assert.ok(createCmd.includes('VICOOP_SKIP_FIREWALL=1'));
+});
+
+test('getContainerName returns the canonical per-kind name', () => {
+  const rc = new RuntimeContainer({
+    backendKind: 'codex',
+    dockerRun: () => ok(),
+  });
+  assert.equal(rc.getContainerName(), 'vicoop-runtime-codex');
 });

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -7,7 +7,7 @@
 //     → pickBackend (cli.ts) decides runtime = 'container'
 //       → new RuntimeContainer({ backendKind, ... }).start()
 //         - pings docker daemon (Decision §6)
-//         - ensures named volumes exist (creds, sessions)
+//         - ensures named volumes exist (agents, creds, sessions)
 //         - looks for an existing container by canonical name; reuses
 //           if found, otherwise pulls the image and creates a new one
 //         - starts the container (firewall + sleep infinity from
@@ -15,21 +15,20 @@
 //       → wires a docker-exec SpawnAdapter (spawn-adapter.ts) into the
 //         backend factory; backend sees a normal SpawnFn signature
 //   bridge client shutdown
-//     → backend.stop() → runtime.stop() fire-and-forget
-//       (docker --restart unless-stopped will not auto-restart after
-//       an explicit `docker stop`, matching expected operator UX)
+//     → backend.stop() → runtime.stop() awaited
 //
-// Containers are intentionally named so a daemon restart finds the
-// previous container instead of leaving orphans behind. The
-// `vicoop-runtime-<kind>` shape keeps it human-readable and easy to
-// `docker exec` / `docker logs` into from the host.
+// Implementation note: everything in here goes through the `docker`
+// CLI (spawnSync), not the dockerode programmatic API. The hijack
+// stream parts already shelled out to the CLI because of
+// oven-sh/bun#22412; once the hijack path was off the table the
+// remaining dockerode lifecycle calls were carrying ssh2 /
+// cpu-features as transitive native deps for no functional reason
+// beyond Decision §1's original "dockerode (programmatic API)" pick.
+// Going all-CLI drops that whole native-build surface and means
+// `docker context` is resolved by the CLI itself — no custom socket
+// path lookup needed.
 
-import { createHash } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import Docker from 'dockerode';
-import type { Container, ContainerInspectInfo, DockerOptions, Exec } from 'dockerode';
+import { spawnSync, spawn } from 'node:child_process';
 import { createLogger, type Logger } from './logger.js';
 
 export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest';
@@ -43,9 +42,6 @@ export interface RuntimeContainerOptions {
   // module stays env-clean.
   image?: string;
   // Host directory bind-mounted as the agent's workspace at /workspace.
-  // Optional — `claude --cwd` and `codex --cwd` can also point inside
-  // the container's /workspace once we land per-context branching
-  // (separate issue).
   workspaceDir?: string;
   // Bridge WS URL forwarded into the container so init-firewall.sh's
   // outbound allowlist resolves the same host the bridge client speaks
@@ -55,13 +51,33 @@ export interface RuntimeContainerOptions {
   // hatch; production runs should leave this off and pass NET_ADMIN.
   skipFirewall?: boolean;
   logger?: Logger;
-  // Test seam — inject a stub Docker client so unit tests don't need
-  // a live daemon.
-  docker?: Docker;
+  // Test seam — inject a custom docker CLI runner so tests can
+  // capture argv + script responses without shelling out.
+  dockerRun?: DockerRun;
+}
+
+export interface DockerResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export type DockerRun = (args: readonly string[]) => DockerResult;
+
+function defaultDockerRun(args: readonly string[]): DockerResult {
+  const r = spawnSync('docker', Array.from(args), { encoding: 'utf8' });
+  return {
+    stdout: r.stdout ?? '',
+    stderr: r.stderr ?? '',
+    exitCode: r.status ?? -1,
+  };
 }
 
 function containerName(kind: string): string {
   return `vicoop-runtime-${kind}`;
+}
+function agentsVolumeName(kind: string): string {
+  return `vicoop-agents-${kind}`;
 }
 function credsVolumeName(kind: string): string {
   return `vicoop-creds-${kind}`;
@@ -71,24 +87,16 @@ function sessionsVolumeName(kind: string): string {
 }
 
 export class RuntimeContainer {
-  private readonly docker: Docker;
   private readonly opts: Required<Pick<RuntimeContainerOptions, 'backendKind' | 'image'>> &
     RuntimeContainerOptions;
   private readonly log: Logger;
-  private container?: Container;
+  private readonly run: DockerRun;
   private started = false;
 
   constructor(opts: RuntimeContainerOptions) {
-    this.opts = {
-      ...opts,
-      image: opts.image ?? DEFAULT_RUNTIME_IMAGE,
-    };
-    // dockerode's zero-arg constructor picks the platform default
-    // (unix:///var/run/docker.sock on linux/mac). We don't pass an
-    // explicit socket path so DOCKER_HOST env still wins for operators
-    // running rootless / podman-with-docker-shim.
-    this.docker = opts.docker ?? new Docker(resolveDockerOptions());
+    this.opts = { ...opts, image: opts.image ?? DEFAULT_RUNTIME_IMAGE };
     this.log = opts.logger ?? createLogger();
+    this.run = opts.dockerRun ?? defaultDockerRun;
   }
 
   // Boots the runtime container, blocking until it's running. Resolves
@@ -96,107 +104,71 @@ export class RuntimeContainer {
   // exception propagate so the daemon exits with a clear error rather
   // than degrade silently.
   async start(): Promise<void> {
-    await this.ensureDaemonReachable();
+    this.ensureDaemonReachable();
     await this.ensureImage();
-    await this.ensureVolumes();
+    this.ensureVolumes();
 
     const name = containerName(this.opts.backendKind);
-    const existing = await this.findContainerByName(name);
-    if (existing) {
-      // Reuse path: a previous bridge-client process (or a manual
-      // operator run) left a container with the same canonical name.
-      // We inspect first to decide whether to just start it or
-      // re-create — re-create only when something runtime-affecting
-      // (image, mounts) drifted, which we keep out of scope for PR B.
-      // Today: reuse and start if stopped.
-      this.container = this.docker.getContainer(existing.Id);
-      const info = await this.container.inspect();
-      if (!info.State.Running) {
-        this.log.info(`runtime container '${name}' exists but stopped — starting`);
-        await this.container.start();
-      } else {
+    if (this.findContainer(name)) {
+      if (this.inspectRunning(name)) {
         this.log.info(`runtime container '${name}' already running — reusing`);
+      } else {
+        this.log.info(`runtime container '${name}' exists but stopped — starting`);
+        this.runDocker(['start', name]);
       }
     } else {
-      this.container = await this.createContainer(name);
-      await this.container.start();
+      this.createContainer(name);
+      this.runDocker(['start', name]);
       this.log.info(`runtime container '${name}' created and started`);
     }
 
-    await this.waitUntilRunning();
+    await this.waitUntilRunning(name);
     this.started = true;
   }
 
-  // Run a one-shot command inside the long-lived runtime container.
-  // Returns the dockerode Exec handle; the caller (spawn-adapter)
-  // wires its stream into the ChildHandle the backends consume.
-  //
-  // `user` lets backend init do the one-time chown step against
-  // named volumes that mount in root-owned (anonymous-bind path).
-  // Default unset → docker uses the image's configured USER (node).
-  async exec(opts: {
-    command: string;
-    args: readonly string[];
-    cwd?: string;
-    env?: readonly string[];
-    user?: string;
-  }): Promise<Exec> {
-    if (!this.started || !this.container) {
-      throw new Error('runtime container not started');
-    }
-    return this.container.exec({
-      Cmd: [opts.command, ...opts.args],
-      AttachStdin: true,
-      AttachStdout: true,
-      AttachStderr: true,
-      Tty: false,
-      ...(opts.cwd ? { WorkingDir: opts.cwd } : {}),
-      ...(opts.env && opts.env.length > 0 ? { Env: [...opts.env] } : {}),
-      ...(opts.user ? { User: opts.user } : {}),
-    });
-  }
-
-  // Best-effort container stop. Fire-and-forget from backend.stop()
-  // (which is sync); errors are logged but do not propagate so a
-  // mid-shutdown daemon never blocks on docker.
+  // Best-effort container stop. Awaited from the daemon's signal
+  // handler so an orderly shutdown actually ends with the container
+  // stopped. Already-stopped / missing containers are tolerated.
   async stop(): Promise<void> {
-    if (!this.container) return;
-    try {
-      await this.container.stop({ t: 10 });
-      this.log.info(`runtime container '${containerName(this.opts.backendKind)}' stopped`);
-    } catch (err) {
-      // 304 = already stopped; not an error
-      const status = (err as { statusCode?: number }).statusCode;
-      if (status !== 304) {
-        this.log.warn(`runtime container stop failed: ${errorMessage(err)}`);
-      }
+    const name = containerName(this.opts.backendKind);
+    const r = this.run(['stop', '-t', '10', name]);
+    if (r.exitCode === 0) {
+      this.log.info(`runtime container '${name}' stopped`);
+      return;
     }
+    // Docker CLI emits "is not running" / "No such container" as
+    // non-zero — both are no-ops for us.
+    if (/is not running|No such container/i.test(r.stderr)) return;
+    this.log.warn(
+      `runtime container stop failed: ${r.stderr.trim() || `exit ${r.exitCode}`}`,
+    );
   }
 
-  // Expose the underlying dockerode handles so spawn-adapter can call
-  // exec / inspect without re-implementing them. Internal use only.
-  getDocker(): Docker {
-    return this.docker;
-  }
-  getContainer(): Container {
-    if (!this.container) throw new Error('runtime container not started');
-    return this.container;
-  }
-
-  // Canonical container name for this backend kind. Used by
-  // spawn-adapter's docker-exec implementation (which shells out to
-  // the docker CLI for bun-compat reasons — see spawn-adapter.ts).
+  // Canonical container name. Used by spawn-adapter to build the
+  // `docker exec` argv for each per-task spawn.
   getContainerName(): string {
     return containerName(this.opts.backendKind);
   }
 
   // ──────────────────────────────────────────────────────────────────
-  private async ensureDaemonReachable(): Promise<void> {
-    try {
-      await this.docker.ping();
-    } catch (err) {
+  private runDocker(args: readonly string[]): DockerResult {
+    const r = this.run(args);
+    if (r.exitCode !== 0) {
       throw new Error(
-        `docker daemon is not reachable (${errorMessage(err)}). ` +
+        `docker ${args[0]} failed (exit ${r.exitCode}): ${r.stderr.trim()}`,
+      );
+    }
+    return r;
+  }
+
+  private ensureDaemonReachable(): void {
+    // `docker version --format '{{.Server.Version}}'` exits non-zero
+    // when the daemon is unreachable and prints a stderr line we
+    // forward verbatim into the operator-facing message.
+    const r = this.run(['version', '--format', '{{.Server.Version}}']);
+    if (r.exitCode !== 0 || r.stdout.trim().length === 0) {
+      throw new Error(
+        `docker daemon is not reachable (${r.stderr.trim() || `exit ${r.exitCode}`}). ` +
           `The container runtime profile (#249) requires a local docker daemon. ` +
           `Switch to runtime: 'host' for this backend, or start docker and retry.`,
       );
@@ -205,109 +177,125 @@ export class RuntimeContainer {
 
   private async ensureImage(): Promise<void> {
     const image = this.opts.image;
-    try {
-      await this.docker.getImage(image).inspect();
-      return;
-    } catch (err) {
-      const status = (err as { statusCode?: number }).statusCode;
-      if (status !== 404) throw err;
-    }
+    const inspect = this.run(['image', 'inspect', image]);
+    if (inspect.exitCode === 0) return;
     this.log.info(`pulling runtime image ${image}`);
-    await new Promise<void>((resolve, reject) => {
-      this.docker.pull(image, (err: Error | null, stream: NodeJS.ReadableStream) => {
-        if (err) return reject(err);
-        // followProgress drains the pull stream; we don't surface
-        // layer-level progress (would spam logs for a 200MB image).
-        this.docker.modem.followProgress(stream, (finishErr: Error | null) => {
-          if (finishErr) reject(finishErr);
-          else resolve();
-        });
-      });
-    });
+    // Streamed pull instead of captured: a cold pull of the runtime
+    // image is ~200MB and takes long enough that swallowing layer
+    // progress looks like a hang to an operator watching the
+    // terminal. The test seam (dockerRun) is bypassed for this one
+    // call by design — pull is operator-visible side-effect, not
+    // a unit-testable step.
+    const r = spawnSync('docker', ['pull', image], { stdio: 'inherit' });
+    if (r.status !== 0) {
+      throw new Error(`docker pull ${image} failed (exit ${r.status ?? -1})`);
+    }
   }
 
-  private async ensureVolumes(): Promise<void> {
+  private ensureVolumes(): void {
+    const kind = this.opts.backendKind;
     const names = [
-      credsVolumeName(this.opts.backendKind),
-      sessionsVolumeName(this.opts.backendKind),
-      // The agents/<kind> tree lives in its own named volume too so
-      // install-backend.sh's installs survive container re-creation.
-      `vicoop-agents-${this.opts.backendKind}`,
+      agentsVolumeName(kind),
+      credsVolumeName(kind),
+      sessionsVolumeName(kind),
     ];
     for (const name of names) {
-      try {
-        await this.docker.getVolume(name).inspect();
-      } catch (err) {
-        const status = (err as { statusCode?: number }).statusCode;
-        if (status !== 404) throw err;
-        await this.docker.createVolume({ Name: name, Labels: { 'vicoop.kind': this.opts.backendKind } });
-        this.log.info(`created named volume '${name}'`);
-      }
+      const inspect = this.run(['volume', 'inspect', name]);
+      if (inspect.exitCode === 0) continue;
+      this.runDocker([
+        'volume',
+        'create',
+        '--label',
+        `vicoop.kind=${kind}`,
+        name,
+      ]);
+      this.log.info(`created named volume '${name}'`);
     }
   }
 
-  private async findContainerByName(name: string): Promise<{ Id: string } | undefined> {
-    const list = await this.docker.listContainers({
-      all: true,
-      filters: { name: [name] },
-    });
-    // listContainers returns names prefixed with "/" — match the bare
-    // name to avoid false positives on substrings.
-    const hit = list.find((c) => c.Names.some((n) => n === `/${name}` || n === name));
-    return hit ? { Id: hit.Id } : undefined;
+  private findContainer(name: string): boolean {
+    // Anchored regex (`^…$`) so `vicoop-runtime-codex` doesn't false-
+    // positive on a hypothetical `vicoop-runtime-codex-2`.
+    const r = this.run([
+      'ps',
+      '-a',
+      '--filter',
+      `name=^${name}$`,
+      '--format',
+      '{{.ID}}',
+    ]);
+    return r.exitCode === 0 && r.stdout.trim().length > 0;
   }
 
-  private async createContainer(name: string): Promise<Container> {
-    const kind = this.opts.backendKind;
-    const env: string[] = [];
-    if (this.opts.bridgeUrl) env.push(`VICOOP_BRIDGE_URL=${this.opts.bridgeUrl}`);
-    if (this.opts.skipFirewall) env.push('VICOOP_SKIP_FIREWALL=1');
+  private inspectRunning(name: string): boolean {
+    const r = this.run(['inspect', '--format', '{{.State.Running}}', name]);
+    return r.exitCode === 0 && r.stdout.trim() === 'true';
+  }
 
-    const binds: string[] = [
-      // Per-kind named volumes — keeps the bridge-client-driven
-      // /data/agents/<kind>, /data/creds/<kind>, /data/sessions/<kind>
-      // persistent across container re-creation. Decisions §4, §5.
-      `vicoop-agents-${kind}:/data/agents/${kind}`,
-      `${credsVolumeName(kind)}:/data/creds/${kind}`,
-      `${sessionsVolumeName(kind)}:/data/sessions/${kind}`,
+  private createContainer(name: string): void {
+    const kind = this.opts.backendKind;
+    const args: string[] = [
+      'create',
+      '--name',
+      name,
+      // Decision §2 — daemon-side belt to the bridge-client's
+      // health-check braces.
+      '--restart',
+      'unless-stopped',
+      // NET_ADMIN / NET_RAW let init-firewall.sh program iptables
+      // inside the container. Without them the entrypoint logs a
+      // warning and skips the allowlist; we add them by default so
+      // outbound isolation is on out of the box.
+      '--cap-add',
+      'NET_ADMIN',
+      '--cap-add',
+      'NET_RAW',
+      '--label',
+      `vicoop.kind=${kind}`,
     ];
+    if (this.opts.bridgeUrl) {
+      args.push('-e', `VICOOP_BRIDGE_URL=${this.opts.bridgeUrl}`);
+    }
+    if (this.opts.skipFirewall) {
+      args.push('-e', 'VICOOP_SKIP_FIREWALL=1');
+    }
+    // Per-kind named volumes — keeps the bridge-client-driven
+    // /data/agents/<kind>, /data/creds/<kind>, /data/sessions/<kind>
+    // persistent across container re-creation. Decisions §4, §5.
+    args.push(
+      '--mount',
+      `type=volume,source=${agentsVolumeName(kind)},target=/data/agents/${kind}`,
+      '--mount',
+      `type=volume,source=${credsVolumeName(kind)},target=/data/creds/${kind}`,
+      '--mount',
+      `type=volume,source=${sessionsVolumeName(kind)},target=/data/sessions/${kind}`,
+    );
     if (this.opts.workspaceDir) {
       // Workspace as a host bind-mount. Per-context branching
       // (a different workspace per task) is intentionally out of
       // scope for this PR — see #249's non-goals.
-      binds.push(`${this.opts.workspaceDir}:/workspace`);
+      args.push(
+        '--mount',
+        `type=bind,source=${this.opts.workspaceDir},target=/workspace`,
+      );
     }
-
-    return this.docker.createContainer({
-      name,
-      Image: this.opts.image,
-      Env: env,
-      Labels: { 'vicoop.kind': kind },
-      HostConfig: {
-        Binds: binds,
-        // Decision §2 — daemon-side belt to the bridge-client's
-        // health-check braces.
-        RestartPolicy: { Name: 'unless-stopped' },
-        // NET_ADMIN / NET_RAW let init-firewall.sh program iptables
-        // inside the container. Without them the entrypoint logs a
-        // warning and skips the allowlist; we add them by default so
-        // outbound isolation is on out of the box.
-        CapAdd: ['NET_ADMIN', 'NET_RAW'],
-      },
-    });
+    args.push(this.opts.image);
+    this.runDocker(args);
   }
 
-  private async waitUntilRunning(): Promise<void> {
-    if (!this.container) throw new Error('runtime container not started');
+  private async waitUntilRunning(name: string): Promise<void> {
     const start = Date.now();
     const timeoutMs = 10_000;
     while (Date.now() - start < timeoutMs) {
-      const info: ContainerInspectInfo = await this.container.inspect();
-      if (info.State.Running) return;
-      if (info.State.Status === 'exited' || info.State.Status === 'dead') {
-        throw new Error(
-          `runtime container entered terminal state '${info.State.Status}' before becoming ready`,
-        );
+      const r = this.run(['inspect', '--format', '{{.State.Status}}', name]);
+      if (r.exitCode === 0) {
+        const status = r.stdout.trim();
+        if (status === 'running') return;
+        if (status === 'exited' || status === 'dead') {
+          throw new Error(
+            `runtime container entered terminal state '${status}' before becoming ready`,
+          );
+        }
       }
       await sleep(200);
     }
@@ -317,78 +305,4 @@ export class RuntimeContainer {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-function errorMessage(e: unknown): string {
-  return e instanceof Error ? e.message : String(e);
-}
-
-// Pick the socket / TCP host dockerode should connect to.
-//
-// dockerode's zero-arg constructor honors $DOCKER_HOST and otherwise
-// falls back to `/var/run/docker.sock`. That misses the common macOS
-// reality where colima / orbstack / rancher-desktop publish their
-// socket somewhere under $HOME and rely on `docker context` to wire
-// the CLI. dockerode doesn't read docker contexts itself, so without
-// this resolver every container-mode bridge client on those setups
-// would fail with `ENOENT /var/run/docker.sock`.
-//
-// Precedence:
-//   1. $DOCKER_HOST  -> return undefined; dockerode parses it.
-//   2. `currentContext` from ~/.docker/config.json -> read its
-//      meta.json's Endpoints.docker.Host (unix:// or tcp://).
-//   3. anything we don't recognize -> return undefined and let
-//      dockerode use its default.
-//
-// Exported so unit tests can exercise it without spinning up a real
-// daemon connection.
-export function resolveDockerOptions(env: NodeJS.ProcessEnv = process.env): DockerOptions | undefined {
-  if (env.DOCKER_HOST) return undefined;
-
-  const home = homedir();
-  const configPath = join(home, '.docker', 'config.json');
-  if (!existsSync(configPath)) return undefined;
-
-  let currentContext: string;
-  try {
-    const config = JSON.parse(readFileSync(configPath, 'utf8'));
-    currentContext = typeof config.currentContext === 'string' ? config.currentContext : 'default';
-  } catch {
-    return undefined;
-  }
-  if (!currentContext || currentContext === 'default') return undefined;
-
-  // docker stores per-context metadata under a sha256-of-context-name
-  // directory. The format is stable enough to lean on directly; the
-  // alternative (shelling out to `docker context inspect`) would
-  // defeat the point of using a programmatic API.
-  const hash = createHash('sha256').update(currentContext).digest('hex');
-  const metaPath = join(home, '.docker', 'contexts', 'meta', hash, 'meta.json');
-  if (!existsSync(metaPath)) return undefined;
-
-  let host: unknown;
-  try {
-    const meta = JSON.parse(readFileSync(metaPath, 'utf8'));
-    host = meta?.Endpoints?.docker?.Host;
-  } catch {
-    return undefined;
-  }
-  if (typeof host !== 'string') return undefined;
-
-  if (host.startsWith('unix://')) {
-    return { socketPath: host.slice('unix://'.length) };
-  }
-  if (host.startsWith('tcp://')) {
-    try {
-      const url = new URL(host);
-      return {
-        host: url.hostname,
-        port: Number(url.port) || 2375,
-        protocol: url.protocol === 'https:' ? 'https' : 'http',
-      };
-    } catch {
-      return undefined;
-    }
-  }
-  return undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,6 @@ importers:
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
-      dockerode:
-        specifier: ^5.0.0
-        version: 5.0.0
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -106,9 +103,6 @@ importers:
         specifier: ^3.23.8
         version: 3.25.76
     devDependencies:
-      '@types/dockerode':
-        specifier: ^4.0.1
-        version: 4.0.1
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
@@ -326,9 +320,6 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-
-  '@balena/dockerignore@1.0.2':
-    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@base-org/account@2.4.0':
     resolution: {integrity: sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==}
@@ -743,20 +734,6 @@ packages:
     resolution: {integrity: sha512-Fakuk190EAKxWSa9YQyr/87g8mvAv8HBvk6yPCPuIoA3bYXF7n6kl0XSqKjSd5VfjEqhtnzQ6zJGzDf1Gv/tJg==}
     engines: {node: '>=8.6'}
 
-  '@grpc/grpc-js@1.14.4':
-    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
-    engines: {node: '>=12.10.0'}
-
-  '@grpc/proto-loader@0.7.15':
-    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
-  '@grpc/proto-loader@0.8.1':
-    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -787,9 +764,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@js-sdsl/ordered-map@4.4.2':
-    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@lit-labs/ssr-dom-shim@1.5.1':
     resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
@@ -974,36 +948,6 @@ packages:
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
     deprecated: 'The package is now available as "qr": npm install qr'
-
-  '@protobufjs/aspromise@1.1.2':
-    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
-
-  '@protobufjs/base64@1.1.2':
-    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
-
-  '@protobufjs/codegen@2.0.5':
-    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
-
-  '@protobufjs/eventemitter@1.1.0':
-    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
-
-  '@protobufjs/fetch@1.1.1':
-    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
-
-  '@protobufjs/float@1.0.2':
-    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
-
-  '@protobufjs/inquire@1.1.2':
-    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
-
-  '@protobufjs/path@1.1.2':
-    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
-
-  '@protobufjs/pool@1.1.0':
-    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
-
-  '@protobufjs/utf8@1.1.1':
-    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rainbow-me/rainbowkit@2.2.10':
     resolution: {integrity: sha512-8+E4die1A2ovN9t3lWxWnwqTGEdFqThXDQRj+E4eDKuUKyymYD+66Gzm6S9yfg8E95c6hmGlavGUfYPtl1EagA==}
@@ -1729,12 +1673,6 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
-  '@types/docker-modem@3.0.6':
-    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
-
-  '@types/dockerode@4.0.1':
-    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1771,9 +1709,6 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -1805,9 +1740,6 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
-
-  '@types/ssh2@1.15.5':
-    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2072,9 +2004,6 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
   async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
 
@@ -2114,9 +2043,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2126,9 +2052,6 @@ packages:
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
-
-  bl@4.1.0:
-    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
@@ -2159,19 +2082,12 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
-  buffer@5.7.1:
-    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bufferutil@4.1.0:
     resolution: {integrity: sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==}
     engines: {node: '>=6.14.2'}
-
-  buildcheck@0.0.7:
-    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
-    engines: {node: '>=10.0.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2229,15 +2145,8 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
 
   clsx@1.2.1:
     resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
@@ -2302,10 +2211,6 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
-
-  cpu-features@0.0.10:
-    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
-    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -2471,14 +2376,6 @@ packages:
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
-
-  docker-modem@5.0.7:
-    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
-    engines: {node: '>= 8.0'}
-
-  dockerode@5.0.0:
-    resolution: {integrity: sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==}
-    engines: {node: '>= 14.17'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2730,9 +2627,6 @@ packages:
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -3178,9 +3072,6 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -3207,9 +3098,6 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -3424,9 +3312,6 @@ packages:
       typescript:
         optional: true
 
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
-
   modern-ahocorasick@1.1.0:
     resolution: {integrity: sha512-sEKPVl2rM+MNVkGQt3ChdmD8YsigmXdn5NifZn6jiwn9LRJpWm8F3guhaqrJT/JOat6pwpbXEk6kv+b9DMIjsQ==}
 
@@ -3445,9 +3330,6 @@ packages:
 
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
-
-  nan@2.27.0:
-    resolution: {integrity: sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3787,10 +3669,6 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.6.0:
-    resolution: {integrity: sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==}
-    engines: {node: '>=12.0.0'}
-
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -4090,9 +3968,6 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  split-ca@1.0.1:
-    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
-
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
@@ -4103,10 +3978,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  ssh2@1.17.0:
-    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
-    engines: {node: '>=10.16.0'}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -4175,13 +4046,6 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -4225,9 +4089,6 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
-
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -4257,9 +4118,6 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -4538,10 +4396,6 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4619,10 +4473,6 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
@@ -4633,17 +4483,9 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4871,8 +4713,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
-
-  '@balena/dockerignore@1.0.2': {}
 
   '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -5288,25 +5128,6 @@ snapshots:
     dependencies:
       tslib: 2.7.0
 
-  '@grpc/grpc-js@1.14.4':
-    dependencies:
-      '@grpc/proto-loader': 0.8.1
-      '@js-sdsl/ordered-map': 4.4.2
-
-  '@grpc/proto-loader@0.7.15':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.6.0
-      yargs: 17.7.2
-
-  '@grpc/proto-loader@0.8.1':
-    dependencies:
-      lodash.camelcase: 4.3.0
-      long: 5.3.2
-      protobufjs: 7.6.0
-      yargs: 17.7.2
-
   '@hono/node-server@1.19.14(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -5336,8 +5157,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@lit-labs/ssr-dom-shim@1.5.1': {}
 
@@ -5627,28 +5446,6 @@ snapshots:
       '@optique/core': 1.0.2
 
   '@paulmillr/qr@0.2.1': {}
-
-  '@protobufjs/aspromise@1.1.2': {}
-
-  '@protobufjs/base64@1.1.2': {}
-
-  '@protobufjs/codegen@2.0.5': {}
-
-  '@protobufjs/eventemitter@1.1.0': {}
-
-  '@protobufjs/fetch@1.1.1':
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-
-  '@protobufjs/float@1.0.2': {}
-
-  '@protobufjs/inquire@1.1.2': {}
-
-  '@protobufjs/path@1.1.2': {}
-
-  '@protobufjs/pool@1.1.0': {}
-
-  '@protobufjs/utf8@1.1.1': {}
 
   '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
     dependencies:
@@ -6874,17 +6671,6 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
-  '@types/docker-modem@3.0.6':
-    dependencies:
-      '@types/node': 22.19.17
-      '@types/ssh2': 1.15.5
-
-  '@types/dockerode@4.0.1':
-    dependencies:
-      '@types/docker-modem': 3.0.6
-      '@types/node': 22.19.17
-      '@types/ssh2': 1.15.5
-
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -6927,10 +6713,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -6967,10 +6749,6 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.17
-
-  '@types/ssh2@1.15.5':
-    dependencies:
-      '@types/node': 18.19.130
 
   '@types/trusted-types@2.0.7': {}
 
@@ -7818,10 +7596,6 @@ snapshots:
 
   array-union@2.1.0: {}
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
   async-mutex@0.2.6:
     dependencies:
       tslib: 2.7.0
@@ -7857,10 +7631,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.19: {}
 
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
-
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -7868,12 +7638,6 @@ snapshots:
   big.js@6.2.2: {}
 
   bignumber.js@9.3.1: {}
-
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
 
   bn.js@5.2.3: {}
 
@@ -7928,11 +7692,6 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -7941,9 +7700,6 @@ snapshots:
   bufferutil@4.1.0:
     dependencies:
       node-gyp-build: 4.8.4
-
-  buildcheck@0.0.7:
-    optional: true
 
   bytes@3.1.2: {}
 
@@ -7994,19 +7750,11 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chownr@1.1.4: {}
-
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
-
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
 
   clsx@1.2.1: {}
 
@@ -8052,12 +7800,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-
-  cpu-features@0.0.10:
-    dependencies:
-      buildcheck: 0.0.7
-      nan: 2.27.0
-    optional: true
 
   crc-32@1.2.2: {}
 
@@ -8178,26 +7920,6 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
-
-  docker-modem@5.0.7:
-    dependencies:
-      debug: 4.4.3
-      readable-stream: 3.6.2
-      split-ca: 1.0.1
-      ssh2: 1.17.0
-    transitivePeerDependencies:
-      - supports-color
-
-  dockerode@5.0.0:
-    dependencies:
-      '@balena/dockerignore': 1.0.2
-      '@grpc/grpc-js': 1.14.4
-      '@grpc/proto-loader': 0.7.15
-      docker-modem: 5.0.7
-      protobufjs: 7.6.0
-      tar-fs: 2.1.4
-    transitivePeerDependencies:
-      - supports-color
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8544,8 +8266,6 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
-
-  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -9021,8 +8741,6 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  lodash.camelcase@4.3.0: {}
-
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -9040,8 +8758,6 @@ snapshots:
   lodash.startcase@4.4.0: {}
 
   lodash@4.18.1: {}
-
-  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -9455,8 +9171,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  mkdirp-classic@0.5.3: {}
-
   modern-ahocorasick@1.1.0: {}
 
   mri@1.2.0: {}
@@ -9468,9 +9182,6 @@ snapshots:
   ms@2.1.3: {}
 
   multiformats@9.9.0: {}
-
-  nan@2.27.0:
-    optional: true
 
   nanoid@3.3.11: {}
 
@@ -9849,21 +9560,6 @@ snapshots:
   process-warning@1.0.0: {}
 
   property-information@7.1.0: {}
-
-  protobufjs@7.6.0:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.5
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.1
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.2
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.17
-      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -10252,21 +9948,11 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  split-ca@1.0.1: {}
-
   split-on-first@1.1.0: {}
 
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
-
-  ssh2@1.17.0:
-    dependencies:
-      asn1: 0.2.6
-      bcrypt-pbkdf: 1.0.2
-    optionalDependencies:
-      cpu-features: 0.0.10
-      nan: 2.27.0
 
   statuses@1.5.0: {}
 
@@ -10333,21 +10019,6 @@ snapshots:
 
   tapable@2.3.2: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.4
-      tar-stream: 2.2.0
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   term-size@2.2.1: {}
 
   thread-stream@0.15.2:
@@ -10388,8 +10059,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  tweetnacl@0.14.5: {}
-
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -10418,8 +10087,6 @@ snapshots:
       multiformats: 9.9.0
 
   uncrypto@0.1.3: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
 
@@ -10748,12 +10415,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrappy@1.0.2: {}
 
   ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10):
@@ -10894,8 +10555,6 @@ snapshots:
 
   y18n@4.0.3: {}
 
-  y18n@5.0.8: {}
-
   yallist@2.1.2: {}
 
   yallist@3.1.1: {}
@@ -10904,8 +10563,6 @@ snapshots:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-
-  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -10920,16 +10577,6 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

After PR #253 moved every hijack-stream call site to the `docker`
CLI (working around [oven-sh/bun#22412](https://github.com/oven-sh/bun/pull/22412)),
the dockerode programmatic API was only still in use by
`RuntimeContainer`'s lifecycle methods — ping, image pull, volume
inspect / create, container list / create / start / inspect / stop.
Those calls are simple enough that going all-CLI is cleaner than
dragging dockerode's transitive `ssh2` / `cpu-features` native add-
ons along for no functional reason beyond #249's original Decision §1
"dockerode (programmatic API)" pick.

The CLI also resolves the current `docker context` itself, so the
custom docker-context resolver we added (to work around dockerode's
zero-arg constructor not understanding colima / orbstack / rancher-
desktop sockets) is no longer needed.

## What changes

- `RuntimeContainer.start / stop / waitUntilRunning / findContainer /
  inspectRunning / ensureVolumes / createContainer /
  ensureDaemonReachable` now all go through `spawnSync('docker', …)`.
  `dockerRun` is injectable for tests.
- `ensureImage` stays on streamed `spawn` with inherited stdio for
  the pull path — a cold pull of the 200 MB runtime image looks
  like a hang otherwise. That's the one operator-visible-progress
  exception to the test seam.
- `resolveDockerOptions` (~80 lines that parsed
  `~/.docker/config.json` + meta files to fill dockerode's
  `socketPath`) is deleted.
- `dockerode` (deps) + `@types/dockerode` (devDeps) removed from
  `packages/client/package.json`; pnpm-lock follows. Client bundle
  drops 537 modules → 319; no more ssh2 / cpu-features native add-
  ons in the install tree.
- `runtime-container.test.ts` rewritten against the new `dockerRun`
  fixture (7 tests: happy start, reuse-running, reuse-stopped,
  daemon-unreachable, stop-tolerates-not-running, env propagation,
  `getContainerName` shape).

## Side benefit for #244

PR #255 had to prep `container/bundled/Dockerfile` to compile the
dockerode native add-ons (`--ignore-scripts` removed,
`build-essential` + `python3` added in the build stage). With
this PR merged that prep is no longer required — the follow-up on
#255 is a revert rather than a workaround.

## Test plan

- [x] `pnpm --filter @vicoop-bridge/client typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 489 tests pass
      (runtime-container.test.ts rewritten with 7 cases on the new
      fixture)
- [x] `bun build --compile --target=bun-darwin-arm64` produces a
      working `vicoop-client` binary (537 → 319 modules)
- [x] End-to-end against `ghcr.io/planetarium/vicoop-runtime:latest`
      on colima: `vicoop-client container init codex --from-host` →
      daemon → a2a `stream` task → SIGTERM. task completes in ~18 s,
      container exits with 143.
- [ ] (CI) check rolls clean on push.

## Related

- #249 — external-runtime profile; Decision §1's dockerode pick is
  the one being revisited
- #253 — landed the docker CLI shell-out for the hijack-stream paths
  (this PR removes what was left over)
- [oven-sh/bun#22412](https://github.com/oven-sh/bun/pull/22412) —
  upstream fix for the bun hijack incompatibility that motivated the
  CLI shell-out in the first place
- #255 — bundled image publish workflow; depends on this PR so the
  bundled build stage doesn't need to compile native add-ons

🤖 Generated with [Claude Code](https://claude.com/claude-code)