### PR TITLE
docs: add AGENTS.md / CLAUDE.md orientation + harden .changeset/README.md

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,11 +6,27 @@ intent files. They drive `@vicoop-bridge/client` versioning, the per-release
 
 ## When to add a changeset
 
-Any PR that should bump `@vicoop-bridge/client` (a behaviour change, fix, or
-docs change relevant to operators) needs a changeset. Changes that only
-touch `@vicoop-bridge/server`, `@vicoop-bridge/protocol`, or
-`@vicoop-bridge/admin-ui` can skip it — those packages are listed under
-`ignore` in `config.json` and are not versioned.
+Any PR that should bump `@vicoop-bridge/client` (a behaviour change, fix,
+or docs change relevant to operators) needs a changeset. Only
+`@vicoop-bridge/client` is versioned via this pipeline.
+
+## When NOT to add a changeset
+
+Skip the changeset entirely if your PR only touches:
+
+- `@vicoop-bridge/server` — deployed via `pnpm deploy:server` / `fly
+  deploy`, not Changesets. Record server breaking changes in the PR
+  description and commit body.
+- `@vicoop-bridge/protocol` — workspace dep only; consumers (client,
+  server) pin via `workspace:*` and rebuild.
+- `@vicoop-bridge/admin-ui` — bundled into the server, ships with it.
+
+These three are listed under `ignore` in `config.json`.
+
+If your PR touches **both** the client and one of the ignored packages,
+write a **client-only** changeset describing the client-side impact.
+Never put the ignored package in the same file as the client (see
+"Rules the pipeline is unforgiving about" below).
 
 ## How
 
@@ -35,3 +51,48 @@ operator-facing summary. The command writes a markdown file under
    new `CHANGELOG.md` entry as the body. A follow-up step then runs
    `scripts/upload-client-release-assets.sh`, which builds the portable
    client bundle and attaches `.tgz` + `.sha256` to that release.
+
+## Rules the pipeline is unforgiving about
+
+`changesets/action` does not inspect what's inside a changeset to
+decide whether to publish vs. open a PR — it just checks whether any
+`.changeset/*.md` files exist and whether `pnpm changeset version`
+errors out. Two failure modes have stalled releases in the past:
+
+1. **Never mix ignored and non-ignored packages in one changeset
+   file.** A single `.md` that bumps both `@vicoop-bridge/client`
+   (versioned) and `@vicoop-bridge/server` (ignored) makes
+   `pnpm changeset version` exit with `Found mixed changeset …`, which
+   halts the entire Release run. If a PR has both-sided impact, split
+   into one client-only `.md` and (optionally) one server-only `.md`.
+   Precedent: #261.
+
+2. **Don't leave changesets targeting only ignored packages on
+   `main`.** Even though they bump nothing, `changesets/action` counts
+   them as "pending" and takes the version-PR path. `pnpm changeset
+   version` then runs as a no-op (no diff), the action tries to open a
+   "chore: version packages" PR with no commits in it, GitHub rejects
+   with `No commits between main and changeset-release/main`, and the
+   publish step (`pnpm changeset tag`) is never reached — so no tag,
+   no GitHub release. Precedent: #262.
+
+   In practice: if you write a server-only changeset to capture a
+   breaking change as changelog-style prose, treat the file as a
+   short-lived artifact — delete it before (or in the same PR as) the
+   next client release. The safer default is to skip server-only
+   changesets entirely and put the prose in the PR description.
+
+## Recovering when the Release run fails
+
+- `Found mixed changeset …` → split the offending file into one
+  changeset per package (one client-only `.md`, one server-only or
+  none at all), then push to `main`.
+- `No commits between main and changeset-release/main` → list
+  `.changeset/*.md` on `main`. If any target only packages from the
+  `ignore` array, delete them, push to `main`. The Release workflow
+  reruns on the push; with zero pending changesets it falls into the
+  publish branch and tags + releases the version already committed by
+  the previous "chore: version packages" merge.
+- The asset-upload step is idempotent and re-runs unconditionally — if
+  it fails between tag-creation and asset-upload, re-trigger via
+  Actions → Release → Run workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,67 @@
+# Repo orientation
+
+Monorepo for `vicoop-bridge` — an A2A bridge that exposes local coding
+agents (claude / codex / openclaw) to Google A2A clients via an
+outbound WebSocket to a public server.
+
+`CLAUDE.md` in the repo root is a symlink to this file. Keep edits to
+this file; both names resolve to the same content.
+
+## Packages
+
+| Path                  | Package                       | Role                                                                                  | Released via      |
+| --------------------- | ----------------------------- | ------------------------------------------------------------------------------------- | ----------------- |
+| `packages/client`     | `@vicoop-bridge/client`       | Bun-compiled CLI operators install to connect their local agent to the bridge server. | Changesets + tags |
+| `packages/server`     | `@vicoop-bridge/server`       | The bridge gateway.                                                                   | `fly deploy`      |
+| `packages/admin-ui`   | `@vicoop-bridge/admin-ui`     | Web UI bundled into the server.                                                       | Bundled w/ server |
+| `packages/protocol`   | `@vicoop-bridge/protocol`     | Shared types / codecs.                                                                | Workspace-only    |
+
+`@vicoop-bridge/{server,protocol,admin-ui}` are listed under `ignore`
+in `.changeset/config.json` and have no published artifact — server
+and admin-ui ship together via `fly deploy`, protocol is consumed
+internally as a workspace dep.
+
+## Common commands
+
+From the repo root:
+
+```bash
+pnpm install                                # install once
+pnpm -r build                               # build all packages (run this before client tests — they import @vicoop-bridge/protocol from its dist/)
+pnpm -r typecheck                           # typecheck all packages
+pnpm --filter @vicoop-bridge/client test    # client tests (~490 today)
+pnpm --filter @vicoop-bridge/server test    # server tests
+pnpm dev:client                             # tsx watch on the client CLI
+pnpm dev:server                             # tsx watch on the server
+pnpm dev:admin-ui                           # vite dev server for the admin UI
+pnpm deploy:server                          # fly deploy the server
+pnpm changeset                              # add a release intent file for the client
+```
+
+## Release flow (client)
+
+1. Add a changeset with your PR (`pnpm changeset`).
+2. The `Release` workflow keeps a single "chore: version packages" PR
+   up to date with the resulting `package.json` bump and the matching
+   `packages/client/CHANGELOG.md` entry.
+3. Merging that Version PR triggers the publish step:
+   `pnpm changeset tag` creates `@vicoop-bridge/client@<version>`, the
+   action pushes the tag and creates the GitHub release, then
+   `scripts/upload-client-release-assets.sh` attaches Bun
+   cross-compiled binaries (macOS / Linux / Windows + `.sha256` for
+   each).
+
+**Full operational rules — including which packages NOT to write
+changesets for, why mixed or ignored-only changesets break the
+pipeline, and how to recover from a stalled Release run — live in
+[`.changeset/README.md`](./.changeset/README.md). Read it before
+authoring or cleaning up changesets.**
+
+## Deeper reading
+
+- [`README.md`](./README.md) — project overview and onboarding pointers
+- [`docs/design.md`](./docs/design.md) — architecture
+- [`docs/install-client.md`](./docs/install-client.md) — operator install + SIWE / registerClient flow
+- [`docs/local-testing.md`](./docs/local-testing.md), [`docs/remote-testing.md`](./docs/remote-testing.md) — testing flows
+- [`docs/claude-e2e.md`](./docs/claude-e2e.md), [`docs/openclaw-e2e.md`](./docs/openclaw-e2e.md) — backend-specific E2E
+- [`docs/container.md`](./docs/container.md) — container runtime profiles (bundled-direct + external-runtime)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

