### PR TITLE
feat(skills): add fork-into-container skill

### DIFF
--- a/skills/fork-into-container/SKILL.md
+++ b/skills/fork-into-container/SKILL.md
@@ -43,10 +43,12 @@ chmod +x "$DEST/fork.sh"
 ## Prerequisites
 
 - **`docker`** reachable from the parent shell (`docker info` works)
-- **`vicoop-client` on `$PATH`** — install with `npm i -g @vicoop-bridge/client`
-  or symlink the binary out of a built workspace checkout. The script
-  invokes `vicoop-client` directly and aborts (`set -e`) at preflight if
-  it's missing.
+- **`vicoop-client` on `$PATH`** — install via the one-liner in
+  [`docs/install-client.md`](../../docs/install-client.md) (downloads the
+  released binary and drops it into `$INSTALL_DIR`), or build from
+  source and symlink. The package is workspace-private — not on npm.
+  The script invokes `vicoop-client` directly and aborts (`set -e`)
+  at preflight if it's missing.
 - **One-time auth on the host** (nothing to re-export per invocation):
   - `claude setup-token` (claude) or `codex login --device-auth` (codex)
   - `vicoop-client auth login` (bridge owner session)
@@ -73,11 +75,20 @@ bash ~/.claude/skills/vicoop-fork-into-container/fork.sh
 bash ~/.codex/skills/vicoop-fork-into-container/fork.sh
 ```
 
+Parent kind (claude vs codex) is detected from the **install path of the
+script itself** — running `~/.codex/skills/.../fork.sh` picks codex,
+running `~/.claude/skills/.../fork.sh` picks claude. The script falls
+back to checking host config-dir presence only when invoked from
+outside either skill tree (e.g. a dev checkout); in the rare case both
+`~/.claude` and `~/.codex` exist *and* the script is outside both
+trees, you'll get a hard error with an instruction to set the override
+below.
+
 Optional env overrides:
 
 | Var | Meaning |
 |---|---|
-| `VICOOP_FORK_KIND` | force `claude` or `codex` instead of auto-detect |
+| `VICOOP_FORK_KIND` | force `claude` or `codex` (only needed when invoked from outside a skill tree with both config dirs present) |
 
 ## What the script does
 

--- a/skills/fork-into-container/SKILL.md
+++ b/skills/fork-into-container/SKILL.md
@@ -14,23 +14,66 @@ volume. What upstream intentionally does **not** carry is the operator's
 *harness* — `skills/`, sub-agents, slash-commands, the project memory
 file. That gap is what this skill fills.
 
-## What you need before invoking
+## Install
 
-Just be **logged in once** on the host:
+This repo just ships the skill source under `skills/fork-into-container/`.
+To actually use it, drop it into your agent's skills tree on the host:
 
-- `claude setup-token` (claude) or `codex login --device-auth` (codex)
-- `vicoop-client auth login` (bridge owner session)
+**Claude Code** (user-wide):
 
-That's it. No env vars, no manually-passed tokens — `--from-host` reads
-the right keychain entry / disk file itself.
+```bash
+DEST=~/.claude/skills/vicoop-fork-into-container
+mkdir -p "$DEST"
+cp -R skills/fork-into-container/. "$DEST/"
+chmod +x "$DEST/fork.sh"
+```
+
+Project-scoped variant: replace `~/.claude` with `.claude` inside the repo
+you're working in.
+
+**Codex**:
+
+```bash
+DEST=~/.codex/skills/vicoop-fork-into-container
+mkdir -p "$DEST"
+cp -R skills/fork-into-container/. "$DEST/"
+chmod +x "$DEST/fork.sh"
+```
+
+## Prerequisites
+
+- **`docker`** reachable from the parent shell (`docker info` works)
+- **`vicoop-client` on `$PATH`** — install with `npm i -g @vicoop-bridge/client`
+  or symlink the binary out of a built workspace checkout. The script
+  invokes `vicoop-client` directly and aborts (`set -e`) at preflight if
+  it's missing.
+- **One-time auth on the host** (nothing to re-export per invocation):
+  - `claude setup-token` (claude) or `codex login --device-auth` (codex)
+  - `vicoop-client auth login` (bridge owner session)
+- **A registered bridge agent** via `vicoop-client agent register`. The
+  skill itself doesn't read the agent id / client token — they sit on
+  disk for the daemon launch step that follows.
 
 ## Invocation
 
+The skill ships one script, `fork.sh`, alongside this SKILL.md. It takes
+no positional arguments; behavior is fully auto-detected or env-driven
+(see the env table below).
+
+When the agent runtime invokes the skill, it already knows the skill's
+directory and runs `fork.sh` from there — no environment plumbing needed.
+
+For manual invocation from a shell, point at the installed path:
+
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")}/fork.sh"
+# Claude install path:
+bash ~/.claude/skills/vicoop-fork-into-container/fork.sh
+
+# Codex install path:
+bash ~/.codex/skills/vicoop-fork-into-container/fork.sh
 ```
 
