### PR TITLE
fix(client,server): surface duplicate-token collision (4009) distinctly (#270)

### DIFF
--- a/.changeset/duplicate-token-collision-warn.md
+++ b/.changeset/duplicate-token-collision-warn.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Recognize WebSocket close code 4009 (another daemon connected with the
+same `AGENT_TOKEN`) as a distinct failure mode: log a dedicated warn line
+naming the cause and the remediation (`pgrep -fl vicoop-client`), and
+floor the next reconnect at `collisionBackoffMs` (default 5 min) so a
+duplicate-token ping-pong damps out within one cycle instead of looping
+at the 30 s exponential-backoff cap forever. 4009 remains non-fatal — if
+the other daemon goes away, this side still recovers on its own.

--- a/.changeset/duplicate-token-collision-warn.md
+++ b/.changeset/duplicate-token-collision-warn.md
@@ -3,9 +3,10 @@
 ---
 
 Recognize WebSocket close code 4009 (another daemon connected with the
-same `AGENT_TOKEN`) as a distinct failure mode: log a dedicated warn line
-naming the cause and the remediation (`pgrep -fl vicoop-client`), and
-floor the next reconnect at `collisionBackoffMs` (default 5 min) so a
+same `CLIENT_TOKEN`, i.e. the bridge's clientId-level duplicate-token
+collision) as a distinct failure mode: log a dedicated warn line naming
+the cause and the remediation (`pgrep -fl vicoop-client`), and floor the
+next reconnect at `collisionBackoffMs` (default 5 min) so a
 duplicate-token ping-pong damps out within one cycle instead of looping
 at the 30 s exponential-backoff cap forever. 4009 remains non-fatal — if
 the other daemon goes away, this side still recovers on its own.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -463,12 +463,14 @@ test('Client stops on 4005 "bad token" too (delete-then-relaunch case, #166)', a
 test('Client surfaces 4009 "duplicate token" with a dedicated warn and floors the reconnect delay (#270)', async () => {
   // The default 4009 path before this fix logged only the generic
   // "disconnected: 4009 …" line and looped reconnects at the normal
-  // exponential backoff. Two daemons running with the same AGENT_TOKEN
-  // ended up ping-ponging each other indefinitely at the 30 s cap.
+  // exponential backoff. Two daemons authenticated with the same
+  // CLIENT_TOKEN (the bridge's clientId-level collision check, not the
+  // operator-visible agent identity) ended up ping-ponging each other
+  // indefinitely at the 30 s cap.
   //
   // The contract we're locking in here:
-  //   1. A clear warn line names both the cause (same AGENT_TOKEN) and the
-  //      remediation (`pgrep -fl vicoop-client`).
+  //   1. A clear warn line names both the cause (same CLIENT_TOKEN) and
+  //      the remediation (`pgrep -fl vicoop-client`).
   //   2. The next reconnect waits at least `collisionBackoffMs` so the
   //      duplicate-token loop damps out on the first cycle instead of
   //      hammering the server at the 30 s cap forever.
@@ -515,10 +517,10 @@ test('Client surfaces 4009 "duplicate token" with a dedicated warn and floors th
     await waitFor(() => helloCount === 1, 'expected initial hello');
     const closedAt = Date.now();
     connections[0]!.close(4009, 'another client with the same token connected');
-    // The warn line must name both the AGENT_TOKEN cause and the
+    // The warn line must name both the CLIENT_TOKEN cause and the
     // pgrep-based remediation — both halves of the contract above.
     await waitFor(
-      () => captured.warn.some((l) => l.includes('AGENT_TOKEN') && l.includes('pgrep')),
+      () => captured.warn.some((l) => l.includes('CLIENT_TOKEN') && l.includes('pgrep')),
       `expected dedicated 4009 warn, got warns: ${captured.warn.join(' | ')}`,
     );
     // Reconnect must respect the collision floor, not the 10 ms normal

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -460,6 +460,84 @@ test('Client stops on 4005 "bad token" too (delete-then-relaunch case, #166)', a
   }
 });
 
+test('Client surfaces 4009 "duplicate token" with a dedicated warn and floors the reconnect delay (#270)', async () => {
+  // The default 4009 path before this fix logged only the generic
+  // "disconnected: 4009 …" line and looped reconnects at the normal
+  // exponential backoff. Two daemons running with the same AGENT_TOKEN
+  // ended up ping-ponging each other indefinitely at the 30 s cap.
+  //
+  // The contract we're locking in here:
+  //   1. A clear warn line names both the cause (same AGENT_TOKEN) and the
+  //      remediation (`pgrep -fl vicoop-client`).
+  //   2. The next reconnect waits at least `collisionBackoffMs` so the
+  //      duplicate-token loop damps out on the first cycle instead of
+  //      hammering the server at the 30 s cap forever.
+  //   3. 4009 is NOT fatal — if the other daemon goes away, this side
+  //      still recovers automatically (just slowly).
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const connections: WebSocket[] = [];
+  let helloCount = 0;
+  wss.on('connection', (ws) => {
+    connections.push(ws);
+    ws.on('message', () => helloCount++);
+  });
+
+  const fatalCalls: Array<{ code: number; reason: string }> = [];
+  const captured = makeSink();
+  // Small collisionBackoffMs keeps the test fast — the production default
+  // is 5 min, which would dominate the test runtime. The point of the
+  // assertion below is the floor *exists*, not its specific value.
+  const COLLISION_FLOOR = 200;
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => {
+      /* no tasks */
+    }),
+    // Normal backoff would be 10 ms here. The collision floor (200 ms)
+    // must override it.
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    heartbeatIntervalMs: 0,
+    collisionBackoffMs: COLLISION_FLOOR,
+    onFatal: (info) => fatalCalls.push(info),
+    logSink: captured.sink,
+  });
+
+  try {
+    client.start();
+    await waitFor(() => helloCount === 1, 'expected initial hello');
+    const closedAt = Date.now();
+    connections[0]!.close(4009, 'another client with the same token connected');
+    // The warn line must name both the AGENT_TOKEN cause and the
+    // pgrep-based remediation — both halves of the contract above.
+    await waitFor(
+      () => captured.warn.some((l) => l.includes('AGENT_TOKEN') && l.includes('pgrep')),
+      `expected dedicated 4009 warn, got warns: ${captured.warn.join(' | ')}`,
+    );
+    // Reconnect must respect the collision floor, not the 10 ms normal
+    // delay. Wait until the second hello lands and verify the elapsed time
+    // is at least the floor (with a small slack for test scheduling).
+    await waitFor(() => helloCount === 2, 'expected reconnect after collision', 2000);
+    const elapsed = Date.now() - closedAt;
+    assert.ok(
+      elapsed >= COLLISION_FLOOR - 20,
+      `reconnect fired in ${elapsed}ms, expected >= ~${COLLISION_FLOOR}ms (collision floor)`,
+    );
+    // 4009 is not fatal — onFatal must NOT have fired.
+    assert.deepEqual(fatalCalls, [], 'onFatal must not fire on 4009');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('Client treats reconnectable closes (1012) as non-terminal and does NOT call onFatal', async () => {
   // Companion to the 4014/4005 tests: a transient close code (here 1012
   // service restart, the same code the reconnect-happy-path test uses)

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -39,6 +39,16 @@ export interface ClientOptions {
   reconnectMaxDelayMs?: number;
   reconnectJitterRatio?: number;
   reconnectStableMs?: number;
+  // Minimum reconnect delay after a 4009 "another client with the same
+  // token connected" close. The default is intentionally large (5 min) so
+  // a duplicate-token ping-pong damps out within one cycle instead of
+  // hammering the bridge — see vicoop-bridge#270. A legitimate handoff
+  // (operator restarts the daemon, old process exits) still recovers; it
+  // just waits this long before reconnecting. Tests override to a small
+  // value so the 4009-specific path is exercisable without a multi-minute
+  // sleep. Setting this below the normal computed backoff has no effect —
+  // the floor only raises the delay, never lowers it.
+  collisionBackoffMs?: number;
   // WebSocket protocol ping interval. The client terminates the socket when
   // a previous ping has not received a pong by the next tick, which turns
   // half-open network failures into a normal reconnect path. Set to 0 to
@@ -81,6 +91,7 @@ const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;
 const DEFAULT_RECONNECT_STABLE_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+const DEFAULT_COLLISION_BACKOFF_MS = 300_000;
 
 export class Client {
   private ws: WebSocket | null = null;
@@ -371,6 +382,30 @@ export class Client {
         this.opts.onFatal?.({ code, reason: reason.toString() });
         return;
       }
+      // 4009 = another daemon registered with the same AGENT_TOKEN and the
+      // bridge replaced us. The "disconnected: 4009 …" line above already
+      // logs the sanitized reason, but on its own it reads like any other
+      // disconnect — operators have to know the close-code table to
+      // recognize the duplicate-token failure mode. Surface a dedicated
+      // WARN with the concrete remediation so the foreground log names
+      // both the cause and the fix on one line (vicoop-bridge#270).
+      //
+      // We deliberately do NOT treat this as fatal: if the other daemon
+      // exits (operator kills it, or it crashes), this side should still
+      // recover automatically. But the default ~30 s exponential backoff
+      // is far too eager — two daemons running concurrently will ping-pong
+      // at the 30 s cap forever, never letting either reach the 60 s
+      // stable window that resets the attempt counter. Floor the next
+      // reconnect at `collisionBackoffMs` (5 min by default) so the
+      // ping-pong damps out after a single cycle.
+      if (code === 4009) {
+        this.logger.warn(
+          'another vicoop-client is connected with the same AGENT_TOKEN — ' +
+            'kill duplicates (`pgrep -fl vicoop-client`) or this daemon will keep being replaced',
+        );
+        this.scheduleReconnect(this.opts.collisionBackoffMs ?? DEFAULT_COLLISION_BACKOFF_MS);
+        return;
+      }
       this.scheduleReconnect();
     });
 
@@ -445,10 +480,17 @@ export class Client {
     this.reconnectResetTimer.unref?.();
   }
 
-  private scheduleReconnect(): void {
+  private scheduleReconnect(floorMs?: number): void {
     if (this.stopped || this.reconnectTimer) return;
     const attempt = this.reconnectAttempt++;
-    const delay = this.nextReconnectDelay(attempt);
+    // `floorMs` lets specific close codes (currently only 4009 duplicate-
+    // token collision) raise the delay above the computed backoff. It only
+    // raises, never lowers — a transient close that happens to schedule
+    // after a collision-floored cycle still uses the normal backoff. Pure
+    // additive change: omitting the argument preserves the previous
+    // behavior byte-for-byte.
+    const computed = this.nextReconnectDelay(attempt);
+    const delay = floorMs !== undefined ? Math.max(computed, floorMs) : computed;
     this.logger.info(`reconnecting in ${delay}ms attempt=${attempt + 1}`);
     // Intentionally NOT unref'd. By the time we get here the WS is gone and
     // the heartbeat / reconnect-reset timers have been cleared, so this timer

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -40,14 +40,16 @@ export interface ClientOptions {
   reconnectJitterRatio?: number;
   reconnectStableMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
-  // token connected" close. The default is intentionally large (5 min) so
-  // a duplicate-token ping-pong damps out within one cycle instead of
-  // hammering the bridge — see vicoop-bridge#270. A legitimate handoff
-  // (operator restarts the daemon, old process exits) still recovers; it
-  // just waits this long before reconnecting. Tests override to a small
-  // value so the 4009-specific path is exercisable without a multi-minute
-  // sleep. Setting this below the normal computed backoff has no effect —
-  // the floor only raises the delay, never lowers it.
+  // token connected" close — i.e. two daemons authenticated with the
+  // same CLIENT_TOKEN colliding at the registry's clientId check. The
+  // default is intentionally large (5 min) so a duplicate-token
+  // ping-pong damps out within one cycle instead of hammering the
+  // bridge — see vicoop-bridge#270. A legitimate handoff (operator
+  // restarts the daemon, old process exits) still recovers; it just
+  // waits this long before reconnecting. Tests override to a small value
+  // so the 4009-specific path is exercisable without a multi-minute
+  // sleep. Setting this below the normal computed backoff has no
+  // effect — the floor only raises the delay, never lowers it.
   collisionBackoffMs?: number;
   // WebSocket protocol ping interval. The client terminates the socket when
   // a previous ping has not received a pong by the next tick, which turns
@@ -382,13 +384,16 @@ export class Client {
         this.opts.onFatal?.({ code, reason: reason.toString() });
         return;
       }
-      // 4009 = another daemon registered with the same AGENT_TOKEN and the
-      // bridge replaced us. The "disconnected: 4009 …" line above already
-      // logs the sanitized reason, but on its own it reads like any other
-      // disconnect — operators have to know the close-code table to
-      // recognize the duplicate-token failure mode. Surface a dedicated
-      // WARN with the concrete remediation so the foreground log names
-      // both the cause and the fix on one line (vicoop-bridge#270).
+      // 4009 = another daemon registered with the same CLIENT_TOKEN (the
+      // token that authenticates the client_id row; 4009 fires when the
+      // bridge sees two live registrations resolving to the same
+      // clientId — see registry.ts) and the bridge replaced us. The
+      // "disconnected: 4009 …" line above already logs the sanitized
+      // reason, but on its own it reads like any other disconnect —
+      // operators have to know the close-code table to recognize the
+      // duplicate-token failure mode. Surface a dedicated WARN with the
+      // concrete remediation so the foreground log names both the cause
+      // and the fix on one line (vicoop-bridge#270).
       //
       // We deliberately do NOT treat this as fatal: if the other daemon
       // exits (operator kills it, or it crashes), this side should still
@@ -400,7 +405,7 @@ export class Client {
       // ping-pong damps out after a single cycle.
       if (code === 4009) {
         this.logger.warn(
-          'another vicoop-client is connected with the same AGENT_TOKEN — ' +
+          'another vicoop-client is connected with the same CLIENT_TOKEN — ' +
             'kill duplicates (`pgrep -fl vicoop-client`) or this daemon will keep being replaced',
         );
         this.scheduleReconnect(this.opts.collisionBackoffMs ?? DEFAULT_COLLISION_BACKOFF_MS);

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -278,8 +278,10 @@ test('disconnectClient closes every ws bound to the client_id with code 4014', (
 });
 
 test('registerAgent emits client_collision and closes the prior ws with the descriptive 4009 reason', (t) => {
-  // Two daemons running with the same AGENT_TOKEN show up here as a second
-  // registerAgent() for the same agentId + clientId. The prior ws must
+  // Two daemons authenticated with the same CLIENT_TOKEN — so the token
+  // hash resolves to the same client row, hence the same clientId — show
+  // up here as a second registerAgent() for the same agentId + clientId.
+  // The prior ws must
   // receive close(4009, 'another client with the same token connected')
   // — both the code and the reason text — so the surviving client surfaces
   // the cause directly in its disconnect log line. A structured

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -277,6 +277,49 @@ test('disconnectClient closes every ws bound to the client_id with code 4014', (
   assert.deepEqual(ws3.closeArgs, []);
 });
 
+test('registerAgent emits client_collision and closes the prior ws with the descriptive 4009 reason', (t) => {
+  // Two daemons running with the same AGENT_TOKEN show up here as a second
+  // registerAgent() for the same agentId + clientId. The prior ws must
+  // receive close(4009, 'another client with the same token connected')
+  // — both the code and the reason text — so the surviving client surfaces
+  // the cause directly in its disconnect log line. A structured
+  // `client_collision` event must also fire so aggregated server logs can
+  // be grepped for flapping agents independently of normal connect/
+  // disconnect noise.
+  const logs: string[] = [];
+  t.mock.method(console, 'log', (...args: unknown[]) => {
+    logs.push(args.map(String).join(' '));
+  });
+  const registry = new Registry();
+  const ws1 = makeRecordingWs();
+  const ws2 = makeRecordingWs();
+  const base = {
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+  };
+  registry.registerAgent({ ...base, ws: ws1, connectedAt: 1000 });
+  registry.registerAgent({ ...base, ws: ws2, connectedAt: 2000 });
+  assert.deepEqual(ws1.closeArgs, [
+    { code: 4009, reason: 'another client with the same token connected' },
+  ]);
+  // The new ws is the live one and must not have been closed.
+  assert.deepEqual(ws2.closeArgs, []);
+  const collisionLine = logs.find((l) => l.includes('client_collision'));
+  assert.ok(collisionLine, `expected client_collision event, got: ${logs.join(' | ')}`);
+  const parsed = JSON.parse(collisionLine) as Record<string, unknown>;
+  assert.equal(parsed.event, 'client_collision');
+  assert.equal(parsed.agentId, 'a1');
+  assert.equal(parsed.clientId, 'c1');
+  // previousConnectedAt surfaces the displaced connection's connectedAt so
+  // operators can see how long the loser had been live before being
+  // replaced — useful when triaging a fast ping-pong vs. a legit handoff
+  // after a long-stable session.
+  assert.equal(parsed.previousConnectedAt, 1000);
+});
+
 test('disconnectClient returns 0 when no agents are bound to the client', () => {
   const registry = new Registry();
   registry.registerAgent({

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -61,11 +61,13 @@ export class Registry {
     const existing = this.agents.get(conn.agentId);
     if (existing) {
       if (existing.clientId === conn.clientId) {
-        // Two daemons running with the same AGENT_TOKEN. Surface a distinct
-        // structured event so fly logs / admin tooling can spot flapping
-        // agents independently of the normal client_connected /
-        // client_disconnected pair — without this, a duplicate-token loop
-        // is indistinguishable from a flaky network in aggregate logs.
+        // Two daemons authenticated with the same CLIENT_TOKEN (so they
+        // resolve to the same clientId row) and racing to register the
+        // same agent. Surface a distinct structured event so fly logs /
+        // admin tooling can spot flapping agents independently of the
+        // normal client_connected / client_disconnected pair — without
+        // this, a duplicate-token loop is indistinguishable from a flaky
+        // network in aggregate logs.
         // agentId is user-controlled (hello frame), so truncate before
         // logging — same defense applied in notifyAgentChange below.
         logEvent('client_collision', {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -61,7 +61,23 @@ export class Registry {
     const existing = this.agents.get(conn.agentId);
     if (existing) {
       if (existing.clientId === conn.clientId) {
-        existing.ws.close(4009, 'replaced by new connection');
+        // Two daemons running with the same AGENT_TOKEN. Surface a distinct
+        // structured event so fly logs / admin tooling can spot flapping
+        // agents independently of the normal client_connected /
+        // client_disconnected pair — without this, a duplicate-token loop
+        // is indistinguishable from a flaky network in aggregate logs.
+        // agentId is user-controlled (hello frame), so truncate before
+        // logging — same defense applied in notifyAgentChange below.
+        logEvent('client_collision', {
+          agentId: truncate(String(conn.agentId), 128),
+          clientId: conn.clientId,
+          previousConnectedAt: existing.connectedAt,
+        });
+        // The close `reason` is what the client surfaces in its disconnect
+        // log line. Spelling out the cause here means an operator reading
+        // the foreground log can recognize the duplicate-token scenario
+        // without cross-referencing close codes.
+        existing.ws.close(4009, 'another client with the same token connected');
         this.agents.set(conn.agentId, conn);
         this.notifyAgentChange(conn.agentId);
         return { ok: true };
@@ -84,7 +100,8 @@ export class Registry {
   //   - 4001-4008 ws.ts (hello timeout, invalid frame, expected hello,
   //     protocol-version mismatch, bad token, registry registration
   //     failed, duplicate hello, agent id not in client allowlist)
-  //   - 4009 registry.ts (this file: `replaced by new connection`)
+  //   - 4009 registry.ts (this file: `another client with the same token
+  //     connected` — duplicate-token collision)
   //   - 4010-4011 ws.ts (agent id owned by a different principal,
   //     reserved agent id)
   //   - 4012-4013 card-resolver.ts (missing card-or-backend, unknown


### PR DESCRIPTION
Closes #270.

## Summary

- **Server (`packages/server/src/registry.ts`).** Change the 4009 close `reason` from `"replaced by new connection"` to `"another client with the same token connected"`, so the client's `disconnected: 4009 …` log already names the cause. Emit a `client_collision` structured event (`agentId`, `clientId`, `previousConnectedAt`) so aggregated logs / admin tooling can spot flapping agents independently of normal `client_connected` / `client_disconnected` pairs. Close-code comment block updated to reflect the new reason text.
- **Client (`packages/client/src/client.ts`).** Branch the close handler on `code === 4009` and log a dedicated WARN naming both the cause (same `CLIENT_TOKEN` — the bridge's clientId-level collision check, distinct from the operator-visible `AGENT_TOKEN` label used by `agent register`) and the remediation (`pgrep -fl vicoop-client`). Floor the next reconnect at `collisionBackoffMs` (new option, default 5 min) via a `floorMs` parameter on `scheduleReconnect()` so a duplicate-token ping-pong damps out within one cycle instead of looping at the 30 s exponential-backoff cap forever. 4009 remains **non-fatal** — if the other daemon goes away, this side still recovers automatically.
- **Changeset.** `@vicoop-bridge/client` minor.

The third option from #270 (admin-ui flapping badge) is deferred — lower ROI, do it only if we keep seeing this in the wild.

## What an operator sees now

Before:

```
[client] disconnected: 4009 replaced by new connection
[client] reconnecting in 2472ms attempt=1
[client] reconnecting in 5466ms attempt=2
... (loops forever at the 30s cap)
```

After:

```
[client] disconnected: 4009 another client with the same token connected
[client] another vicoop-client is connected with the same CLIENT_TOKEN — kill duplicates (`pgrep -fl vicoop-client`) or this daemon will keep being replaced
[client] reconnecting in 300000ms attempt=1
```

## Test plan

- [x] `pnpm -r build` — all packages
- [x] `pnpm -r typecheck` — all packages
- [x] `pnpm --filter @vicoop-bridge/server test` — 222 pass (incl. new `registerAgent emits client_collision …` test)
- [x] `pnpm --filter @vicoop-bridge/client test` — 496 pass (incl. new `Client surfaces 4009 "duplicate token" …` test)
- [ ] Manual: spin up two `vicoop-client` processes with the same `CLIENT_TOKEN`, confirm the new WARN line appears in the loser's log and the next reconnect waits ~5 min instead of ~30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)