### PR TITLE
fix(server): resolve PostGraphile DeleteClientPayload type conflict

### DIFF
--- a/.changeset/hotfix-postgraphile-delete-conflict.md
+++ b/.changeset/hotfix-postgraphile-delete-conflict.md
@@ -1,0 +1,20 @@
+---
+'@vicoop-bridge/server': patch
+---
+
+Hide PostGraphile auto-generated `deleteClient` / `deleteAgent` mutations.
+
+The previous PR introduced `delete_client(TEXT)`, which PostGraphile
+surfaces as a `deleteClient(input: …): DeleteClientPayload` mutation.
+That collided with the auto-generated row-by-PK delete on the `clients`
+table (same mutation name, same payload type name), producing a
+`A type naming conflict has occurred — two entities have tried to define
+the same type 'DeleteClientPayload'` build error in the server log on
+startup. The server kept running (it's a recoverable schema-build error)
+but the custom mutation was not callable via GraphQL.
+
+Fix: extend the existing `@omit create` comments on `clients` and `agents`
+to `@omit create,delete`, so the only delete path on either table is the
+semantic `delete_client(TEXT)` SQL function. Bypassing the wrapper via
+`deleteAgentById` would also leave an orphan `clients` row, so blocking
+it here is the right behavior independent of the type conflict.

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -233,7 +233,12 @@ COMMENT ON COLUMN clients.token_hash IS E'@omit';
 -- Block the auto-generated create mutation: token_hash cannot be supplied via
 -- GraphQL (it is @omit) so PostGraphile's createClient would fail at runtime.
 -- Clients must be created through register_client() which generates the token.
-COMMENT ON TABLE clients IS E'@omit create';
+-- Also block auto-generated delete: the custom delete_client(TEXT) SQL
+-- function (below) is the canonical path because it cleans up both the
+-- legacy clients row and the agents shadow row; exposing PostGraphile's
+-- deleteClientById alongside it also causes a `DeleteClientPayload` type
+-- name conflict on schema build.
+COMMENT ON TABLE clients IS E'@omit create,delete';
 
 -- ============================================================
 -- 3b. Agents table (unified server-side persistence model)
@@ -292,7 +297,12 @@ CREATE POLICY agents_postgraphile ON agents
   WITH CHECK (true);
 
 COMMENT ON COLUMN agents.token_hash IS E'@omit';
-COMMENT ON TABLE agents IS E'@omit create';
+-- Mirrors `clients`: token_hash is server-managed (no create), and the
+-- semantic delete path is `delete_client(TEXT)` which removes both the
+-- agents row and the legacy clients row in one transaction. Letting
+-- GraphQL clients call `deleteAgentById` directly would leave an orphan
+-- `clients` row.
+COMMENT ON TABLE agents IS E'@omit create,delete';
 
 -- ------------------------------------------------------------
 -- 3a. Client CRUD mutations (exposed by PostGraphile)


### PR DESCRIPTION
## Summary

Hotfix for #259. After merge, the server logged on every boot:

\`\`\`
Error: A type naming conflict has occurred - two entities have tried to define the same type 'DeleteClientPayload'.
\`\`\`

PostGraphile auto-generates a row-PK \`deleteClient\` mutation on the \`clients\` table; my new \`delete_client(TEXT)\` SQL function produces a mutation of the same name and the same payload type. The error is "recoverable" (server keeps running) but \`mutate_deleteClient\` was not actually callable via GraphQL.

Fix: extend \`@omit create\` → \`@omit create,delete\` on \`clients\` and \`agents\`. The semantic \`delete_client(TEXT)\` wrapper is now the only delete path on either table — also the right behavior independently, since it cleans up the legacy \`clients\` row and the \`agents\` shadow row in one transaction.

## Test plan

- [x] \`pnpm --filter @vicoop-bridge/server typecheck\` clean
- [ ] Watch deploy log on merge: no more \`DeleteClientPayload\` conflict on \`[server] schema ensured\` boot
- [ ] GraphQL: \`mutation { deleteClient(input: { clientId: \"…\" }) { ... } }\` resolves (was 404 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)