-Optional override:
+Optional env overrides:
 
 | Var | Meaning |
 |---|---|
@@ -39,21 +82,26 @@ Optional override:
 ## What the script does
 
 1. Detect parent kind from env / `~/.claude` vs `~/.codex` presence.
-2. If `vicoop-runtime-<kind>` is **not** already running, invoke
+2. If `vicoop-runtime-<kind>` is **not** present at all, invoke
    `vicoop-client container init <kind> --from-host`. Upstream pulls
-   creds, installs the agent CLI, compat-checks the version.
-3. Stage a curated payload to `mktemp -d`:
+   creds, installs the agent CLI, compat-checks the version, and (per
+   #271) leaves the container stopped.
+3. Capture the container's running state. If stopped, `docker start`
+   it for the inject window; restore it to its original state on exit
+   so the upstream "stopped after init" convention isn't broken.
+4. Stage a curated payload to `mktemp -d`:
    - `skills/`, `agents/`, `commands/` subtrees
-   - `CLAUDE.md` or `AGENTS.md`
-   - Defensive `find -delete` for anything credential-shaped that a
-     skill may have shipped inline.
-4. `tar -C $STAGE -cf - . | docker exec -i -u node $CONTAINER bash -c "tar -C /data/creds/<kind> -xf -"`.
+   - `CLAUDE.md` (and its transitive `@`-imports — claude only;
+     `AGENTS.md` has no equivalent directive) or `AGENTS.md`
+   - Defensive `find -delete` for credential-shaped names and macOS
+     AppleDouble `._*` sidecars.
+5. `tar -C $STAGE --no-xattrs -cf - . | docker exec -i -u node $CONTAINER bash -c "tar -C /data/creds/<kind> -xf -"`.
    Tar-pipe (not `docker cp`) so the extract runs as the `node` user
    and the agent CLI can traverse the files immediately.
-5. Print the daemon-start command:
-   `vicoop-client --backend <kind> --runtime container`
-6. Emit `{container, kind, injected_into}` JSON for the parent agent
-   to chain off of.
+6. Print the daemon-start command:
+   `vicoop-client --backend <kind> --runtime container --runtime-name <kind>`
+7. Emit `{container, runtime_name, kind, injected_into}` JSON for the
+   parent agent to chain off of.
 
 ## What this skill does NOT do
 

--- a/skills/fork-into-container/SKILL.md
+++ b/skills/fork-into-container/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: vicoop-fork-into-container
+description: Top up the per-backend vicoop-bridge runtime container with the parent agent's curated harness — its `skills/`, sub-agents, slash-commands, and project memory file (`CLAUDE.md` / `AGENTS.md`). Bootstraps the runtime container itself via `vicoop-client container init <kind> --from-host` if it's not already present, so the operator only needs to be logged in once. Use when the user says "fork into a container", "spawn an isolated copy with my skills", "컨테이너로 분기", "내 하네스까지 가져가서 격리된 에이전트로 띄워줘", "샌드박스에서 돌려".
+allowed-tools: Bash
+---
+
+# Fork-into-Container
+
+This skill is a thin layer on top of `vicoop-client container init`.
+Upstream already handles **auth, image, and volume lifecycle** — it pulls
+the operator's host creds (macOS Keychain or `~/.claude/.credentials.json`
+or `~/.codex/auth.json`) straight into the runtime container's named
+volume. What upstream intentionally does **not** carry is the operator's
+*harness* — `skills/`, sub-agents, slash-commands, the project memory
+file. That gap is what this skill fills.
+
+## What you need before invoking
+
+Just be **logged in once** on the host:
+
+- `claude setup-token` (claude) or `codex login --device-auth` (codex)
+- `vicoop-client auth login` (bridge owner session)
+
+That's it. No env vars, no manually-passed tokens — `--from-host` reads
+the right keychain entry / disk file itself.
+
+## Invocation
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")}/fork.sh"
+```
+
+Optional override:
+
+| Var | Meaning |
+|---|---|
+| `VICOOP_FORK_KIND` | force `claude` or `codex` instead of auto-detect |
+
+## What the script does
+
+1. Detect parent kind from env / `~/.claude` vs `~/.codex` presence.
+2. If `vicoop-runtime-<kind>` is **not** already running, invoke
+   `vicoop-client container init <kind> --from-host`. Upstream pulls
+   creds, installs the agent CLI, compat-checks the version.
+3. Stage a curated payload to `mktemp -d`:
+   - `skills/`, `agents/`, `commands/` subtrees
+   - `CLAUDE.md` or `AGENTS.md`
+   - Defensive `find -delete` for anything credential-shaped that a
+     skill may have shipped inline.
+4. `tar -C $STAGE -cf - . | docker exec -i -u node $CONTAINER bash -c "tar -C /data/creds/<kind> -xf -"`.
+   Tar-pipe (not `docker cp`) so the extract runs as the `node` user
+   and the agent CLI can traverse the files immediately.
+5. Print the daemon-start command:
+   `vicoop-client --backend <kind> --runtime container`
+6. Emit `{container, kind, injected_into}` JSON for the parent agent
+   to chain off of.
+
+## What this skill does NOT do
+
+- **Start the daemon.** The bridge client is a long-running process;
+  the operator launches it in their own shell after this skill
+  finishes. (Auto-starting from inside a skill is awkward and racy.)
+- **Re-inject on every call.** Tar-extract overlays existing files;
+  re-running the skill refreshes the harness in place. Removed files
+  on the host stay in the container until the operator wipes the
+  creds volume.
+- **Carry MCP servers, `settings.json`, or hooks.** Those are commonly
+  bound to host-absolute paths or sockets and don't survive the
+  container boundary without rewriting; left out of the allowlist on
+  purpose.
+
+## Why this is much smaller than v1
+
+The v1 prototype tried to spawn the bundled-direct container with a
+half-dozen env vars (`VICOOP_BRIDGE_TOKEN`, `VICOOP_AGENT_ID`,
+`CLAUDE_CODE_OAUTH_TOKEN`, …) hand-rolled by the operator. Upstream's
+external-runtime profile + `container init --from-host` removed every
+one of those — bridge auth lives in the host bridge client (it never
+enters the container at all), and backend auth is auto-pulled. This
+skill now just plugs the one remaining gap.

--- a/skills/fork-into-container/fork.sh
+++ b/skills/fork-into-container/fork.sh
@@ -18,16 +18,33 @@ log() { printf '[fork] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 
 # ── detect parent kind ────────────────────────────────────────────────────
+# Priority (strongest signal first):
+#   1) VICOOP_FORK_KIND env override                     (caller handles)
+#   2) Install path of *this script* — if it lives under
+#      ~/.codex/skills/... or ~/.claude/skills/... the operator
+#      explicitly put it in that agent's tree, which is a far stronger
+#      intent signal than "both config dirs happen to exist"
+#   3) Host config-dir presence (claude / codex / both → ask)
 detect_kind() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+    # Require the full ".../<agent>/skills/..." shape so we don't
+    # false-match unrelated paths that just happen to contain
+    # `/.claude/` as an ancestor (e.g. `~/foo/.claude/worktrees/...`).
+    case "/$script_dir/" in
+        */.codex/skills/*)  echo codex;  return ;;
+        */.claude/skills/*) echo claude; return ;;
+    esac
+
     local has_claude=0 has_codex=0
     [[ -n "${CLAUDE_CONFIG_DIR:-}" || -d "$HOME/.claude" ]] && has_claude=1
     [[ -n "${CODEX_HOME:-}"        || -d "$HOME/.codex"  ]] && has_codex=1
     if (( has_claude && ! has_codex )); then echo claude; return; fi
     if (( has_codex  && ! has_claude )); then echo codex;  return; fi
     if (( has_claude && has_codex )); then
-        log "both ~/.claude and ~/.codex present — defaulting to claude."
-        log "set VICOOP_FORK_KIND=codex to override."
-        echo claude; return
+        log "both ~/.claude and ~/.codex present and script is outside either"
+        log "skill tree — set VICOOP_FORK_KIND=claude|codex to disambiguate."
+        die "cannot pick parent kind unambiguously"
     fi
     die "could not detect parent kind — set VICOOP_FORK_KIND=claude|codex"
 }

--- a/skills/fork-into-container/fork.sh
+++ b/skills/fork-into-container/fork.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# vicoop fork-into-container — inject the parent agent's curated harness
+# (skills/, agents/, commands/, CLAUDE.md or AGENTS.md) into the
+# per-backend runtime container managed by `vicoop-client container`.
+#
+# Auth, image, volume lifecycle are all delegated to upstream:
+#   `vicoop-client container init <kind> --from-host`
+# already reads creds from the host Keychain / disk and copies them
+# into the runtime container's creds volume. This script's only job is
+# to top-up the *harness* pieces that upstream intentionally doesn't
+# carry.
+#
+# See SKILL.md for the user-facing contract.
+
+set -euo pipefail
+
+log() { printf '[fork] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+# ── detect parent kind ────────────────────────────────────────────────────
+detect_kind() {
+    local has_claude=0 has_codex=0
+    [[ -n "${CLAUDE_CONFIG_DIR:-}" || -d "$HOME/.claude" ]] && has_claude=1
+    [[ -n "${CODEX_HOME:-}"        || -d "$HOME/.codex"  ]] && has_codex=1
+    if (( has_claude && ! has_codex )); then echo claude; return; fi
+    if (( has_codex  && ! has_claude )); then echo codex;  return; fi
+    if (( has_claude && has_codex )); then
+        log "both ~/.claude and ~/.codex present — defaulting to claude."
+        log "set VICOOP_FORK_KIND=codex to override."
+        echo claude; return
+    fi
+    die "could not detect parent kind — set VICOOP_FORK_KIND=claude|codex"
+}
+
+KIND="${VICOOP_FORK_KIND:-$(detect_kind)}"
+case "$KIND" in claude|codex) ;; *) die "unsupported VICOOP_FORK_KIND='$KIND' (expected claude|codex)" ;; esac
+log "parent kind: $KIND"
+
+case "$KIND" in
+    claude) SRC_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; MEMORY_FILE="CLAUDE.md" ;;
+    codex)  SRC_DIR="${CODEX_HOME:-$HOME/.codex}";          MEMORY_FILE="AGENTS.md" ;;
+esac
+[[ -d "$SRC_DIR" ]] || die "source config dir not found: $SRC_DIR"
+log "source: $SRC_DIR"
+
+# ── preflight ─────────────────────────────────────────────────────────────
+command -v docker         >/dev/null 2>&1 || die "docker not found in PATH"
+command -v vicoop-client  >/dev/null 2>&1 || die "vicoop-client not found in PATH (install: https://github.com/planetarium/vicoop-bridge)"
+docker info >/dev/null 2>&1 || die "docker daemon not reachable"
+
+CONTAINER="vicoop-runtime-$KIND"
+TARGET="/data/creds/$KIND"
+
+# ── ensure runtime container exists (delegates auth + image + volume) ──────
+if docker inspect "$CONTAINER" >/dev/null 2>&1; then
+    log "runtime container present: $CONTAINER (reusing)"
+else
+    log "runtime container absent — bootstrapping via vicoop-client container init"
+    vicoop-client container init "$KIND" --from-host
+fi
+
+# ── stage curated harness ─────────────────────────────────────────────────
+# Allowlist only — credentials live in upstream's --from-host path,
+# session/project state stays host-side on purpose.
+STAGE="$(mktemp -d -t vicoop-fork.XXXXXX)"
+trap 'rm -rf "$STAGE"' EXIT
+log "staging at: $STAGE"
+
+for d in skills agents commands; do
+    if [[ -d "$SRC_DIR/$d" ]]; then
+        cp -R "$SRC_DIR/$d" "$STAGE/$d"
+        log "  + $d/"
+    fi
+done
+if [[ -f "$SRC_DIR/$MEMORY_FILE" ]]; then
+    cp "$SRC_DIR/$MEMORY_FILE" "$STAGE/$MEMORY_FILE"
+    log "  + $MEMORY_FILE"
+    # Claude Code's CLAUDE.md supports `@<path>` import directives
+    # that pull other files in at parse time. Codex's AGENTS.md has
+    # no equivalent, so we only resolve imports for claude.
+    #
+    # Policy: only follow imports that resolve inside SRC_DIR — anything
+    # outside (e.g. `@~/Documents/notes.md`) is a host coupling we don't
+    # carry into the container. Cap recursion at depth 5 (matches the
+    # upstream parser) and skip lines inside ``` fences. If python3
+    # isn't available the resolver is skipped with a warning; the file
+    # itself still travels, just without its imports.
+    if [[ "$KIND" == "claude" ]]; then
+        if command -v python3 >/dev/null 2>&1; then
+            python3 - "$SRC_DIR" "$STAGE" "$MEMORY_FILE" <<'PY' 2>&1 | sed 's|^|[fork]   |' >&2
+import os, re, sys
+src   = os.path.realpath(sys.argv[1])
+stage = os.path.realpath(sys.argv[2])
+root  = sys.argv[3]
+MAX_DEPTH = 5
+IMPORT_RE = re.compile(r'^[\t ]*@(\S+)')
+FENCE_RE  = re.compile(r'^[\t ]*```')
+seen = set()
+def walk(path, depth):
+    rp = os.path.realpath(path)
+    if rp in seen:
+        return
+    seen.add(rp)
+    if depth > MAX_DEPTH:
+        print(f'WARN: depth >{MAX_DEPTH} at {os.path.relpath(rp, src)}; stopping recursion')
+        return
+    try:
+        with open(rp, encoding='utf-8', errors='replace') as f:
+            in_fence = False
+            for line in f:
+                if FENCE_RE.match(line):
+                    in_fence = not in_fence
+                    continue
+                if in_fence:
+                    continue
+                m = IMPORT_RE.match(line)
+                if not m:
+                    continue
+                ref = os.path.expanduser(m.group(1))
+                base = os.path.dirname(rp)
+                ref_abs = os.path.realpath(os.path.join(base, ref))
+                if not (ref_abs == src or ref_abs.startswith(src + os.sep)):
+                    print(f'WARN: skip @{m.group(1)} from {os.path.relpath(rp, src)}: '
+                          f'resolves outside SRC_DIR ({ref_abs})')
+                    continue
+                if not os.path.isfile(ref_abs):
+                    print(f'WARN: @{m.group(1)} not found at {ref_abs}')
+                    continue
+                rel = os.path.relpath(ref_abs, src)
+                dest = os.path.join(stage, rel)
+                os.makedirs(os.path.dirname(dest) or stage, exist_ok=True)
+                with open(ref_abs, 'rb') as r, open(dest, 'wb') as w:
+                    w.write(r.read())
+                print(f'+ {rel} (@-import via {os.path.relpath(rp, src)})')
+                walk(ref_abs, depth + 1)
+    except OSError as e:
+        print(f'WARN: could not read {rp}: {e}')
+walk(os.path.join(src, root), 0)
+PY
+        else
+            log "  WARN: python3 not found — @-imports inside $MEMORY_FILE are not followed"
+        fi
+    fi
+fi
+
+# Defensive scrub — a skill or agent may have shipped a credential
+# inline; cheap insurance on top of the allowlist. The `._*` entries
+# are macOS AppleDouble sidecars that BSD tar emits for extended
+# attributes; GNU tar inside the container treats them as ordinary
+# files and would pollute the creds dir.
+find "$STAGE" \( \
+    -iname 'credentials*' -o \
+    -iname '.credentials*' -o \
+    -iname 'auth.json'     -o \
+    -iname '*.token'       -o \
+    -iname '*.pem'         -o \
+    -iname 'id_rsa*'       -o \
+    -name  '._*'           \
+\) -print -delete >&2 || true
+
+# ── inject via `tar | docker exec` ────────────────────────────────────────
+# We tar-pipe instead of `docker cp` so we can extract as the `node`
+# user (the cp'd files would otherwise land root-owned and the agent
+# CLI couldn't traverse them on first invocation).
+if [[ -n "$(ls -A "$STAGE" 2>/dev/null || true)" ]]; then
+    log "injecting into $CONTAINER:$TARGET"
+    # COPYFILE_DISABLE=1 stops BSD tar (macOS) from emitting AppleDouble
+    # `._*` sidecars; --no-xattrs stops it from inlining `com.apple.*`
+    # xattrs in pax extended headers (which GNU tar inside the container
+    # would otherwise warn about for every file). No-op on Linux hosts.
+    COPYFILE_DISABLE=1 tar --no-xattrs -C "$STAGE" -cf - . \
+        | docker exec -i -u node "$CONTAINER" \
+              bash -c "tar -C '$TARGET' -xf -"
+else
+    log "nothing to inject (source has no skills/agents/commands/$MEMORY_FILE)"
+fi
+
+log ""
+log "done. start the bridge daemon (in another shell) with:"
+log "    vicoop-client --backend $KIND --runtime container"
+
+printf '{"container":"%s","kind":"%s","injected_into":"%s"}\n' \
+    "$CONTAINER" "$KIND" "$TARGET"

