### PR TITLE
feat(client)!: CLI surface cleanup — unify --cwd/--runtime, polish help

### DIFF
--- a/.changeset/help-cleanup.md
+++ b/.changeset/help-cleanup.md
@@ -1,5 +1,10 @@
 ---
-'@vicoop-bridge/client': patch
+'@vicoop-bridge/client': minor
 ---
 
-CLI help cleanup: drop the `--runtime` option from `container init` (it was a placeholder that only accepted `container` and exited with an error for `host`); name the `KIND` positional and list its valid values (`claude`, `codex`); remove the noisy config-precedence blurb from the help output (it leaked under every subcommand) — the same content lives in `docs/install-client.md`; on parse errors, scope the pre-error help to the partially parsed subcommand instead of dumping the full root usage.
+CLI cleanup (breaking flag changes):
+
+- **Unify per-backend `--cwd` / `--runtime`.** The daemon flags `--claude-cwd`, `--codex-cwd`, `--claude-runtime`, `--codex-runtime` are replaced by `--cwd` and `--runtime`. The new flags are scoped to whichever backend `--backend` selects; on the config side, `backends.claude.{cwd,runtime}` and `backends.codex.{cwd,runtime}` keep their per-backend shape. Scripts passing the old flags must update.
+- **`container init` polish.** Drop the placeholder `--runtime` option (only `container` was implemented; `host` exited with an error); name the `KIND` positional and list its valid values (`claude`, `codex`).
+- **Help output cleanup.** Remove the noisy config-precedence blurb from `--help` (the same content lives in `docs/install-client.md`). Strip internal `#NNN` / `PR <letter>` issue references from operator-facing descriptions and runtime error messages.
+- **Scoped pre-error help.** On parse errors, render the partially parsed subcommand's help (e.g. `vicoop-client container` prints just the `container` group) instead of dumping the full root usage.

--- a/.changeset/help-cleanup.md
+++ b/.changeset/help-cleanup.md
@@ -2,4 +2,4 @@
 '@vicoop-bridge/client': patch
 ---
 
-CLI help cleanup: drop the `--runtime` option from `container init` (it was a placeholder that only accepted `container` and exited with an error for `host`); name the `KIND` positional and list its valid values (`claude`, `codex`); move the config-precedence note from the always-on footer to the top-level `--help` only, so it no longer prints under every subcommand; on parse errors, scope the pre-error help to the partially parsed subcommand instead of dumping the full root usage.
+CLI help cleanup: drop the `--runtime` option from `container init` (it was a placeholder that only accepted `container` and exited with an error for `host`); name the `KIND` positional and list its valid values (`claude`, `codex`); remove the noisy config-precedence blurb from the help output (it leaked under every subcommand) — the same content lives in `docs/install-client.md`; on parse errors, scope the pre-error help to the partially parsed subcommand instead of dumping the full root usage.

--- a/.changeset/help-cleanup.md
+++ b/.changeset/help-cleanup.md
@@ -4,7 +4,7 @@
 
 CLI cleanup (breaking flag changes):
 
-- **Unify per-backend `--cwd` / `--runtime`.** The daemon flags `--claude-cwd`, `--codex-cwd`, `--claude-runtime`, `--codex-runtime` are replaced by `--cwd` and `--runtime`. The new flags are scoped to whichever backend `--backend` selects; on the config side, `backends.claude.{cwd,runtime}` and `backends.codex.{cwd,runtime}` keep their per-backend shape. Scripts passing the old flags must update.
+- **Unify per-backend `--cwd` / `--runtime`.** The daemon flags `--claude-cwd`, `--codex-cwd`, `--claude-runtime`, `--codex-runtime` are replaced by `--cwd` and `--runtime`. The new flags are scoped to whichever backend `--backend` selects; on the config side, `backends.claude.{cwd,runtime}` and `backends.codex.{cwd,runtime}` keep their per-backend shape. Scripts passing the old flags must update. Pairing `--cwd` / `--runtime` with a backend that doesn't support them (echo / openclaw / vicoop-codex) is now a hard error instead of being silently ignored.
 - **`container init` polish.** Drop the placeholder `--runtime` option (only `container` was implemented; `host` exited with an error); name the `KIND` positional and list its valid values (`claude`, `codex`).
 - **Help output cleanup.** Remove the noisy config-precedence blurb from `--help` (the same content lives in `docs/install-client.md`). Strip internal `#NNN` / `PR <letter>` issue references from operator-facing descriptions and runtime error messages.
 - **Scoped pre-error help.** On parse errors, render the partially parsed subcommand's help (e.g. `vicoop-client container` prints just the `container` group) instead of dumping the full root usage.

