### PR TITLE
chore(changesets): unblock release pipeline, target client 0.20.0

### DIFF
--- a/.changeset/agent-delete-client.md
+++ b/.changeset/agent-delete-client.md
@@ -1,0 +1,38 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Rename `agent revoke` to `agent delete` and align with the server's
+hard-delete semantics.
+
+The server-side soft-delete machinery is being removed (see companion
+server changeset / `feat(server,client)!:` commit); the CLI follows
+suit. The deprecated flat alias `vicoop-client revoke-client` is
+preserved with a deprecation warning that now points at
+`agent delete`, so existing scripts keep working through this
+release — that's why this is shipped as a minor rather than a major
+bump.
+
+**New / changed**
+
+- `vicoop-client agent revoke <TARGET>` →
+  `vicoop-client agent delete <TARGET>`. The new `delete` subcommand
+  prompts `Delete agent "<TARGET>"? [y/N]` before calling the API;
+  pass `--yes` / `-y` to skip (required for non-TTY usage like
+  scripts and CI).
+- The deprecated `vicoop-client revoke-client` flat alias now points
+  at `agent delete` in its warning text. It still calls the same
+  endpoint and skips the prompt (preserving script behavior).
+- Daemon close-code 4014 reason text changes from `"client revoked"`
+  to `"client deleted"`; the log line is now `client deleted by
+  owner; stopping`. The behavior (exit non-zero, no reconnect) is
+  unchanged.
+
+**Migration**
+
+- Interactive users on `vicoop-client agent revoke …`: switch to
+  `agent delete …` and confirm the prompt.
+- Scripts on the same: switch to `agent delete --yes …`.
+- Scripts on the legacy `vicoop-client revoke-client …` flat form:
+  no immediate action required, but plan to move to `agent delete
+  --yes` before the deprecated alias is removed.

--- a/.changeset/agent-delete-server.md
+++ b/.changeset/agent-delete-server.md
@@ -1,9 +1,8 @@
 ---
 '@vicoop-bridge/server': major
-'@vicoop-bridge/client': major
 ---
 
-Rename agent revocation to deletion and switch to hard delete.
+Rename agent revocation to deletion and switch to hard delete (server side).
 
 The previous `revoke_client()` flow set `revoked = TRUE` on the `agents`
 and `clients` rows but kept them around for "audit history." Nothing
@@ -30,24 +29,8 @@ it.
 - `GET /admin-api/clients` no longer includes a `revoked` field on each
   client.
 
-**Client CLI (breaking)**
-
-- `vicoop-client agent revoke <TARGET>` → `vicoop-client agent delete <TARGET>`.
-  The new `delete` subcommand prompts `Delete agent "<TARGET>"? [y/N]`
-  before calling the API; pass `--yes` / `-y` to skip (required for
-  non-TTY usage like scripts and CI).
-- The deprecated `vicoop-client revoke-client` flat alias now points at
-  `agent delete` in its warning text. It still calls the same endpoint
-  and skips the prompt (preserving script behavior).
-- Daemon close-code 4014 reason text changes from `"client revoked"` to
-  `"client deleted"`; the log line is now `client deleted by owner;
-  stopping`. The behavior (exit non-zero, no reconnect) is unchanged.
-
 **Migration**
 
-- Operators using `vicoop-client agent revoke …` interactively: switch
-  to `agent delete …` and confirm the prompt.
-- Scripts using the same: switch to `agent delete --yes …`.
 - API consumers reading `revoked: true` from the DELETE response:
   switch to `deleted: true`. Consumers reading the `revoked` field on
   `GET /admin-api/clients` rows: remove that field — agents that exist

--- a/.changeset/win32-cmd-shim-spawn.md
+++ b/.changeset/win32-cmd-shim-spawn.md
@@ -1,0 +1,21 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Route `node:child_process.spawn` through the shell on Windows so the
+codex / vicoop-codex backends can resolve the npm-installed `.cmd`
+shims (#254).
+
+`spawn('vicoop-codex', …)` and `spawn('codex', …)` fail with ENOENT
+on Windows because npm publishes the binaries as `.cmd` shims that
+Node cannot resolve without going through `cmd.exe`. Setting
+`shell: process.platform === 'win32'` in both `defaultSpawn`
+(vicoop-codex backend) and `defaultAppServerSpawn` (codex app-server
+RPC) lets win32 take the shim-resolution path; POSIX hosts keep
+`shell: false` to avoid the spawn-with-shell deprecation warning and
+quoting surprises.
+
+Safe because `command` and `args` at both call sites are fully
+internal to the bridge client (`'vicoop-codex' / ['call']` and
+`'codex' / ['app-server']`); no operator-supplied tokens enter the
+argv, so shell-injection is not a concern.


### PR DESCRIPTION
## Summary

The Release workflow on `main` has been failing since #259 landed:

```
🦋 error Found mixed changeset agent-delete
🦋 error Found ignored packages: @vicoop-bridge/server
🦋 error Found not ignored packages: @vicoop-bridge/client
🦋 error Mixed changesets that contain both ignored and not ignored
       packages are not allowed
```

Changesets v2 refuses to run `version` when a single changeset bumps both an ignored package (`@vicoop-bridge/server` lives in the `ignore` array in `.changeset/config.json`) and a non-ignored one (`@vicoop-bridge/client`). That left the existing `chore: version packages` PR #246 stuck on a snapshot from before #259 and #260 landed, and blocked any new bridge-client release.

This PR fixes the pipeline so the next bridge-client release can ship as **0.20.0**.

## Changes

- Split `.changeset/agent-delete.md` into two single-package changesets:
  - `agent-delete-server.md` — `@vicoop-bridge/server: major` (still ignored at release time; the entry is informational)
  - `agent-delete-client.md` — `@vicoop-bridge/client: **minor**`
- Downgrade the client side from major to minor. Justification: the legacy flat alias `vicoop-client revoke-client` is preserved with a deprecation warning that now points at `agent delete`, so existing scripts keep working through this release. Per request, target version is **0.20.0** (not 1.0.0).
- Add `.changeset/win32-cmd-shim-spawn.md` — `@vicoop-bridge/client: patch` for #254 (win32 `.cmd` shim spawn fix), which landed without a changeset and would otherwise be missing from the 0.20.0 CHANGELOG.

## Verified locally

- `pnpm changeset status` resolves client at **minor**.
- `pnpm changeset version` runs cleanly with no mixed-changeset error and bumps `packages/client/package.json` from `0.19.1` → `0.20.0`.
- `pnpm --filter @vicoop-bridge/client typecheck` ✓
- `pnpm --filter @vicoop-bridge/client build` ✓
- `pnpm --filter @vicoop-bridge/client test` — 490 / 490 pass.

## Test plan

- [ ] Merge this PR.
- [ ] Confirm the Release workflow on `main` succeeds (the previous run at `31e5f07` failed at the `changeset version` step).
- [ ] Confirm the `chore: version packages` PR (#246) auto-refreshes to bump client to `0.20.0` and includes the `agent delete` rename + the win32 `.cmd` shim fix in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)