--- a/skills/fork-into-container/fork.sh
+++ b/skills/fork-into-container/fork.sh
@@ -59,11 +59,34 @@ else
     vicoop-client container init "$KIND" --from-host
 fi
 
+# ── bring container up only for the inject window ────────────────────────
+# Upstream `container init` (post-#271) leaves the runtime stopped; the
+# bridge daemon's RuntimeContainer.start() will bring it up at launch.
+# `docker exec` for inject needs it running *now* though — so start it
+# if we found it stopped, and put it back the way we found it on exit
+# (matches the state convention upstream introduced).
+WAS_RUNNING=0
+if docker inspect "$CONTAINER" --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+    WAS_RUNNING=1
+fi
+if (( ! WAS_RUNNING )); then
+    log "starting $CONTAINER for inject (was stopped)"
+    docker start "$CONTAINER" >/dev/null
+fi
+
+cleanup() {
+    [[ -n "${STAGE:-}" ]] && rm -rf "$STAGE"
+    if (( ! WAS_RUNNING )); then
+        log "restoring $CONTAINER to stopped state"
+        docker stop "$CONTAINER" >/dev/null 2>&1 || true
+    fi
+}
+trap cleanup EXIT
+
 # ── stage curated harness ─────────────────────────────────────────────────
 # Allowlist only — credentials live in upstream's --from-host path,
 # session/project state stays host-side on purpose.
 STAGE="$(mktemp -d -t vicoop-fork.XXXXXX)"
