### PR TITLE
feat(client): auto-detect in-container daemon, relax backend sandbox

### DIFF
--- a/.changeset/auto-detect-container.md
+++ b/.changeset/auto-detect-container.md
@@ -1,0 +1,34 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Auto-detect when the bridge client itself is running inside a
+container (bundled-direct profile, #244) and apply the same
+sandbox-relaxation the external-runtime profile (#249) already
+gets when it spawns an *outside* runtime container.
+
+Previously, `--<kind>-runtime container` was the only path that
+flipped claude's `sandbox.failIfUnavailable=false` and codex's
+default to `danger-full-access`. The bundled image's in-container
+`vicoop-client` daemon had no way to know its own context — so it
+defaulted to the host-process safety floor (read-only / refuse-
+unsandboxed) and a codex file-write task got rejected as
+"escalation request was rejected" on the first try.
+
+Detection delegates to [`is-inside-container`][lib] (37M weekly
+downloads, MIT, single dep on `is-docker`), which already covers
+the signals we care about for the operator footprint
+(`/.dockerenv`, `/run/.containerenv`, `/proc/self/cgroup`,
+`/proc/self/mountinfo`). `pickBackend` treats
+`runtime !== undefined || isInsideContainer()` as the unified
+"already isolated" condition for both claude and codex; the
+runtime-container lifecycle flow is untouched. Operator-explicit
+overrides (`--codex-sandbox …`, claude settings file) always win.
+
+Verified end-to-end: rebuilt the bundled image, ran headless
+bootstrap, injected codex creds, restarted, and ran a
+`stream` task that writes `/tmp/d.txt` and reads it back —
+previously this rejected on codex's read-only sandbox
+escalation; now it completes cleanly.
+
+[lib]: https://github.com/sindresorhus/is-inside-container

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,7 @@
     "@optique/core": "1.0.2",
     "@optique/run": "1.0.2",
     "@vicoop-bridge/protocol": "workspace:*",
+    "is-inside-container": "^1.0.0",
     "semver": "^7.8.0",
     "ws": "^8.18.0",
     "zod": "^3.23.8"

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -22,6 +22,7 @@ import type { Backend } from './backend.js';
 import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
 import { createDockerExecSpawn, type SpawnFn } from './spawn-adapter.js';
 import { containerCmd, runContainerInitCli } from './container-init.js';
+import isInsideContainer from 'is-inside-container';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
 import { BACKENDS_MANIFEST } from './backends-manifest.js';
@@ -301,13 +302,16 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         cwd: args.claudeCwd,
         bridgeUrl: args.server,
       });
-      // Container mode supersedes claude's bwrap sandbox with the
-      // outer container's own isolation, so the runtime image
-      // deliberately doesn't ship bwrap / socat. Without this
-      // override claude 2.1.x exits 1 on first task with
-      // "sandbox.failIfUnavailable is set" because its default
-      // setting refuses unsandboxed execution.
-      const settings = runtime ? disableClaudeSandboxGuard(baseSettings) : baseSettings;
+      // claude's bwrap sandbox is redundant when *we* are already
+      // isolated — either because the daemon spawned an external
+      // runtime container (`runtime` set) or because the daemon
+      // itself is running inside a container (bundled-direct #244).
+      // Either way the outer container is the real isolation
+      // boundary; layering bwrap inside it just makes the runtime
+      // image carry deps it doesn't need and trips
+      // `sandbox.failIfUnavailable` on first task.
+      const isolated = runtime !== undefined || isInsideContainer();
+      const settings = isolated ? disableClaudeSandboxGuard(baseSettings) : baseSettings;
       const backend = createClaudeBackend({
         cwd,
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
@@ -323,17 +327,17 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         cwd: args.codexCwd,
         bridgeUrl: args.server,
       });