--- a/.changeset/help-cleanup.md
+++ b/.changeset/help-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+CLI help cleanup: drop the `--runtime` option from `container init` (it was a placeholder that only accepted `container` and exited with an error for `host`); name the `KIND` positional and list its valid values (`claude`, `codex`); move the config-precedence note from the always-on footer to the top-level `--help` only, so it no longer prints under every subcommand; on parse errors, scope the pre-error help to the partially parsed subcommand instead of dumping the full root usage.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -278,11 +278,13 @@ re-runs.
 > reachable as a CLI flag and as a `config.json` field — pick whichever
 > surface fits the deployment. Top-level fields (`server_url`,
 > `server_token`, `agent_id`, `backend`, `card`) map to `--server`,
-> `--token`, `--agentId`, `--backend`, `--card`. Backend-specific fields
-> under `backends.*` map to `--claude-cwd`, `--claude-settings-file`,
-> `--codex-cwd`, `--codex-sandbox`, `--openclaw-gateway`,
-> `--openclaw-gateway-token`, `--openclaw-agent`,
-> `--openclaw-openai-compat-agent`, `--openclaw-task-timeout-ms`.
+> `--token`, `--agentId`, `--backend`, `--card`. Per-backend `cwd` /
+> `runtime` keys under `backends.<active>.*` map to the unified
+> `--cwd` / `--runtime` flags (scoped to whichever backend `--backend`
+> selected). Backend-specific fields map to `--claude-settings-file`,
+> `--codex-sandbox`, `--openclaw-gateway`, `--openclaw-gateway-token`,
+> `--openclaw-agent`, `--openclaw-openai-compat-agent`,
+> `--openclaw-task-timeout-ms`.
 
 > **Env vars are out of the runtime-config chain.** Past releases also
 > consulted `SERVER_URL` / `SERVER_TOKEN` / `AGENT_ID` / `BACKEND` /