-trap 'rm -rf "$STAGE"' EXIT
 log "staging at: $STAGE"
 
 for d in skills agents commands; do
@@ -177,7 +200,7 @@ fi
 
 log ""
 log "done. start the bridge daemon (in another shell) with:"
-log "    vicoop-client --backend $KIND --runtime container"
+log "    vicoop-client --backend $KIND --runtime container --runtime-name $KIND"
 
-printf '{"container":"%s","kind":"%s","injected_into":"%s"}\n' \
-    "$CONTAINER" "$KIND" "$TARGET"
+printf '{"container":"%s","runtime_name":"%s","kind":"%s","injected_into":"%s"}\n' \
+    "$CONTAINER" "$KIND" "$KIND" "$TARGET"


### PR DESCRIPTION
## Summary
- Adds `skills/fork-into-container/` — an operator-side skill that tops up the per-backend `vicoop-runtime-<kind>` container with the host agent's curated harness: `skills/`, `agents/`, `commands/`, and `CLAUDE.md` (or `AGENTS.md`) including transitive `@`-imports.
- Bootstraps the runtime container via `vicoop-client container init <kind> --from-host` when absent, so the parent shell needs **zero new env vars** beyond what the operator already has from `claude setup-token` / `codex login` and `vicoop-client auth login`.