-      // Container isolation supersedes codex's sandbox the same way
-      // it supersedes claude's bwrap one: the outer container caps
-      // what the agent can reach, so codex's host-process sandbox
-      // is double-duty. In host mode codex's own default ('read-only')
-      // is the right safety floor; in container mode we lift it to
-      // 'danger-full-access' so codex can actually write to
-      // /workspace and run bash — operator override (--codex-sandbox
-      // / config) still wins for the rare case where someone wants
-      // belt-and-suspenders.
+      // Same reasoning as the claude branch: codex's host-process
+      // sandbox doubles up with the outer container's isolation.
+      // In a true host context (no runtime container, daemon
+      // running directly on the host) codex's own 'read-only'
+      // default is the right safety floor; in isolated contexts
+      // we lift it to 'danger-full-access' so codex can write to
+      // /workspace and run bash. Operator override
+      // (--codex-sandbox / config) still wins.
+      const isolated = runtime !== undefined || isInsideContainer();
       const explicitSandbox = coerceCodexSandbox(args, backends.codex?.sandbox_mode);
-      const sandboxMode = runtime
+      const sandboxMode = isolated
         ? (explicitSandbox ?? 'danger-full-access')
         : explicitSandbox;
       const backend = createCodexBackend({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
+      is-inside-container:
+        specifier: ^1.0.0
+        version: 1.0.0
       semver:
         specifier: ^7.8.0
         version: 7.8.0
@@ -2846,6 +2849,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2864,6 +2872,11 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -8539,6 +8552,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -8556,6 +8571,10 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-number@7.0.0: {}
 


### PR DESCRIPTION
## Summary

#249's external-runtime path flipped claude's
`sandbox.failIfUnavailable=false` and codex's
`sandboxMode='danger-full-access'` only when the daemon was
spawning a runtime container from the *outside* (the
`--<kind>-runtime container` flag). The bundled-direct profile
(#244) inverts that geometry: the daemon itself runs inside the
bundled container image, with no programmatic way to know it.
Result: the bundled image's first codex file-write task bounced
("escalation request was rejected") because host-process safety
defaults stayed on inside an already-isolated environment.

This PR teaches `pickBackend` that "we're already inside a
container" is just as good a reason to relax the sandbox as
"we spawned the outer container ourselves."

## Detection

Delegated to [`is-inside-container`](https://github.com/sindresorhus/is-inside-container)
(37M weekly downloads, MIT, single dep on `is-docker`). It already
covers the signals that matter for our operator footprint:

- `/.dockerenv` — Docker writes this into every container
- `/run/.containerenv` — podman's equivalent
- `/proc/self/cgroup` — docker substring
- `/proc/self/mountinfo` — `/docker/containers/` substring

Net cost: +1 transitive dep (also sindresorhus, ~5KB), no native
build, no custom maintenance burden. We considered rolling our
own to also catch `kubepods` / `containerd` / `crio` etc. via a
broader cgroup regex, but the library covers the deployment
shapes #244 actually ships (docker / podman) and the broader
regex can be a follow-up if a k8s deployment shape ever shows
up.

## Surface

- `packages/client/src/cli.ts` — `pickBackend`'s claude and codex
  branches use `runtime !== undefined || isInsideContainer()` as
  the unified isolation condition; the runtime-container
  lifecycle flow itself is unchanged. Operator-explicit
  `--codex-sandbox` / claude settings-file overrides always win.
- `packages/client/package.json` — `is-inside-container@^1` added
  as a runtime dep.

## Test plan

- [x] `pnpm typecheck` clean, full client suite passes (489 tests)
- [x] `bun build --compile` (321 modules) → working
      vicoop-client binary
- [x] Bundled image rebuilt with the new client;
      `docker run -e VICOOP_BRIDGE_TOKEN=... -e VICOOP_AGENT_ID=... -e VICOOP_BACKEND=codex ...`
      → headless bootstrap + codex auth inject + restart, then a2a
      `stream` task "write 'lib-detected!' to /tmp/L.txt and read
      back" completes. Pre-fix the same task rejected on codex's
      read-only sandbox escalation.
- [x] External-runtime profile (#249) unchanged: `runtime !== undefined`
      term still fires when the host-side daemon spawns its own
      runtime container.

## Related

- #244 — bundled-direct profile; this closes the in-container
  sandbox-defaults gap surfaced by #255's image-publish e2e
- #249 — external-runtime profile; provided the original
  `pickBackend` isolation gating that auto-detect now extends
- [`sindresorhus/is-inside-container`](https://github.com/sindresorhus/is-inside-container) — the detection library

🤖 Generated with [Claude Code](https://claude.com/claude-code)