### PR TITLE
[codex] Require explicit container runtime init

### DIFF
--- a/.changeset/container-runtime-require-init.md
+++ b/.changeset/container-runtime-require-init.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Require `vicoop-client container init <kind>` before daemon container runtime startup instead of auto-creating missing runtime containers.

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -77,7 +77,7 @@ export const daemonFlagsFields = {
     description: message`Working directory for the spawned backend process. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside a vicoop-runtime container the bridge client orchestrates. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
+    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
 
   // Backend-specific (Claude)

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -364,10 +364,11 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
 //
 // - 'host' (default): nothing to do. The backend factory's built-in
 //   defaultSpawn handles host child_process.spawn unchanged.
-// - 'container': starts a long-lived vicoop-runtime container for this
-//   kind and returns a docker-exec SpawnFn the backend factory plugs
-//   into its spawn slot. cwd, if any, is rewritten to /workspace; the
-//   original host path becomes the bind-mount source.
+// - 'container': reuses or starts an existing long-lived vicoop-runtime
+//   container for this kind and returns a docker-exec SpawnFn the
+//   backend factory plugs into its spawn slot. cwd, if any, is
+//   rewritten to /workspace; the original host path is expected to be
+//   the bind-mount source from container init.
 async function resolveRuntime(args: {
   kind: 'claude' | 'codex';
   runtime: 'host' | 'container' | undefined;

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -60,6 +60,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     backendKind: opts.kind,
     image: opts.image ?? process.env.VICOOP_RUNTIME_IMAGE ?? DEFAULT_RUNTIME_IMAGE,
     bridgeUrl: opts.bridgeUrl,
+    createIfMissing: true,
     logger: opts.logger,
   });
 
@@ -142,7 +143,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     }
 
     log.info(`runtime container for ${opts.kind} ready. start daemon with:`);
-    log.info(`    vicoop-client --backend ${opts.kind} --${opts.kind}-runtime container`);
+    log.info(`    vicoop-client --backend ${opts.kind} --runtime container`);
     return 0;
   } finally {
     // Leave the container running. The next daemon launch reuses

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -29,15 +29,15 @@ function fail(stderr: string, exitCode = 1): DockerResult {
   return { stdout: '', stderr, exitCode };
 }
 
-// Helper for the "happy start" sequence shape. The image pull path
-// is bypassed (ensureImage finds the image on the first inspect),
-// the three volumes are inspected → created, then the container is
-// inspected (absent) → created → started, then waitUntilRunning's
-// first poll sees `running`. That's what most tests need; the
-// negative tests override the relevant entries to inject failures.
-function happyStartResponses(): RunResponse[] {
+// Helper for the container-init creation sequence shape. The image
+// pull path is bypassed (ensureImage finds the image on the first
+// inspect), the three volumes are inspected → created, then the
+// container is inspected (absent) → created → started, then
+// waitUntilRunning's first poll sees `running`.
+function happyCreateResponses(): RunResponse[] {
   return [
     ok('28.0.0'), // version (ensureDaemonReachable)
+    ok(''), // ps -a --filter (no existing container)
     ok(), // image inspect — found
     fail('volume not found', 1), // volume inspect agents
     ok(), // volume create agents
@@ -45,28 +45,29 @@ function happyStartResponses(): RunResponse[] {
     ok(), // volume create creds
     fail('volume not found', 1), // volume inspect sessions
     ok(), // volume create sessions
-    ok(''), // ps -a --filter (no existing container)
     ok(), // create container
     ok(), // start container
     ok('running'), // waitUntilRunning poll
   ];
 }
 
-test('start: pulls nothing when image is cached, creates+starts a fresh container', async () => {
-  const { run, calls } = makeDockerFixture(happyStartResponses());
+test('start: with createIfMissing pulls nothing when image is cached, creates+starts a fresh container', async () => {
+  const { run, calls } = makeDockerFixture(happyCreateResponses());
   const rc = new RuntimeContainer({
     backendKind: 'claude',
     image: 'test/runtime:latest',
     workspaceDir: '/host/workspace',
     bridgeUrl: 'wss://bridge.example',
+    createIfMissing: true,
     dockerRun: run,
   });
   await rc.start();
 
-  // version → image inspect → 3×volume(inspect|create) → ps → create → start → inspect-running
+  // version → ps → image inspect → 3×volume(inspect|create) → create → start → inspect-running
   assert.equal(calls.length, 12);
   assert.deepEqual(calls[0].slice(0, 2), ['version', '--format']);
-  assert.deepEqual(calls[1], ['image', 'inspect', 'test/runtime:latest']);
+  assert.deepEqual(calls[1].slice(0, 2), ['ps', '-a']);
+  assert.deepEqual(calls[2], ['image', 'inspect', 'test/runtime:latest']);
 
   // Volumes created with the expected labels
   const volumeCreates = calls.filter((c) => c[0] === 'volume' && c[1] === 'create');
@@ -115,10 +116,6 @@ test('start: pulls nothing when image is cached, creates+starts a fresh containe
 test('start: reuses an existing running container (no create, no start)', async () => {
   const { run, calls } = makeDockerFixture([
     ok('28.0.0'),
-    ok(), // image inspect
-    ok(), // volume inspect agents — present
-    ok(), // volume inspect creds
-    ok(), // volume inspect sessions
     ok('abc123'), // ps -a — match
     ok('true'), // inspect Running
     ok('running'), // wait poll
@@ -145,10 +142,6 @@ test('start: reuses an existing running container (no create, no start)', async 
 test('start: starts an existing stopped container', async () => {
   const { run, calls } = makeDockerFixture([
     ok('28.0.0'),
-    ok(),
-    ok(),
-    ok(),
-    ok(),
     ok('abc123'), // ps -a — found
     ok('false'), // inspect Running — stopped
     ok(), // start
@@ -165,6 +158,26 @@ test('start: starts an existing stopped container', async () => {
     calls.filter((c) => c[0] === 'start'),
     [['start', 'vicoop-runtime-codex']],
   );
+});
+
+test('start: missing container is a hard error unless createIfMissing is set', async () => {
+  const { run, calls } = makeDockerFixture([
+    ok('28.0.0'),
+    ok(''), // ps -a — absent
+  ]);
+  const rc = new RuntimeContainer({
+    backendKind: 'codex',
+    image: 'test/runtime:latest',
+    dockerRun: run,
+  });
+
+  await assert.rejects(
+    rc.start(),
+    /runtime container 'vicoop-runtime-codex' does not exist.*vicoop-client container init codex/s,
+  );
+  assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
+  assert.equal(calls.filter((c) => c[0] === 'volume').length, 0);
+  assert.equal(calls.filter((c) => c[0] === 'image').length, 0);
 });
 
 test('start: docker daemon unreachable surfaces an actionable error', async () => {
@@ -192,12 +205,13 @@ test('stop: tolerates already-stopped containers', async () => {
 });
 
 test('Env carries VICOOP_BRIDGE_URL and optional skip-firewall toggle', async () => {
-  const { run, calls } = makeDockerFixture(happyStartResponses());
+  const { run, calls } = makeDockerFixture(happyCreateResponses());
   const rc = new RuntimeContainer({
     backendKind: 'claude',
     image: 'test/runtime:latest',
     bridgeUrl: 'wss://bridge.example',
     skipFirewall: true,
+    createIfMissing: true,
     dockerRun: run,
   });
   await rc.start();

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -7,10 +7,9 @@
 //     → pickBackend (cli.ts) decides runtime = 'container'
 //       → new RuntimeContainer({ backendKind, ... }).start()
 //         - pings docker daemon (Decision §6)
-//         - ensures named volumes exist (agents, creds, sessions)
 //         - looks for an existing container by canonical name; reuses
-//           if found, otherwise pulls the image and creates a new one
-//         - starts the container (firewall + sleep infinity from
+//           if found, otherwise fails with an init hint
+//         - starts a stopped container (firewall + sleep infinity from
 //           container/runtime/entrypoint.sh in PR A)
 //       → wires a docker-exec SpawnAdapter (spawn-adapter.ts) into the
 //         backend factory; backend sees a normal SpawnFn signature
@@ -50,6 +49,10 @@ export interface RuntimeContainerOptions {
   // Skip the in-container firewall init. Mostly a dev / CI escape
   // hatch; production runs should leave this off and pass NET_ADMIN.
   skipFirewall?: boolean;
+  // Creation is intentionally opt-in. Daemon startup should only
+  // consume a runtime container the operator already initialized with
+  // `vicoop-client container init <kind>`.
+  createIfMissing?: boolean;
   logger?: Logger;
   // Test seam — inject a custom docker CLI runner so tests can
   // capture argv + script responses without shelling out.
@@ -105,8 +108,6 @@ export class RuntimeContainer {
   // than degrade silently.
   async start(): Promise<void> {
     this.ensureDaemonReachable();
-    await this.ensureImage();
-    this.ensureVolumes();
 
     const name = containerName(this.opts.backendKind);
     if (this.findContainer(name)) {
@@ -117,6 +118,15 @@ export class RuntimeContainer {
         this.runDocker(['start', name]);
       }
     } else {
+      if (!this.opts.createIfMissing) {
+        throw new Error(
+          `runtime container '${name}' does not exist. ` +
+            `Create it first with \`vicoop-client container init ${this.opts.backendKind}\`, ` +
+            `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container\`.`,
+        );
+      }
+      await this.ensureImage();
+      this.ensureVolumes();
       this.createContainer(name);
       this.runDocker(['start', name]);
       this.log.info(`runtime container '${name}' created and started`);


### PR DESCRIPTION
## Summary

- Make daemon `--runtime container` startup reuse or start only an existing `vicoop-runtime-<kind>` container.
- Keep runtime container and volume creation behind `vicoop-client container init <kind>` via an explicit `createIfMissing` path.
- Add a client patch changeset and update CLI/help text plus runtime-container tests for the missing-container error.

## Why

When a container runtime backend had never been initialized, daemon startup auto-created an empty runtime container. That let the client connect successfully, but the first task failed later because the backend CLI was not installed inside the container.

Now the startup failure points operators at the required setup command before accepting tasks.

## Validation

- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/client test`