### PR TITLE
[codex] add name-based container runtime management

### DIFF
--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` and named runtime instances for cleanup and multi-instance workflows.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` and named runtime instances for cleanup and multi-instance workflows. `container init` now fails when the target runtime already exists instead of reinstalling into it.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for name-based cleanup and named runtime instances for multi-instance workflows. `container init` now assigns a runtime name even when `--name` is omitted and fails when the target runtime already exists instead of reinstalling into it.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for name-based cleanup and named runtime instances for multi-instance workflows. `container rm` removes the container and volumes by default, with `--preserve-volumes` for credential/session retention. `container init` now assigns a runtime name even when `--name` is omitted and fails when the target runtime already exists instead of reinstalling into it.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for cleanup.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` and named runtime instances for cleanup and multi-instance workflows.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` and named runtime instances for cleanup and multi-instance workflows. `container init` now fails when the target runtime already exists instead of reinstalling into it.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for name-based cleanup and named runtime instances for multi-instance workflows. `container init` now assigns a runtime name even when `--name` is omitted and fails when the target runtime already exists instead of reinstalling into it.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for name-based cleanup and named runtime instances for multi-instance workflows. `container rm` removes the container and volumes by default, with `--preserve-volumes` for credential/session retention. `container init` now assigns a runtime name even when `--name` is omitted and fails when the target runtime already exists instead of reinstalling into it.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for name-based cleanup and named runtime instances for multi-instance workflows. `container rm` removes the container and volumes by default, with `--preserve-volumes` for credential/session retention. `container init` now assigns a runtime name even when `--name` is omitted, stops the initialized container until daemon startup, and fails when the target runtime already exists instead of reinstalling into it.

--- a/.changeset/container-ls-runtime-state.md
+++ b/.changeset/container-ls-runtime-state.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Add `vicoop-client container ls` / `list` to show managed runtime container and volume state.
+Add `vicoop-client container ls` / `list` to show managed runtime container and volume state, plus `container rm` / `remove` for cleanup.

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -120,6 +120,35 @@ test('--runtime + --cwd with --backend claude is accepted', () => {
   assert.equal(r.args.cwd, '/repo');
 });
 
+test('--runtime-name is accepted for container-capable backends', () => {
+  const r = mergeClientArgs(
+    {
+      token: 't',
+      agentId: 'a',
+      backend: 'codex',
+      runtime: 'container',
+      runtimeName: 'work',
+    },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.runtimeName, 'work');
+});
+
+test('--runtime-name with a non-runtime-capable backend is a hard error', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'echo', runtimeName: 'work' },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--runtime-name') && e.includes('echo')),
+    `expected error mentioning --runtime-name and echo, got: ${r.errors.join(' | ')}`,
+  );
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',
@@ -128,11 +157,13 @@ test('parseFlags picks up known flags', () => {
     '--backend', 'claude',
     '--card', '/c.json',
     '--config', '/etc/vicoop/config.json',
+    '--runtime-name', 'work',
   ]);
   assert.equal(r.ok, true);
   if (!r.ok) return;
   assert.equal(r.flags.server, 'wss://x');
   assert.equal(r.flags.token, 't');