@@ -522,7 +524,7 @@ different repository than the one `vicoop-client` itself runs in:
 ```sh
 "$INSTALL_DIR/vicoop-client" \
   --backend claude \
-  --claude-cwd "$HOME/vicoop-bridge"
+  --cwd "$HOME/vicoop-bridge"
 ```
 
 Both knobs can also live in the canonical `config.json` (resolved per Step
@@ -533,7 +535,7 @@ the daemon-level precedence (Step 6 intro).
 
 | Flag | `backends.claude.*` |
 |---|---|
-| `--claude-cwd` | `cwd` |
+| `--cwd` | `cwd` |
 | `--claude-settings-file` | `settings` (JSON object) |
 
 > **Sandbox-on by default.** When neither `--claude-settings-file` nor
@@ -546,9 +548,10 @@ the daemon-level precedence (Step 6 intro).
 > complete `settings` object — it replaces the default entirely. To run
 > without a sandbox, pass `{ "sandbox": { "enabled": false } }`.
 
-`--claude-cwd` defaults to the current working directory of the client
+`--cwd` defaults to the current working directory of the client
 process. Set it when the released bundle lives outside the repository you
-want Claude to edit.
+want Claude to edit. (Same flag is shared with the Codex backend; it's
+scoped to whichever backend `--backend` selects.)
 
 The Claude backend also injects a small `--append-system-prompt` on every
 spawned `claude` telling it its own A2A mention (`@<agentId>@<host>`) so
@@ -620,7 +623,7 @@ different repository / loosen the sandbox:
 ```sh
 "$INSTALL_DIR/vicoop-client" \
   --backend codex \
-  --codex-cwd "$HOME/vicoop-bridge" \
+  --cwd "$HOME/vicoop-bridge" \
   --codex-sandbox workspace-write
 ```
 
@@ -631,15 +634,17 @@ The flag wins over config.
 
 | Flag | `backends.codex.*` |
 |---|---|
-| `--codex-cwd` | `cwd` |
+| `--cwd` | `cwd` |
 | `--codex-sandbox` | `sandbox_mode` |
 
-`--codex-cwd` defaults to the current working directory of the client
-process. The v1 backend accepts text plus inline image `file.bytes`
-inputs and returns text output. `--codex-sandbox` is optional and
-accepts `read-only`, `workspace-write`, or `danger-full-access`; the
-client passes it to Codex as `-c sandbox_mode="<mode>"` so the same
-setting applies to fresh and resumed Codex sessions.
+`--cwd` defaults to the current working directory of the client
+process (shared with the Claude backend; scoped to whichever backend
+`--backend` selects). The v1 backend accepts text plus inline image
+`file.bytes` inputs and returns text output. `--codex-sandbox` is
+optional and accepts `read-only`, `workspace-write`, or
+`danger-full-access`; the client passes it to Codex as
+`-c sandbox_mode="<mode>"` so the same setting applies to fresh and
+resumed Codex sessions.
 
 > **Sandbox-on by default.** With neither `--codex-sandbox` nor
 > `backends.codex.sandbox_mode` set, the backend passes

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -74,6 +74,50 @@ test('missing required args reported as a list', () => {
   // backend defaults to 'echo' and server defaults to DEFAULT_BRIDGE_URL,
   // so only the two credential fields can be missing.
   assert.deepEqual(r.missing, ['token', 'agentId']);
+  assert.deepEqual(r.errors, []);
+});
+
+test('--runtime with a non-runtime-capable backend is a hard error', () => {
+  // echo (and openclaw / vicoop-codex) don't have a runtime container
+  // profile; passing --runtime with one of them is almost always an
+  // operator typo, so surface it instead of silently ignoring.
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'echo', runtime: 'container' },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--runtime') && e.includes('echo')),
+    `expected error mentioning --runtime and echo, got: ${r.errors.join(' | ')}`,
+  );
+});
+
+test('--cwd with a non-process-spawning backend is a hard error', () => {
+  // openclaw routes tasks over a gateway WS; there's no host-side child
+  // process to give a working directory to.
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'openclaw', cwd: '/some/dir' },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--cwd') && e.includes('openclaw')),
+    `expected error mentioning --cwd and openclaw, got: ${r.errors.join(' | ')}`,
+  );
+});
+
+test('--runtime + --cwd with --backend claude is accepted', () => {
+  // Positive control: the supported pairing must still parse cleanly.
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', runtime: 'container', cwd: '/repo' },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.runtime, 'container');
+  assert.equal(r.args.cwd, '/repo');
 });
 
 test('parseFlags picks up known flags', () => {

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -127,14 +127,14 @@ test('parseFlags promotes env-only knobs to first-class flags (issue #189 §1)',
   // backend factories receive them via DaemonArgs rather than reading
   // process.env directly.
   const r = parseFlags([
-    '--claude-cwd', '/workspaces/repo',
+    '--cwd', '/workspaces/repo',
     '--codex-sandbox', 'workspace-write',
     '--openclaw-gateway', 'ws://gw:18789',
     '--openclaw-task-timeout-ms', '60000',
   ]);
   assert.equal(r.ok, true);
   if (!r.ok) return;
-  assert.equal(r.flags.claudeCwd, '/workspaces/repo');
+  assert.equal(r.flags.cwd, '/workspaces/repo');
   assert.equal(r.flags.codexSandbox, 'workspace-write');
   assert.equal(r.flags.openclawGateway, 'ws://gw:18789');
   assert.equal(r.flags.openclawTaskTimeoutMs, 60000);
@@ -178,34 +178,48 @@ test('mergeClientArgs trims and treats whitespace-only flag values as unset', ()
   assert.equal(r.args.card, undefined);
 });
 
-test('CLI backend flag wins over config backends.claude.cwd', () => {
-  // Issue #189 §1: --claude-cwd is a first-class flag. Config layer wins last.
+test('--cwd flag overrides the active backend\'s config cwd', () => {
+  // Issue #189 §1: --cwd is a first-class flag. Config layer wins last.
+  // After the per-backend → unified flag refactor the merge step scopes
+  // the config fallback to whichever `--backend` is active.
   const r = mergeClientArgs(
-    { token: 't', agentId: 'a', claudeCwd: '/from-flag' },
+    { token: 't', agentId: 'a', backend: 'claude', cwd: '/from-flag' },
     { backends: { claude: { cwd: '/from-config' } } },
   );
   assert.equal(r.ok, true);
   if (!r.ok) return;
-  assert.equal(r.args.claudeCwd, '/from-flag');
+  assert.equal(r.args.cwd, '/from-flag');
 });
 
-test('config backends.claude.cwd is the only fallback (no env)', () => {
+test('config backends.<active>.cwd is the only fallback (no env)', () => {
   // Issue #189 §5: env is out of the chain entirely. Setting CLAUDE_CWD
   // in process.env has no effect here.
   const previous = process.env.CLAUDE_CWD;
   process.env.CLAUDE_CWD = '/from-env';
   try {
     const r = mergeClientArgs(
-      { token: 't', agentId: 'a' },
+      { token: 't', agentId: 'a', backend: 'claude' },
       { backends: { claude: { cwd: '/from-config' } } },
     );
     assert.equal(r.ok, true);
     if (!r.ok) return;
-    assert.equal(r.args.claudeCwd, '/from-config');
+    assert.equal(r.args.cwd, '/from-config');
   } finally {
     if (previous === undefined) delete process.env.CLAUDE_CWD;
     else process.env.CLAUDE_CWD = previous;
   }
+});
+
+test('config backends.codex.cwd resolves when --backend codex is active', () => {
+  // Mirror of the claude case: the unified flag resolution must pick the
+  // correct per-backend config key based on the active backend selection.
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'codex' },
+    { backends: { codex: { cwd: '/codex-from-config' }, claude: { cwd: '/claude-from-config' } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.cwd, '/codex-from-config');
 });
 
 test('env vars in the daemon-config chain are ignored entirely (issue #189 §5)', () => {

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -72,26 +72,22 @@ export const daemonFlagsFields = {
     description: message`Backend implementation. Default: \`echo\`.`,
   })),
 
-  // Backend-specific (Claude)
-  claudeCwd: optional(option('--claude-cwd', string({ metavar: 'PATH' }), {
-    description: message`Working directory for the spawned \`claude\`.`,
+  // Backend runtime placement (applies to the active --backend)
+  cwd: optional(option('--cwd', string({ metavar: 'PATH' }), {
+    description: message`Working directory for the spawned backend process (claude / codex). Ignored by backends without a host-side process.`,
   })),
+  runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
+    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates. Applies to claude / codex; ignored by backends without a runtime container profile.`,
+  })),
+
+  // Backend-specific (Claude)
   claudeSettingsFile: optional(option('--claude-settings-file', string({ metavar: 'PATH' }), {
     description: message`Path to a JSON file used as Claude \`--settings\`.`,
   })),
-  claudeRuntime: optional(option('--claude-runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run \`claude\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates.`,
-  })),
 
   // Backend-specific (Codex)
-  codexCwd: optional(option('--codex-cwd', string({ metavar: 'PATH' }), {
-    description: message`Working directory for the spawned \`codex\`.`,
-  })),
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
     description: message`Codex sandbox mode.`,
-  })),
-  codexRuntime: optional(option('--codex-runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run \`codex\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates.`,
   })),
 
   // Backend-specific (OpenClaw)
@@ -127,14 +123,14 @@ export interface DaemonArgs {
   card?: string;
   backend: string;
   backends?: BackendConfigs;
-  // Flag-derived overrides for env-only knobs. These take precedence over
-  // env when set; merge logic in cli.ts threads them into backend factories.
-  claudeCwd?: string;
+  // Flag-derived overrides. These take precedence over the config layer
+  // when set; merge logic in cli.ts threads them into backend factories.
+  // cwd / runtime apply to the active backend (claude / codex); the merge
+  // step resolves the config fallback against `backends.<active>.{cwd,runtime}`.
+  cwd?: string;
+  runtime?: BackendRuntime;
   claudeSettingsFile?: string;
-  claudeRuntime?: BackendRuntime;
-  codexCwd?: string;
   codexSandbox?: CodexSandboxMode;
-  codexRuntime?: BackendRuntime;
   openclawGateway?: string;
   openclawGatewayToken?: string;
   openclawAgent?: string;
@@ -200,21 +196,32 @@ export function mergeClientArgs(
 ): { ok: true; args: DaemonArgs } | { ok: false; missing: string[] } {
   const card = pick(flags.card) || config.card;
   const backends = config.backends ?? {};
+  const backend = pick(flags.backend) || config.backend || 'echo';
+
+  // cwd / runtime are backend-agnostic at the flag level; the config-side
+  // fallback comes from whichever backend is active, since `backends.claude`
+  // and `backends.codex` carry independent `cwd` / `runtime` keys in config.
+  const activeCwd =
+    backend === 'claude' ? backends.claude?.cwd
+    : backend === 'codex' ? backends.codex?.cwd
+    : undefined;
+  const activeRuntime =
+    backend === 'claude' ? backends.claude?.runtime
+    : backend === 'codex' ? backends.codex?.runtime
+    : undefined;
 
   const resolved: DaemonArgs = {
     server: pick(flags.server) || config.server_url || DEFAULT_BRIDGE_URL,
     token: pick(flags.token) || config.server_token || '',
     agentId: pick(flags.agentId) || config.agent_id || '',
     card: card === '' ? undefined : card,
-    backend: pick(flags.backend) || config.backend || 'echo',
+    backend,
     backends: config.backends,
-    claudeCwd: pick(flags.claudeCwd) || backends.claude?.cwd || undefined,
+    cwd: pick(flags.cwd) || activeCwd || undefined,
+    runtime: flags.runtime ?? activeRuntime,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
-    claudeRuntime: flags.claudeRuntime ?? backends.claude?.runtime,
-    codexCwd: pick(flags.codexCwd) || backends.codex?.cwd || undefined,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
-    codexRuntime: flags.codexRuntime ?? backends.codex?.runtime,
     openclawGateway:
       pick(flags.openclawGateway) || backends.openclaw?.gateway_url || undefined,
     openclawGatewayToken:
@@ -231,10 +238,9 @@ export function mergeClientArgs(
   };
 
   // Empty-string normalisation for the optional path-ish fields so callers
-  // can `if (resolved.claudeCwd)` cleanly instead of having to filter "".
-  if (resolved.claudeCwd === '') resolved.claudeCwd = undefined;
+  // can `if (resolved.cwd)` cleanly instead of having to filter "".
+  if (resolved.cwd === '') resolved.cwd = undefined;
   if (resolved.claudeSettingsFile === '') resolved.claudeSettingsFile = undefined;
-  if (resolved.codexCwd === '') resolved.codexCwd = undefined;
   if (resolved.openclawGateway === '') resolved.openclawGateway = undefined;
   if (resolved.openclawGatewayToken === '') resolved.openclawGatewayToken = undefined;
   if (resolved.openclawAgent === '') resolved.openclawAgent = undefined;

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -74,10 +74,10 @@ export const daemonFlagsFields = {
 
   // Backend runtime placement (applies to the active --backend)
   cwd: optional(option('--cwd', string({ metavar: 'PATH' }), {
-    description: message`Working directory for the spawned backend process (claude / codex). Ignored by backends without a host-side process.`,
+    description: message`Working directory for the spawned backend process. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates. Applies to claude / codex; ignored by backends without a runtime container profile.`,
+    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
 
   // Backend-specific (Claude)
@@ -190,10 +190,23 @@ function pickSandbox(v: string | undefined): CodexSandboxMode | undefined {
 // shorthand. At runtime, `parseFlags()` returns the full shape — every key
 // present with `undefined` for unset flags — but the merge logic reads each
 // field independently and tolerates missing keys.
+// Backends that actually consume the unified --cwd / --runtime flags. The
+// other backends (echo / openclaw / vicoop-codex) don't spawn a per-task
+// child process and don't have a vicoop-runtime container profile, so
+// passing the flag with one of them is almost always an operator typo —
+// surface it as a parse-time error rather than letting the value sit
+// inert.
+const CWD_BACKENDS: ReadonlySet<string> = new Set(['claude', 'codex']);
+const RUNTIME_BACKENDS: ReadonlySet<string> = new Set(['claude', 'codex']);
+
+export type MergeClientArgsResult =
+  | { ok: true; args: DaemonArgs }
+  | { ok: false; missing: string[]; errors: string[] };
+
 export function mergeClientArgs(
   flags: Partial<DaemonFlags>,
   config: ClientConfig,
-): { ok: true; args: DaemonArgs } | { ok: false; missing: string[] } {
+): MergeClientArgsResult {
   const card = pick(flags.card) || config.card;
   const backends = config.backends ?? {};
   const backend = pick(flags.backend) || config.backend || 'echo';
@@ -253,6 +266,23 @@ export function mergeClientArgs(
   if (!resolved.agentId) missing.push('agentId');
   // `server` always has DEFAULT_BRIDGE_URL fallback so it's never missing.
   // `backend` always has 'echo' fallback.
-  if (missing.length) return { ok: false, missing };
+
+  // Backend-compat checks for the unified flags. We only flag the *flag*
+  // (operator-set) variant; values that come purely from a stale config
+  // overlay are silently dropped above by the active-backend-scoped
+  // lookup, which is the correct behaviour for that source.
+  const errors: string[] = [];
+  if (flags.runtime !== undefined && !RUNTIME_BACKENDS.has(backend)) {
+    errors.push(
+      `--runtime is not supported by --backend ${backend}; only claude / codex have a runtime container profile`,
+    );
+  }
+  if (pick(flags.cwd) && !CWD_BACKENDS.has(backend)) {
+    errors.push(
+      `--cwd is not supported by --backend ${backend}; only claude / codex spawn a backend process with a working directory`,
+    );
+  }
+
+  if (missing.length || errors.length) return { ok: false, missing, errors };
   return { ok: true, args: resolved };
 }

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -80,7 +80,7 @@ export const daemonFlagsFields = {
     description: message`Path to a JSON file used as Claude \`--settings\`.`,
   })),
   claudeRuntime: optional(option('--claude-runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run \`claude\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates (#249).`,
+    description: message`Where to run \`claude\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates.`,
   })),
 
   // Backend-specific (Codex)
@@ -91,7 +91,7 @@ export const daemonFlagsFields = {
     description: message`Codex sandbox mode.`,
   })),
   codexRuntime: optional(option('--codex-runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run \`codex\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates (#249).`,
+    description: message`Where to run \`codex\`. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates.`,
   })),
 
   // Backend-specific (OpenClaw)

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -522,7 +522,10 @@ async function main(): Promise<void> {
   const parsed = run(cli, {
     programName: 'vicoop-client',
     brief: message`A2A bridge client daemon. Connects a local backend (echo, openclaw, claude, codex) to a deployed vicoop-bridge server.`,
-    footer: message`Precedence: CLI flag > --config <path> > canonical config.json > built-in default. Env vars are not consulted for runtime config (config-location vars like VICOOP_HOME / XDG_CONFIG_HOME / HOME are honored separately). See docs/install-client.md for the full operator guide.`,
+    // `description` only renders on the top-level `--help` (optique gates it
+    // behind `!isSubcommandHelp`); a `footer` here would leak into every
+    // subcommand's help as a fallback. Keep precedence detail root-only.
+    description: message`Precedence: CLI flag > --config <path> > canonical config.json > built-in default. Env vars are not consulted for runtime config (config-location vars like VICOOP_HOME / XDG_CONFIG_HOME / HOME are honored separately). See docs/install-client.md for the full operator guide.`,
     // Both `--help`/`-h` and the `help` subcommand. The explicit `names`
     // list enables the `-h` short alias optique doesn't register by
     // default. Same for `--version`/`-v`.
@@ -534,7 +537,12 @@ async function main(): Promise<void> {
       value: clientVersion,
       option: { names: ['--version', '-v'] },
     },
-    aboveError: 'usage',
+    // `help` scopes the pre-error doc to whatever subcommand was
+    // partially parsed (optique calls `getDocPage(parser, args)`), so
+    // `vicoop-client container` prints just the `container` group's
+    // help instead of dumping the full root usage block. Falls back
+    // to `usage` automatically when no scoped doc is available.
+    aboveError: 'help',
   });
 
   switch (parsed.action) {

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -522,10 +522,6 @@ async function main(): Promise<void> {
   const parsed = run(cli, {
     programName: 'vicoop-client',
     brief: message`A2A bridge client daemon. Connects a local backend (echo, openclaw, claude, codex) to a deployed vicoop-bridge server.`,
-    // `description` only renders on the top-level `--help` (optique gates it
-    // behind `!isSubcommandHelp`); a `footer` here would leak into every
-    // subcommand's help as a fallback. Keep precedence detail root-only.
-    description: message`Precedence: CLI flag > --config <path> > canonical config.json > built-in default. Env vars are not consulted for runtime config (config-location vars like VICOOP_HOME / XDG_CONFIG_HOME / HOME are honored separately). See docs/install-client.md for the full operator guide.`,
     // Both `--help`/`-h` and the `help` subcommand. The explicit `names`
     // list enables the `-h` short alias optique doesn't register by
     // default. Same for `--version`/`-v`.

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -298,8 +298,8 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         : backends.claude?.settings;
       const { spawn, cwd, runtime } = await resolveRuntime({
         kind: 'claude',
-        runtime: args.claudeRuntime,
-        cwd: args.claudeCwd,
+        runtime: args.runtime,
+        cwd: args.cwd,
         bridgeUrl: args.server,
       });
       // claude's bwrap sandbox is redundant when *we* are already
@@ -323,8 +323,8 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
     case 'codex': {
       const { spawn, cwd, runtime } = await resolveRuntime({
         kind: 'codex',
-        runtime: args.codexRuntime,
-        cwd: args.codexCwd,
+        runtime: args.runtime,
+        cwd: args.cwd,
         bridgeUrl: args.server,
       });
       // Same reasoning as the claude branch: codex's host-process

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -200,7 +200,10 @@ function resolveDaemonArgs(parsed: Extract<CliArgs, { action: 'daemon' }>): Args
   }
   const result = mergeClientArgs(parsed, config);
   if (!result.ok) {
-    console.error(`missing required args: ${result.missing.join(', ')}`);
+    if (result.missing.length) {
+      console.error(`missing required args: ${result.missing.join(', ')}`);
+    }
+    for (const e of result.errors) console.error(e);
     process.exit(1);
   }
   return result.args;

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -1,46 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  runContainerInit,
   collectClaudeHostCreds,
   collectCodexHostCreds,
 } from './container-init.js';
-
-// A logger spy good enough for assertions on the "what got logged"
-// surface. container init's logger surface is the public contract
-// for operator-facing messages, so it's the right place to anchor
-// tests that don't want to mock the whole dockerode stack.
-function makeLogger() {
-  const records: Array<{ level: string; args: unknown[] }> = [];
-  return {
-    records,
-    logger: {
-      level: 'info' as const,
-      error: (...args: unknown[]) => records.push({ level: 'error', args }),
-      warn: (...args: unknown[]) => records.push({ level: 'warn', args }),
-      info: (...args: unknown[]) => records.push({ level: 'info', args }),
-      debug: (...args: unknown[]) => records.push({ level: 'debug', args }),
-    },
-  };
-}
-
-test('host runtime is rejected with code 64 and a clear hint', async () => {
-  const { logger, records } = makeLogger();
-  const code = await runContainerInit({
-    kind: 'codex',
-    runtime: 'host',
-    fromHost: false,
-    logger,
-  });
-  assert.equal(code, 64);
-  const errorLines = records
-    .filter((r) => r.level === 'error')
-    .map((r) => r.args.join(' '));
-  assert.ok(
-    errorLines.some((line) => line.includes('--runtime container only')),
-    'expected an error mentioning the host-mode limitation',
-  );
-});
 
 // ──────────────────────────────────────────────────────────────────
 // collectClaudeHostCreds

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -32,10 +32,6 @@ import { createLogger, type Logger } from './logger.js';
 
 export interface ContainerInitOptions {
   kind: InstallableBackendKind;
-  // Future-proofing — today only 'container' is implemented. host
-  // mode prints an actionable error rather than guessing how the
-  // operator wants the agent CLI installed on their OS.
-  runtime: 'host' | 'container';
   // When true, copy the operator's existing host creds into the
   // container creds volume. When false, leave creds empty and let
   // the operator run an interactive auth flow themselves.
@@ -59,14 +55,6 @@ export interface ContainerInitOptions {
 // the CLI can `process.exit(code)` uniformly.
 export async function runContainerInit(opts: ContainerInitOptions): Promise<number> {
   const log = opts.logger ?? createLogger();
-  if (opts.runtime !== 'container') {
-    log.error(
-      `container init currently supports --runtime container only. ` +
-        `For host mode, install ${opts.kind} via its official installer and ` +
-        `run \`vicoop-client --backend ${opts.kind}\` directly.`,
-    );
-    return 64;
-  }
 
   const runtime = new RuntimeContainer({
     backendKind: opts.kind,
@@ -393,19 +381,14 @@ function authHintFor(kind: InstallableBackendKind): string {
 // ──────────────────────────────────────────────────────────────────────────
 
 const BACKEND_KINDS = ['claude', 'codex'] as const;
-const RUNTIME_MODES = ['host', 'container'] as const;
 
 const containerInitSubCmd = command(
   'init',
   object({
     action: constant('container-init' as const),
-    kind: argument(choice([...BACKEND_KINDS])),
-    runtime: withDefault(
-      option('--runtime', choice([...RUNTIME_MODES]), {
-        description: message`Where the backend runs. \`container\` (default) boots a vicoop-runtime container; \`host\` is reserved for a future cut.`,
-      }),
-      'container' as const,
-    ),
+    kind: argument(choice([...BACKEND_KINDS], { metavar: 'KIND' }), {
+      description: message`Backend agent CLI to install into the runtime container. One of: \`claude\`, \`codex\`.`,
+    }),
     fromHost: withDefault(
       flag('--from-host', {
         description: message`Copy the operator's existing host creds into the container's per-backend creds volume (macOS keychain for claude, ~/.codex for codex). Off by default — explicit opt-in for the runtime-isolation tradeoff.`,
@@ -448,7 +431,6 @@ export async function runContainerInitCli(args: ContainerInitArgs): Promise<numb
   try {
     return await runContainerInit({
       kind: args.kind,
-      runtime: args.runtime,
       fromHost: args.fromHost,
       ...(args.image ? { image: args.image } : {}),
       ...(args.bridgeUrl ? { bridgeUrl: args.bridgeUrl } : {}),

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -408,7 +408,7 @@ const containerInitSubCmd = command(
   }),
   {
     brief: message`Bootstrap a per-backend runtime container.`,
-    description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --<kind>-runtime container\`.`,
+    description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\`.`,
   },
 );
 
@@ -417,7 +417,7 @@ export const containerCmd = command(
   longestMatch(containerInitSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds). Pairs with the daemon flags \`--claude-runtime container\` / \`--codex-runtime container\`.`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
   },
 );
 

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -407,7 +407,7 @@ const containerInitSubCmd = command(
     ),
   }),
   {
-    brief: message`Bootstrap a per-backend runtime container (#249 PR C).`,
+    brief: message`Bootstrap a per-backend runtime container.`,
     description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --<kind>-runtime container\`.`,
   },
 );

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -169,7 +169,7 @@ export class RuntimeContainer {
     if (r.exitCode !== 0 || r.stdout.trim().length === 0) {
       throw new Error(
         `docker daemon is not reachable (${r.stderr.trim() || `exit ${r.exitCode}`}). ` +
-          `The container runtime profile (#249) requires a local docker daemon. ` +
+          `The container runtime profile requires a local docker daemon. ` +
           `Switch to runtime: 'host' for this backend, or start docker and retry.`,
       );
     }

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -39,7 +39,7 @@ export const setupCmd = command(
       description: message`Principal allowed to call this agent. Repeatable; comma-separated lists also accepted within a single occurrence.`,
     })),
     envFile: optional(option('--write-env-file', string({ metavar: 'PATH' }), {
-      description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars (#189 §5); the file is purely an operator-side credentials backup / scripting hook.`,
+      description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars; the file is purely an operator-side credentials backup / scripting hook.`,
     })),
     // `--env-file` is an alias for `--write-env-file` (older docs used it).
     envFileAlias: optional(option('--env-file', string({ metavar: 'PATH' }))),
@@ -55,7 +55,7 @@ export const setupCmd = command(
   }),
   {
     brief: message`[deprecated] Use \`agent register\`.`,
-    description: message`Deprecated alias for \`vicoop-client agent register\` (#224). Calls the bridge's \`registerClient\` GraphQL mutation, persists daemon credentials to \`~/.vicoop/config.json\`, and supports \`--write-env-file\` for an optional shell-sourceable env file. Will be removed in a future release.`,
+    description: message`Deprecated alias for \`vicoop-client agent register\`. Calls the bridge's \`registerClient\` GraphQL mutation, persists daemon credentials to \`~/.vicoop/config.json\`, and supports \`--write-env-file\` for an optional shell-sourceable env file. Will be removed in a future release.`,
   },
 );
 
@@ -66,13 +66,13 @@ export const agentRegisterCmd = command(
   object({
     action: constant('agent-register' as const),
     agentId: option('--agent-id', string({ metavar: 'ID' }), {
-      description: message`Agent id (routing key external A2A callers will use). After #219 the server enforces a single agent per registration.`,
+      description: message`Agent id (routing key external A2A callers will use). The server enforces a single agent per registration.`,
     }),
     callers: multiple(option('--caller', string({ metavar: 'PRINCIPAL' }), {
       description: message`Principal allowed to call this agent. Repeatable; comma-separated lists also accepted within a single occurrence.`,
     })),
     envFile: optional(option('--write-env-file', string({ metavar: 'PATH' }), {
-      description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars (#189 §5); the file is purely an operator-side credentials backup / scripting hook.`,
+      description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars; the file is purely an operator-side credentials backup / scripting hook.`,
     })),
     envFileAlias: optional(option('--env-file', string({ metavar: 'PATH' }))),
     server: optional(option('--server', string({ metavar: 'URL' }), {
@@ -87,7 +87,7 @@ export const agentRegisterCmd = command(
   }),
   {
     brief: message`Register an agent and persist daemon credentials.`,
-    description: message`Calls the bridge's \`registerClient\` GraphQL mutation (compat name; the unified server model from #219 is agent-first) using the owner-session bearer saved by \`vicoop-client login\`, receives a one-time AGENT_TOKEN, and writes the daemon credentials into the canonical \`~/.vicoop/config.json\` (mode 600). The token is unrecoverable after this single output; back up config.json before rotating hosts. \`--json\` skips disk persistence and prints the raw response instead.`,
+    description: message`Calls the bridge's \`registerClient\` GraphQL mutation (compat name; the unified server model is agent-first) using the owner-session bearer saved by \`vicoop-client login\`, receives a one-time AGENT_TOKEN, and writes the daemon credentials into the canonical \`~/.vicoop/config.json\` (mode 600). The token is unrecoverable after this single output; back up config.json before rotating hosts. \`--json\` skips disk persistence and prints the raw response instead.`,
   },
 );
 


### PR DESCRIPTION
Breaking change to the client CLI flag surface plus help/output cleanup.

## Summary
- **Unify `--cwd` / `--runtime`.** Drop `--claude-cwd`, `--codex-cwd`, `--claude-runtime`, `--codex-runtime` in favor of single `--cwd` and `--runtime` flags scoped to whichever backend `--backend` selects. The two pairs were always mutually exclusive at runtime (`--backend` picks one backend per daemon, the other pair was inert). Config side keeps `backends.<active>.{cwd,runtime}` per-backend; the merge step in `mergeClientArgs` resolves against the active backend.
- **`container init` polish.** Drop the placeholder `--runtime` option (only `container` was implemented; `host` exited with code 64). Name the positional `KIND` and list valid values (`claude`, `codex`).
- **Help output cleanup.** Move the verbose config-precedence note out of `--help` entirely (still documented in `docs/install-client.md:270`). Strip internal `#NNN` / `PR <letter>` references from operator-facing descriptions and runtime error messages.
- **Scoped pre-error help.** Switch `aboveError` from `usage` to `help` so a partial parse like `vicoop-client container` prints the `container` group's scoped help instead of the full root usage dump (falls back to `usage` automatically when no scoped doc is available).

## Migration
| Old | New |
| --- | --- |
| `--claude-cwd <path>` | `--cwd <path>` (with `--backend claude`) |
| `--codex-cwd <path>` | `--cwd <path>` (with `--backend codex`) |
| `--claude-runtime <host\|container>` | `--runtime <host\|container>` (with `--backend claude`) |
| `--codex-runtime <host\|container>` | `--runtime <host\|container>` (with `--backend codex`) |

`config.json` is unchanged — `backends.claude.cwd`, `backends.codex.runtime`, etc. still apply per backend.

## Test plan
- [x] `pnpm -F @vicoop-bridge/client typecheck`
- [x] `pnpm -F @vicoop-bridge/client test` — 490/490
- [x] Manual: `vicoop-client --help` shows unified `--cwd` / `--runtime`, no precedence blurb
- [x] Manual: `vicoop-client container` (no subcommand) prints scoped `container` help, not full root usage
- [x] Manual: `vicoop-client container init --help` shows `KIND` with valid values, no `--runtime` flag, no precedence note

🤖 Generated with [Claude Code](https://claude.com/claude-code)