### PR TITLE
feat(server,client)!: rename agent revoke to delete, hard-delete rows

### DIFF
--- a/.changeset/agent-delete.md
+++ b/.changeset/agent-delete.md
@@ -1,0 +1,58 @@
+---
+'@vicoop-bridge/server': major
+'@vicoop-bridge/client': major
+---
+
+Rename agent revocation to deletion and switch to hard delete.
+
+The previous `revoke_client()` flow set `revoked = TRUE` on the `agents`
+and `clients` rows but kept them around for "audit history." Nothing
+actually consumed the soft-deleted state — `ws.ts` filtered it out as
+"not found," no message log or audit table referenced the rows, and
+`unrevoke_client()` had zero callers. The soft-delete pattern added DB
+weight and a misleading mental model with no payoff, so this PR removes
+it.
+
+**Schema (breaking)**
+
+- Drops `revoked` column from `agents` and `clients`.
+- Replaces `revoke_client(TEXT)` and `unrevoke_client(TEXT)` SQL
+  functions with `delete_client(TEXT)` that hard-deletes both rows.
+  `agent_policies` is cleaned up via `ON DELETE CASCADE`.
+- `client_with_token` composite drops its `revoked` field (affects
+  `register_client` / `rotate_client_token` GraphQL response shape).
+
+**HTTP API (breaking response shape)**
+
+- `DELETE /admin-api/clients/:target` now returns
+  `{ client_id, client_name, deleted: true, closed_connections }` instead
+  of `{ … revoked: true, … }`. The URL and method are unchanged.
+- `GET /admin-api/clients` no longer includes a `revoked` field on each
+  client.
+
+**Client CLI (breaking)**
+
+- `vicoop-client agent revoke <TARGET>` → `vicoop-client agent delete <TARGET>`.
+  The new `delete` subcommand prompts `Delete agent "<TARGET>"? [y/N]`
+  before calling the API; pass `--yes` / `-y` to skip (required for
+  non-TTY usage like scripts and CI).
+- The deprecated `vicoop-client revoke-client` flat alias now points at
+  `agent delete` in its warning text. It still calls the same endpoint
+  and skips the prompt (preserving script behavior).
+- Daemon close-code 4014 reason text changes from `"client revoked"` to
+  `"client deleted"`; the log line is now `client deleted by owner;
+  stopping`. The behavior (exit non-zero, no reconnect) is unchanged.
+
+**Migration**
+
+- Operators using `vicoop-client agent revoke …` interactively: switch
+  to `agent delete …` and confirm the prompt.
+- Scripts using the same: switch to `agent delete --yes …`.
+- API consumers reading `revoked: true` from the DELETE response:
+  switch to `deleted: true`. Consumers reading the `revoked` field on
+  `GET /admin-api/clients` rows: remove that field — agents that exist
+  are by definition active.
+- Direct GraphQL callers of `mutate_revokeClient` /
+  `mutate_unrevokeClient`: switch to `mutate_deleteClient(clientId)`.
+  There is no replacement for unrevoke; re-register if you need the
+  agent back.

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -8,8 +8,8 @@ import {
   runAgentCallersAdd,
   runAgentCallersList,
   runAgentCallersRemove,
+  runAgentDelete,
   runAgentList,
-  runAgentRevoke,
   runListAgents,
   runListCallers,
   runListClients,
@@ -19,8 +19,8 @@ import {
   type AgentCallersAddArgs,
   type AgentCallersListArgs,
   type AgentCallersRemoveArgs,
+  type AgentDeleteArgs,
   type AgentListArgs,
-  type AgentRevokeArgs,
   type ListAgentsArgs,
   type ListCallersArgs,
   type ListClientsArgs,
@@ -57,10 +57,10 @@ const revokeClientArgs = (
 ): RevokeClientArgs => ({ action: 'revoke-client', target, ...SHARED, ...p });
 const agentListArgsFn = (p: Partial<AgentListArgs> = {}): AgentListArgs =>
   ({ action: 'agent-list', ...SHARED, connected: false, ...p });
-const agentRevokeArgsFn = (
+const agentDeleteArgsFn = (
   target: string,
-  p: Partial<AgentRevokeArgs> = {},
-): AgentRevokeArgs => ({ action: 'agent-revoke', target, ...SHARED, ...p });
+  p: Partial<AgentDeleteArgs> = {},
+): AgentDeleteArgs => ({ action: 'agent-delete', target, yes: true, ...SHARED, ...p });
 const agentCallersListArgsFn = (
   agentId: string,
   p: Partial<AgentCallersListArgs> = {},
@@ -330,7 +330,6 @@ test('list-clients calls GET /admin-api/clients and renders rows with connected 
           client_name: 'usage-test-1',
           owner_principal: 'eth:0xabc',
           allowed_agent_ids: ['agent-a'],
-          revoked: false,
           connected: false,
           created_at: '2026-05-07T00:00:00.000Z',
         },
@@ -347,7 +346,7 @@ test('list-clients calls GET /admin-api/clients and renders rows with connected 
   const out = stdout.read();
   // Table-form: header row + data row.
   assert.match(out, /CLIENT_ID\s+CLIENT_NAME\s+ALLOWED_AGENT_IDS/);
-  assert.match(out, /^cid-1\s+usage-test-1\s+agent-a\s+false\s+false\b/m);
+  assert.match(out, /^cid-1\s+usage-test-1\s+agent-a\s+false\b/m);
 });
 
 test('list-clients --json prints raw JSON', async (t) => {
@@ -368,7 +367,7 @@ test('revoke-client DELETEs /admin-api/clients/<target>', async (t) => {
     body: {
       client_id: 'cid-1',
       client_name: 'usage-test-1',
-      revoked: true,
+      deleted: true,
       closed_connections: 0,
     },
   });
@@ -384,7 +383,7 @@ test('revoke-client URL-encodes the target (so names with /, : survive)', async 
   captureStdout(t);
   const target = 'weird/name:with-colon';
   const { calls } = installFetch(t, {
-    body: { client_id: 'cid', client_name: target, revoked: true, closed_connections: 0 },
+    body: { client_id: 'cid', client_name: target, deleted: true, closed_connections: 0 },
   });
   const code = await runRevokeClient(revokeClientArgs(target));
   assert.equal(code, 0);
@@ -426,7 +425,7 @@ test('subcommand surfaces server error on non-2xx response', async (t) => {
 // `agent list` calls the same /admin-api/clients endpoint as the legacy
 // list-clients (the server-side unified persistence in #219 makes them
 // equivalent), but renders rows agent-id-first to match the operator-facing
-// model and includes registration_id/revoked/connected fields.
+// model.
 test('agent list calls GET /admin-api/clients and renders agent-centric rows', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   const stdout = captureStdout(t);
@@ -439,7 +438,6 @@ test('agent list calls GET /admin-api/clients and renders agent-centric rows', a
           client_name: 'codex on Mac',
           owner_principal: 'eth:0xabc',
           allowed_agent_ids: ['agent-a'],
-          revoked: false,
           connected: true,
           created_at: '2026-05-07T00:00:00.000Z',
         },
@@ -454,8 +452,8 @@ test('agent list calls GET /admin-api/clients and renders agent-centric rows', a
   const out = stdout.read();
   // Header row puts AGENT_ID first. The legacy client_id is intentionally
   // omitted from the human table — it remains available via --json.
-  assert.match(out, /AGENT_ID\s+NAME\s+CONNECTED\s+REVOKED\s+REGISTERED_AT\s*$/m);
-  assert.match(out, /^agent-a\s+codex on Mac\s+true\s+false\s+\S+\s*$/m);
+  assert.match(out, /AGENT_ID\s+NAME\s+CONNECTED\s+REGISTERED_AT\s*$/m);
+  assert.match(out, /^agent-a\s+codex on Mac\s+true\s+\S+\s*$/m);
   assert.doesNotMatch(out, /cid-1/);
 });
 
@@ -470,13 +468,13 @@ test('agent list --connected filters to connected rows in human + JSON output', 
         {
           client_id: 'cid-1', agent_id: 'agent-a', client_name: 'live',
           owner_principal: 'eth:0xabc', allowed_agent_ids: ['agent-a'],
-          revoked: false, connected: true,
+          connected: true,
           created_at: '2026-05-07T00:00:00.000Z',
         },
         {
           client_id: 'cid-2', agent_id: 'agent-b', client_name: 'stale',
           owner_principal: 'eth:0xabc', allowed_agent_ids: ['agent-b'],
-          revoked: false, connected: false,
+          connected: false,
           created_at: '2026-05-07T00:00:00.000Z',
         },
       ],
@@ -499,21 +497,39 @@ test('agent list --connected with no live agents prints the empty-state line', a
   assert.match(stdout.read(), /no connected agents/);
 });
 
-// `agent revoke` keeps the legacy DELETE /admin-api/clients/<target> endpoint
+// `agent delete` keeps the legacy DELETE /admin-api/clients/<target> endpoint
 // because the server-side resolver (admin-api.ts resolveClient) accepts an
 // agent_id, the legacy client_id, or the registration name. No new endpoint
 // is required.
-test('agent revoke DELETEs /admin-api/clients/<AGENT_ID>', async (t) => {
+test('agent delete --yes DELETEs /admin-api/clients/<AGENT_ID>', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   captureStdout(t);
   const { calls } = installFetch(t, {
-    body: { client_id: 'cid', client_name: 'agent-a', revoked: true, closed_connections: 1 },
+    body: { client_id: 'cid', client_name: 'agent-a', deleted: true, closed_connections: 1 },
   });
 
-  const code = await runAgentRevoke(agentRevokeArgsFn('agent-a'));
+  // agentDeleteArgsFn defaults `yes: true` so the handler skips the Y/N
+  // prompt; the prompt path is exercised in a separate test below.
+  const code = await runAgentDelete(agentDeleteArgsFn('agent-a'));
   assert.equal(code, 0);
   assert.equal(calls[0].method, 'DELETE');
   assert.equal(calls[0].url, `${BRIDGE}/admin-api/clients/agent-a`);
+});
+
+test('agent delete without --yes aborts when stdin is not a TTY', async (t) => {
+  // Confirm-or-abort is unconditional for non-TTY stdin (e.g. CI, pipes) so
+  // a script that forgot --yes does not silently delete. The test harness
+  // runs under node:test which is non-TTY, exercising the abort branch.
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stderr = captureStderr(t);
+  const { calls } = installFetch(t, {
+    body: { client_id: 'cid', client_name: 'agent-a', deleted: true, closed_connections: 0 },
+  });
+
+  const code = await runAgentDelete(agentDeleteArgsFn('agent-a', { yes: false }));
+  assert.equal(code, 1);
+  assert.match(stderr.read(), /aborted/);
+  assert.equal(calls.length, 0, 'must not have hit the API');
 });
 
 test('agent callers list/add/remove hit the existing /admin-api/agents/:id/callers routes', async (t) => {
@@ -574,14 +590,14 @@ test('legacy list-clients warns and points at agent list', async (t) => {
   assert.match(stderr.read(), /list-clients.*deprecated.*agent list/s);
 });
 
-test('legacy revoke-client warns and points at agent revoke', async (t) => {
+test('legacy revoke-client warns and points at agent delete', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   captureStdout(t);
   const stderr = captureStderr(t);
-  installFetch(t, { body: { client_id: 'c', client_name: 'n', revoked: true, closed_connections: 0 } });
+  installFetch(t, { body: { client_id: 'c', client_name: 'n', deleted: true, closed_connections: 0 } });
 
   assert.equal(await runRevokeClient(revokeClientArgs('n')), 0);
-  assert.match(stderr.read(), /revoke-client.*deprecated.*agent revoke/s);
+  assert.match(stderr.read(), /revoke-client.*deprecated.*agent delete/s);
 });
 
 test('legacy {add,remove,list}-caller all emit the agent-callers deprecation hint', async (t) => {

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -47,20 +47,23 @@ const agentListSubCmd = command(
   }),
   {
     brief: message`List agent registrations under this owner.`,
-    description: message`Calls GET /admin-api/clients (backed by the unified \`agents\` table) and prints one block per agent, including revoked and disconnected ones. Use --connected to filter to live daemons.`,
+    description: message`Calls GET /admin-api/clients (backed by the unified \`agents\` table) and prints one block per agent, including disconnected ones. Use --connected to filter to live daemons.`,
   },
 );
 
-const agentRevokeSubCmd = command(
-  'revoke',
+const agentDeleteSubCmd = command(
+  'delete',
   object({
-    action: constant('agent-revoke' as const),
+    action: constant('agent-delete' as const),
     ...sharedFlags,
     target: argument(string({ metavar: 'AGENT_ID' })),
+    yes: withDefault(flag('--yes', {
+      description: message`Skip the confirmation prompt.`,
+    }), false),
   }),
   {
-    brief: message`Revoke an agent by id (or registration name).`,
-    description: message`Calls DELETE /admin-api/clients/<AGENT_ID>. Marks the agent revoked=true and, if a daemon is live, closes its WebSocket with code 4014. The row is preserved for audit history. The legacy client_id and the registration name are still accepted for backward compatibility.`,
+    brief: message`Delete an agent by id (or registration name).`,
+    description: message`Calls DELETE /admin-api/clients/<AGENT_ID>. Hard-deletes the agents and clients rows, and if a daemon is live closes its WebSocket with code 4014 ("client deleted") so it exits without reconnecting. There is no undo. The legacy client_id and the registration name are still accepted for backward compatibility. Prompts for Y/N confirmation unless --yes / -y is set.`,
   },
 );
 
@@ -114,16 +117,16 @@ const agentCallersSubCmd = command(
 
 export const agentCmd = command(
   'agent',
-  longestMatch(agentRegisterCmd, agentListSubCmd, agentRevokeSubCmd, agentCallersSubCmd),
+  longestMatch(agentRegisterCmd, agentListSubCmd, agentDeleteSubCmd, agentCallersSubCmd),
   {
     brief: message`Manage agent registrations and their allowed callers.`,
-    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`revoke\`, \`callers {list,add,remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`delete\`, \`callers {list,add,remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
   },
 );
 
 export type AgentCliArgs = InferValue<typeof agentCmd>;
 export type AgentListArgs = Extract<AgentCliArgs, { action: 'agent-list' }>;
-export type AgentRevokeArgs = Extract<AgentCliArgs, { action: 'agent-revoke' }>;
+export type AgentDeleteArgs = Extract<AgentCliArgs, { action: 'agent-delete' }>;
 export type AgentCallersListArgs = Extract<AgentCliArgs, { action: 'agent-callers-list' }>;
 export type AgentCallersAddArgs = Extract<AgentCliArgs, { action: 'agent-callers-add' }>;
 export type AgentCallersRemoveArgs = Extract<AgentCliArgs, { action: 'agent-callers-remove' }>;
@@ -203,8 +206,8 @@ export const revokeClientCmd = command(
     target: argument(string({ metavar: 'CLIENT_ID_OR_NAME' })),
   }),
   {
-    brief: message`[deprecated] Use \`agent revoke\`.`,
-    description: message`Deprecated alias for \`vicoop-client agent revoke\`. Will be removed in a future release.`,
+    brief: message`[deprecated] Use \`agent delete\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent delete\`. Hard-deletes the agent (renamed from revoke). Will be removed in a future release.`,
   },
 );
 
@@ -371,11 +374,10 @@ function renderAgentRegistrationList(body: unknown, connectedOnly: boolean): str
     String(c.agent_id ?? ((c.allowed_agent_ids as string[] | undefined)?.[0] ?? '')),
     String(c.client_name ?? ''),
     String(c.connected),
-    String(c.revoked),
     String(c.created_at ?? ''),
   ]);
   return renderTable(
-    ['AGENT_ID', 'NAME', 'CONNECTED', 'REVOKED', 'REGISTERED_AT'],
+    ['AGENT_ID', 'NAME', 'CONNECTED', 'REGISTERED_AT'],
     tableRows,
   );
 }
@@ -397,28 +399,27 @@ function renderClientList(body: unknown): string {
     String(c.client_id ?? ''),
     String(c.client_name ?? ''),
     (c.allowed_agent_ids as string[] | undefined)?.join(',') ?? '',
-    String(c.revoked),
     String(c.connected),
     String(c.created_at ?? ''),
   ]);
   return renderTable(
-    ['CLIENT_ID', 'CLIENT_NAME', 'ALLOWED_AGENT_IDS', 'REVOKED', 'CONNECTED', 'CREATED_AT'],
+    ['CLIENT_ID', 'CLIENT_NAME', 'ALLOWED_AGENT_IDS', 'CONNECTED', 'CREATED_AT'],
     tableRows,
   );
 }
 
-function renderRevokeResult(body: unknown): string {
+function renderDeleteResult(body: unknown): string {
   if (!body || typeof body !== 'object') return String(body);
   const b = body as {
     client_id?: string;
     client_name?: string;
-    revoked?: boolean;
+    deleted?: boolean;
     closed_connections?: number;
   };
   return [
     `client_id:          ${b.client_id}`,
     `client_name:        ${b.client_name}`,
-    `revoked:            ${b.revoked}`,
+    `deleted:            ${b.deleted}`,
     `closed_connections: ${b.closed_connections}`,
   ].join('\n');
 }
@@ -467,21 +468,62 @@ export async function runAgentList(args: AgentListArgs): Promise<number> {
   return emit(filtered, args.json, (b) => renderAgentRegistrationList(b, args.connected));
 }
 
-export async function runAgentRevoke(args: AgentRevokeArgs): Promise<number> {
+// Y/N confirmation prompt for destructive actions. Returns true when the
+// operator typed `y` / `yes` (case-insensitive). Any other input — including
+// EOF, just-pressing-enter, or stdin not being a TTY — returns false so a
+// non-interactive invocation does not silently delete. Operators in scripts
+// must pass --yes / -y to bypass.
+async function confirmYN(promptText: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`${promptText} [y/N] `);
+  return new Promise((resolve) => {
+    let buf = '';
+    const onData = (chunk: Buffer): void => {
+      buf += chunk.toString('utf8');
+      const nl = buf.indexOf('\n');
+      if (nl < 0) return;
+      process.stdin.off('data', onData);
+      process.stdin.pause();
+      const answer = buf.slice(0, nl).trim().toLowerCase();
+      resolve(answer === 'y' || answer === 'yes');
+    };
+    process.stdin.resume();
+    process.stdin.on('data', onData);
+  });
+}
+
+async function execAgentDelete(
+  session: Session,
+  target: string,
+  json: boolean,
+): Promise<number> {
+  const result = await callApi({
+    session,
+    method: 'DELETE',
+    path: `/admin-api/clients/${encodeURIComponent(target)}`,
+  });
+  return emit(result, json, renderDeleteResult);
+}
+
+export async function runAgentDelete(args: AgentDeleteArgs): Promise<number> {
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
     return 1;
   }
+  if (!args.yes) {
+    const ok = await confirmYN(
+      `Delete agent "${args.target}"? This hard-deletes the registration and cannot be undone.`,
+    );
+    if (!ok) {
+      process.stderr.write('aborted\n');
+      return 1;
+    }
+  }
   // The server-side resolver accepts agent_id, legacy client_id, or the
   // registration name (admin-api.ts resolveClient), so we can keep the
   // same endpoint and let the operator pass any of those.
-  const result = await callApi({
-    session,
-    method: 'DELETE',
-    path: `/admin-api/clients/${encodeURIComponent(args.target)}`,
-  });
-  return emit(result, args.json, renderRevokeResult);
+  return execAgentDelete(session, args.target, args.json);
 }
 
 interface CallerCommonArgs {
@@ -589,18 +631,16 @@ export async function runListClients(args: ListClientsArgs): Promise<number> {
 }
 
 export async function runRevokeClient(args: RevokeClientArgs): Promise<number> {
-  warnDeprecated('revoke-client', 'agent revoke');
+  warnDeprecated('revoke-client', 'agent delete');
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);
     return 1;
   }
-  const result = await callApi({
-    session,
-    method: 'DELETE',
-    path: `/admin-api/clients/${encodeURIComponent(args.target)}`,
-  });
-  return emit(result, args.json, renderRevokeResult);
+  // The deprecated alias intentionally skips the Y/N prompt to preserve the
+  // previous behavior of revoke-client (revocation was script-friendly). The
+  // new `agent delete` command is the prompting form.
+  return execAgentDelete(session, args.target, args.json);
 }
 
 export async function runListAgents(args: ListAgentsArgs): Promise<number> {

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -33,7 +33,7 @@ import {
   addCallerCmd, agentCmd, listAgentsCmd, listCallersCmd, listClientsCmd,
   removeCallerCmd, revokeClientCmd,
   runAddCaller, runAgentCallersAdd, runAgentCallersList, runAgentCallersRemove,
-  runAgentList, runAgentRevoke, runListAgents, runListCallers, runListClients,
+  runAgentDelete, runAgentList, runListAgents, runListCallers, runListClients,
   runRemoveCaller, runRevokeClient,
 } from './admin-cli.js';
 import { authWhoamiCmd, whoamiCmd, runAuthWhoami, runWhoami } from './whoami.js';
@@ -463,8 +463,8 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     backendKind: args.backend,
     backend,
     // Daemon entrypoint: a fatal terminal close (currently 4014 "client
-    // revoked") should drop the process with a non-zero exit so
-    // systemd / a parent supervisor sees the revocation as a hard
+    // deleted") should drop the process with a non-zero exit so
+    // systemd / a parent supervisor sees the deletion as a hard
     // failure instead of masking it as a transient disconnect. The
     // Client class deliberately does not call process.exit itself —
     // tests and future in-process embedders pass a non-exiting callback.
@@ -576,8 +576,8 @@ async function main(): Promise<void> {
     case 'agent-list':
       process.exit(await runAgentList(parsed));
       break;
-    case 'agent-revoke':
-      process.exit(await runAgentRevoke(parsed));
+    case 'agent-delete':
+      process.exit(await runAgentDelete(parsed));
       break;
     case 'agent-callers-list':
       process.exit(await runAgentCallersList(parsed));

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -351,8 +351,8 @@ test('Client reconnects after WebSocket close and sends hello again', async () =
   }
 });
 
-test('Client stops on 4014 "client revoked", invokes onFatal, and does NOT reconnect (#166)', async () => {
-  // When the bridge revokes the client mid-flight, the daemon must:
+test('Client stops on 4014 "client deleted", invokes onFatal, and does NOT reconnect (#166)', async () => {
+  // When the bridge deletes the client mid-flight, the daemon must:
   //   1. surface the fatal close via `onFatal` so the entrypoint can
   //      drive process exit (the Client itself never calls process.exit),
   //   2. mark itself stopped and clear the reconnect timer so it does
@@ -396,10 +396,10 @@ test('Client stops on 4014 "client revoked", invokes onFatal, and does NOT recon
   try {
     client.start();
     await waitFor(() => helloCount === 1, 'expected initial hello');
-    connections[0]!.close(4014, 'client revoked');
+    connections[0]!.close(4014, 'client deleted');
     await waitFor(() => fatalCalls.length === 1, 'expected onFatal to fire');
     assert.equal(fatalCalls[0]!.code, 4014);
-    assert.equal(fatalCalls[0]!.reason, 'client revoked');
+    assert.equal(fatalCalls[0]!.reason, 'client deleted');
     assert.equal(internals.stopped, true, 'client must mark itself stopped');
     assert.equal(internals.reconnectTimer, null, 'reconnect must not be scheduled');
     // Give the (would-be) reconnect plenty of headroom to misfire — if
@@ -413,10 +413,10 @@ test('Client stops on 4014 "client revoked", invokes onFatal, and does NOT recon
   }
 });
 
-test('Client stops on 4005 "bad token" too (revoke-then-relaunch case, #166)', async () => {
+test('Client stops on 4005 "bad token" too (delete-then-relaunch case, #166)', async () => {
   // 4005 is what ws.ts emits when the token lookup returns no row —
   // either the operator pasted the wrong secret, or the daemon was
-  // relaunched after revocation without rotating. Both are permanent
+  // relaunched after deletion without rotating. Both are permanent
   // auth failures, so the daemon must surface onFatal instead of
   // looping reconnects against an unreachable row.
   const server = createServer();

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -61,7 +61,7 @@ export interface ClientOptions {
   // this unset and logs land on `console.log` / `.warn` / `.error`.
   logSink?: ConsoleSink;
   // Invoked when the daemon hits a non-recoverable terminal close code
-  // (currently 4014 "client revoked" and 4005 "bad token" — see the
+  // (currently 4014 "client deleted" and 4005 "bad token" — see the
   // close-handler in `connect()` for the rationale on each). The Client
   // itself only tears down its own state — `stopped = true`, reconnect
   // timer cleared, inflight tasks aborted — and delegates the
@@ -70,7 +70,7 @@ export interface ClientOptions {
   // tests that construct a Client can't recover from a forced exit,
   // and future embedders (a long-running parent process hosting
   // multiple clients) need to keep running after one client is
-  // revoked. The production entrypoint (`cli.ts runClient`) wires this
+  // deleted. The production entrypoint (`cli.ts runClient`) wires this
   // to `process.exit(1)`; tests pass a capturing callback.
   onFatal?: (info: { code: number; reason: string }) => void;
 }
@@ -339,20 +339,19 @@ export class Client {
       this.ws = null;
       // Terminal auth failures the daemon cannot recover from by waiting:
       //
-      //   - **4014 "client revoked"** (issue #166). The DB row was just
-      //     flagged `revoked = true` by an owner-side `vicoop-client
-      //     revoke-client` (the row stays — soft revocation, not
-      //     deletion — but ws.ts's `revoked = false` filter excludes it).
-      //     Future hellos will be rejected with 4005 anyway, so we exit
-      //     immediately rather than wait one more reconnect cycle.
+      //   - **4014 "client deleted"** (issue #166). The DB row was just
+      //     hard-deleted by an owner-side `vicoop-client agent delete`.
+      //     Future hellos will be rejected with 4005 anyway (the row is
+      //     gone), so we exit immediately rather than wait one more
+      //     reconnect cycle.
       //
       //   - **4005 "bad token"**. ws.ts only emits 4005 after a
-      //     `SELECT … WHERE token_hash = $1 AND revoked = false` returns
-      //     no row — either the token is wrong (operator copy/paste, or
-      //     daemon was relaunched after revocation without rotating) or
-      //     the row is revoked but the daemon missed the live 4014 close.
-      //     In both cases the failure is permanent: no amount of backoff
-      //     produces a row that matches. Looping just spams the bridge.
+      //     `SELECT … WHERE token_hash = $1` returns no row — either the
+      //     token is wrong (operator copy/paste, or daemon was relaunched
+      //     after deletion without rotating) or the row was deleted and
+      //     the daemon missed the live 4014 close. In both cases the
+      //     failure is permanent: no amount of backoff produces a row
+      //     that matches. Looping just spams the bridge.
       //
       // Other close codes (4001-4004 / 4006-4013) might be transient or
       // bug-shaped but are out of scope for this PR — they continue to
@@ -364,7 +363,7 @@ export class Client {
       // surfaces the failure instead of masking it as a transient
       // network hiccup.
       if (code === 4014 || code === 4005) {
-        const label = code === 4014 ? 'client revoked by owner' : 'bridge rejected token';
+        const label = code === 4014 ? 'client deleted by owner' : 'bridge rejected token';
         this.logger.error(`${label}; stopping (code=${code})`);
         this.stopped = true;
         this.clearReconnectTimer();

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -73,6 +73,7 @@ BEGIN
     DROP FUNCTION IF EXISTS rotate_client_token(TEXT);
     DROP FUNCTION IF EXISTS revoke_client(TEXT);
     DROP FUNCTION IF EXISTS unrevoke_client(TEXT);
+    DROP FUNCTION IF EXISTS delete_client(TEXT);
     DROP FUNCTION IF EXISTS update_client_allowed_agents(TEXT, TEXT[]);
     DROP TYPE IF EXISTS client_with_token CASCADE;
     -- normalize_wallet_address used to validate VARCHAR(42); not needed
@@ -180,13 +181,16 @@ CREATE TABLE IF NOT EXISTS clients (
   client_name       TEXT NOT NULL,
   token_hash        TEXT NOT NULL UNIQUE,
   allowed_agent_ids TEXT[] NOT NULL DEFAULT '{}',
-  revoked           BOOLEAN NOT NULL DEFAULT FALSE,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 -- Idempotent: existing dev DBs from PR A only have the columns above sans
 -- owner_email. Add it here so re-applying schema.sql brings them forward.
 ALTER TABLE clients ADD COLUMN IF NOT EXISTS owner_email TEXT;
+-- Drop the legacy soft-delete column. As of #XXX agents/clients are
+-- hard-deleted; the column is unused everywhere and the trigger / function
+-- paths below stop referencing it in the same change.
+ALTER TABLE clients DROP COLUMN IF EXISTS revoked;
 
 ALTER TABLE clients ENABLE ROW LEVEL SECURITY;
 
@@ -245,7 +249,6 @@ CREATE TABLE IF NOT EXISTS agents (
   name              TEXT NOT NULL,
   token_hash        TEXT NOT NULL UNIQUE,
   allowed_callers   TEXT[] NOT NULL DEFAULT '{}',
-  revoked           BOOLEAN NOT NULL DEFAULT FALSE,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -253,8 +256,9 @@ CREATE TABLE IF NOT EXISTS agents (
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_email TEXT;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS client_id TEXT UNIQUE DEFAULT gen_random_uuid()::text;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS allowed_callers TEXT[] NOT NULL DEFAULT '{}';
-ALTER TABLE agents ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+-- See clients.revoked drop note above. Agents was the shadow column.
+ALTER TABLE agents DROP COLUMN IF EXISTS revoked;
 UPDATE agents SET client_id = gen_random_uuid()::text WHERE client_id IS NULL;
 ALTER TABLE agents ALTER COLUMN client_id SET NOT NULL;
 
@@ -359,19 +363,17 @@ CREATE TRIGGER agents_assert_no_reserved_agent_id
   FOR EACH ROW EXECUTE FUNCTION trg_agents_assert_no_reserved_agent_id();
 
 -- Token-carrying return type for register / rotate.
--- Wrapped in DO so the migration is idempotent.
-DO $$ BEGIN
-  CREATE TYPE client_with_token AS (
-    id                TEXT,
-    owner_principal   TEXT,
-    client_name       TEXT,
-    allowed_agent_ids TEXT[],
-    revoked           BOOLEAN,
-    created_at        TIMESTAMPTZ,
-    token             TEXT
-  );
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+-- Wrapped in DO so the migration is idempotent. Dropped-and-recreated to
+-- match the post-#XXX shape after the `revoked` field was removed.
+DROP TYPE IF EXISTS client_with_token CASCADE;
+CREATE TYPE client_with_token AS (
+  id                TEXT,
+  owner_principal   TEXT,
+  client_name       TEXT,
+  allowed_agent_ids TEXT[],
+  created_at        TIMESTAMPTZ,
+  token             TEXT
+);
 
 -- Register a new client. Admins may pass an explicit owner_principal to create
 -- on behalf of another principal; non-admins own the client themselves
@@ -434,7 +436,7 @@ BEGIN
   )
   ON CONFLICT (id) DO NOTHING;
 
-  SELECT v_client_id, a.owner_principal, a.name, ARRAY[a.id], a.revoked, a.created_at, v_raw_token
+  SELECT v_client_id, a.owner_principal, a.name, ARRAY[a.id], a.created_at, v_raw_token
   FROM agents a
   WHERE a.id = v_agent_id
   INTO v_row;
@@ -446,62 +448,55 @@ $$;
 COMMENT ON FUNCTION register_client(TEXT, TEXT[], TEXT) IS
   'Register a new client. Admins may pass ownerPrincipal to create on behalf of another principal; non-admins always own the resulting client. Returns the raw bearer token — shown only once.';
 
--- Mark a client as revoked. Does not delete the row so history is preserved.
--- RLS authorizes the update (owner or admin).
-CREATE OR REPLACE FUNCTION revoke_client(client_id TEXT)
+-- Drop the legacy soft-delete functions on re-deploy. The top-of-file
+-- migration block only runs them on the wallet→principal path; on a DB
+-- that's already migrated we still want the obsolete functions gone so
+-- nothing can call them.
+DROP FUNCTION IF EXISTS revoke_client(TEXT);
+DROP FUNCTION IF EXISTS unrevoke_client(TEXT);
+
+-- Hard-delete a client and its shadow agents row. Replaces the legacy
+-- revoke/unrevoke pair: the soft-delete flag was never observed by any
+-- audit/log path, and the only consumer (`ws.ts`) treated revoked rows as
+-- "not found" anyway, so the soft state added no real value. Deleting the
+-- `clients` row cascades to `agent_policies` via FK ON DELETE CASCADE.
+-- RLS authorizes the delete (owner or admin).
+CREATE OR REPLACE FUNCTION delete_client(client_id TEXT)
 RETURNS clients
   LANGUAGE plpgsql
   SECURITY INVOKER
 AS $$
 DECLARE
   v_row clients;
+  v_target_client_id TEXT;
 BEGIN
-  UPDATE agents AS a SET revoked = TRUE, updated_at = now()
-  WHERE a.client_id = revoke_client.client_id OR a.id = revoke_client.client_id;
+  -- Resolve to the canonical clients.id whether the caller passed the
+  -- client_id or the agent_id (which is the same string after #218).
+  SELECT a.client_id INTO v_target_client_id
+  FROM agents a
+  WHERE a.client_id = delete_client.client_id OR a.id = delete_client.client_id;
 
-  UPDATE clients AS c SET revoked = TRUE
-  WHERE c.id = revoke_client.client_id
-     OR c.id = (SELECT client_id FROM agents WHERE id = revoke_client.client_id)
+  IF v_target_client_id IS NULL THEN
+    v_target_client_id := delete_client.client_id;
+  END IF;
+
+  DELETE FROM agents AS a
+  WHERE a.client_id = v_target_client_id;
+
+  DELETE FROM clients AS c
+  WHERE c.id = v_target_client_id
   RETURNING c.* INTO v_row;
 
   IF NOT FOUND THEN
-    RAISE EXCEPTION 'client not found or not authorized: %', revoke_client.client_id;
+    RAISE EXCEPTION 'client not found or not authorized: %', delete_client.client_id;
   END IF;
 
   RETURN v_row;
 END;
 $$;
 
-COMMENT ON FUNCTION revoke_client(TEXT) IS
-  'Set revoked=true on a client. Active WebSocket sessions keep running until they reconnect; registry sync is out of scope here.';
-
--- Clear the revoked flag.
-CREATE OR REPLACE FUNCTION unrevoke_client(client_id TEXT)
-RETURNS clients
-  LANGUAGE plpgsql
-  SECURITY INVOKER
-AS $$
-DECLARE
-  v_row clients;
-BEGIN
-  UPDATE agents AS a SET revoked = FALSE, updated_at = now()
-  WHERE a.client_id = unrevoke_client.client_id OR a.id = unrevoke_client.client_id;
-
-  UPDATE clients AS c SET revoked = FALSE
-  WHERE c.id = unrevoke_client.client_id
-     OR c.id = (SELECT client_id FROM agents WHERE id = unrevoke_client.client_id)
-  RETURNING c.* INTO v_row;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION 'client not found or not authorized: %', unrevoke_client.client_id;
-  END IF;
-
-  RETURN v_row;
-END;
-$$;
-
-COMMENT ON FUNCTION unrevoke_client(TEXT) IS
-  'Clear the revoked flag on a client.';
+COMMENT ON FUNCTION delete_client(TEXT) IS
+  'Hard-delete a client and its agent registration. Active WebSocket sessions are closed asynchronously by the admin-api caller (Registry.disconnectClient) — registry sync is out of scope here.';
 
 -- Issue a new bearer token for an existing client, replacing token_hash.
 -- Returns the raw token — shown only once.
@@ -526,7 +521,7 @@ BEGIN
   SET token_hash = v_token_hash
   WHERE c.id = rotate_client_token.client_id
      OR c.id = (SELECT client_id FROM agents WHERE id = rotate_client_token.client_id)
-  RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.revoked, c.created_at, v_raw_token
+  RETURNING c.id, c.owner_principal, c.client_name, c.allowed_agent_ids, c.created_at, v_raw_token
   INTO v_row;
 
   IF NOT FOUND THEN
@@ -684,7 +679,6 @@ INSERT INTO agents (
   name,
   token_hash,
   allowed_callers,
-  revoked,
   created_at,
   updated_at
 )
@@ -696,7 +690,6 @@ SELECT
   c.client_name,
   c.token_hash,
   COALESCE(ap.allowed_callers, '{}'),
-  c.revoked,
   c.created_at,
   COALESCE(ap.updated_at, c.created_at)
 FROM clients c
@@ -879,17 +872,14 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE O
 -- surface entirely). Revoke PUBLIC and grant back only to the authenticated
 -- role and to app_postgraphile (used for introspection).
 REVOKE EXECUTE ON FUNCTION register_client(TEXT, TEXT[], TEXT) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION revoke_client(TEXT) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION unrevoke_client(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION delete_client(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION rotate_client_token(TEXT) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION update_client_allowed_agents(TEXT, TEXT[]) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION agent_id_available(TEXT) FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION register_client(TEXT, TEXT[], TEXT)
   TO app_authenticated, app_postgraphile;
-GRANT EXECUTE ON FUNCTION revoke_client(TEXT)
-  TO app_authenticated, app_postgraphile;
-GRANT EXECUTE ON FUNCTION unrevoke_client(TEXT)
+GRANT EXECUTE ON FUNCTION delete_client(TEXT)
   TO app_authenticated, app_postgraphile;
 GRANT EXECUTE ON FUNCTION rotate_client_token(TEXT)
   TO app_authenticated, app_postgraphile;

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -365,7 +365,7 @@ test(
       });
       assert.equal(res.status, 200);
       const body = (await res.json()) as {
-        clients: Array<{ client_id: string; connected: boolean; revoked: boolean }>;
+        clients: Array<{ client_id: string; connected: boolean }>;
       };
       const setupAClientId = setupA.clientId;
       const ids = body.clients.map((c) => c.client_id);
@@ -373,7 +373,6 @@ test(
       assert.ok(!ids.includes(setupB.clientId), 'should not see other owner’s client');
       const a = body.clients.find((c) => c.client_id === setupAClientId)!;
       assert.equal(a.connected, true);
-      assert.equal(a.revoked, false);
     } finally {
       if (setupA) await teardown(sql, ownerA, setupA.clientId);
       if (setupB) await teardown(sql, ownerB, setupB.clientId);
@@ -413,7 +412,7 @@ test(
 );
 
 test(
-  'DELETE /admin-api/clients/:target sets revoked=true and closes the live WS with 4014',
+  'DELETE /admin-api/clients/:target hard-deletes the row and closes the live WS with 4014',
   { skip: !hasDb },
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
@@ -448,19 +447,23 @@ test(
       assert.equal(res.status, 200);
       const body = (await res.json()) as {
         client_id: string;
-        revoked: boolean;
+        deleted: boolean;
         closed_connections: number;
       };
       assert.equal(body.client_id, setup.clientId);
-      assert.equal(body.revoked, true);
+      assert.equal(body.deleted, true);
       assert.equal(body.closed_connections, 1);
-      assert.deepEqual(closeArgs, [{ code: 4014, reason: 'client revoked' }]);
+      assert.deepEqual(closeArgs, [{ code: 4014, reason: 'client deleted' }]);
 
-      // DB row reflects the revocation.
-      const rows = await sql<{ revoked: boolean }[]>`
-        SELECT revoked FROM clients WHERE id = ${setup.clientId}
+      // DB rows are gone.
+      const clientsRows = await sql<{ id: string }[]>`
+        SELECT id FROM clients WHERE id = ${setup.clientId}
       `;
-      assert.equal(rows[0]?.revoked, true);
+      assert.equal(clientsRows.length, 0);
+      const agentsRows = await sql<{ id: string }[]>`
+        SELECT id FROM agents WHERE client_id = ${setup.clientId}
+      `;
+      assert.equal(agentsRows.length, 0);
     } finally {
       if (setup) await teardown(sql, owner, setup.clientId);
       await sql.end();
@@ -474,7 +477,7 @@ test(
   async () => {
     const sql = postgres(process.env.DATABASE_URL!);
     const owner = `eth:0x${'7'.repeat(40)}`;
-    const uniqueName = `revoke-test-name-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const uniqueName = `delete-test-name-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     let setup: SetupResult | null = null;
     try {
       setup = await setupOwner(sql, owner);
@@ -524,12 +527,12 @@ test(
       assert.match(body.error, /Ambiguous client name/);
       assert.match(body.error, /Specify client_id/);
 
-      // Neither client should be revoked — the ambiguous lookup must abort
+      // Neither client should be deleted — the ambiguous lookup must abort
       // before any state change.
-      const rows = await sql<{ id: string; revoked: boolean }[]>`
-        SELECT id, revoked FROM clients WHERE id IN (${setupA.clientId}, ${setupB.clientId})
+      const rows = await sql<{ id: string }[]>`
+        SELECT id FROM clients WHERE id IN (${setupA.clientId}, ${setupB.clientId})
       `;
-      for (const r of rows) assert.equal(r.revoked, false);
+      assert.equal(rows.length, 2);
     } finally {
       if (setupA) await teardown(sql, owner, setupA.clientId);
       if (setupB) await teardown(sql, owner, setupB.clientId);
@@ -584,11 +587,11 @@ test(
       );
       assert.equal(res.status, 404);
 
-      // ownerB's row remains intact.
-      const rows = await sql<{ revoked: boolean }[]>`
-        SELECT revoked FROM clients WHERE id = ${setupB.clientId}
+      // ownerB's row remains intact (not deleted by A's request).
+      const rows = await sql<{ id: string }[]>`
+        SELECT id FROM clients WHERE id = ${setupB.clientId}
       `;
-      assert.equal(rows[0]?.revoked, false);
+      assert.equal(rows.length, 1);
     } finally {
       if (setupA) await teardown(sql, ownerA, setupA.clientId);
       if (setupB) await teardown(sql, ownerB, setupB.clientId);
@@ -607,8 +610,8 @@ test(
       const app = createHttpApp({ db: sql, registry });
       const list = await app.request('/admin-api/clients');
       assert.equal(list.status, 401);
-      const revoke = await app.request('/admin-api/clients/anything', { method: 'DELETE' });
-      assert.equal(revoke.status, 401);
+      const del = await app.request('/admin-api/clients/anything', { method: 'DELETE' });
+      assert.equal(del.status, 401);
     } finally {
       await sql.end();
     }

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -224,7 +224,6 @@ export interface ClientListItem {
   client_name: string;
   owner_principal: string;
   allowed_agent_ids: string[];
-  revoked: boolean;
   created_at: string;
   /**
    * True iff at least one agent owned by this client is currently registered
@@ -243,7 +242,7 @@ export async function listClientsForOwner(
   const rows = await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
     return tx`
-      SELECT client_id, id, owner_principal, name, revoked, created_at
+      SELECT client_id, id, owner_principal, name, created_at
       FROM agents
       ORDER BY created_at DESC
     `;
@@ -263,7 +262,6 @@ export async function listClientsForOwner(
     client_name: r.name as string,
     owner_principal: r.owner_principal as string,
     allowed_agent_ids: [r.id as string],
-    revoked: r.revoked as boolean,
     created_at:
       r.created_at instanceof Date
         ? r.created_at.toISOString()
@@ -272,11 +270,11 @@ export async function listClientsForOwner(
   }));
 }
 
-export interface RevokeClientResult {
+export interface DeleteClientResult {
   client_id: string;
   client_name: string;
-  revoked: boolean;
-  /** Number of live WebSocket connections closed as part of this revoke. */
+  deleted: true;
+  /** Number of live WebSocket connections closed as part of this delete. */
   closed_connections: number;
 }
 
@@ -320,29 +318,26 @@ async function resolveClient(
   return { id: byName[0].id as string, client_name: byName[0].client_name as string };
 }
 
-export async function revokeClientForOwner(
+export async function deleteClientForOwner(
   db: Sql,
   registry: Registry,
   principalId: string,
   target: string,
-): Promise<RevokeClientResult> {
+): Promise<DeleteClientResult> {
   const resolved = await resolveClient(db, principalId, target);
 
   await db.begin(async (tx) => {
     await setRlsContext(tx, principalId);
-    // revoke_client() is SECURITY INVOKER and re-checks RLS; resolveClient()
-    // already verified the row is visible to this principal so the UPDATE
-    // inside will succeed (or NOT FOUND if a concurrent delete happened, in
-    // which case the function raises — we let that propagate as 500 because
-    // it's a genuinely unexpected race, not a user-facing error condition).
+    // RLS-scoped DELETE; resolveClient() already verified the row is visible
+    // to this principal so the DELETE inside will succeed (or affect zero
+    // rows if a concurrent delete happened, which is acceptable — the
+    // resulting closed_connections=0 is still a correct response).
     await tx`
-      UPDATE agents
-      SET revoked = TRUE, updated_at = now()
+      DELETE FROM agents
       WHERE client_id = ${resolved.id}
     `;
     await tx`
-      UPDATE clients
-      SET revoked = TRUE
+      DELETE FROM clients
       WHERE id = ${resolved.id}
     `;
   });
@@ -354,7 +349,7 @@ export async function revokeClientForOwner(
   return {
     client_id: resolved.id,
     client_name: resolved.client_name,
-    revoked: true,
+    deleted: true,
     closed_connections: closedConnections,
   };
 }

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -126,7 +126,6 @@ Agents are local services that connect to the server via WebSocket and expose an
 - **owner_principal**: Principal of the owner (e.g. \`eth:0x<40 hex>\` or \`google:sub:<sub>\`)
 - **name**: Human-readable label
 - **allowed_callers**: Principals allowed to call this agent; empty means public
-- **revoked**: Whether this agent registration has been revoked
 - **created_at**: When it was created
 - **token_hash**: Not exposed via GraphQL — use \`mutate_registerClient\` or \`mutate_rotateClientToken\` to obtain tokens
 
@@ -135,10 +134,10 @@ Agents are local services that connect to the server via WebSocket and expose an
 - Use \`query_*\` tools to read agents and compatibility client rows. RLS enforces ownership (admins see all).
 - Client lifecycle mutations are exposed as custom GraphQL functions:
   - \`mutate_registerClient(clientName, allowedAgentIds, ownerPrincipal?)\` — compatibility wrapper that creates one agent registration and returns the raw bearer token (shown only once). \`allowedAgentIds\` must contain exactly one id. Admins may pass \`ownerPrincipal\` to create on behalf of another principal; non-admins always own the resulting agent.
-  - \`mutate_revokeClient(clientId)\` / \`mutate_unrevokeClient(clientId)\` — toggle the \`revoked\` flag. Existing WebSocket sessions stay connected until they reconnect.
+  - \`mutate_deleteClient(clientId)\` — hard-deletes the agent + client rows. Active WebSocket sessions are closed with code 4014 ("client deleted") so the daemon exits without reconnecting. There is no undo; re-register if you need the agent back.
   - \`mutate_rotateClientToken(clientId)\` — issues a new bearer token and invalidates the previous one. Returns the raw token once.
   - \`mutate_updateClientAllowedAgents(clientId, allowedAgentIds)\` — compatibility wrapper for changing the single agent id; \`allowedAgentIds\` must contain exactly one id.
-- Do NOT use the auto-generated \`mutate_updateClientById\` or \`mutate_deleteClientById\` for revoke/token rotation — always prefer the semantic mutations above.
+- Do NOT use the auto-generated \`mutate_updateClientById\` or \`mutate_deleteClientById\` for delete/token rotation — always prefer the semantic mutations above.
 - Use \`list_active_agents\` to see currently connected agents.
 - Use \`add_caller\` / \`remove_caller\` / \`list_callers\` to manage per-agent access control. Do not use GraphQL mutations to manage \`allowed_callers\`.
 - Use \`list_caller_tokens\` / \`revoke_caller_token\` (admin only) to manage opaque caller tokens. Issued via either Google OAuth device flow (provider=google) or SIWE exchange (provider=siwe).
@@ -173,7 +172,7 @@ Your conversation history is persisted in PostgreSQL. You remember all previous 
 ## PostGraphile Conventions
 
 - **Connection types**: List queries return \`{ nodes { ...fields } totalCount }\`.
-- **Filtering**: Use \`condition\` argument, e.g. \`condition: { revoked: false }\`.
+- **Filtering**: Use \`condition\` argument, e.g. \`condition: { ownerPrincipal: "eth:0x..." }\`.
 - **Sorting**: Use \`orderBy\` with values like \`CREATED_AT_DESC\`.
 - **Field naming**: snake_case SQL → camelCase GraphQL (e.g. \`owner_principal\` → \`ownerPrincipal\`).
 `;
@@ -473,7 +472,7 @@ export interface AdminAgentOptions {
 }
 
 const ADMIN_DESCRIPTION =
-  'Manages client registration, revocation, and access control for Vicoop Bridge Server. ' +
+  'Manages client registration, deletion, and access control for Vicoop Bridge Server. ' +
   'Clients are WebSocket services that bridge local A2A agents to the server. Each client ' +
   'is scoped to an owner wallet and an explicit agent ID allowlist. Requires a bridge-issued ' +
   'opaque caller token (vbc_caller_*) tied to a wallet principal; obtain one by signing a ' +
@@ -502,7 +501,7 @@ export function createAdminA2XAgent(opts: AdminAgentOptions): {
       id: 'client-management',
       name: 'Client Management',
       description:
-        'Register, revoke, and list clients with per-agent-id authorization. Wallet-based ownership with RLS.',
+        'Register, delete, and list clients with per-agent-id authorization. Wallet-based ownership with RLS.',
       tags: ['admin', 'auth', 'client', 'siwe'],
     })
     .addSecurityScheme(

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -16,11 +16,11 @@ import { getAdminWallets } from './admin-scope.js';
 import {
   AdminApiError,
   addCaller,
+  deleteClientForOwner,
   listActiveAgents,
   listCallers,
   listClientsForOwner,
   removeCaller,
-  revokeClientForOwner,
 } from './admin-api.js';
 import { agentAuthMiddleware, getAgentConn, getCaller } from './agent-auth.js';
 import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
@@ -386,7 +386,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       // not through this path, but kept in the union so a future
       // AdminApiError with status 401 still typechecks), 403 forbidden,
       // 404 not-found / RLS-hidden, 409 ambiguous-client-name from
-      // revokeClientForOwner.
+      // deleteClientForOwner.
       return c.json({ error: err.message }, err.status as 400 | 401 | 403 | 404 | 409);
     }
     logEvent('admin_api_error', { error: String(err) });
@@ -454,17 +454,17 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     }
   });
 
-  // Revoke a client by id or unique name. The target travels in the URL path
+  // Delete a client by id or unique name. The target travels in the URL path
   // and may be a UUID `client_id` or a `client_name`; the server resolves
   // the ambiguity (404 if neither matches, 409 with the candidate ids if a
-  // name matches multiple rows). On success, sets `revoked = true` and
-  // closes every live WS bound to the client with code 4014 — see the
-  // close-code rationale in Registry.disconnectClient.
+  // name matches multiple rows). On success, hard-deletes the agents +
+  // clients rows and closes every live WS bound to the client with code
+  // 4014 — see the close-code rationale in Registry.disconnectClient.
   app.delete('/admin-api/clients/:target', async (c) => {
     const auth = await authOwnerSession(c);
     if (!auth.ok) return adminApiUnauthorized(c, auth);
     try {
-      const result = await revokeClientForOwner(
+      const result = await deleteClientForOwner(
         opts.db,
         opts.registry,
         auth.principalId,

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -252,9 +252,9 @@ test('notifyAgentChange log cannot be hijacked by newline injection via agentId'
 });
 
 test('disconnectClient closes every ws bound to the client_id with code 4014', () => {
-  // Two agents owned by the revoked client + one agent owned by an unrelated
+  // Two agents owned by the deleted client + one agent owned by an unrelated
   // client. After disconnectClient('c1'), only the first two sockets see a
-  // close, and they see code 4014 with the "client revoked" reason. The
+  // close, and they see code 4014 with the "client deleted" reason. The
   // unrelated socket is untouched.
   const registry = new Registry();
   const ws1 = makeRecordingWs();
@@ -272,8 +272,8 @@ test('disconnectClient closes every ws bound to the client_id with code 4014', (
 
   const closed = registry.disconnectClient('c1');
   assert.equal(closed, 2);
-  assert.deepEqual(ws1.closeArgs, [{ code: 4014, reason: 'client revoked' }]);
-  assert.deepEqual(ws2.closeArgs, [{ code: 4014, reason: 'client revoked' }]);
+  assert.deepEqual(ws1.closeArgs, [{ code: 4014, reason: 'client deleted' }]);
+  assert.deepEqual(ws2.closeArgs, [{ code: 4014, reason: 'client deleted' }]);
   assert.deepEqual(ws3.closeArgs, []);
 });
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -74,11 +74,11 @@ export class Registry {
   }
 
   // Close every live WebSocket whose ClientConnection.clientId matches.
-  // Used by the admin-api revoke-client path so a daemon whose client row
-  // was just revoked sees a distinct close code (4014) and exits without
+  // Used by the admin-api delete-client path so a daemon whose client row
+  // was just deleted sees a distinct close code (4014) and exits without
   // reconnecting. Returns the number of connections closed; callers
   // surface that to the operator as confirmation that an orphan vs a
-  // live daemon was revoked.
+  // live daemon was deleted.
   //
   // 4014 is the next unused slot in the bridge's WS close-code range:
   //   - 4001-4008 ws.ts (hello timeout, invalid frame, expected hello,
@@ -90,7 +90,7 @@ export class Registry {
   //   - 4012-4013 card-resolver.ts (missing card-or-backend, unknown
   //     backend kind)
   // Reusing any of those would make the daemon misclassify unrelated
-  // handshake failures as revocation and exit instead of backing off.
+  // handshake failures as deletion and exit instead of backing off.
   //
   // The close itself fires this WS's own `close` handler asynchronously,
   // which in turn calls unregisterAgent and removes the entry from the
@@ -101,7 +101,7 @@ export class Registry {
     let closed = 0;
     for (const conn of this.agents.values()) {
       if (conn.clientId !== clientId) continue;
-      conn.ws.close(4014, 'client revoked');
+      conn.ws.close(4014, 'client deleted');
       closed++;
     }
     return closed;

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -24,10 +24,14 @@ interface ClientRow {
 }
 
 async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
+  // Agent registrations are hard-deleted by admin-api.deleteClientForOwner,
+  // so token_hash lookup alone is sufficient: a stale token whose row was
+  // deleted simply matches nothing and the daemon sees the 4005 "bad token"
+  // path.
   const rows = await sql<ClientRow[]>`
     SELECT id, client_id, owner_principal, allowed_callers
     FROM agents
-    WHERE token_hash = ${hash} AND revoked = false
+    WHERE token_hash = ${hash}
   `;
   return rows[0] ?? null;
 }


### PR DESCRIPTION
## Summary

- `revoke_client()` → `delete_client()`. Hard-deletes agents+clients rows (and agent_policies via FK cascade) instead of flipping `revoked = TRUE`. The soft-delete had no real consumer.
- Drops the `revoked` column from `agents` and `clients`, removes `unrevoke_client()` (dead code), and prunes `revoked` from the `client_with_token` composite.
- Renames `vicoop-client agent revoke` → `vicoop-client agent delete` with a Y/N confirmation prompt (`--yes` / `-y` to skip). Non-TTY stdin aborts unless `--yes` is set.
- DELETE `/admin-api/clients/:target` response: `{ revoked: true }` → `{ deleted: true }`. GET `/admin-api/clients` no longer carries `revoked`.
- Daemon close-code 4014 reason changes from `"client revoked"` to `"client deleted"`. Behavior (exit non-zero, no reconnect) unchanged.

See `.changeset/agent-delete.md` for the full migration notes.

## Why no soft-delete?

The codebase explore turned up zero load-bearing consumers:
- No audit/message log tables reference agent_id/client_id.
- `ws.ts` filtered `revoked = false` on token lookup — equivalent to row-absent.
- `unrevoke_client()` had no callers anywhere.
- The only FK (`agent_policies.client_id`) is `ON DELETE CASCADE` already.

So we ship hard delete and a clearer mental model.

## Test plan

- [x] `pnpm -r typecheck` clean (server, client, protocol, admin-ui)
- [x] `pnpm -r test`: server 182/0, client 490/0
- [x] New unit test: `agent delete --yes` DELETEs `/admin-api/clients/<target>`
- [x] New unit test: `agent delete` without `--yes` aborts on non-TTY stdin (no API hit)
- [x] Updated: registry close-code 4014 reason → `'client deleted'`
- [x] Updated: client.ts close-handler `onFatal` for 4014 → reason `'client deleted'`
- [ ] DB integration tests (`admin-api.test.ts`) — skipped in CI without `DATABASE_URL`; reviewer with local Postgres should run `DATABASE_URL=… pnpm --filter @vicoop-bridge/server test` to confirm `delete_client()` + new response shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)