+  assert.equal(r.flags.runtimeName, 'work');
   assert.equal(r.flags.agentId, 'a');
   assert.equal(r.flags.backend, 'claude');
   assert.equal(r.flags.card, '/c.json');

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -79,6 +79,9 @@ export const daemonFlagsFields = {
   runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
     description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
+  runtimeName: optional(option('--runtime-name', string({ metavar: 'NAME' }), {
+    description: message`Named runtime container instance to use with \`--runtime container\`. Omit for the default per-kind runtime.`,
+  })),
 
   // Backend-specific (Claude)
   claudeSettingsFile: optional(option('--claude-settings-file', string({ metavar: 'PATH' }), {
@@ -129,6 +132,7 @@ export interface DaemonArgs {
   // step resolves the config fallback against `backends.<active>.{cwd,runtime}`.
   cwd?: string;
   runtime?: BackendRuntime;
+  runtimeName?: string;
   claudeSettingsFile?: string;
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
@@ -222,6 +226,10 @@ export function mergeClientArgs(
     backend === 'claude' ? backends.claude?.runtime
     : backend === 'codex' ? backends.codex?.runtime
     : undefined;
+  const activeRuntimeName =
+    backend === 'claude' ? backends.claude?.runtime_name
+    : backend === 'codex' ? backends.codex?.runtime_name
+    : undefined;
 
   const resolved: DaemonArgs = {
     server: pick(flags.server) || config.server_url || DEFAULT_BRIDGE_URL,
@@ -232,6 +240,7 @@ export function mergeClientArgs(
     backends: config.backends,
     cwd: pick(flags.cwd) || activeCwd || undefined,
     runtime: flags.runtime ?? activeRuntime,
+    runtimeName: pick(flags.runtimeName) || activeRuntimeName || undefined,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
@@ -257,6 +266,7 @@ export function mergeClientArgs(
   if (resolved.openclawGateway === '') resolved.openclawGateway = undefined;
   if (resolved.openclawGatewayToken === '') resolved.openclawGatewayToken = undefined;
   if (resolved.openclawAgent === '') resolved.openclawAgent = undefined;
+  if (resolved.runtimeName === '') resolved.runtimeName = undefined;
   if (resolved.openclawOpenaiCompatAgent === '') {
     resolved.openclawOpenaiCompatAgent = undefined;
   }
@@ -275,6 +285,11 @@ export function mergeClientArgs(
   if (flags.runtime !== undefined && !RUNTIME_BACKENDS.has(backend)) {
     errors.push(
       `--runtime is not supported by --backend ${backend}; only claude / codex have a runtime container profile`,
+    );
+  }
+  if (pick(flags.runtimeName) && !RUNTIME_BACKENDS.has(backend)) {
+    errors.push(
+      `--runtime-name is not supported by --backend ${backend}; only claude / codex have a runtime container profile`,
     );
   }
   if (pick(flags.cwd) && !CWD_BACKENDS.has(backend)) {

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -80,7 +80,7 @@ export const daemonFlagsFields = {
     description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtimeName: optional(option('--runtime-name', string({ metavar: 'NAME' }), {
-    description: message`Named runtime container instance to use with \`--runtime container\`. Omit for the default per-kind runtime.`,
+    description: message`Runtime container instance name to use with \`--runtime container\`. Omit to use the active backend kind as the generated name.`,
   })),
 
   // Backend-specific (Claude)

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -307,6 +307,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       const { spawn, cwd, runtime } = await resolveRuntime({
         kind: 'claude',
         runtime: args.runtime,
+        runtimeName: args.runtimeName,
         cwd: args.cwd,
         bridgeUrl: args.server,
       });
@@ -332,6 +333,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       const { spawn, cwd, runtime } = await resolveRuntime({
         kind: 'codex',
         runtime: args.runtime,
+        runtimeName: args.runtimeName,
         cwd: args.cwd,
         bridgeUrl: args.server,
       });
@@ -377,6 +379,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
 async function resolveRuntime(args: {
   kind: 'claude' | 'codex';
   runtime: 'host' | 'container' | undefined;
+  runtimeName: string | undefined;
   cwd: string | undefined;
   bridgeUrl: string;
 }): Promise<{ spawn?: SpawnFn; cwd?: string; runtime?: RuntimeContainer }> {
@@ -385,6 +388,7 @@ async function resolveRuntime(args: {
   }
   const runtime = new RuntimeContainer({
     backendKind: args.kind,
+    runtimeName: args.runtimeName,
     image: process.env.VICOOP_RUNTIME_IMAGE || DEFAULT_RUNTIME_IMAGE,
     workspaceDir: args.cwd,
     bridgeUrl: args.bridgeUrl,

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -21,7 +21,7 @@ import { createVicoopCodexBackend } from './backends/vicoop-codex.js';
 import type { Backend } from './backend.js';
 import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
 import { createDockerExecSpawn, type SpawnFn } from './spawn-adapter.js';
-import { containerCmd, runContainerInitCli } from './container-init.js';
+import { containerCmd, runContainerInitCli, runContainerListCli } from './container-init.js';
 import isInsideContainer from 'is-inside-container';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
@@ -619,6 +619,9 @@ async function main(): Promise<void> {
       break;
     case 'container-init':
       process.exit(await runContainerInitCli(parsed));
+      break;
+    case 'container-list':
+      process.exit(await runContainerListCli(parsed));
       break;
     case 'daemon':
       // Long-running. Do not exit — client.start() keeps the event loop

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -21,7 +21,12 @@ import { createVicoopCodexBackend } from './backends/vicoop-codex.js';
 import type { Backend } from './backend.js';
 import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
 import { createDockerExecSpawn, type SpawnFn } from './spawn-adapter.js';
-import { containerCmd, runContainerInitCli, runContainerListCli } from './container-init.js';
+import {
+  containerCmd,
+  runContainerInitCli,
+  runContainerListCli,
+  runContainerRemoveCli,
+} from './container-init.js';
 import isInsideContainer from 'is-inside-container';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
@@ -622,6 +627,9 @@ async function main(): Promise<void> {
       break;
     case 'container-list':
       process.exit(await runContainerListCli(parsed));
+      break;
+    case 'container-remove':
+      process.exit(await runContainerRemoveCli(parsed));
       break;
     case 'daemon':
       // Long-running. Do not exit — client.start() keeps the event loop

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -165,7 +165,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
     card: '/path/card.json',
     backends: {
       claude: { cwd: '/srv/work', settings: { sandbox: { enabled: true } } },
-      codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write' },
+      codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
         gateway_url: 'ws://127.0.0.1:18789',
         gateway_token: 'gt',
@@ -183,7 +183,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
     card: '/path/card.json',
     backends: {
       claude: { cwd: '/srv/work', settings: { sandbox: { enabled: true } } },
-      codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write' },
+      codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
         gateway_url: 'ws://127.0.0.1:18789',
         gateway_token: 'gt',
@@ -315,6 +315,7 @@ test('normalizeConfig accepts backends.codex with sandbox_mode and approval_deci
           cwd: '/srv',
           sandbox_mode: 'workspace-write',
           approval_decision: 'acceptForSession',
+          runtime_name: 'work',
         },
       },
     }),
@@ -327,6 +328,7 @@ test('normalizeConfig accepts backends.codex with sandbox_mode and approval_deci
         cwd: '/srv',
         sandbox_mode: 'workspace-write',
         approval_decision: 'acceptForSession',
+        runtime_name: 'work',
       },
     },
   });

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -110,6 +110,7 @@ export interface ClaudeBackendConfig {
   cwd?: string;
   settings?: Record<string, unknown>;
   runtime?: BackendRuntime;
+  runtime_name?: string;
 }
 
 export interface CodexBackendConfig {
@@ -118,6 +119,7 @@ export interface CodexBackendConfig {
   /** What to answer when codex requests user approval. Default `decline`. */
   approval_decision?: 'accept' | 'acceptForSession' | 'decline';
   runtime?: BackendRuntime;
+  runtime_name?: string;
 }
 
 export interface OpenclawBackendConfig {
@@ -231,11 +233,13 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
       const cwd = asString(claudeRaw.cwd);
       const settings = asRecord(claudeRaw.settings);
       const runtime = pickBackendRuntime(claudeRaw.runtime);
-      if (cwd || settings || runtime) {
+      const runtimeName = asString(claudeRaw.runtime_name);
+      if (cwd || settings || runtime || runtimeName) {
         out.claude = {};
         if (cwd) out.claude.cwd = cwd;
         if (settings) out.claude.settings = settings;
         if (runtime) out.claude.runtime = runtime;
+        if (runtimeName) out.claude.runtime_name = runtimeName;
       }
     }
     const codexRaw = asRecord(backends.codex);
@@ -250,12 +254,14 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
           ? (approvalRaw as 'accept' | 'acceptForSession' | 'decline')
           : undefined;
       const runtime = pickBackendRuntime(codexRaw.runtime);
-      if (cwd || validSandbox || validApproval || runtime) {
+      const runtimeName = asString(codexRaw.runtime_name);
+      if (cwd || validSandbox || validApproval || runtime || runtimeName) {
         out.codex = {};
         if (cwd) out.codex.cwd = cwd;
         if (validSandbox) out.codex.sandbox_mode = validSandbox;
         if (validApproval) out.codex.approval_decision = validApproval;
         if (runtime) out.codex.runtime = runtime;
+        if (runtimeName) out.codex.runtime_name = runtimeName;
       }
     }
     const ocRaw = asRecord(backends.openclaw);

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -277,6 +277,17 @@ test('removeRuntimeContainer: missing resources are reported without throwing', 
   assert.equal(parsed.container.removed, false);
 });
 
+test('removeRuntimeContainer: docker can report missing resources on stdout with exit 0', () => {
+  const result = removeRuntimeContainer({
+    kind: 'claude',
+    removeVolumes: true,
+    dockerRun: () => ok('Error response from daemon: No such container: vicoop-runtime-claude'),
+  });
+
+  assert.equal(result.container.removed, false);
+  assert.equal(result.volumes.every((v) => !v.removed && !v.skipped), true);
+});
+
 test('removeRuntimeContainer: unexpected docker failures throw', () => {
   assert.throws(
     () =>

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -5,7 +5,10 @@ import {
   collectCodexHostCreds,
   formatRuntimeList,
   formatRuntimeListJson,
+  formatRuntimeRemoveJson,
+  formatRuntimeRemoveResult,
   listRuntimeContainers,
+  removeRuntimeContainer,
 } from './container-init.js';
 import type { DockerResult } from './runtime-container.js';
 
@@ -212,6 +215,84 @@ test('formatRuntimeList and JSON output include volume state', () => {
   assert.equal(parsed[1].volumes.creds.present, true);
 });
 
+// ──────────────────────────────────────────────────────────────────
+// container rm
+// ──────────────────────────────────────────────────────────────────
+
+test('removeRuntimeContainer: removes container and keeps volumes by default', () => {
+  const calls: Array<readonly string[]> = [];
+  const result = removeRuntimeContainer({
+    kind: 'claude',
+    removeVolumes: false,
+    dockerRun: (args) => {
+      calls.push(args);
+      return ok('');
+    },
+  });
+
+  assert.deepEqual(calls, [['rm', '-f', 'vicoop-runtime-claude']]);
+  assert.equal(result.container.removed, true);
+  assert.deepEqual(
+    result.volumes.map((v) => [v.name, v.removed, v.skipped]),
+    [
+      ['vicoop-agents-claude', false, true],
+      ['vicoop-creds-claude', false, true],
+      ['vicoop-sessions-claude', false, true],
+    ],
+  );
+  assert.match(formatRuntimeRemoveResult(result), /kept volumes/);
+});
+
+test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
+  const calls: Array<readonly string[]> = [];
+  const result = removeRuntimeContainer({
+    kind: 'codex',
+    removeVolumes: true,
+    dockerRun: (args) => {
+      calls.push(args);
+      return ok('');
+    },
+  });
+
+  assert.deepEqual(calls, [
+    ['rm', '-f', 'vicoop-runtime-codex'],
+    ['volume', 'rm', 'vicoop-agents-codex'],
+    ['volume', 'rm', 'vicoop-creds-codex'],
+    ['volume', 'rm', 'vicoop-sessions-codex'],
+  ]);
+  assert.equal(result.volumes.every((v) => v.removed && !v.skipped), true);
+});
+
+test('removeRuntimeContainer: missing resources are reported without throwing', () => {
+  const result = removeRuntimeContainer({
+    kind: 'claude',
+    removeVolumes: true,
+    dockerRun: () => fail('Error: No such container or volume', 1),
+  });
+
+  assert.equal(result.container.removed, false);
+  assert.equal(result.volumes.every((v) => !v.removed && !v.skipped), true);
+  const parsed = JSON.parse(formatRuntimeRemoveJson(result));
+  assert.equal(parsed.container.name, 'vicoop-runtime-claude');
+  assert.equal(parsed.container.removed, false);
+});
+
+test('removeRuntimeContainer: unexpected docker failures throw', () => {
+  assert.throws(
+    () =>
+      removeRuntimeContainer({
+        kind: 'codex',
+        removeVolumes: false,
+        dockerRun: () => fail('permission denied', 1),
+      }),
+    /docker rm -f vicoop-runtime-codex failed/,
+  );
+});
+
 function ok(stdout = ''): DockerResult {
   return { stdout, stderr: '', exitCode: 0 };
+}
+
+function fail(stderr: string, exitCode = 1): DockerResult {
+  return { stdout: '', stderr, exitCode };
 }

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -176,12 +176,12 @@ test('listRuntimeContainers: fixed rows from managed docker labels', () => {
     '{{json .}}',
   ]);
   assert.equal(rows[0].kind, 'claude');
-  assert.equal(rows[0].name, 'default');
+  assert.equal(rows[0].name, 'claude');
   assert.equal(rows[0].container.state, 'running');
   assert.equal(rows[0].container.image, 'runtime:latest');
   assert.equal(rows[0].volumes.sessions.present, true);
   assert.equal(rows[1].kind, 'codex');
-  assert.equal(rows[1].name, 'default');
+  assert.equal(rows[1].name, 'codex');
   assert.equal(rows[1].container.state, 'stopped');
   assert.equal(rows[1].volumes.agents.present, true);
   assert.equal(rows[1].volumes.creds.present, false);
@@ -199,7 +199,7 @@ test('listRuntimeContainers: no containers returns no rows', () => {
   assert.deepEqual(rows, []);
 });
 
-test('listRuntimeContainers: includes legacy canonical containers by name', () => {
+test('listRuntimeContainers: includes unlabeled canonical containers by name', () => {
   const rows = listRuntimeContainers({
     dockerRun: (args) => {
       if (args[0] === 'ps' && args.includes('label=vicoop.managed-by=vicoop-bridge')) {
@@ -210,7 +210,7 @@ test('listRuntimeContainers: includes legacy canonical containers by name', () =
           JSON.stringify({
             Names: 'vicoop-runtime-codex',
             State: 'running',
-            Image: 'runtime:legacy',
+            Image: 'runtime:unlabeled',
             Labels: 'vicoop.kind=codex',
           }),
         );
@@ -239,10 +239,10 @@ test('listRuntimeContainers: includes legacy canonical containers by name', () =
     [
       [
         'codex',
-        'default',
+        'codex',
         'vicoop-runtime-codex',
         'running',
-        'runtime:legacy',
+        'runtime:unlabeled',
         true,
         true,
         true,
@@ -260,23 +260,23 @@ test('formatRuntimeList and JSON output include volume state', () => {
             Names: 'vicoop-runtime-codex',
             State: 'exited',
             Image: 'runtime:latest',
-            Labels: 'vicoop.kind=codex,vicoop.name=default',
+            Labels: 'vicoop.kind=codex,vicoop.name=codex',
           }),
         );
       }
       return ok(
         JSON.stringify({
           Name: 'vicoop-creds-codex',
-          Labels: 'vicoop.kind=codex,vicoop.name=default',
+          Labels: 'vicoop.kind=codex,vicoop.name=codex',
         }),
       );
     },
   });
 
   assert.match(formatRuntimeList(rows), /KIND\s+NAME\s+CONTAINER\s+IMAGE\s+AGENTS\s+CREDS\s+SESSIONS/);
-  assert.match(formatRuntimeList(rows), /codex\s+default\s+stopped\s+runtime:latest\s+no\s+yes\s+no/);
+  assert.match(formatRuntimeList(rows), /codex\s+codex\s+stopped\s+runtime:latest\s+no\s+yes\s+no/);
   const parsed = JSON.parse(formatRuntimeListJson(rows));
-  assert.equal(parsed[0].name, 'default');
+  assert.equal(parsed[0].name, 'codex');
   assert.equal(parsed[0].volumes.creds.name, 'vicoop-creds-codex');
   assert.equal(parsed[0].volumes.creds.present, true);
 });
@@ -305,7 +305,7 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
       if (args[0] === 'ps') {
         return ok(
           JSON.stringify({
-            Names: 'vicoop-runtime-codex-work',
+            Names: 'vicoop-runtime-work',
             State: 'running',
             Image: 'runtime:named',
             Labels: 'vicoop.kind=codex,vicoop.name=work',
@@ -315,11 +315,11 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
       return ok(
         [
           JSON.stringify({
-            Name: 'vicoop-agents-codex-work',
+            Name: 'vicoop-agents-work',
             Labels: 'vicoop.kind=codex,vicoop.name=work',
           }),
           JSON.stringify({
-            Name: 'vicoop-creds-codex-work',
+            Name: 'vicoop-creds-work',
             Labels: 'vicoop.kind=codex,vicoop.name=work',
           }),
         ].join('\n'),
@@ -329,12 +329,12 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
 
   assert.deepEqual(
     rows.map((row) => [row.kind, row.name, row.container.name, row.container.state]),
-    [['codex', 'work', 'vicoop-runtime-codex-work', 'running']],
+    [['codex', 'work', 'vicoop-runtime-work', 'running']],
   );
   const named = rows[0];
   assert.equal(named.volumes.agents.present, true);
   assert.equal(named.volumes.creds.present, true);
-  assert.equal(named.volumes.sessions.name, 'vicoop-sessions-codex-work');
+  assert.equal(named.volumes.sessions.name, 'vicoop-sessions-work');
   assert.equal(named.volumes.sessions.present, false);
 });
 
@@ -345,8 +345,7 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
 test('removeRuntimeContainer: removes container and keeps volumes by default', () => {
   const calls: Array<readonly string[]> = [];
   const result = removeRuntimeContainer({
-    kind: 'claude',
-    runtimeName: 'work',
+    name: 'work',
     removeVolumes: false,
     dockerRun: (args) => {
       calls.push(args);
@@ -354,15 +353,29 @@ test('removeRuntimeContainer: removes container and keeps volumes by default', (
     },
   });
 
-  assert.deepEqual(calls, [['rm', '-f', 'vicoop-runtime-claude-work']]);
+  assert.deepEqual(calls, [
+    [
+      'ps',
+      '-a',
+      '--filter',
+      'label=vicoop.managed-by=vicoop-bridge',
+      '--filter',
+      'label=vicoop.component=runtime',
+      '--format',
+      '{{json .}}',
+    ],
+    ['ps', '-a', '--filter', 'name=^vicoop-runtime-', '--format', '{{json .}}'],
+    ['volume', 'ls', '--format', '{{json .}}'],
+    ['rm', '-f', 'vicoop-runtime-work'],
+  ]);
   assert.equal(result.container.removed, true);
   assert.equal(result.name, 'work');
   assert.deepEqual(
     result.volumes.map((v) => [v.name, v.removed, v.skipped]),
     [
-      ['vicoop-agents-claude-work', false, true],
-      ['vicoop-creds-claude-work', false, true],
-      ['vicoop-sessions-claude-work', false, true],
+      ['vicoop-agents-work', false, true],
+      ['vicoop-creds-work', false, true],
+      ['vicoop-sessions-work', false, true],
     ],
   );
   assert.match(formatRuntimeRemoveResult(result), /kept volumes/);
@@ -371,7 +384,7 @@ test('removeRuntimeContainer: removes container and keeps volumes by default', (
 test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
   const calls: Array<readonly string[]> = [];
   const result = removeRuntimeContainer({
-    kind: 'codex',
+    name: 'codex',
     removeVolumes: true,
     dockerRun: (args) => {
       calls.push(args);
@@ -380,6 +393,18 @@ test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
   });
 
   assert.deepEqual(calls, [
+    [
+      'ps',
+      '-a',
+      '--filter',
+      'label=vicoop.managed-by=vicoop-bridge',
+      '--filter',
+      'label=vicoop.component=runtime',
+      '--format',
+      '{{json .}}',
+    ],
+    ['ps', '-a', '--filter', 'name=^vicoop-runtime-', '--format', '{{json .}}'],
+    ['volume', 'ls', '--format', '{{json .}}'],
     ['rm', '-f', 'vicoop-runtime-codex'],
     ['volume', 'rm', 'vicoop-agents-codex'],
     ['volume', 'rm', 'vicoop-creds-codex'],
@@ -390,9 +415,12 @@ test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
 
 test('removeRuntimeContainer: missing resources are reported without throwing', () => {
   const result = removeRuntimeContainer({
-    kind: 'claude',
+    name: 'claude',
     removeVolumes: true,
-    dockerRun: () => fail('Error: No such container or volume', 1),
+    dockerRun: (args) => {
+      if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
+      return fail('Error: No such container or volume', 1);
+    },
   });
 
   assert.equal(result.container.removed, false);
@@ -404,9 +432,12 @@ test('removeRuntimeContainer: missing resources are reported without throwing', 
 
 test('removeRuntimeContainer: docker can report missing resources on stdout with exit 0', () => {
   const result = removeRuntimeContainer({
-    kind: 'claude',
+    name: 'claude',
     removeVolumes: true,
-    dockerRun: () => ok('Error response from daemon: No such container: vicoop-runtime-claude'),
+    dockerRun: (args) => {
+      if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
+      return ok('Error response from daemon: No such container: vicoop-runtime-claude');
+    },
   });
 
   assert.equal(result.container.removed, false);
@@ -417,9 +448,12 @@ test('removeRuntimeContainer: unexpected docker failures throw', () => {
   assert.throws(
     () =>
       removeRuntimeContainer({
-        kind: 'codex',
+        name: 'codex',
         removeVolumes: false,
-        dockerRun: () => fail('permission denied', 1),
+        dockerRun: (args) => {
+          if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
+          return fail('permission denied', 1);
+        },
       }),
     /docker rm -f vicoop-runtime-codex failed/,
   );

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -3,7 +3,11 @@ import assert from 'node:assert/strict';
 import {
   collectClaudeHostCreds,
   collectCodexHostCreds,
+  formatRuntimeList,
+  formatRuntimeListJson,
+  listRuntimeContainers,
 } from './container-init.js';
+import type { DockerResult } from './runtime-container.js';
 
 // ──────────────────────────────────────────────────────────────────
 // collectClaudeHostCreds
@@ -104,3 +108,110 @@ test('collectCodexHostCreds: neither file present returns empty', () => {
   });
   assert.deepEqual(files, []);
 });
+
+// ──────────────────────────────────────────────────────────────────
+// container ls
+// ──────────────────────────────────────────────────────────────────
+
+test('listRuntimeContainers: fixed rows from managed docker labels', () => {
+  const calls: Array<readonly string[]> = [];
+  const dockerRun = (args: readonly string[]): DockerResult => {
+    calls.push(args);
+    if (args[0] === 'ps') {
+      return ok(
+        [
+          JSON.stringify({
+            Names: 'vicoop-runtime-claude',
+            State: 'running',
+            Image: 'runtime:latest',
+          }),
+          JSON.stringify({
+            Names: 'vicoop-runtime-codex',
+            State: 'exited',
+            Image: 'runtime:old',
+          }),
+        ].join('\n'),
+      );
+    }
+    if (args[0] === 'volume') {
+      return ok(
+        [
+          JSON.stringify({ Name: 'vicoop-agents-claude' }),
+          JSON.stringify({ Name: 'vicoop-creds-claude' }),
+          JSON.stringify({ Name: 'vicoop-sessions-claude' }),
+          JSON.stringify({ Name: 'vicoop-agents-codex' }),
+        ].join('\n'),
+      );
+    }
+    throw new Error(`unexpected docker args: ${args.join(' ')}`);
+  };
+
+  const rows = listRuntimeContainers({ dockerRun });
+
+  assert.deepEqual(calls[0], [
+    'ps',
+    '-a',
+    '--filter',
+    'label=vicoop.managed-by=vicoop-bridge',
+    '--filter',
+    'label=vicoop.component=runtime',
+    '--format',
+    '{{json .}}',
+  ]);
+  assert.deepEqual(calls[1], [
+    'volume',
+    'ls',
+    '--filter',
+    'label=vicoop.managed-by=vicoop-bridge',
+    '--filter',
+    'label=vicoop.component=runtime',
+    '--format',
+    '{{json .}}',
+  ]);
+  assert.equal(rows[0].kind, 'claude');
+  assert.equal(rows[0].container.state, 'running');
+  assert.equal(rows[0].container.image, 'runtime:latest');
+  assert.equal(rows[0].volumes.sessions.present, true);
+  assert.equal(rows[1].kind, 'codex');
+  assert.equal(rows[1].container.state, 'stopped');
+  assert.equal(rows[1].volumes.agents.present, true);
+  assert.equal(rows[1].volumes.creds.present, false);
+  assert.equal(rows[1].volumes.sessions.present, false);
+});
+
+test('listRuntimeContainers: missing resources stay visible', () => {
+  const rows = listRuntimeContainers({
+    dockerRun: (args) => {
+      assert.ok(args[0] === 'ps' || args[0] === 'volume');
+      return ok('');
+    },
+  });
+
+  assert.deepEqual(
+    rows.map((row) => [row.kind, row.container.state, row.container.image]),
+    [
+      ['claude', 'missing', null],
+      ['codex', 'missing', null],
+    ],
+  );
+  assert.equal(rows.every((row) => !row.volumes.agents.present), true);
+});
+
+test('formatRuntimeList and JSON output include volume state', () => {
+  const rows = listRuntimeContainers({
+    dockerRun: (args) => {
+      if (args[0] === 'ps') return ok('');
+      return ok(JSON.stringify({ Name: 'vicoop-creds-codex' }));
+    },
+  });
+
+  assert.match(formatRuntimeList(rows), /KIND\s+CONTAINER\s+IMAGE\s+AGENTS\s+CREDS\s+SESSIONS/);
+  assert.match(formatRuntimeList(rows), /codex\s+missing\s+-\s+no\s+yes\s+no/);
+  const parsed = JSON.parse(formatRuntimeListJson(rows));
+  assert.equal(parsed[1].volumes.creds.name, 'vicoop-creds-codex');
+  assert.equal(parsed[1].volumes.creds.present, true);
+});
+
+function ok(stdout = ''): DockerResult {
+  return { stdout, stderr: '', exitCode: 0 };
+}

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -184,7 +184,7 @@ test('listRuntimeContainers: fixed rows from managed docker labels', () => {
   assert.equal(rows[1].volumes.sessions.present, false);
 });
 
-test('listRuntimeContainers: missing resources stay visible', () => {
+test('listRuntimeContainers: no containers returns no rows', () => {
   const rows = listRuntimeContainers({
     dockerRun: (args) => {
       assert.ok(args[0] === 'ps' || args[0] === 'volume');
@@ -192,30 +192,55 @@ test('listRuntimeContainers: missing resources stay visible', () => {
     },
   });
 
-  assert.deepEqual(
-    rows.map((row) => [row.kind, row.container.state, row.container.image]),
-    [
-      ['claude', 'missing', null],
-      ['codex', 'missing', null],
-    ],
-  );
-  assert.equal(rows.every((row) => !row.volumes.agents.present), true);
+  assert.deepEqual(rows, []);
 });
 
 test('formatRuntimeList and JSON output include volume state', () => {
   const rows = listRuntimeContainers({
     dockerRun: (args) => {
-      if (args[0] === 'ps') return ok('');
-      return ok(JSON.stringify({ Name: 'vicoop-creds-codex' }));
+      if (args[0] === 'ps') {
+        return ok(
+          JSON.stringify({
+            Names: 'vicoop-runtime-codex',
+            State: 'exited',
+            Image: 'runtime:latest',
+            Labels: 'vicoop.kind=codex,vicoop.name=default',
+          }),
+        );
+      }
+      return ok(
+        JSON.stringify({
+          Name: 'vicoop-creds-codex',
+          Labels: 'vicoop.kind=codex,vicoop.name=default',
+        }),
+      );
     },
   });
 
   assert.match(formatRuntimeList(rows), /KIND\s+NAME\s+CONTAINER\s+IMAGE\s+AGENTS\s+CREDS\s+SESSIONS/);
-  assert.match(formatRuntimeList(rows), /codex\s+default\s+missing\s+-\s+no\s+yes\s+no/);
+  assert.match(formatRuntimeList(rows), /codex\s+default\s+stopped\s+runtime:latest\s+no\s+yes\s+no/);
   const parsed = JSON.parse(formatRuntimeListJson(rows));
-  assert.equal(parsed[1].name, 'default');
-  assert.equal(parsed[1].volumes.creds.name, 'vicoop-creds-codex');
-  assert.equal(parsed[1].volumes.creds.present, true);
+  assert.equal(parsed[0].name, 'default');
+  assert.equal(parsed[0].volumes.creds.name, 'vicoop-creds-codex');
+  assert.equal(parsed[0].volumes.creds.present, true);
+});
+
+test('listRuntimeContainers: volume-only leftovers do not create rows', () => {
+  const rows = listRuntimeContainers({
+    dockerRun: (args) => {
+      if (args[0] === 'ps') return ok('');
+      return ok(
+        JSON.stringify({
+          Name: 'vicoop-creds-codex-work',
+          Labels: 'vicoop.kind=codex,vicoop.name=work',
+        }),
+      );
+    },
+  });
+
+  assert.deepEqual(rows, []);
+  assert.equal(formatRuntimeList(rows), 'KIND  NAME  CONTAINER  IMAGE  AGENTS  CREDS  SESSIONS');
+  assert.equal(formatRuntimeListJson(rows), '[]');
 });
 
 test('listRuntimeContainers: includes named runtime instances discovered from labels', () => {
@@ -248,13 +273,9 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
 
   assert.deepEqual(
     rows.map((row) => [row.kind, row.name, row.container.name, row.container.state]),
-    [
-      ['claude', 'default', 'vicoop-runtime-claude', 'missing'],
-      ['codex', 'default', 'vicoop-runtime-codex', 'missing'],
-      ['codex', 'work', 'vicoop-runtime-codex-work', 'running'],
-    ],
+    [['codex', 'work', 'vicoop-runtime-codex-work', 'running']],
   );
-  const named = rows[2];
+  const named = rows[0];
   assert.equal(named.volumes.agents.present, true);
   assert.equal(named.volumes.creds.present, true);
   assert.equal(named.volumes.sessions.name, 'vicoop-sessions-codex-work');

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -342,11 +342,11 @@ test('listRuntimeContainers: includes named runtime instances discovered from la
 // container rm
 // ──────────────────────────────────────────────────────────────────
 
-test('removeRuntimeContainer: removes container and keeps volumes by default', () => {
+test('removeRuntimeContainer: removes container and volumes by default', () => {
   const calls: Array<readonly string[]> = [];
   const result = removeRuntimeContainer({
     name: 'work',
-    removeVolumes: false,
+    preserveVolumes: false,
     dockerRun: (args) => {
       calls.push(args);
       return ok('');
@@ -367,25 +367,28 @@ test('removeRuntimeContainer: removes container and keeps volumes by default', (
     ['ps', '-a', '--filter', 'name=^vicoop-runtime-', '--format', '{{json .}}'],
     ['volume', 'ls', '--format', '{{json .}}'],
     ['rm', '-f', 'vicoop-runtime-work'],
+    ['volume', 'rm', 'vicoop-agents-work'],
+    ['volume', 'rm', 'vicoop-creds-work'],
+    ['volume', 'rm', 'vicoop-sessions-work'],
   ]);
   assert.equal(result.container.removed, true);
   assert.equal(result.name, 'work');
   assert.deepEqual(
     result.volumes.map((v) => [v.name, v.removed, v.skipped]),
     [
-      ['vicoop-agents-work', false, true],
-      ['vicoop-creds-work', false, true],
-      ['vicoop-sessions-work', false, true],
+      ['vicoop-agents-work', true, false],
+      ['vicoop-creds-work', true, false],
+      ['vicoop-sessions-work', true, false],
     ],
   );
-  assert.match(formatRuntimeRemoveResult(result), /kept volumes/);
+  assert.match(formatRuntimeRemoveResult(result), /removed volume vicoop-agents-work/);
 });
 
-test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
+test('removeRuntimeContainer: --preserve-volumes keeps all canonical volumes', () => {
   const calls: Array<readonly string[]> = [];
   const result = removeRuntimeContainer({
     name: 'codex',
-    removeVolumes: true,
+    preserveVolumes: true,
     dockerRun: (args) => {
       calls.push(args);
       return ok('');
@@ -406,17 +409,15 @@ test('removeRuntimeContainer: --volumes removes all canonical volumes', () => {
     ['ps', '-a', '--filter', 'name=^vicoop-runtime-', '--format', '{{json .}}'],
     ['volume', 'ls', '--format', '{{json .}}'],
     ['rm', '-f', 'vicoop-runtime-codex'],
-    ['volume', 'rm', 'vicoop-agents-codex'],
-    ['volume', 'rm', 'vicoop-creds-codex'],
-    ['volume', 'rm', 'vicoop-sessions-codex'],
   ]);
-  assert.equal(result.volumes.every((v) => v.removed && !v.skipped), true);
+  assert.equal(result.volumes.every((v) => !v.removed && v.skipped), true);
+  assert.match(formatRuntimeRemoveResult(result), /kept volumes/);
 });
 
 test('removeRuntimeContainer: missing resources are reported without throwing', () => {
   const result = removeRuntimeContainer({
     name: 'claude',
-    removeVolumes: true,
+    preserveVolumes: false,
     dockerRun: (args) => {
       if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
       return fail('Error: No such container or volume', 1);
@@ -433,7 +434,7 @@ test('removeRuntimeContainer: missing resources are reported without throwing', 
 test('removeRuntimeContainer: docker can report missing resources on stdout with exit 0', () => {
   const result = removeRuntimeContainer({
     name: 'claude',
-    removeVolumes: true,
+    preserveVolumes: false,
     dockerRun: (args) => {
       if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
       return ok('Error response from daemon: No such container: vicoop-runtime-claude');
@@ -449,7 +450,7 @@ test('removeRuntimeContainer: unexpected docker failures throw', () => {
     () =>
       removeRuntimeContainer({
         name: 'codex',
-        removeVolumes: false,
+        preserveVolumes: true,
         dockerRun: (args) => {
           if (args[0] === 'ps' || (args[0] === 'volume' && args[1] === 'ls')) return ok('');
           return fail('permission denied', 1);

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -172,10 +172,12 @@ test('listRuntimeContainers: fixed rows from managed docker labels', () => {
     '{{json .}}',
   ]);
   assert.equal(rows[0].kind, 'claude');
+  assert.equal(rows[0].name, 'default');
   assert.equal(rows[0].container.state, 'running');
   assert.equal(rows[0].container.image, 'runtime:latest');
   assert.equal(rows[0].volumes.sessions.present, true);
   assert.equal(rows[1].kind, 'codex');
+  assert.equal(rows[1].name, 'default');
   assert.equal(rows[1].container.state, 'stopped');
   assert.equal(rows[1].volumes.agents.present, true);
   assert.equal(rows[1].volumes.creds.present, false);
@@ -208,11 +210,55 @@ test('formatRuntimeList and JSON output include volume state', () => {
     },
   });
 
-  assert.match(formatRuntimeList(rows), /KIND\s+CONTAINER\s+IMAGE\s+AGENTS\s+CREDS\s+SESSIONS/);
-  assert.match(formatRuntimeList(rows), /codex\s+missing\s+-\s+no\s+yes\s+no/);
+  assert.match(formatRuntimeList(rows), /KIND\s+NAME\s+CONTAINER\s+IMAGE\s+AGENTS\s+CREDS\s+SESSIONS/);
+  assert.match(formatRuntimeList(rows), /codex\s+default\s+missing\s+-\s+no\s+yes\s+no/);
   const parsed = JSON.parse(formatRuntimeListJson(rows));
+  assert.equal(parsed[1].name, 'default');
   assert.equal(parsed[1].volumes.creds.name, 'vicoop-creds-codex');
   assert.equal(parsed[1].volumes.creds.present, true);
+});
+
+test('listRuntimeContainers: includes named runtime instances discovered from labels', () => {
+  const rows = listRuntimeContainers({
+    dockerRun: (args) => {
+      if (args[0] === 'ps') {
+        return ok(
+          JSON.stringify({
+            Names: 'vicoop-runtime-codex-work',
+            State: 'running',
+            Image: 'runtime:named',
+            Labels: 'vicoop.kind=codex,vicoop.name=work',
+          }),
+        );
+      }
+      return ok(
+        [
+          JSON.stringify({
+            Name: 'vicoop-agents-codex-work',
+            Labels: 'vicoop.kind=codex,vicoop.name=work',
+          }),
+          JSON.stringify({
+            Name: 'vicoop-creds-codex-work',
+            Labels: 'vicoop.kind=codex,vicoop.name=work',
+          }),
+        ].join('\n'),
+      );
+    },
+  });
+
+  assert.deepEqual(
+    rows.map((row) => [row.kind, row.name, row.container.name, row.container.state]),
+    [
+      ['claude', 'default', 'vicoop-runtime-claude', 'missing'],
+      ['codex', 'default', 'vicoop-runtime-codex', 'missing'],
+      ['codex', 'work', 'vicoop-runtime-codex-work', 'running'],
+    ],
+  );
+  const named = rows[2];
+  assert.equal(named.volumes.agents.present, true);
+  assert.equal(named.volumes.creds.present, true);
+  assert.equal(named.volumes.sessions.name, 'vicoop-sessions-codex-work');
+  assert.equal(named.volumes.sessions.present, false);
 });
 
 // ──────────────────────────────────────────────────────────────────
@@ -223,6 +269,7 @@ test('removeRuntimeContainer: removes container and keeps volumes by default', (
   const calls: Array<readonly string[]> = [];
   const result = removeRuntimeContainer({
     kind: 'claude',
+    runtimeName: 'work',
     removeVolumes: false,
     dockerRun: (args) => {
       calls.push(args);
@@ -230,14 +277,15 @@ test('removeRuntimeContainer: removes container and keeps volumes by default', (
     },
   });
 
-  assert.deepEqual(calls, [['rm', '-f', 'vicoop-runtime-claude']]);
+  assert.deepEqual(calls, [['rm', '-f', 'vicoop-runtime-claude-work']]);
   assert.equal(result.container.removed, true);
+  assert.equal(result.name, 'work');
   assert.deepEqual(
     result.volumes.map((v) => [v.name, v.removed, v.skipped]),
     [
-      ['vicoop-agents-claude', false, true],
-      ['vicoop-creds-claude', false, true],
-      ['vicoop-sessions-claude', false, true],
+      ['vicoop-agents-claude-work', false, true],
+      ['vicoop-creds-claude-work', false, true],
+      ['vicoop-sessions-claude-work', false, true],
     ],
   );
   assert.match(formatRuntimeRemoveResult(result), /kept volumes/);

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -162,12 +162,16 @@ test('listRuntimeContainers: fixed rows from managed docker labels', () => {
     '{{json .}}',
   ]);
   assert.deepEqual(calls[1], [
+    'ps',
+    '-a',
+    '--filter',
+    'name=^vicoop-runtime-',
+    '--format',
+    '{{json .}}',
+  ]);
+  assert.deepEqual(calls[2], [
     'volume',
     'ls',
-    '--filter',
-    'label=vicoop.managed-by=vicoop-bridge',
-    '--filter',
-    'label=vicoop.component=runtime',
     '--format',
     '{{json .}}',
   ]);
@@ -193,6 +197,58 @@ test('listRuntimeContainers: no containers returns no rows', () => {
   });
 
   assert.deepEqual(rows, []);
+});
+
+test('listRuntimeContainers: includes legacy canonical containers by name', () => {
+  const rows = listRuntimeContainers({
+    dockerRun: (args) => {
+      if (args[0] === 'ps' && args.includes('label=vicoop.managed-by=vicoop-bridge')) {
+        return ok('');
+      }
+      if (args[0] === 'ps') {
+        return ok(
+          JSON.stringify({
+            Names: 'vicoop-runtime-codex',
+            State: 'running',
+            Image: 'runtime:legacy',
+            Labels: 'vicoop.kind=codex',
+          }),
+        );
+      }
+      return ok(
+        [
+          JSON.stringify({ Name: 'vicoop-agents-codex', Labels: 'vicoop.kind=codex' }),
+          JSON.stringify({ Name: 'vicoop-creds-codex', Labels: 'vicoop.kind=codex' }),
+          JSON.stringify({ Name: 'vicoop-sessions-codex', Labels: 'vicoop.kind=codex' }),
+        ].join('\n'),
+      );
+    },
+  });
+
+  assert.deepEqual(
+    rows.map((row) => [
+      row.kind,
+      row.name,
+      row.container.name,
+      row.container.state,
+      row.container.image,
+      row.volumes.agents.present,
+      row.volumes.creds.present,
+      row.volumes.sessions.present,
+    ]),
+    [
+      [
+        'codex',
+        'default',
+        'vicoop-runtime-codex',
+        'running',
+        'runtime:legacy',
+        true,
+        true,
+        true,
+      ],
+    ],
+  );
 });
 
 test('formatRuntimeList and JSON output include volume state', () => {

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -112,6 +112,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     image: opts.image ?? process.env.VICOOP_RUNTIME_IMAGE ?? DEFAULT_RUNTIME_IMAGE,
     bridgeUrl: opts.bridgeUrl,
     createIfMissing: true,
+    failIfExists: true,
     logger: opts.logger,
   });
 
@@ -776,7 +777,7 @@ const containerInitSubCmd = command(
   }),
   {
     brief: message`Bootstrap a per-backend runtime container.`,
-    description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\` or \`vicoop-runtime-<kind>-<name>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\` and, for named runtimes, \`--runtime-name <name>\`.`,
+    description: message`One-shot setup for the container-runtime profile: creates \`vicoop-runtime-<kind>\` or \`vicoop-runtime-<kind>-<name>\`, fails if that runtime already exists, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\` and, for named runtimes, \`--runtime-name <name>\`.`,
   },
 );
 

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -182,28 +182,33 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
         log.error(`--from-host: ${(err as Error).message}`);
         log.error(
           `Rerun without --from-host to leave creds empty for an interactive auth flow ` +
-            `(docker exec -it ${containerName} ${authHintFor(opts.kind)}).`,
+            `(${authCommandFor(containerName, opts.kind)}).`,
         );
         return 1;
       }
     } else {
       log.info(
         `--from-host not set: leaving creds empty. To auth inside the container run\n` +
-          `    docker exec -it ${containerName} ${authHintFor(opts.kind)}`,
+          `    ${authCommandFor(containerName, opts.kind)}`,
       );
     }
 
-    log.info(`runtime container for ${opts.kind} ready. start daemon with:`);
+    log.info(`runtime container for ${opts.kind} initialized. start daemon with:`);
     log.info(
       `    vicoop-client --backend ${opts.kind} --runtime container --runtime-name ${runtimeName}`,
     );
     return 0;
   } finally {
-    // Leave the container running. The next daemon launch reuses
-    // it; an explicit cleanup is `vicoop-client container rm <name>`
-    // (operator's job, on purpose — they may be about to start the
-    // daemon).
+    await runtime.stop();
   }
+}
+
+function authCommandFor(containerName: string, kind: InstallableBackendKind): string {
+  return (
+    `docker start ${containerName} >/dev/null && ` +
+    `docker exec -it ${containerName} ${authHintFor(kind)} && ` +
+    `docker stop ${containerName} >/dev/null`
+  );
 }
 
 // Run `docker exec [--user U] <container> <cmd...>` with stdio

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -534,31 +534,42 @@ function removeDockerResource(
 function readManagedContainers(
   dockerRun: DockerRun,
 ): Map<string, { state: string; image: string | null }> {
-  const r = dockerRun([
-    'ps',
-    '-a',
-    '--filter',
-    `label=${RUNTIME_MANAGED_BY_LABEL}`,
-    '--filter',
-    `label=${RUNTIME_COMPONENT_LABEL}`,
-    '--format',
-    '{{json .}}',
-  ]);
-  if (r.exitCode !== 0) {
-    throw new Error(`docker ps failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
-  }
-
   const result = new Map<string, { state: string; image: string | null }>();
-  for (const entry of parseDockerJsonLines(r.stdout, 'docker ps')) {
-    const name = stringField(entry, 'Names') ?? stringField(entry, 'Name');
-    if (!name) continue;
-    const labels = parseDockerLabels(stringField(entry, 'Labels'));
-    const runtime = runtimeFromLabelsOrName(labels, name, 'container');
-    if (!runtime) continue;
-    result.set(runtimeKey(runtime.kind, runtime.runtimeName), {
-      state: stringField(entry, 'State') ?? '',
-      image: stringField(entry, 'Image'),
-    });
+  for (const args of [
+    [
+      'ps',
+      '-a',
+      '--filter',
+      `label=${RUNTIME_MANAGED_BY_LABEL}`,
+      '--filter',
+      `label=${RUNTIME_COMPONENT_LABEL}`,
+      '--format',
+      '{{json .}}',
+    ],
+    [
+      'ps',
+      '-a',
+      '--filter',
+      'name=^vicoop-runtime-',
+      '--format',
+      '{{json .}}',
+    ],
+  ] as const) {
+    const r = dockerRun(args);
+    if (r.exitCode !== 0) {
+      throw new Error(`docker ps failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
+    }
+    for (const entry of parseDockerJsonLines(r.stdout, 'docker ps')) {
+      const name = stringField(entry, 'Names') ?? stringField(entry, 'Name');
+      if (!name) continue;
+      const labels = parseDockerLabels(stringField(entry, 'Labels'));
+      const runtime = runtimeFromLabelsOrName(labels, name, 'container');
+      if (!runtime) continue;
+      result.set(runtimeKey(runtime.kind, runtime.runtimeName), {
+        state: stringField(entry, 'State') ?? '',
+        image: stringField(entry, 'Image'),
+      });
+    }
   }
   return result;
 }
@@ -567,10 +578,6 @@ function readManagedVolumes(dockerRun: DockerRun): Map<string, Set<string>> {
   const r = dockerRun([
     'volume',
     'ls',
-    '--filter',
-    `label=${RUNTIME_MANAGED_BY_LABEL}`,
-    '--filter',
-    `label=${RUNTIME_COMPONENT_LABEL}`,
     '--format',
     '{{json .}}',
   ]);

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -509,8 +509,9 @@ function removeDockerResource(
   resource: 'container' | 'volume',
 ): boolean {
   const r = dockerRun(args);
+  const output = `${r.stdout}\n${r.stderr}`;
+  if (/No such container|No such volume|not found/i.test(output)) return false;
   if (r.exitCode === 0) return true;
-  if (/No such container|No such volume|not found/i.test(r.stderr)) return false;
   throw new Error(`docker ${args.join(' ')} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
 }
 

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -26,7 +26,18 @@ import { argument, command, constant, flag, option } from '@optique/core/primiti
 import { message } from '@optique/core/message';
 import { choice, string } from '@optique/core/valueparser';
 import type { InferValue } from '@optique/core/parser';
-import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
+import {
+  agentsVolumeName,
+  containerName,
+  credsVolumeName,
+  defaultDockerRun,
+  RuntimeContainer,
+  DEFAULT_RUNTIME_IMAGE,
+  RUNTIME_COMPONENT_LABEL,
+  RUNTIME_MANAGED_BY_LABEL,
+  sessionsVolumeName,
+  type DockerRun,
+} from './runtime-container.js';
 import { BACKENDS_MANIFEST, type InstallableBackendKind } from './backends-manifest.js';
 import { createLogger, type Logger } from './logger.js';
 
@@ -46,6 +57,26 @@ export interface ContainerInitOptions {
   // would use; included as a parameter so tests can override.
   bridgeUrl?: string;
   logger?: Logger;
+}
+
+type RuntimeContainerState = 'running' | 'stopped' | 'missing';
+
+export interface RuntimeListRow {
+  kind: InstallableBackendKind;
+  container: {
+    name: string;
+    state: RuntimeContainerState;
+    image: string | null;
+  };
+  volumes: {
+    agents: { name: string; present: boolean };
+    creds: { name: string; present: boolean };
+    sessions: { name: string; present: boolean };
+  };
+}
+
+export interface ContainerListOptions {
+  dockerRun?: DockerRun;
 }
 
 // Returns the process exit code the CLI should use. Throws only on
@@ -365,6 +396,138 @@ function authHintFor(kind: InstallableBackendKind): string {
   return `<kind>-specific auth command`;
 }
 
+export function listRuntimeContainers(opts: ContainerListOptions = {}): RuntimeListRow[] {
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
+  const containers = readManagedContainers(dockerRun);
+  const volumes = readManagedVolumes(dockerRun);
+
+  return BACKEND_KINDS.map((kind) => {
+    const expectedContainerName = containerName(kind);
+    const container = containers.get(expectedContainerName);
+    return {
+      kind,
+      container: {
+        name: expectedContainerName,
+        state: container ? normalizeContainerState(container.state) : 'missing',
+        image: container?.image ?? null,
+      },
+      volumes: {
+        agents: volumePresence(volumes, agentsVolumeName(kind)),
+        creds: volumePresence(volumes, credsVolumeName(kind)),
+        sessions: volumePresence(volumes, sessionsVolumeName(kind)),
+      },
+    };
+  });
+}
+
+export function formatRuntimeList(rows: readonly RuntimeListRow[]): string {
+  const table = [
+    ['KIND', 'CONTAINER', 'IMAGE', 'AGENTS', 'CREDS', 'SESSIONS'],
+    ...rows.map((row) => [
+      row.kind,
+      row.container.state,
+      row.container.image ?? '-',
+      presentCell(row.volumes.agents.present),
+      presentCell(row.volumes.creds.present),
+      presentCell(row.volumes.sessions.present),
+    ]),
+  ];
+  const widths = table[0].map((_, i) => Math.max(...table.map((r) => r[i].length)));
+  return table
+    .map((row) => row.map((cell, i) => cell.padEnd(widths[i])).join('  ').trimEnd())
+    .join('\n');
+}
+
+export function formatRuntimeListJson(rows: readonly RuntimeListRow[]): string {
+  return JSON.stringify(rows, null, 2);
+}
+
+function readManagedContainers(
+  dockerRun: DockerRun,
+): Map<string, { state: string; image: string | null }> {
+  const r = dockerRun([
+    'ps',
+    '-a',
+    '--filter',
+    `label=${RUNTIME_MANAGED_BY_LABEL}`,
+    '--filter',
+    `label=${RUNTIME_COMPONENT_LABEL}`,
+    '--format',
+    '{{json .}}',
+  ]);
+  if (r.exitCode !== 0) {
+    throw new Error(`docker ps failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
+  }
+
+  const result = new Map<string, { state: string; image: string | null }>();
+  for (const entry of parseDockerJsonLines(r.stdout, 'docker ps')) {
+    const name = stringField(entry, 'Names') ?? stringField(entry, 'Name');
+    if (!name) continue;
+    result.set(name, {
+      state: stringField(entry, 'State') ?? '',
+      image: stringField(entry, 'Image'),
+    });
+  }
+  return result;
+}
+
+function readManagedVolumes(dockerRun: DockerRun): Set<string> {
+  const r = dockerRun([
+    'volume',
+    'ls',
+    '--filter',
+    `label=${RUNTIME_MANAGED_BY_LABEL}`,
+    '--filter',
+    `label=${RUNTIME_COMPONENT_LABEL}`,
+    '--format',
+    '{{json .}}',
+  ]);
+  if (r.exitCode !== 0) {
+    throw new Error(`docker volume ls failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
+  }
+
+  const result = new Set<string>();
+  for (const entry of parseDockerJsonLines(r.stdout, 'docker volume ls')) {
+    const name = stringField(entry, 'Name');
+    if (name) result.add(name);
+  }
+  return result;
+}
+
+function parseDockerJsonLines(stdout: string, command: string): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        rows.push(parsed as Record<string, unknown>);
+      }
+    } catch (e) {
+      throw new Error(`${command} returned invalid JSON: ${(e as Error).message}`);
+    }
+  }
+  return rows;
+}
+
+function normalizeContainerState(state: string): RuntimeContainerState {
+  return state === 'running' ? 'running' : 'stopped';
+}
+
+function volumePresence(volumes: Set<string>, name: string): RuntimeListRow['volumes']['agents'] {
+  return { name, present: volumes.has(name) };
+}
+
+function presentCell(present: boolean): string {
+  return present ? 'yes' : 'no';
+}
+
+function stringField(row: Record<string, unknown>, field: string): string | null {
+  const value = row[field];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CLI surface (`vicoop-client container init <kind> [opts]`)
 //
@@ -413,17 +576,39 @@ const containerInitSubCmd = command(
   },
 );
 
+function containerListCommand(name: 'ls' | 'list') {
+  return command(
+    name,
+    object({
+      action: constant('container-list' as const),
+      json: withDefault(flag('--json', {
+        description: message`Emit machine-readable JSON.`,
+      }), false),
+    }),
+    {
+      brief: message`List runtime containers and volumes.`,
+      description: message`Prints one row per supported runtime kind, showing whether the managed Docker container is running, stopped, or missing and whether each expected named volume exists.`,
+    },
+  );
+}
+
+const containerListSubCmd = longestMatch(
+  containerListCommand('ls'),
+  containerListCommand('list'),
+);
+
 export const containerCmd = command(
   'container',
-  longestMatch(containerInitSubCmd),
+  longestMatch(containerInitSubCmd, containerListSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
   },
 );
 
 export type ContainerCliArgs = InferValue<typeof containerCmd>;
 export type ContainerInitArgs = Extract<ContainerCliArgs, { action: 'container-init' }>;
+export type ContainerListArgs = Extract<ContainerCliArgs, { action: 'container-list' }>;
 
 // Adapter from optique-parsed args → runContainerInit's typed
 // options. Lives here (not in cli.ts) so the command surface and
@@ -438,6 +623,17 @@ export async function runContainerInitCli(args: ContainerInitArgs): Promise<numb
     });
   } catch (err) {
     console.error(`container init failed: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+export async function runContainerListCli(args: ContainerListArgs): Promise<number> {
+  try {
+    const rows = listRuntimeContainers();
+    process.stdout.write((args.json ? formatRuntimeListJson(rows) : formatRuntimeList(rows)) + '\n');
+    return 0;
+  } catch (err) {
+    console.error(`container ls failed: ${(err as Error).message}`);
     return 1;
   }
 }

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -33,9 +33,12 @@ import {
   defaultDockerRun,
   RuntimeContainer,
   DEFAULT_RUNTIME_IMAGE,
+  DEFAULT_RUNTIME_INSTANCE,
   RUNTIME_COMPONENT_LABEL,
   RUNTIME_MANAGED_BY_LABEL,
+  runtimeInstanceLabel,
   sessionsVolumeName,
+  validateRuntimeName,
   type DockerRun,
 } from './runtime-container.js';
 import { BACKENDS_MANIFEST, type InstallableBackendKind } from './backends-manifest.js';
@@ -43,6 +46,7 @@ import { createLogger, type Logger } from './logger.js';
 
 export interface ContainerInitOptions {
   kind: InstallableBackendKind;
+  runtimeName?: string;
   // When true, copy the operator's existing host creds into the
   // container creds volume. When false, leave creds empty and let
   // the operator run an interactive auth flow themselves.
@@ -63,6 +67,7 @@ type RuntimeContainerState = 'running' | 'stopped' | 'missing';
 
 export interface RuntimeListRow {
   kind: InstallableBackendKind;
+  name: string;
   container: {
     name: string;
     state: RuntimeContainerState;
@@ -81,12 +86,14 @@ export interface ContainerListOptions {
 
 export interface ContainerRemoveOptions {
   kind: InstallableBackendKind;
+  runtimeName?: string;
   removeVolumes: boolean;
   dockerRun?: DockerRun;
 }
 
 export interface RuntimeRemoveResult {
   kind: InstallableBackendKind;
+  name: string;
   container: { name: string; removed: boolean };
   volumes: Array<{ name: string; removed: boolean; skipped: boolean }>;
 }
@@ -101,6 +108,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
 
   const runtime = new RuntimeContainer({
     backendKind: opts.kind,
+    runtimeName: opts.runtimeName,
     image: opts.image ?? process.env.VICOOP_RUNTIME_IMAGE ?? DEFAULT_RUNTIME_IMAGE,
     bridgeUrl: opts.bridgeUrl,
     createIfMissing: true,
@@ -110,7 +118,8 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
   try {
     await runtime.start();
 
-    const containerName = `vicoop-runtime-${opts.kind}`;
+    const runtimeName = validateRuntimeName(opts.runtimeName);
+    const containerName = containerNameFor(opts.kind, runtimeName);
 
     // (1) chown the per-kind sub-trees so subsequent install-backend
     // (running as the image's `node` user) can mkdir into them.
@@ -181,7 +190,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     } else {
       log.info(
         `--from-host not set: leaving creds empty. To auth inside the container run\n` +
-          `    docker exec -it vicoop-runtime-${opts.kind} ${authHintFor(opts.kind)}`,
+          `    docker exec -it ${containerName} ${authHintFor(opts.kind)}`,
       );
     }
 
@@ -412,21 +421,28 @@ export function listRuntimeContainers(opts: ContainerListOptions = {}): RuntimeL
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const containers = readManagedContainers(dockerRun);
   const volumes = readManagedVolumes(dockerRun);
+  const keys = new Set<string>();
+  for (const kind of BACKEND_KINDS) keys.add(runtimeKey(kind, undefined));
+  for (const key of containers.keys()) keys.add(key);
+  for (const key of volumes.keys()) keys.add(key);
 
-  return BACKEND_KINDS.map((kind) => {
-    const expectedContainerName = containerName(kind);
-    const container = containers.get(expectedContainerName);
+  return Array.from(keys).map(parseRuntimeKey).sort(compareRuntimeKeys).map(({ kind, runtimeName }) => {
+    const key = runtimeKey(kind, runtimeName);
+    const expectedContainerName = containerNameFor(kind, runtimeName);
+    const container = containers.get(key);
+    const runtimeVolumes = volumes.get(key) ?? new Set<string>();
     return {
       kind,
+      name: runtimeInstanceLabel(runtimeName),
       container: {
         name: expectedContainerName,
         state: container ? normalizeContainerState(container.state) : 'missing',
         image: container?.image ?? null,
       },
       volumes: {
-        agents: volumePresence(volumes, agentsVolumeName(kind)),
-        creds: volumePresence(volumes, credsVolumeName(kind)),
-        sessions: volumePresence(volumes, sessionsVolumeName(kind)),
+        agents: volumePresence(runtimeVolumes, agentsVolumeName(kind, runtimeName)),
+        creds: volumePresence(runtimeVolumes, credsVolumeName(kind, runtimeName)),
+        sessions: volumePresence(runtimeVolumes, sessionsVolumeName(kind, runtimeName)),
       },
     };
   });
@@ -434,9 +450,10 @@ export function listRuntimeContainers(opts: ContainerListOptions = {}): RuntimeL
 
 export function formatRuntimeList(rows: readonly RuntimeListRow[]): string {
   const table = [
-    ['KIND', 'CONTAINER', 'IMAGE', 'AGENTS', 'CREDS', 'SESSIONS'],
+    ['KIND', 'NAME', 'CONTAINER', 'IMAGE', 'AGENTS', 'CREDS', 'SESSIONS'],
     ...rows.map((row) => [
       row.kind,
+      row.name,
       row.container.state,
       row.container.image ?? '-',
       presentCell(row.volumes.agents.present),
@@ -456,9 +473,11 @@ export function formatRuntimeListJson(rows: readonly RuntimeListRow[]): string {
 
 export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRemoveResult {
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
-  const name = containerName(opts.kind);
+  const runtimeName = validateRuntimeName(opts.runtimeName);
+  const name = containerNameFor(opts.kind, runtimeName);
   const result: RuntimeRemoveResult = {
     kind: opts.kind,
+    name: runtimeInstanceLabel(runtimeName),
     container: {
       name,
       removed: removeDockerResource(dockerRun, ['rm', '-f', name], 'container'),
@@ -467,9 +486,9 @@ export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRem
   };
 
   for (const volumeName of [
-    agentsVolumeName(opts.kind),
-    credsVolumeName(opts.kind),
-    sessionsVolumeName(opts.kind),
+    agentsVolumeName(opts.kind, runtimeName),
+    credsVolumeName(opts.kind, runtimeName),
+    sessionsVolumeName(opts.kind, runtimeName),
   ]) {
     result.volumes.push({
       name: volumeName,
@@ -536,7 +555,10 @@ function readManagedContainers(
   for (const entry of parseDockerJsonLines(r.stdout, 'docker ps')) {
     const name = stringField(entry, 'Names') ?? stringField(entry, 'Name');
     if (!name) continue;
-    result.set(name, {
+    const labels = parseDockerLabels(stringField(entry, 'Labels'));
+    const runtime = runtimeFromLabelsOrName(labels, name, 'container');
+    if (!runtime) continue;
+    result.set(runtimeKey(runtime.kind, runtime.runtimeName), {
       state: stringField(entry, 'State') ?? '',
       image: stringField(entry, 'Image'),
     });
@@ -544,7 +566,7 @@ function readManagedContainers(
   return result;
 }
 
-function readManagedVolumes(dockerRun: DockerRun): Set<string> {
+function readManagedVolumes(dockerRun: DockerRun): Map<string, Set<string>> {
   const r = dockerRun([
     'volume',
     'ls',
@@ -559,10 +581,17 @@ function readManagedVolumes(dockerRun: DockerRun): Set<string> {
     throw new Error(`docker volume ls failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
   }
 
-  const result = new Set<string>();
+  const result = new Map<string, Set<string>>();
   for (const entry of parseDockerJsonLines(r.stdout, 'docker volume ls')) {
     const name = stringField(entry, 'Name');
-    if (name) result.add(name);
+    if (!name) continue;
+    const labels = parseDockerLabels(stringField(entry, 'Labels'));
+    const runtime = runtimeFromLabelsOrName(labels, name, 'volume');
+    if (!runtime) continue;
+    const key = runtimeKey(runtime.kind, runtime.runtimeName);
+    const names = result.get(key) ?? new Set<string>();
+    names.add(name);
+    result.set(key, names);
   }
   return result;
 }
@@ -601,6 +630,99 @@ function stringField(row: Record<string, unknown>, field: string): string | null
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
+function containerNameFor(kind: InstallableBackendKind, runtimeName: string | undefined): string {
+  return containerName(kind, runtimeName);
+}
+
+function runtimeKey(kind: InstallableBackendKind, runtimeName: string | undefined): string {
+  return `${kind}\0${runtimeName ?? ''}`;
+}
+
+function parseRuntimeKey(key: string): { kind: InstallableBackendKind; runtimeName: string | undefined } {
+  const [kind, runtimeName] = key.split('\0') as [InstallableBackendKind, string | undefined];
+  return { kind, runtimeName: runtimeName || undefined };
+}
+
+function compareRuntimeKeys(
+  a: { kind: InstallableBackendKind; runtimeName: string | undefined },
+  b: { kind: InstallableBackendKind; runtimeName: string | undefined },
+): number {
+  const kindDiff = BACKEND_KINDS.indexOf(a.kind) - BACKEND_KINDS.indexOf(b.kind);
+  if (kindDiff !== 0) return kindDiff;
+  if (!a.runtimeName && b.runtimeName) return -1;
+  if (a.runtimeName && !b.runtimeName) return 1;
+  return (a.runtimeName ?? '').localeCompare(b.runtimeName ?? '');
+}
+
+function parseDockerLabels(raw: string | null): Map<string, string> {
+  const labels = new Map<string, string>();
+  if (!raw) return labels;
+  for (const part of raw.split(',')) {
+    const idx = part.indexOf('=');
+    if (idx <= 0) continue;
+    labels.set(part.slice(0, idx), part.slice(idx + 1));
+  }
+  return labels;
+}
+
+function runtimeFromLabelsOrName(
+  labels: Map<string, string>,
+  resourceName: string,
+  resource: 'container' | 'volume',
+): { kind: InstallableBackendKind; runtimeName: string | undefined } | null {
+  const kindLabel = labels.get('vicoop.kind');
+  const kind =
+    kindLabel && (BACKEND_KINDS as readonly string[]).includes(kindLabel)
+      ? (kindLabel as InstallableBackendKind)
+      : parseKindFromResourceName(resourceName, resource);
+  if (!kind) return null;
+  const rawName = labels.get('vicoop.name');
+  if (rawName) {
+    return {
+      kind,
+      runtimeName: rawName === DEFAULT_RUNTIME_INSTANCE ? undefined : validateRuntimeName(rawName),
+    };
+  }
+  return { kind, runtimeName: parseRuntimeNameFromResourceName(resourceName, kind, resource) };
+}
+
+function parseKindFromResourceName(
+  name: string,
+  resource: 'container' | 'volume',
+): InstallableBackendKind | null {
+  for (const kind of BACKEND_KINDS) {
+    if (resource === 'container') {
+      if (name === containerName(kind) || name.startsWith(`${containerName(kind)}-`)) return kind;
+      continue;
+    }
+    for (const prefix of ['vicoop-agents', 'vicoop-creds', 'vicoop-sessions']) {
+      const base = `${prefix}-${kind}`;
+      if (name === base || name.startsWith(`${base}-`)) return kind;
+    }
+  }
+  return null;
+}
+
+function parseRuntimeNameFromResourceName(
+  name: string,
+  kind: InstallableBackendKind,
+  resource: 'container' | 'volume',
+): string | undefined {
+  const bases =
+    resource === 'container'
+      ? [containerName(kind)]
+      : [
+          agentsVolumeName(kind),
+          credsVolumeName(kind),
+          sessionsVolumeName(kind),
+        ];
+  for (const base of bases) {
+    if (name === base) return undefined;
+    if (name.startsWith(`${base}-`)) return validateRuntimeName(name.slice(base.length + 1));
+  }
+  return undefined;
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // CLI surface (`vicoop-client container init <kind> [opts]`)
 //
@@ -626,6 +748,11 @@ const containerInitSubCmd = command(
     kind: argument(choice([...BACKEND_KINDS], { metavar: 'KIND' }), {
       description: message`Backend agent CLI to install into the runtime container. One of: \`claude\`, \`codex\`.`,
     }),
+    name: optional(
+      option('--name', string({ metavar: 'NAME' }), {
+        description: message`Optional runtime instance name. Omit for the default per-kind runtime; named runtimes use Docker resources suffixed with -<name>.`,
+      }),
+    ),
     fromHost: withDefault(
       flag('--from-host', {
         description: message`Copy the operator's existing host creds into the container's per-backend creds volume (macOS keychain for claude, ~/.codex for codex). Off by default — explicit opt-in for the runtime-isolation tradeoff.`,
@@ -645,7 +772,7 @@ const containerInitSubCmd = command(
   }),
   {
     brief: message`Bootstrap a per-backend runtime container.`,
-    description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\`.`,
+    description: message`One-shot setup for the container-runtime profile: boots \`vicoop-runtime-<kind>\` or \`vicoop-runtime-<kind>-<name>\`, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\` and, for named runtimes, \`--runtime-name <name>\`.`,
   },
 );
 
@@ -678,6 +805,11 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
       kind: argument(choice([...BACKEND_KINDS], { metavar: 'KIND' }), {
         description: message`Runtime kind to remove. One of: \`claude\`, \`codex\`.`,
       }),
+      name: optional(
+        option('--name', string({ metavar: 'NAME' }), {
+          description: message`Optional runtime instance name to remove. Omit for the default per-kind runtime.`,
+        }),
+      ),
       volumes: withDefault(flag('--volumes', {
         description: message`Also remove the runtime's agents, creds, and sessions named volumes. Off by default so credentials and sessions survive container recreation.`,
       }), false),
@@ -687,7 +819,7 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
     }),
     {
       brief: message`Remove a runtime container.`,
-      description: message`Removes the per-kind runtime container. Named volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
+      description: message`Removes the per-kind runtime container, or a named runtime when --name is set. Named volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
     },
   );
 }
@@ -718,6 +850,7 @@ export async function runContainerInitCli(args: ContainerInitArgs): Promise<numb
   try {
     return await runContainerInit({
       kind: args.kind,
+      runtimeName: args.name,
       fromHost: args.fromHost,
       ...(args.image ? { image: args.image } : {}),
       ...(args.bridgeUrl ? { bridgeUrl: args.bridgeUrl } : {}),
@@ -743,6 +876,7 @@ export async function runContainerRemoveCli(args: ContainerRemoveArgs): Promise<
   try {
     const result = removeRuntimeContainer({
       kind: args.kind,
+      runtimeName: args.name,
       removeVolumes: args.volumes,
     });
     process.stdout.write(

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -33,10 +33,9 @@ import {
   defaultDockerRun,
   RuntimeContainer,
   DEFAULT_RUNTIME_IMAGE,
-  DEFAULT_RUNTIME_INSTANCE,
   RUNTIME_COMPONENT_LABEL,
   RUNTIME_MANAGED_BY_LABEL,
-  runtimeInstanceLabel,
+  runtimeInstanceName,
   sessionsVolumeName,
   validateRuntimeName,
   type DockerRun,
@@ -85,14 +84,13 @@ export interface ContainerListOptions {
 }
 
 export interface ContainerRemoveOptions {
-  kind: InstallableBackendKind;
-  runtimeName?: string;
+  name: string;
   removeVolumes: boolean;
   dockerRun?: DockerRun;
 }
 
 export interface RuntimeRemoveResult {
-  kind: InstallableBackendKind;
+  kind: InstallableBackendKind | null;
   name: string;
   container: { name: string; removed: boolean };
   volumes: Array<{ name: string; removed: boolean; skipped: boolean }>;
@@ -119,7 +117,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
   try {
     await runtime.start();
 
-    const runtimeName = validateRuntimeName(opts.runtimeName);
+    const runtimeName = runtimeInstanceName(opts.kind, opts.runtimeName);
     const containerName = containerNameFor(opts.kind, runtimeName);
 
     // (1) chown the per-kind sub-trees so subsequent install-backend
@@ -156,7 +154,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     if (!installed) {
       log.error(
         `installed ${opts.kind} did not produce a parseable --version at /data/agents/${opts.kind}/bin/${opts.kind}. ` +
-          `The install recipe likely failed silently; rerun \`vicoop-client container init ${opts.kind}\` and inspect the [install] output.`,
+          `The install recipe likely failed silently; rerun \`vicoop-client container init ${opts.kind} --name ${runtimeName}\` and inspect the [install] output.`,
       );
       return 1;
     }
@@ -184,7 +182,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
         log.error(`--from-host: ${(err as Error).message}`);
         log.error(
           `Rerun without --from-host to leave creds empty for an interactive auth flow ` +
-            `(docker exec -it vicoop-runtime-${opts.kind} ${authHintFor(opts.kind)}).`,
+            `(docker exec -it ${containerName} ${authHintFor(opts.kind)}).`,
         );
         return 1;
       }
@@ -196,11 +194,13 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     }
 
     log.info(`runtime container for ${opts.kind} ready. start daemon with:`);
-    log.info(`    vicoop-client --backend ${opts.kind} --runtime container`);
+    log.info(
+      `    vicoop-client --backend ${opts.kind} --runtime container --runtime-name ${runtimeName}`,
+    );
     return 0;
   } finally {
     // Leave the container running. The next daemon launch reuses
-    // it; an explicit cleanup is `docker stop vicoop-runtime-<kind>`
+    // it; an explicit cleanup is `vicoop-client container rm <name>`
     // (operator's job, on purpose — they may be about to start the
     // daemon).
   }
@@ -424,26 +424,29 @@ export function listRuntimeContainers(opts: ContainerListOptions = {}): RuntimeL
   const volumes = readManagedVolumes(dockerRun);
   const keys = new Set(containers.keys());
 
-  return Array.from(keys).map(parseRuntimeKey).sort(compareRuntimeKeys).map(({ kind, runtimeName }) => {
-    const key = runtimeKey(kind, runtimeName);
-    const expectedContainerName = containerNameFor(kind, runtimeName);
-    const container = containers.get(key);
-    const runtimeVolumes = volumes.get(key) ?? new Set<string>();
-    return {
-      kind,
-      name: runtimeInstanceLabel(runtimeName),
-      container: {
-        name: expectedContainerName,
-        state: container ? normalizeContainerState(container.state) : 'missing',
-        image: container?.image ?? null,
-      },
-      volumes: {
-        agents: volumePresence(runtimeVolumes, agentsVolumeName(kind, runtimeName)),
-        creds: volumePresence(runtimeVolumes, credsVolumeName(kind, runtimeName)),
-        sessions: volumePresence(runtimeVolumes, sessionsVolumeName(kind, runtimeName)),
-      },
-    };
-  });
+  return Array.from(keys)
+    .map((key) => parseRuntimeKey(key, containers))
+    .sort(compareRuntimeKeys)
+    .map(({ kind, runtimeName }) => {
+      const key = runtimeKey(runtimeName);
+      const expectedContainerName = containerNameFor(kind, runtimeName);
+      const container = containers.get(key);
+      const runtimeVolumes = volumes.get(key) ?? new Set<string>();
+      return {
+        kind,
+        name: runtimeName,
+        container: {
+          name: container?.name ?? expectedContainerName,
+          state: container ? normalizeContainerState(container.state) : 'missing',
+          image: container?.image ?? null,
+        },
+        volumes: {
+          agents: volumePresence(runtimeVolumes, agentsVolumeName(kind, runtimeName)),
+          creds: volumePresence(runtimeVolumes, credsVolumeName(kind, runtimeName)),
+          sessions: volumePresence(runtimeVolumes, sessionsVolumeName(kind, runtimeName)),
+        },
+      };
+    });
 }
 
 export function formatRuntimeList(rows: readonly RuntimeListRow[]): string {
@@ -471,23 +474,29 @@ export function formatRuntimeListJson(rows: readonly RuntimeListRow[]): string {
 
 export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRemoveResult {
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
-  const runtimeName = validateRuntimeName(opts.runtimeName);
-  const name = containerNameFor(opts.kind, runtimeName);
+  const runtimeName = validateRuntimeName(opts.name);
+  if (!runtimeName) throw new Error('runtime name is required');
+  const runtime = findRuntimeByName(dockerRun, runtimeName);
+  const kind = runtime?.kind ?? null;
+  const containerResourceName = runtime?.container.name ?? runtimeContainerResourceName(runtimeName);
+  const volumeNames = runtime
+    ? [runtime.volumes.agents.name, runtime.volumes.creds.name, runtime.volumes.sessions.name]
+    : [
+        runtimeVolumeResourceName('agents', runtimeName),
+        runtimeVolumeResourceName('creds', runtimeName),
+        runtimeVolumeResourceName('sessions', runtimeName),
+      ];
   const result: RuntimeRemoveResult = {
-    kind: opts.kind,
-    name: runtimeInstanceLabel(runtimeName),
+    kind,
+    name: runtimeName,
     container: {
-      name,
-      removed: removeDockerResource(dockerRun, ['rm', '-f', name], 'container'),
+      name: containerResourceName,
+      removed: removeDockerResource(dockerRun, ['rm', '-f', containerResourceName], 'container'),
     },
     volumes: [],
   };
 
-  for (const volumeName of [
-    agentsVolumeName(opts.kind, runtimeName),
-    credsVolumeName(opts.kind, runtimeName),
-    sessionsVolumeName(opts.kind, runtimeName),
-  ]) {
+  for (const volumeName of volumeNames) {
     result.volumes.push({
       name: volumeName,
       removed: opts.removeVolumes
@@ -498,6 +507,24 @@ export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRem
   }
 
   return result;
+}
+
+function findRuntimeByName(
+  dockerRun: DockerRun,
+  runtimeName: string,
+): RuntimeListRow | null {
+  return listRuntimeContainers({ dockerRun }).find((row) => row.name === runtimeName) ?? null;
+}
+
+function runtimeContainerResourceName(runtimeName: string): string {
+  return `vicoop-runtime-${runtimeName}`;
+}
+
+function runtimeVolumeResourceName(
+  volume: 'agents' | 'creds' | 'sessions',
+  runtimeName: string,
+): string {
+  return `vicoop-${volume}-${runtimeName}`;
 }
 
 export function formatRuntimeRemoveResult(result: RuntimeRemoveResult): string {
@@ -534,8 +561,14 @@ function removeDockerResource(
 
 function readManagedContainers(
   dockerRun: DockerRun,
-): Map<string, { state: string; image: string | null }> {
-  const result = new Map<string, { state: string; image: string | null }>();
+): Map<
+  string,
+  { kind: InstallableBackendKind; name: string; state: string; image: string | null }
+> {
+  const result = new Map<
+    string,
+    { kind: InstallableBackendKind; name: string; state: string; image: string | null }
+  >();
   for (const args of [
     [
       'ps',
@@ -566,7 +599,9 @@ function readManagedContainers(
       const labels = parseDockerLabels(stringField(entry, 'Labels'));
       const runtime = runtimeFromLabelsOrName(labels, name, 'container');
       if (!runtime) continue;
-      result.set(runtimeKey(runtime.kind, runtime.runtimeName), {
+      result.set(runtimeKey(runtime.runtimeName), {
+        kind: runtime.kind,
+        name,
         state: stringField(entry, 'State') ?? '',
         image: stringField(entry, 'Image'),
       });
@@ -593,7 +628,7 @@ function readManagedVolumes(dockerRun: DockerRun): Map<string, Set<string>> {
     const labels = parseDockerLabels(stringField(entry, 'Labels'));
     const runtime = runtimeFromLabelsOrName(labels, name, 'volume');
     if (!runtime) continue;
-    const key = runtimeKey(runtime.kind, runtime.runtimeName);
+    const key = runtimeKey(runtime.runtimeName);
     const names = result.get(key) ?? new Set<string>();
     names.add(name);
     result.set(key, names);
@@ -622,7 +657,10 @@ function normalizeContainerState(state: string): RuntimeContainerState {
   return state === 'running' ? 'running' : 'stopped';
 }
 
-function volumePresence(volumes: Set<string>, name: string): RuntimeListRow['volumes']['agents'] {
+function volumePresence(
+  volumes: Set<string>,
+  name: string,
+): RuntimeListRow['volumes']['agents'] {
   return { name, present: volumes.has(name) };
 }
 
@@ -635,28 +673,30 @@ function stringField(row: Record<string, unknown>, field: string): string | null
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-function containerNameFor(kind: InstallableBackendKind, runtimeName: string | undefined): string {
+function containerNameFor(kind: InstallableBackendKind, runtimeName: string): string {
   return containerName(kind, runtimeName);
 }
 
-function runtimeKey(kind: InstallableBackendKind, runtimeName: string | undefined): string {
-  return `${kind}\0${runtimeName ?? ''}`;
+function runtimeKey(runtimeName: string): string {
+  return runtimeName;
 }
 
-function parseRuntimeKey(key: string): { kind: InstallableBackendKind; runtimeName: string | undefined } {
-  const [kind, runtimeName] = key.split('\0') as [InstallableBackendKind, string | undefined];
-  return { kind, runtimeName: runtimeName || undefined };
+function parseRuntimeKey(
+  key: string,
+  containers: Map<string, { kind: InstallableBackendKind }>,
+): { kind: InstallableBackendKind; runtimeName: string } {
+  const container = containers.get(key);
+  if (!container) throw new Error(`runtime '${key}' disappeared while listing`);
+  return { kind: container.kind, runtimeName: key };
 }
 
 function compareRuntimeKeys(
-  a: { kind: InstallableBackendKind; runtimeName: string | undefined },
-  b: { kind: InstallableBackendKind; runtimeName: string | undefined },
+  a: { kind: InstallableBackendKind; runtimeName: string },
+  b: { kind: InstallableBackendKind; runtimeName: string },
 ): number {
   const kindDiff = BACKEND_KINDS.indexOf(a.kind) - BACKEND_KINDS.indexOf(b.kind);
   if (kindDiff !== 0) return kindDiff;
-  if (!a.runtimeName && b.runtimeName) return -1;
-  if (a.runtimeName && !b.runtimeName) return 1;
-  return (a.runtimeName ?? '').localeCompare(b.runtimeName ?? '');
+  return a.runtimeName.localeCompare(b.runtimeName);
 }
 
 function parseDockerLabels(raw: string | null): Map<string, string> {
@@ -674,7 +714,7 @@ function runtimeFromLabelsOrName(
   labels: Map<string, string>,
   resourceName: string,
   resource: 'container' | 'volume',
-): { kind: InstallableBackendKind; runtimeName: string | undefined } | null {
+): { kind: InstallableBackendKind; runtimeName: string } | null {
   const kindLabel = labels.get('vicoop.kind');
   const kind =
     kindLabel && (BACKEND_KINDS as readonly string[]).includes(kindLabel)
@@ -683,12 +723,11 @@ function runtimeFromLabelsOrName(
   if (!kind) return null;
   const rawName = labels.get('vicoop.name');
   if (rawName) {
-    return {
-      kind,
-      runtimeName: rawName === DEFAULT_RUNTIME_INSTANCE ? undefined : validateRuntimeName(rawName),
-    };
+    const runtimeName = validateRuntimeName(rawName);
+    if (runtimeName) return { kind, runtimeName };
   }
-  return { kind, runtimeName: parseRuntimeNameFromResourceName(resourceName, kind, resource) };
+  const runtimeName = parseRuntimeNameFromResourceName(resourceName, kind, resource);
+  return runtimeName ? { kind, runtimeName } : null;
 }
 
 function parseKindFromResourceName(
@@ -712,7 +751,7 @@ function parseRuntimeNameFromResourceName(
   name: string,
   kind: InstallableBackendKind,
   resource: 'container' | 'volume',
-): string | undefined {
+): string | null {
   const bases =
     resource === 'container'
       ? [containerName(kind)]
@@ -722,10 +761,10 @@ function parseRuntimeNameFromResourceName(
           sessionsVolumeName(kind),
         ];
   for (const base of bases) {
-    if (name === base) return undefined;
-    if (name.startsWith(`${base}-`)) return validateRuntimeName(name.slice(base.length + 1));
+    if (name === base) return kind;
+    if (name.startsWith(`${base}-`)) return validateRuntimeName(name.slice(base.length + 1)) ?? null;
   }
-  return undefined;
+  return null;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -755,7 +794,7 @@ const containerInitSubCmd = command(
     }),
     name: optional(
       option('--name', string({ metavar: 'NAME' }), {
-        description: message`Optional runtime instance name. Omit for the default per-kind runtime; named runtimes use Docker resources suffixed with -<name>.`,
+        description: message`Runtime instance name. Omit to use the backend kind as the generated name.`,
       }),
     ),
     fromHost: withDefault(
@@ -777,7 +816,7 @@ const containerInitSubCmd = command(
   }),
   {
     brief: message`Bootstrap a per-backend runtime container.`,
-    description: message`One-shot setup for the container-runtime profile: creates \`vicoop-runtime-<kind>\` or \`vicoop-runtime-<kind>-<name>\`, fails if that runtime already exists, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container\` and, for named runtimes, \`--runtime-name <name>\`.`,
+    description: message`One-shot setup for the container-runtime profile: creates \`vicoop-runtime-<name>\`, where --name defaults to the backend kind, fails if that runtime already exists, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container --runtime-name <name>\`.`,
   },
 );
 
@@ -792,7 +831,7 @@ function containerListCommand(name: 'ls' | 'list') {
     }),
     {
       brief: message`List runtime containers and volumes.`,
-      description: message`Prints one row per supported runtime kind, showing whether the managed Docker container is running, stopped, or missing and whether each expected named volume exists.`,
+      description: message`Prints one row per managed runtime container, showing its kind, name, running state, image, and volume presence.`,
     },
   );
 }
@@ -807,14 +846,9 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
     name,
     object({
       action: constant('container-remove' as const),
-      kind: argument(choice([...BACKEND_KINDS], { metavar: 'KIND' }), {
-        description: message`Runtime kind to remove. One of: \`claude\`, \`codex\`.`,
+      name: argument(string({ metavar: 'NAME' }), {
+        description: message`Runtime instance name to remove.`,
       }),
-      name: optional(
-        option('--name', string({ metavar: 'NAME' }), {
-          description: message`Optional runtime instance name to remove. Omit for the default per-kind runtime.`,
-        }),
-      ),
       volumes: withDefault(flag('--volumes', {
         description: message`Also remove the runtime's agents, creds, and sessions named volumes. Off by default so credentials and sessions survive container recreation.`,
       }), false),
@@ -824,7 +858,7 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
     }),
     {
       brief: message`Remove a runtime container.`,
-      description: message`Removes the per-kind runtime container, or a named runtime when --name is set. Named volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
+      description: message`Removes a runtime container by name. Volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
     },
   );
 }
@@ -839,7 +873,7 @@ export const containerCmd = command(
   longestMatch(containerInitSubCmd, containerListSubCmd, containerRemoveSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container, optionally volumes). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container by name, optionally volumes). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
   },
 );
 
@@ -880,8 +914,7 @@ export async function runContainerListCli(args: ContainerListArgs): Promise<numb
 export async function runContainerRemoveCli(args: ContainerRemoveArgs): Promise<number> {
   try {
     const result = removeRuntimeContainer({
-      kind: args.kind,
-      runtimeName: args.name,
+      name: args.name,
       removeVolumes: args.volumes,
     });
     process.stdout.write(

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -85,7 +85,7 @@ export interface ContainerListOptions {
 
 export interface ContainerRemoveOptions {
   name: string;
-  removeVolumes: boolean;
+  preserveVolumes: boolean;
   dockerRun?: DockerRun;
 }
 
@@ -499,10 +499,10 @@ export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRem
   for (const volumeName of volumeNames) {
     result.volumes.push({
       name: volumeName,
-      removed: opts.removeVolumes
-        ? removeDockerResource(dockerRun, ['volume', 'rm', volumeName], 'volume')
-        : false,
-      skipped: !opts.removeVolumes,
+      removed: opts.preserveVolumes
+        ? false
+        : removeDockerResource(dockerRun, ['volume', 'rm', volumeName], 'volume'),
+      skipped: opts.preserveVolumes,
     });
   }
 
@@ -533,7 +533,7 @@ export function formatRuntimeRemoveResult(result: RuntimeRemoveResult): string {
   ];
   if (result.volumes.every((v) => v.skipped)) {
     lines.push(
-      `kept volumes ${result.volumes.map((v) => v.name).join(', ')} (pass --volumes to remove)`,
+      `kept volumes ${result.volumes.map((v) => v.name).join(', ')}`,
     );
   } else {
     for (const volume of result.volumes) {
@@ -849,8 +849,8 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
       name: argument(string({ metavar: 'NAME' }), {
         description: message`Runtime instance name to remove.`,
       }),
-      volumes: withDefault(flag('--volumes', {
-        description: message`Also remove the runtime's agents, creds, and sessions named volumes. Off by default so credentials and sessions survive container recreation.`,
+      preserveVolumes: withDefault(flag('--preserve-volumes', {
+        description: message`Keep the runtime's agents, creds, and sessions named volumes. Off by default so cleanup removes all runtime Docker resources.`,
       }), false),
       json: withDefault(flag('--json', {
         description: message`Emit machine-readable JSON.`,
@@ -858,7 +858,7 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
     }),
     {
       brief: message`Remove a runtime container.`,
-      description: message`Removes a runtime container by name. Volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
+      description: message`Removes a runtime container and its agents, creds, and sessions volumes by name. Pass --preserve-volumes to keep the volumes.`,
     },
   );
 }
@@ -873,7 +873,7 @@ export const containerCmd = command(
   longestMatch(containerInitSubCmd, containerListSubCmd, containerRemoveSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container by name, optionally volumes). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container and volumes by name). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
   },
 );
 
@@ -915,7 +915,7 @@ export async function runContainerRemoveCli(args: ContainerRemoveArgs): Promise<
   try {
     const result = removeRuntimeContainer({
       name: args.name,
-      removeVolumes: args.volumes,
+      preserveVolumes: args.preserveVolumes,
     });
     process.stdout.write(
       (args.json ? formatRuntimeRemoveJson(result) : formatRuntimeRemoveResult(result)) + '\n',

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -79,6 +79,18 @@ export interface ContainerListOptions {
   dockerRun?: DockerRun;
 }
 
+export interface ContainerRemoveOptions {
+  kind: InstallableBackendKind;
+  removeVolumes: boolean;
+  dockerRun?: DockerRun;
+}
+
+export interface RuntimeRemoveResult {
+  kind: InstallableBackendKind;
+  container: { name: string; removed: boolean };
+  volumes: Array<{ name: string; removed: boolean; skipped: boolean }>;
+}
+
 // Returns the process exit code the CLI should use. Throws only on
 // programmer-error (e.g. unsupported kind reaching this function).
 // Operational failures (docker unreachable, install recipe non-zero,
@@ -442,6 +454,66 @@ export function formatRuntimeListJson(rows: readonly RuntimeListRow[]): string {
   return JSON.stringify(rows, null, 2);
 }
 
+export function removeRuntimeContainer(opts: ContainerRemoveOptions): RuntimeRemoveResult {
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
+  const name = containerName(opts.kind);
+  const result: RuntimeRemoveResult = {
+    kind: opts.kind,
+    container: {
+      name,
+      removed: removeDockerResource(dockerRun, ['rm', '-f', name], 'container'),
+    },
+    volumes: [],
+  };
+
+  for (const volumeName of [
+    agentsVolumeName(opts.kind),
+    credsVolumeName(opts.kind),
+    sessionsVolumeName(opts.kind),
+  ]) {
+    result.volumes.push({
+      name: volumeName,
+      removed: opts.removeVolumes
+        ? removeDockerResource(dockerRun, ['volume', 'rm', volumeName], 'volume')
+        : false,
+      skipped: !opts.removeVolumes,
+    });
+  }
+
+  return result;
+}
+
+export function formatRuntimeRemoveResult(result: RuntimeRemoveResult): string {
+  const lines = [
+    `${result.container.removed ? 'removed' : 'missing'} container ${result.container.name}`,
+  ];
+  if (result.volumes.every((v) => v.skipped)) {
+    lines.push(
+      `kept volumes ${result.volumes.map((v) => v.name).join(', ')} (pass --volumes to remove)`,
+    );
+  } else {
+    for (const volume of result.volumes) {
+      lines.push(`${volume.removed ? 'removed' : 'missing'} volume ${volume.name}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function formatRuntimeRemoveJson(result: RuntimeRemoveResult): string {
+  return JSON.stringify(result, null, 2);
+}
+
+function removeDockerResource(
+  dockerRun: DockerRun,
+  args: readonly string[],
+  resource: 'container' | 'volume',
+): boolean {
+  const r = dockerRun(args);
+  if (r.exitCode === 0) return true;
+  if (/No such container|No such volume|not found/i.test(r.stderr)) return false;
+  throw new Error(`docker ${args.join(' ')} failed (exit ${r.exitCode}): ${r.stderr.trim()}`);
+}
+
 function readManagedContainers(
   dockerRun: DockerRun,
 ): Map<string, { state: string; image: string | null }> {
@@ -597,18 +669,46 @@ const containerListSubCmd = longestMatch(
   containerListCommand('list'),
 );
 
+function containerRemoveCommand(name: 'rm' | 'remove') {
+  return command(
+    name,
+    object({
+      action: constant('container-remove' as const),
+      kind: argument(choice([...BACKEND_KINDS], { metavar: 'KIND' }), {
+        description: message`Runtime kind to remove. One of: \`claude\`, \`codex\`.`,
+      }),
+      volumes: withDefault(flag('--volumes', {
+        description: message`Also remove the runtime's agents, creds, and sessions named volumes. Off by default so credentials and sessions survive container recreation.`,
+      }), false),
+      json: withDefault(flag('--json', {
+        description: message`Emit machine-readable JSON.`,
+      }), false),
+    }),
+    {
+      brief: message`Remove a runtime container.`,
+      description: message`Removes the per-kind runtime container. Named volumes are kept by default; pass --volumes to remove the agents, creds, and sessions volumes too.`,
+    },
+  );
+}
+
+const containerRemoveSubCmd = longestMatch(
+  containerRemoveCommand('rm'),
+  containerRemoveCommand('remove'),
+);
+
 export const containerCmd = command(
   'container',
-  longestMatch(containerInitSubCmd, containerListSubCmd),
+  longestMatch(containerInitSubCmd, containerListSubCmd, containerRemoveSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<kind>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container, optionally volumes). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
   },
 );
 
 export type ContainerCliArgs = InferValue<typeof containerCmd>;
 export type ContainerInitArgs = Extract<ContainerCliArgs, { action: 'container-init' }>;
 export type ContainerListArgs = Extract<ContainerCliArgs, { action: 'container-list' }>;
+export type ContainerRemoveArgs = Extract<ContainerCliArgs, { action: 'container-remove' }>;
 
 // Adapter from optique-parsed args → runContainerInit's typed
 // options. Lives here (not in cli.ts) so the command surface and
@@ -634,6 +734,22 @@ export async function runContainerListCli(args: ContainerListArgs): Promise<numb
     return 0;
   } catch (err) {
     console.error(`container ls failed: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+export async function runContainerRemoveCli(args: ContainerRemoveArgs): Promise<number> {
+  try {
+    const result = removeRuntimeContainer({
+      kind: args.kind,
+      removeVolumes: args.volumes,
+    });
+    process.stdout.write(
+      (args.json ? formatRuntimeRemoveJson(result) : formatRuntimeRemoveResult(result)) + '\n',
+    );
+    return 0;
+  } catch (err) {
+    console.error(`container rm failed: ${(err as Error).message}`);
     return 1;
   }
 }

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -421,10 +421,7 @@ export function listRuntimeContainers(opts: ContainerListOptions = {}): RuntimeL
   const dockerRun = opts.dockerRun ?? defaultDockerRun;
   const containers = readManagedContainers(dockerRun);
   const volumes = readManagedVolumes(dockerRun);
-  const keys = new Set<string>();
-  for (const kind of BACKEND_KINDS) keys.add(runtimeKey(kind, undefined));
-  for (const key of containers.keys()) keys.add(key);
-  for (const key of volumes.keys()) keys.add(key);
+  const keys = new Set(containers.keys());
 
   return Array.from(keys).map(parseRuntimeKey).sort(compareRuntimeKeys).map(({ kind, runtimeName }) => {
     const key = runtimeKey(kind, runtimeName);

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -77,6 +77,8 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   );
   for (const v of volumeCreates) {
     assert.ok(v.includes('vicoop.kind=claude'), `label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.managed-by=vicoop-bridge'), `managed label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.component=runtime'), `component label on ${v.join(' ')}`);
   }
 
   // Container create argv: --name, --restart unless-stopped, NET_ADMIN+RAW,
@@ -90,6 +92,9 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   assert.equal(argv[restartIdx + 1], 'unless-stopped');
   assert.ok(argv.includes('NET_ADMIN'));
   assert.ok(argv.includes('NET_RAW'));
+  assert.ok(argv.includes('vicoop.managed-by=vicoop-bridge'));
+  assert.ok(argv.includes('vicoop.component=runtime'));
+  assert.ok(argv.includes('vicoop.kind=claude'));
   assert.ok(
     argv.some((a) => a === 'type=bind,source=/host/workspace,target=/workspace'),
     'host workspace mounted',

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -79,7 +79,7 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
     assert.ok(v.includes('vicoop.kind=claude'), `label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.managed-by=vicoop-bridge'), `managed label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.component=runtime'), `component label on ${v.join(' ')}`);
-    assert.ok(v.includes('vicoop.name=default'), `instance label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.name=claude'), `instance label on ${v.join(' ')}`);
   }
 
   // Container create argv: --name, --restart unless-stopped, NET_ADMIN+RAW,
@@ -96,7 +96,7 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   assert.ok(argv.includes('vicoop.managed-by=vicoop-bridge'));
   assert.ok(argv.includes('vicoop.component=runtime'));
   assert.ok(argv.includes('vicoop.kind=claude'));
-  assert.ok(argv.includes('vicoop.name=default'));
+  assert.ok(argv.includes('vicoop.name=claude'));
   assert.ok(
     argv.some((a) => a === 'type=bind,source=/host/workspace,target=/workspace'),
     'host workspace mounted',
@@ -162,7 +162,7 @@ test('start: failIfExists rejects an existing container during init', async () =
 
   await assert.rejects(
     rc.start(),
-    /runtime container 'vicoop-runtime-codex-work' already exists.*container rm codex --name work/s,
+    /runtime container 'vicoop-runtime-work' already exists.*container rm work/s,
   );
   assert.equal(calls.filter((c) => c[0] === 'start').length, 0);
   assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
@@ -281,7 +281,7 @@ test('getContainerName returns the canonical per-kind name', () => {
   assert.equal(rc.getContainerName(), 'vicoop-runtime-codex');
 });
 
-test('runtimeName suffixes container and volumes', async () => {
+test('runtimeName selects container and volume names', async () => {
   const { run, calls } = makeDockerFixture(happyCreateResponses());
   const rc = new RuntimeContainer({
     backendKind: 'codex',
@@ -292,21 +292,21 @@ test('runtimeName suffixes container and volumes', async () => {
   });
   await rc.start();
 
-  assert.equal(rc.getContainerName(), 'vicoop-runtime-codex-work');
+  assert.equal(rc.getContainerName(), 'vicoop-runtime-work');
   const volumeCreates = calls.filter((c) => c[0] === 'volume' && c[1] === 'create');
   assert.deepEqual(
     volumeCreates.map((c) => c[c.length - 1]).sort(),
     [
-      'vicoop-agents-codex-work',
-      'vicoop-creds-codex-work',
-      'vicoop-sessions-codex-work',
+      'vicoop-agents-work',
+      'vicoop-creds-work',
+      'vicoop-sessions-work',
     ].sort(),
   );
   assert.equal(volumeCreates.every((c) => c.includes('vicoop.name=work')), true);
   const createCmd = calls.find((c) => c[0] === 'create') as readonly string[];
-  assert.ok(createCmd.includes('vicoop-runtime-codex-work'));
+  assert.ok(createCmd.includes('vicoop-runtime-work'));
   assert.ok(createCmd.includes('vicoop.name=work'));
   assert.ok(
-    createCmd.some((a) => a === 'type=volume,source=vicoop-creds-codex-work,target=/data/creds/codex'),
+    createCmd.some((a) => a === 'type=volume,source=vicoop-creds-work,target=/data/creds/codex'),
   );
 });

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -146,6 +146,52 @@ test('start: reuses an existing running container (no create, no start)', async 
   );
 });
 
+test('start: failIfExists rejects an existing container during init', async () => {
+  const { run, calls } = makeDockerFixture([
+    ok('28.0.0'),
+    ok('abc123'), // ps -a — match
+  ]);
+  const rc = new RuntimeContainer({
+    backendKind: 'codex',
+    runtimeName: 'work',
+    image: 'test/runtime:latest',
+    createIfMissing: true,
+    failIfExists: true,
+    dockerRun: run,
+  });
+
+  await assert.rejects(
+    rc.start(),
+    /runtime container 'vicoop-runtime-codex-work' already exists.*container rm codex --name work/s,
+  );
+  assert.equal(calls.filter((c) => c[0] === 'start').length, 0);
+  assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
+});
+
+test('start: failIfExists rejects existing volumes before creating a container', async () => {
+  const { run, calls } = makeDockerFixture([
+    ok('28.0.0'),
+    ok(''), // ps -a — no container
+    fail('volume not found', 1), // agents absent
+    ok(), // creds exists
+    fail('volume not found', 1), // sessions absent
+  ]);
+  const rc = new RuntimeContainer({
+    backendKind: 'claude',
+    image: 'test/runtime:latest',
+    createIfMissing: true,
+    failIfExists: true,
+    dockerRun: run,
+  });
+
+  await assert.rejects(
+    rc.start(),
+    /runtime volumes already exist: vicoop-creds-claude.*container rm claude --volumes/s,
+  );
+  assert.equal(calls.filter((c) => c[0] === 'image').length, 0);
+  assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
+});
+
 test('start: starts an existing stopped container', async () => {
   const { run, calls } = makeDockerFixture([
     ok('28.0.0'),

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -79,6 +79,7 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
     assert.ok(v.includes('vicoop.kind=claude'), `label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.managed-by=vicoop-bridge'), `managed label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.component=runtime'), `component label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.name=default'), `instance label on ${v.join(' ')}`);
   }
 
   // Container create argv: --name, --restart unless-stopped, NET_ADMIN+RAW,
@@ -95,6 +96,7 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   assert.ok(argv.includes('vicoop.managed-by=vicoop-bridge'));
   assert.ok(argv.includes('vicoop.component=runtime'));
   assert.ok(argv.includes('vicoop.kind=claude'));
+  assert.ok(argv.includes('vicoop.name=default'));
   assert.ok(
     argv.some((a) => a === 'type=bind,source=/host/workspace,target=/workspace'),
     'host workspace mounted',
@@ -231,4 +233,34 @@ test('getContainerName returns the canonical per-kind name', () => {
     dockerRun: () => ok(),
   });
   assert.equal(rc.getContainerName(), 'vicoop-runtime-codex');
+});
+
+test('runtimeName suffixes container and volumes', async () => {
+  const { run, calls } = makeDockerFixture(happyCreateResponses());
+  const rc = new RuntimeContainer({
+    backendKind: 'codex',
+    runtimeName: 'work',
+    image: 'test/runtime:latest',
+    createIfMissing: true,
+    dockerRun: run,
+  });
+  await rc.start();
+
+  assert.equal(rc.getContainerName(), 'vicoop-runtime-codex-work');
+  const volumeCreates = calls.filter((c) => c[0] === 'volume' && c[1] === 'create');
+  assert.deepEqual(
+    volumeCreates.map((c) => c[c.length - 1]).sort(),
+    [
+      'vicoop-agents-codex-work',
+      'vicoop-creds-codex-work',
+      'vicoop-sessions-codex-work',
+    ].sort(),
+  );
+  assert.equal(volumeCreates.every((c) => c.includes('vicoop.name=work')), true);
+  const createCmd = calls.find((c) => c[0] === 'create') as readonly string[];
+  assert.ok(createCmd.includes('vicoop-runtime-codex-work'));
+  assert.ok(createCmd.includes('vicoop.name=work'));
+  assert.ok(
+    createCmd.some((a) => a === 'type=volume,source=vicoop-creds-codex-work,target=/data/creds/codex'),
+  );
 });

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -186,7 +186,7 @@ test('start: failIfExists rejects existing volumes before creating a container',
 
   await assert.rejects(
     rc.start(),
-    /runtime volumes already exist: vicoop-creds-claude.*container rm claude --volumes/s,
+    /runtime volumes already exist: vicoop-creds-claude.*container rm claude/s,
   );
   assert.equal(calls.filter((c) => c[0] === 'image').length, 0);
   assert.equal(calls.filter((c) => c[0] === 'create').length, 0);

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -60,6 +60,11 @@ export interface RuntimeContainerOptions {
   // consume a runtime container the operator already initialized with
   // `vicoop-client container init <kind>`.
   createIfMissing?: boolean;
+  // When creating from `container init`, fail if the target container
+  // or any canonical volume already exists. This keeps init as a
+  // fresh-create command instead of silently reinstalling into an
+  // existing runtime.
+  failIfExists?: boolean;
   logger?: Logger;
   // Test seam — inject a custom docker CLI runner so tests can
   // capture argv + script responses without shelling out.
@@ -146,6 +151,12 @@ export class RuntimeContainer {
 
     const name = containerName(this.opts.backendKind, this.opts.runtimeName);
     if (this.findContainer(name)) {
+      if (this.opts.failIfExists) {
+        throw new Error(
+          `runtime container '${name}' already exists. ` +
+            `Remove it first with \`${this.removeHint()}\`, then rerun init.`,
+        );
+      }
       if (this.inspectRunning(name)) {
         this.log.info(`runtime container '${name}' already running — reusing`);
       } else {
@@ -164,6 +175,9 @@ export class RuntimeContainer {
               this.opts.runtimeName ? ` --runtime-name ${this.opts.runtimeName}` : ''
             }\`.`,
         );
+      }
+      if (this.opts.failIfExists) {
+        this.ensureFreshVolumes();
       }
       await this.ensureImage();
       this.ensureVolumes();
@@ -245,12 +259,7 @@ export class RuntimeContainer {
   private ensureVolumes(): void {
     const kind = this.opts.backendKind;
     const runtimeName = this.opts.runtimeName;
-    const names = [
-      agentsVolumeName(kind, runtimeName),
-      credsVolumeName(kind, runtimeName),
-      sessionsVolumeName(kind, runtimeName),
-    ];
-    for (const name of names) {
+    for (const name of this.volumeNames()) {
       const inspect = this.run(['volume', 'inspect', name]);
       if (inspect.exitCode === 0) continue;
       this.runDocker([
@@ -268,6 +277,27 @@ export class RuntimeContainer {
       ]);
       this.log.info(`created named volume '${name}'`);
     }
+  }
+
+  private ensureFreshVolumes(): void {
+    const existing = this.volumeNames().filter(
+      (name) => this.run(['volume', 'inspect', name]).exitCode === 0,
+    );
+    if (existing.length === 0) return;
+    throw new Error(
+      `runtime volumes already exist: ${existing.join(', ')}. ` +
+        `Remove them first with \`${this.removeHint()} --volumes\`, then rerun init.`,
+    );
+  }
+
+  private volumeNames(): string[] {
+    const kind = this.opts.backendKind;
+    const runtimeName = this.opts.runtimeName;
+    return [
+      agentsVolumeName(kind, runtimeName),
+      credsVolumeName(kind, runtimeName),
+      sessionsVolumeName(kind, runtimeName),
+    ];
   }
 
   private findContainer(name: string): boolean {
@@ -345,6 +375,12 @@ export class RuntimeContainer {
     }
     args.push(this.opts.image);
     this.runDocker(args);
+  }
+
+  private removeHint(): string {
+    return `vicoop-client container rm ${this.opts.backendKind}${
+      this.opts.runtimeName ? ` --name ${this.opts.runtimeName}` : ''
+    }`;
   }
 
   private async waitUntilRunning(name: string): Promise<void> {

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -34,14 +34,13 @@ export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest'
 
 export const RUNTIME_MANAGED_BY_LABEL = 'vicoop.managed-by=vicoop-bridge';
 export const RUNTIME_COMPONENT_LABEL = 'vicoop.component=runtime';
-export const DEFAULT_RUNTIME_INSTANCE = 'default';
 
 export interface RuntimeContainerOptions {
-  // Which backend this container hosts. Used in the canonical
-  // container/volume names so claude and codex get isolated runtimes.
+  // Which backend this container hosts. Stored as metadata and used for
+  // backend-specific install paths inside the shared runtime image.
   backendKind: string;
-  // Optional per-kind runtime instance name. Omitted means the legacy
-  // default names (`vicoop-runtime-<kind>`, `vicoop-agents-<kind>`, ...).
+  // Runtime instance name. Omitted means the backend kind is used as the
+  // generated name, so identity stays name-based without an unnamed mode.
   runtimeName?: string;
   // OCI image to run. Defaults to DEFAULT_RUNTIME_IMAGE; env override
   // `VICOOP_RUNTIME_IMAGE` is resolved by the caller (cli.ts) so this
@@ -96,37 +95,34 @@ export function validateRuntimeName(name: string | undefined): string | undefine
       `runtime name must match [a-z0-9][a-z0-9_.-]{0,31}; got '${name}'`,
     );
   }
-  if (trimmed === DEFAULT_RUNTIME_INSTANCE) {
-    throw new Error(
-      `runtime name '${DEFAULT_RUNTIME_INSTANCE}' is reserved; omit --name/--runtime-name for the default runtime`,
-    );
-  }
   return trimmed;
 }
 
-export function runtimeInstanceLabel(name: string | undefined): string {
-  return name ?? DEFAULT_RUNTIME_INSTANCE;
+export function defaultRuntimeName(kind: string): string {
+  const name = validateRuntimeName(kind);
+  if (!name) throw new Error(`backend kind '${kind}' cannot be used as a runtime name`);
+  return name;
 }
 
-function runtimeSuffix(name: string | undefined): string {
-  return name ? `-${name}` : '';
+export function runtimeInstanceName(kind: string, name: string | undefined): string {
+  return validateRuntimeName(name) ?? defaultRuntimeName(kind);
 }
 
 export function containerName(kind: string, runtimeName?: string): string {
-  return `vicoop-runtime-${kind}${runtimeSuffix(runtimeName)}`;
+  return `vicoop-runtime-${runtimeInstanceName(kind, runtimeName)}`;
 }
 export function agentsVolumeName(kind: string, runtimeName?: string): string {
-  return `vicoop-agents-${kind}${runtimeSuffix(runtimeName)}`;
+  return `vicoop-agents-${runtimeInstanceName(kind, runtimeName)}`;
 }
 export function credsVolumeName(kind: string, runtimeName?: string): string {
-  return `vicoop-creds-${kind}${runtimeSuffix(runtimeName)}`;
+  return `vicoop-creds-${runtimeInstanceName(kind, runtimeName)}`;
 }
 export function sessionsVolumeName(kind: string, runtimeName?: string): string {
-  return `vicoop-sessions-${kind}${runtimeSuffix(runtimeName)}`;
+  return `vicoop-sessions-${runtimeInstanceName(kind, runtimeName)}`;
 }
 
 export class RuntimeContainer {
-  private readonly opts: Required<Pick<RuntimeContainerOptions, 'backendKind' | 'image'>> &
+  private readonly opts: Required<Pick<RuntimeContainerOptions, 'backendKind' | 'image' | 'runtimeName'>> &
     RuntimeContainerOptions;
   private readonly log: Logger;
   private readonly run: DockerRun;
@@ -135,7 +131,7 @@ export class RuntimeContainer {
   constructor(opts: RuntimeContainerOptions) {
     this.opts = {
       ...opts,
-      runtimeName: validateRuntimeName(opts.runtimeName),
+      runtimeName: runtimeInstanceName(opts.backendKind, opts.runtimeName),
       image: opts.image ?? DEFAULT_RUNTIME_IMAGE,
     };
     this.log = opts.logger ?? createLogger();
@@ -165,15 +161,10 @@ export class RuntimeContainer {
       }
     } else {
       if (!this.opts.createIfMissing) {
-        const initHint = this.opts.runtimeName
-          ? `vicoop-client container init ${this.opts.backendKind} --name ${this.opts.runtimeName}`
-          : `vicoop-client container init ${this.opts.backendKind}`;
         throw new Error(
           `runtime container '${name}' does not exist. ` +
-            `Create it first with \`${initHint}\`, ` +
-            `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container${
-              this.opts.runtimeName ? ` --runtime-name ${this.opts.runtimeName}` : ''
-            }\`.`,
+            `Create it first with \`vicoop-client container init ${this.opts.backendKind} --name ${this.opts.runtimeName}\`, ` +
+            `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container --runtime-name ${this.opts.runtimeName}\`.`,
         );
       }
       if (this.opts.failIfExists) {
@@ -272,7 +263,7 @@ export class RuntimeContainer {
         '--label',
         `vicoop.kind=${kind}`,
         '--label',
-        `vicoop.name=${runtimeInstanceLabel(runtimeName)}`,
+        `vicoop.name=${runtimeName}`,
         name,
       ]);
       this.log.info(`created named volume '${name}'`);
@@ -345,7 +336,7 @@ export class RuntimeContainer {
       '--label',
       `vicoop.kind=${kind}`,
       '--label',
-      `vicoop.name=${runtimeInstanceLabel(runtimeName)}`,
+      `vicoop.name=${runtimeName}`,
     ];
     if (this.opts.bridgeUrl) {
       args.push('-e', `VICOOP_BRIDGE_URL=${this.opts.bridgeUrl}`);
@@ -378,9 +369,7 @@ export class RuntimeContainer {
   }
 
   private removeHint(): string {
-    return `vicoop-client container rm ${this.opts.backendKind}${
-      this.opts.runtimeName ? ` --name ${this.opts.runtimeName}` : ''
-    }`;
+    return `vicoop-client container rm ${this.opts.runtimeName}`;
   }
 
   private async waitUntilRunning(name: string): Promise<void> {

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -32,6 +32,9 @@ import { createLogger, type Logger } from './logger.js';
 
 export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest';
 
+export const RUNTIME_MANAGED_BY_LABEL = 'vicoop.managed-by=vicoop-bridge';
+export const RUNTIME_COMPONENT_LABEL = 'vicoop.component=runtime';
+
 export interface RuntimeContainerOptions {
   // Which backend this container hosts. Used in the canonical
   // container/volume names so claude and codex get isolated runtimes.
@@ -67,7 +70,7 @@ export interface DockerResult {
 
 export type DockerRun = (args: readonly string[]) => DockerResult;
 
-function defaultDockerRun(args: readonly string[]): DockerResult {
+export function defaultDockerRun(args: readonly string[]): DockerResult {
   const r = spawnSync('docker', Array.from(args), { encoding: 'utf8' });
   return {
     stdout: r.stdout ?? '',
@@ -76,16 +79,16 @@ function defaultDockerRun(args: readonly string[]): DockerResult {
   };
 }
 
-function containerName(kind: string): string {
+export function containerName(kind: string): string {
   return `vicoop-runtime-${kind}`;
 }
-function agentsVolumeName(kind: string): string {
+export function agentsVolumeName(kind: string): string {
   return `vicoop-agents-${kind}`;
 }
-function credsVolumeName(kind: string): string {
+export function credsVolumeName(kind: string): string {
   return `vicoop-creds-${kind}`;
 }
-function sessionsVolumeName(kind: string): string {
+export function sessionsVolumeName(kind: string): string {
   return `vicoop-sessions-${kind}`;
 }
 
@@ -216,6 +219,10 @@ export class RuntimeContainer {
         'volume',
         'create',
         '--label',
+        RUNTIME_MANAGED_BY_LABEL,
+        '--label',
+        RUNTIME_COMPONENT_LABEL,
+        '--label',
         `vicoop.kind=${kind}`,
         name,
       ]);
@@ -260,6 +267,10 @@ export class RuntimeContainer {
       'NET_ADMIN',
       '--cap-add',
       'NET_RAW',
+      '--label',
+      RUNTIME_MANAGED_BY_LABEL,
+      '--label',
+      RUNTIME_COMPONENT_LABEL,
       '--label',
       `vicoop.kind=${kind}`,
     ];

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -277,7 +277,7 @@ export class RuntimeContainer {
     if (existing.length === 0) return;
     throw new Error(
       `runtime volumes already exist: ${existing.join(', ')}. ` +
-        `Remove them first with \`${this.removeHint()} --volumes\`, then rerun init.`,
+        `Remove them first with \`${this.removeHint()}\`, then rerun init.`,
     );
   }
 

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -34,11 +34,15 @@ export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest'
 
 export const RUNTIME_MANAGED_BY_LABEL = 'vicoop.managed-by=vicoop-bridge';
 export const RUNTIME_COMPONENT_LABEL = 'vicoop.component=runtime';
+export const DEFAULT_RUNTIME_INSTANCE = 'default';
 
 export interface RuntimeContainerOptions {
   // Which backend this container hosts. Used in the canonical
   // container/volume names so claude and codex get isolated runtimes.
   backendKind: string;
+  // Optional per-kind runtime instance name. Omitted means the legacy
+  // default names (`vicoop-runtime-<kind>`, `vicoop-agents-<kind>`, ...).
+  runtimeName?: string;
   // OCI image to run. Defaults to DEFAULT_RUNTIME_IMAGE; env override
   // `VICOOP_RUNTIME_IMAGE` is resolved by the caller (cli.ts) so this
   // module stays env-clean.
@@ -79,17 +83,41 @@ export function defaultDockerRun(args: readonly string[]): DockerResult {
   };
 }
 
-export function containerName(kind: string): string {
-  return `vicoop-runtime-${kind}`;
+export function validateRuntimeName(name: string | undefined): string | undefined {
+  const trimmed = name?.trim();
+  if (!trimmed) return undefined;
+  if (!/^[a-z0-9][a-z0-9_.-]{0,31}$/.test(trimmed)) {
+    throw new Error(
+      `runtime name must match [a-z0-9][a-z0-9_.-]{0,31}; got '${name}'`,
+    );
+  }
+  if (trimmed === DEFAULT_RUNTIME_INSTANCE) {
+    throw new Error(
+      `runtime name '${DEFAULT_RUNTIME_INSTANCE}' is reserved; omit --name/--runtime-name for the default runtime`,
+    );
+  }
+  return trimmed;
 }
-export function agentsVolumeName(kind: string): string {
-  return `vicoop-agents-${kind}`;
+
+export function runtimeInstanceLabel(name: string | undefined): string {
+  return name ?? DEFAULT_RUNTIME_INSTANCE;
 }
-export function credsVolumeName(kind: string): string {
-  return `vicoop-creds-${kind}`;
+
+function runtimeSuffix(name: string | undefined): string {
+  return name ? `-${name}` : '';
 }
-export function sessionsVolumeName(kind: string): string {
-  return `vicoop-sessions-${kind}`;
+
+export function containerName(kind: string, runtimeName?: string): string {
+  return `vicoop-runtime-${kind}${runtimeSuffix(runtimeName)}`;
+}
+export function agentsVolumeName(kind: string, runtimeName?: string): string {
+  return `vicoop-agents-${kind}${runtimeSuffix(runtimeName)}`;
+}
+export function credsVolumeName(kind: string, runtimeName?: string): string {
+  return `vicoop-creds-${kind}${runtimeSuffix(runtimeName)}`;
+}
+export function sessionsVolumeName(kind: string, runtimeName?: string): string {
+  return `vicoop-sessions-${kind}${runtimeSuffix(runtimeName)}`;
 }
 
 export class RuntimeContainer {
@@ -100,7 +128,11 @@ export class RuntimeContainer {
   private started = false;
 
   constructor(opts: RuntimeContainerOptions) {
-    this.opts = { ...opts, image: opts.image ?? DEFAULT_RUNTIME_IMAGE };
+    this.opts = {
+      ...opts,
+      runtimeName: validateRuntimeName(opts.runtimeName),
+      image: opts.image ?? DEFAULT_RUNTIME_IMAGE,
+    };
     this.log = opts.logger ?? createLogger();
     this.run = opts.dockerRun ?? defaultDockerRun;
   }
@@ -112,7 +144,7 @@ export class RuntimeContainer {
   async start(): Promise<void> {
     this.ensureDaemonReachable();
 
-    const name = containerName(this.opts.backendKind);
+    const name = containerName(this.opts.backendKind, this.opts.runtimeName);
     if (this.findContainer(name)) {
       if (this.inspectRunning(name)) {
         this.log.info(`runtime container '${name}' already running — reusing`);
@@ -122,10 +154,15 @@ export class RuntimeContainer {
       }
     } else {
       if (!this.opts.createIfMissing) {
+        const initHint = this.opts.runtimeName
+          ? `vicoop-client container init ${this.opts.backendKind} --name ${this.opts.runtimeName}`
+          : `vicoop-client container init ${this.opts.backendKind}`;
         throw new Error(
           `runtime container '${name}' does not exist. ` +
-            `Create it first with \`vicoop-client container init ${this.opts.backendKind}\`, ` +
-            `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container\`.`,
+            `Create it first with \`${initHint}\`, ` +
+            `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container${
+              this.opts.runtimeName ? ` --runtime-name ${this.opts.runtimeName}` : ''
+            }\`.`,
         );
       }
       await this.ensureImage();
@@ -143,7 +180,7 @@ export class RuntimeContainer {
   // handler so an orderly shutdown actually ends with the container
   // stopped. Already-stopped / missing containers are tolerated.
   async stop(): Promise<void> {
-    const name = containerName(this.opts.backendKind);
+    const name = containerName(this.opts.backendKind, this.opts.runtimeName);
     const r = this.run(['stop', '-t', '10', name]);
     if (r.exitCode === 0) {
       this.log.info(`runtime container '${name}' stopped`);
@@ -160,7 +197,7 @@ export class RuntimeContainer {
   // Canonical container name. Used by spawn-adapter to build the
   // `docker exec` argv for each per-task spawn.
   getContainerName(): string {
-    return containerName(this.opts.backendKind);
+    return containerName(this.opts.backendKind, this.opts.runtimeName);
   }
 
   // ──────────────────────────────────────────────────────────────────
@@ -207,10 +244,11 @@ export class RuntimeContainer {
 
   private ensureVolumes(): void {
     const kind = this.opts.backendKind;
+    const runtimeName = this.opts.runtimeName;
     const names = [
-      agentsVolumeName(kind),
-      credsVolumeName(kind),
-      sessionsVolumeName(kind),
+      agentsVolumeName(kind, runtimeName),
+      credsVolumeName(kind, runtimeName),
+      sessionsVolumeName(kind, runtimeName),
     ];
     for (const name of names) {
       const inspect = this.run(['volume', 'inspect', name]);
@@ -224,6 +262,8 @@ export class RuntimeContainer {
         RUNTIME_COMPONENT_LABEL,
         '--label',
         `vicoop.kind=${kind}`,
+        '--label',
+        `vicoop.name=${runtimeInstanceLabel(runtimeName)}`,
         name,
       ]);
       this.log.info(`created named volume '${name}'`);
@@ -251,6 +291,7 @@ export class RuntimeContainer {
 
   private createContainer(name: string): void {
     const kind = this.opts.backendKind;
+    const runtimeName = this.opts.runtimeName;
     const args: string[] = [
       'create',
       '--name',
@@ -273,6 +314,8 @@ export class RuntimeContainer {
       RUNTIME_COMPONENT_LABEL,
       '--label',
       `vicoop.kind=${kind}`,
+      '--label',
+      `vicoop.name=${runtimeInstanceLabel(runtimeName)}`,
     ];
     if (this.opts.bridgeUrl) {
       args.push('-e', `VICOOP_BRIDGE_URL=${this.opts.bridgeUrl}`);
@@ -285,11 +328,11 @@ export class RuntimeContainer {
     // persistent across container re-creation. Decisions §4, §5.
     args.push(
       '--mount',
-      `type=volume,source=${agentsVolumeName(kind)},target=/data/agents/${kind}`,
+      `type=volume,source=${agentsVolumeName(kind, runtimeName)},target=/data/agents/${kind}`,
       '--mount',
-      `type=volume,source=${credsVolumeName(kind)},target=/data/creds/${kind}`,
+      `type=volume,source=${credsVolumeName(kind, runtimeName)},target=/data/creds/${kind}`,
       '--mount',
-      `type=volume,source=${sessionsVolumeName(kind)},target=/data/sessions/${kind}`,
+      `type=volume,source=${sessionsVolumeName(kind, runtimeName)},target=/data/sessions/${kind}`,
     );
     if (this.opts.workspaceDir) {
       // Workspace as a host bind-mount. Per-context branching


### PR DESCRIPTION
## Summary

Adds `vicoop-client container ls` / `container list` for inspecting managed runtime Docker resources, `container rm` / `container remove` for cleanup, and named runtime instances so one kind can have multiple local runtimes.

## Details

- Treats runtime identity as a name, while `kind` is metadata for listing and backend install/selection.
- `container init <kind>` now assigns a runtime name even when `--name` is omitted; the generated name is the backend kind (`claude`, `codex`, etc.).
- Uses name-based Docker resources like `vicoop-runtime-<name>`, `vicoop-agents-<name>`, `vicoop-creds-<name>`, and `vicoop-sessions-<name>`.
- Stops the runtime container at the end of `container init`; the daemon starts it when `--runtime container` is used.
- Lists managed runtime rows based on managed runtime containers, not volume-only leftovers.
- Reports `KIND`, `NAME`, container state, image, and expected agents/creds/sessions volume presence.
- Supports `--json` for list and remove output.
- Adds managed Docker labels to newly created runtime containers and volumes so Docker remains the source of truth.
- Makes `container init` a fresh-create command: it fails if the target runtime container or any canonical volume already exists.
- Supports daemon selection with `--runtime-name <name>` and config `backends.<kind>.runtime_name`; omitting it uses the active backend kind as the generated runtime name.
- Removes runtime containers and volumes by name with `container rm <name>` by default.
- Supports `container rm <name> --preserve-volumes` when credentials/sessions should survive container cleanup.
- Handles Docker's missing-resource output even when the Docker CLI exits 0.

Closes #266.

## Validation

- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/client test -- --test-name-pattern "RuntimeContainer|container"`
- `pnpm --filter @vicoop-bridge/client build`
- `pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts container rm --help`
- Local Docker smoke: `container init codex` now leaves `vicoop-runtime-codex` stopped; `container rm codex` with no flags removed `vicoop-runtime-codex` and all three `vicoop-{agents,creds,sessions}-codex` volumes.
- Final local `container ls` shows the existing `claude` runtime as `stopped`.