Lightweight repo orientation for agents (Claude Code, Codex, etc.) and humans landing in the repo for the first time, plus the release-pipeline rules learned the hard way during the 0.20.0 client release (see #261, #262).

## What's in here

- **`AGENTS.md`** — canonical orientation file. Single-entry-point summary of:
  - Which packages are versioned (`@vicoop-bridge/client` only) vs. deployed (`@vicoop-bridge/server` via `fly deploy`) vs. workspace-only (`@vicoop-bridge/protocol`, `@vicoop-bridge/admin-ui`).
  - Common commands from the repo root (`pnpm -r build`, `pnpm --filter … test`, `pnpm dev:*`, `pnpm deploy:server`, `pnpm changeset`).
  - Three-step release flow summary, with a pointer to `.changeset/README.md` for the detailed rules.
  - Links into existing `docs/` for design, install, testing, container profiles.

  Intentionally narrow — not a duplicate of `README.md` or `docs/`, just a navigable jumping-off point.

- **`CLAUDE.md`** — symlink to `AGENTS.md` (git mode `120000`). Both names resolve to the same content, no sync burden.

- **`.changeset/README.md`** — two new sections capturing the failure modes from this release cycle:
  - *Rules the pipeline is unforgiving about*: (1) never mix ignored + non-ignored packages in one changeset file (would have prevented #261), (2) don't leave changesets that target only ignored packages sitting on `main` (would have prevented #262).
  - *Recovering when the Release run fails*: diagnostic-keyed instructions for the two failure modes above, plus the note that the asset-upload step is idempotent.

  Detailed operational content lives here, not in `AGENTS.md`, because this is the file someone authoring or cleaning up a changeset will actually open.

## Why split the operational rules between two files

`AGENTS.md` is the "first 30 seconds in this repo" file — anyone reading it just needs to know enough to find the right place. The changeset rules are detailed and only relevant when you're working with `.changeset/*.md`; putting them in front of someone who opens that directory is more likely to actually shape behavior than burying them in a generic root file.

## Test plan

- [ ] Verify `CLAUDE.md` is a symlink in the merged tree (`ls -la CLAUDE.md` shows `→ AGENTS.md`).
- [ ] Verify `cat CLAUDE.md` returns the same content as `cat AGENTS.md`.
- [ ] No code changes — no test suite needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)