## Why
Upstream `container init --from-host` (#244, #249) ships creds but intentionally leaves the *harness* behind. This skill fills that gap at task time — parent-agent driven, opt-in, per-fork.

A future `container init --with-harness` flag at init time may make sense separately, but it solves a different problem (operator policy, eager copy at init) and is **not** part of this PR.

## What it does (in order)
1. Detect parent kind from env (`CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `~/.claude` / `~/.codex`).
2. If `vicoop-runtime-<kind>` is absent, invoke `vicoop-client container init <kind> --from-host` (delegates auth, image pull, volume creation, compat check).
3. Stage a curated subset of the source config dir to a tempdir.
4. Walk `CLAUDE.md` for `@`-imports (claude only — `AGENTS.md` has no equivalent), pulling each referenced file at the same relative path. Cycle-break via `visited` set, max depth 5, code-fence-aware, imports resolving outside `SRC_DIR` are warned + skipped.
5. Defensive scrub for anything credential-shaped + macOS AppleDouble sidecars.
6. `tar -C $STAGE --no-xattrs -cf - . | docker exec -i -u node $CONTAINER bash -c 'tar -C /data/creds/<kind> -xf -'` so the extract runs as `node` and files are immediately traversable by the agent CLI.
7. Emit `{container, kind, injected_into}` JSON for the parent agent to chain off of.

## What's NOT in this PR
- **Tests**: integration only (Docker + host creds). Tracked for the eventual `--with-harness` upstream PR where it can land as TS unit tests against mocked docker.
- **Out-of-tree `@`-imports**: `@~/Documents/foo.md` style references that resolve outside the source config dir are intentionally warned + skipped, not inlined or path-rewritten.
- **Daemon lifecycle**: the skill stops at inject. Operator launches `vicoop-client --backend <kind> --runtime container` themselves in another shell.
- **MCP servers / settings.json / hooks**: left out of the allowlist on purpose — typically host-coupled (absolute paths, sockets) and don't survive the container boundary without rewriting.

## Test plan
- [x] Manual E2E on macOS 25.3 (Claude 2.1.148, Codex 0.133.0, Docker 27.4.0) against the deployed bridge:
  - claude fork: runtime container bootstrapped from scratch, host `~/.claude/{skills,commands,CLAUDE.md,RTK.md}` injected (RTK.md picked up via `@RTK.md` import), byte-identical to host.
  - codex fork: runtime container reused, `~/.codex/skills/` injected.
  - `vicoop-client --backend codex --runtime container` daemon connected to deployed bridge, hello logged, agent A2A endpoint published, SIGINT clean shutdown.
- [ ] Linux host smoke (`COPYFILE_DISABLE` / `--no-xattrs` are no-ops on GNU tar; unrun).
- [ ] Behavior when host has no harness at all (empty `~/.claude/{skills,agents,commands}` and no memory file) — falls through to "nothing to inject" log; unrun on a fresh host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)