### PR TITLE
feat(client): surface Claude Task subagent start/finish messages

### DIFF
--- a/.changeset/claude-task-subagent-bookends.md
+++ b/.changeset/claude-task-subagent-bookends.md
@@ -1,0 +1,16 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Surface Claude Task subagent activity as user-visible bookend messages.
+When the model invokes the built-in `Task` tool, the bridge now emits a
+`claude-message` artifact reading `Task started: <description>` (and a
+matching `Task completed: <description>` / `Task failed: <description>`
+when the subagent's `tool_result` returns). These bookends fire
+regardless of the traceability extension opt-in, closing the otherwise
+silent window between the model's Task call and its final response —
+previously callers (e.g. a Slack relay) saw zero progress while the
+subagent ran and could not tell whether the run had stalled. Artifact
+`metadata.event` carries `subagent-started` / `subagent-completed` /
+`subagent-failed` plus the `toolUseId` so consumers can correlate or
+style the lifecycle.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1542,7 +1542,56 @@ test('truncates a long tool_use input summary to a bounded length', async () => 
   assert.ok(textPart.text.endsWith('…'), 'truncation marker expected at tail');
 });
 
-test('Task tool_use surfaces start/finish bookend messages without traceability opt-in', async () => {
+test('subagent tool_use under the legacy "Task" name also fires bookends', async () => {
+  // The wire-level name from `claude -p --output-format stream-json` is
+  // `Agent` (verified against claude 2.1.148), but the user-facing
+  // surface and historical name is `Task`. We accept both so the
+  // bookends keep working if Claude Code renames the wire identifier.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_legacy_name',
+              name: 'Task',
+              input: { description: 'Legacy name path' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_legacy_name',
+              content: [{ type: 'text', text: 'ok' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'done' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('legacy path'), emit, NEVER);
+
+  const events = frames
+    .filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact')
+    .map((a) => a.artifact.metadata?.event)
+    .filter(Boolean);
+  assert.deepEqual(events, ['subagent-started', 'subagent-completed']);
+});
+
+test('subagent tool_use surfaces start/finish bookend messages without traceability opt-in', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1553,7 +1602,7 @@ test('Task tool_use surfaces start/finish bookend messages without traceability 
             {
               type: 'tool_use',
               id: 'tu_task_1',
-              name: 'Task',
+              name: 'Agent',
               input: { description: 'Search Bson transaction handlers', prompt: 'Find …' },
             },
           ],
@@ -1615,7 +1664,7 @@ test('Task tool_result with is_error=true emits a "Task failed" bookend', async 
             {
               type: 'tool_use',
               id: 'tu_task_err',
-              name: 'Task',
+              name: 'Agent',
               input: { description: 'Audit migrations', prompt: 'Check …' },
             },
           ],
@@ -1663,7 +1712,7 @@ test('Task bookend messages co-exist with trace artifacts when traceability is r
             {
               type: 'tool_use',
               id: 'tu_task_trace',
-              name: 'Task',
+              name: 'Agent',
               input: { description: 'Trace flow' },
             },
           ],
@@ -1714,7 +1763,7 @@ test('Task description falls back to bare "Task" when input.description is missi
             {
               type: 'tool_use',
               id: 'tu_task_nodesc',
-              name: 'Task',
+              name: 'Agent',
               input: { prompt: 'Do something' },
             },
           ],

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1542,6 +1542,200 @@ test('truncates a long tool_use input summary to a bounded length', async () => 
   assert.ok(textPart.text.endsWith('…'), 'truncation marker expected at tail');
 });
 
+test('Task tool_use surfaces start/finish bookend messages without traceability opt-in', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_task_1',
+              name: 'Task',
+              input: { description: 'Search Bson transaction handlers', prompt: 'Find …' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_task_1',
+              content: [{ type: 'text', text: 'subagent done' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Here is the summary.' }] },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'Here is the summary.' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  // Note: assign() — NO traceability extension.
+  await backend.handle(assign('look into Bson'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // Without trace, we get: subagent-started, subagent-completed, then the
+  // final assistant text. No claude-tool-call / claude-tool-result.
+  assert.deepEqual(
+    artifacts.map((a) => a.artifact.name),
+    ['claude-message', 'claude-message', 'claude-message'],
+  );
+  assert.equal(textOf(artifacts[0]), 'Task started: Search Bson transaction handlers');
+  assert.equal(artifacts[0].artifact.metadata?.event, 'subagent-started');
+  assert.equal(artifacts[0].artifact.metadata?.toolUseId, 'tu_task_1');
+  assert.equal(textOf(artifacts[1]), 'Task completed: Search Bson transaction handlers');
+  assert.equal(artifacts[1].artifact.metadata?.event, 'subagent-completed');
+  assert.equal(artifacts[1].artifact.metadata?.toolUseId, 'tu_task_1');
+  assert.equal(textOf(artifacts[2]), 'Here is the summary.');
+});
+
+test('Task tool_result with is_error=true emits a "Task failed" bookend', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_task_err',
+              name: 'Task',
+              input: { description: 'Audit migrations', prompt: 'Check …' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_task_err',
+              is_error: true,
+              content: [{ type: 'text', text: 'subagent error' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'gave up' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('try the audit'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  const failed = artifacts.find((a) => a.artifact.metadata?.event === 'subagent-failed');
+  assert.ok(failed, 'expected a subagent-failed message');
+  assert.equal(textOf(failed), 'Task failed: Audit migrations');
+});
+
+test('Task bookend messages co-exist with trace artifacts when traceability is requested', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_task_trace',
+              name: 'Task',
+              input: { description: 'Trace flow' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_task_trace',
+              content: [{ type: 'text', text: 'ok' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'done' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assignWithTraceability('trace it'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  const names = artifacts.map((a) => a.artifact.name);
+  // Sequence: started bookend, tool-call trace, completed bookend.
+  // Text-only tool_result content emits no claude-tool-result (only
+  // image/document blocks do), so we don't expect one for this run.
+  assert.deepEqual(names, ['claude-message', 'claude-tool-call', 'claude-message']);
+  assert.equal(artifacts[0].artifact.metadata?.event, 'subagent-started');
+  assert.equal(artifacts[2].artifact.metadata?.event, 'subagent-completed');
+});
+
+test('Task description falls back to bare "Task" when input.description is missing', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_task_nodesc',
+              name: 'Task',
+              input: { prompt: 'Do something' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('go'), emit, NEVER);
+
+  const started = frames
+    .filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact')
+    .find((a) => a.artifact.metadata?.event === 'subagent-started');
+  assert.ok(started, 'expected a subagent-started message even without description');
+  assert.equal(textOf(started), 'Task started: Task');
+});
+
 test('heartbeat: emits task.status after heartbeatMs of silence and stops at terminal time', async () => {
   // Initialize as a no-op so the type stays `() => void` instead of
   // `(() => void) | null`. The closure-mutation path through setIntervalFn

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -796,6 +796,60 @@ function extractAssistantToolUses(content: unknown): ToolUseBlock[] {
   return out;
 }
 
+// Cap on the Task `description` text we surface in subagent bookend
+// messages. Same head-truncation rule as tool-call summaries — long
+// descriptions get a single-char ellipsis so consumers can still tell
+// the message was clipped.
+const TASK_DESCRIPTION_MAX_CHARS = 200;
+
+// Pull the human-readable description out of a Task tool's input object.
+// Claude Code's built-in Task tool accepts `{ description, prompt,
+// subagent_type }`; `description` is the short 3-5-word label the model
+// is supposed to write. Returns the empty string if the field is missing
+// or unusable — the caller falls back to a bare "Task" label.
+function extractTaskDescription(input: unknown): string {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return '';
+  const i = input as { description?: unknown };
+  if (typeof i.description !== 'string') return '';
+  const trimmed = i.description.trim();
+  if (!trimmed) return '';
+  return clipTo(trimmed, TASK_DESCRIPTION_MAX_CHARS);
+}
+
+interface TaskCompletion {
+  toolUseId: string;
+  description: string;
+  isError: boolean;
+}
+
+// Walk a `user`-role event's content array for `tool_result` blocks
+// matching tool_use_ids we previously registered as in-flight Task runs.
+// We surface a bookend message per match so callers see the subagent
+// finished even when the subagent itself emitted no user-visible text
+// (its output is packed into the tool_result fed back to the main
+// agent, not into the assistant stream).
+function extractTaskCompletions(
+  content: unknown,
+  registry: ReadonlyMap<string, string>,
+): TaskCompletion[] {
+  if (!Array.isArray(content)) return [];
+  const out: TaskCompletion[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as { type?: unknown; tool_use_id?: unknown; is_error?: unknown };
+    if (b.type !== 'tool_result') continue;
+    if (typeof b.tool_use_id !== 'string') continue;
+    const description = registry.get(b.tool_use_id);
+    if (description === undefined) continue;
+    out.push({
+      toolUseId: b.tool_use_id,
+      description,
+      isError: b.is_error === true,
+    });
+  }
+  return out;
+}
+
 // Pull image/document blocks out of a `user`-role event's `tool_result`
 // content array. MCP screenshot tools, image-generation tools, and built-in
 // Read on a media file all surface here. Returned in encounter order.
@@ -1498,6 +1552,14 @@ export function createClaudeBackend(
       let aborted = false;
       let settled = false;
       const emitTraceArtifacts = traceabilityRequested(task);
+      // tool_use_id → description for in-flight Task subagent runs.
+      // Populated when a `Task` tool_use is observed; drained when the
+      // matching tool_result returns so we can bookend the long silence
+      // while the subagent is running with a visible "started/completed"
+      // message. Surfaces regardless of the traceability opt-in because
+      // without it callers see ZERO progress between the model's Task
+      // call and its final response.
+      const activeTaskRuns = new Map<string, string>();
 
       // Register this task with the send_file MCP server (if running) so
       // tool calls landing during this run resolve to this task's emit().
@@ -1555,6 +1617,37 @@ export function createClaudeBackend(
             parts,
             extensions: [TRACEABILITY_EXTENSION_URI],
             metadata: { traceType: 'tool-result' },
+          },
+          lastChunk: true,
+        });
+        emittedAnyArtifact = true;
+      };
+
+      // Surface a subagent lifecycle bookend as a `claude-message`
+      // artifact (NOT a trace artifact) so callers see it without opting
+      // into the traceability extension. The structured event +
+      // toolUseId on `metadata` let smart consumers style/correlate
+      // start↔end, but a plain text reader sees a normal chat message.
+      const emitSubagentEventArtifact = (
+        event: 'subagent-started' | 'subagent-completed' | 'subagent-failed',
+        toolUseId: string,
+        description: string,
+      ): void => {
+        const verb =
+          event === 'subagent-started'
+            ? 'started'
+            : event === 'subagent-completed'
+              ? 'completed'
+              : 'failed';
+        const label = description || 'Task';
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: randomUUID(),
+            name: 'claude-message',
+            parts: [{ kind: 'text', text: `Task ${verb}: ${label}` }],
+            metadata: { event, toolUseId },
           },
           lastChunk: true,
         });
@@ -1624,13 +1717,38 @@ export function createClaudeBackend(
               });
               child.stdin.write(toolResult + '\n');
               try { child.stdin.end(); } catch { /* best effort */ }
-            } else if (emitTraceArtifacts) {
-              emitToolCallArtifact(tu);
+            } else {
+              // Surface Task starts as user-visible messages independently
+              // of the trace artifact stream — they bookend the otherwise
+              // silent window while the subagent runs. Trace artifact (if
+              // requested) still fires so trace-aware consumers see the
+              // structured tool-call alongside the human-readable bookend.
+              if (tu.toolName === 'Task' && tu.toolUseId) {
+                const description = extractTaskDescription(tu.input);
+                activeTaskRuns.set(tu.toolUseId, description);
+                emitSubagentEventArtifact('subagent-started', tu.toolUseId, description);
+              }
+              if (emitTraceArtifacts) emitToolCallArtifact(tu);
             }
           }
           return;
         }
         if (evt.type === 'user') {
+          // Task completion bookends must fire BEFORE the trace gate —
+          // they are always user-visible, regardless of the traceability
+          // opt-in, to close the loop on the start message we emitted
+          // above. A subagent that errored surfaces as "Task failed: ..."
+          // so the caller can tell their request didn't quietly succeed.
+          if (activeTaskRuns.size > 0) {
+            for (const done of extractTaskCompletions(evt.message?.content, activeTaskRuns)) {
+              activeTaskRuns.delete(done.toolUseId);
+              emitSubagentEventArtifact(
+                done.isError ? 'subagent-failed' : 'subagent-completed',
+                done.toolUseId,
+                done.description,
+              );
+            }
+          }
           if (!emitTraceArtifacts) return;
           // tool_result events come in as a synthetic user message in the
           // stream-json transcript; pull out any image/document blocks and

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -802,8 +802,16 @@ function extractAssistantToolUses(content: unknown): ToolUseBlock[] {
 // the message was clipped.
 const TASK_DESCRIPTION_MAX_CHARS = 200;
 
-// Pull the human-readable description out of a Task tool's input object.
-// Claude Code's built-in Task tool accepts `{ description, prompt,
+// Tool names that, on the wire, identify a Claude Code subagent
+// invocation. The user-facing tool is "Task" in the docs and the
+// interactive UI, but `claude -p --output-format stream-json` emits
+// `name: "Agent"` in the assistant tool_use block (verified against
+// claude 2.1.148). We accept both so the bookends stay correct if
+// Claude Code renames the wire identifier in either direction.
+const SUBAGENT_TOOL_NAMES: ReadonlySet<string> = new Set(['Agent', 'Task']);
+
+// Pull the human-readable description out of a subagent tool's input
+// object. Claude Code's Agent/Task tool accepts `{ description, prompt,
 // subagent_type }`; `description` is the short 3-5-word label the model
 // is supposed to write. Returns the empty string if the field is missing
 // or unusable — the caller falls back to a bare "Task" label.
@@ -1718,12 +1726,13 @@ export function createClaudeBackend(
               child.stdin.write(toolResult + '\n');
               try { child.stdin.end(); } catch { /* best effort */ }
             } else {
-              // Surface Task starts as user-visible messages independently
-              // of the trace artifact stream — they bookend the otherwise
-              // silent window while the subagent runs. Trace artifact (if
-              // requested) still fires so trace-aware consumers see the
-              // structured tool-call alongside the human-readable bookend.
-              if (tu.toolName === 'Task' && tu.toolUseId) {
+              // Surface subagent starts as user-visible messages
+              // independently of the trace artifact stream — they
+              // bookend the otherwise silent window while the subagent
+              // runs. Trace artifact (if requested) still fires so
+              // trace-aware consumers see the structured tool-call
+              // alongside the human-readable bookend.
+              if (SUBAGENT_TOOL_NAMES.has(tu.toolName) && tu.toolUseId) {
                 const description = extractTaskDescription(tu.input);
                 activeTaskRuns.set(tu.toolUseId, description);
                 emitSubagentEventArtifact('subagent-started', tu.toolUseId, description);


### PR DESCRIPTION
## Summary
- Emit a `claude-message` artifact `Task started: <description>` when the model invokes the built-in `Task` tool, and a matching `Task completed: <description>` / `Task failed: <description>` when its `tool_result` returns. These bookends fire regardless of the traceability extension opt-in, closing the silent window between the `Task` call and the model's final reply — previously a Slack/A2A caller saw zero progress while the subagent ran (Claude Code packs the subagent's output into the parent `tool_result` rather than emitting it as an assistant message) and could not tell whether the run had stalled.
- Artifact `metadata.event` carries `subagent-started` / `subagent-completed` / `subagent-failed` plus the `toolUseId` so consumers can correlate the start↔end pair or restyle the lifecycle without parsing the text.
- Trace-aware callers still receive the existing `claude-tool-call` artifact alongside the bookend — the two paths are additive.

## Test plan
- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm -r build`
- [x] `pnpm --filter @vicoop-bridge/client test` (517/517 — adds 4 new tests: no-trace bookend, `is_error: true` → failed, trace co-existence, missing `description` fallback)
- [ ] Manual smoke: invoke a Task-using prompt over a Slack relay and confirm the start/finish messages appear without trace opt-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)