### PR TITLE
refactor(client): gate Claude subagent bookends on traceability ext

### DIFF
--- a/.changeset/gate-subagent-bookends-on-traceability.md
+++ b/.changeset/gate-subagent-bookends-on-traceability.md
@@ -1,0 +1,30 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Reshape the Claude subagent lifecycle bookend (added in #274) as a
+proper trace artifact. The previous version emitted unconditionally as
+a `claude-message`, which leaked execution-trace detail to callers
+that had not opted into the traceability extension and made the
+artifact-name semantics ("model's words to the user") incorrect. The
+bookend now rides the same opt-in as `claude-tool-call` /
+`claude-tool-result`:
+
+- Artifact name: `claude-subagent-event`
+- `extensions: [traceability/v1]` and `metadata.traceType: "subagent-event"`
+- Carries the same lifecycle text (`Task started/completed/failed:
+  <description>`) plus a structured `data` part
+  (`{event, toolUseId, description}`) for correlation
+- Only emitted when the task's `requestedExtensions` (or the inbound
+  message's `extensions`) includes the traceability URI
+
+Trace-aware A2A consumers already render `claude-tool-call` for the
+underlying `Agent` invocation; the bookend pair adds value over that
+alone because text-only subagent results don't fire a
+`claude-tool-result` — without the explicit "completed" marker, trace
+consumers would see "started" with no matching finish event.
+
+Verified end-to-end against the deployed bridge: trace ON → both
+bookend artifacts plus the raw `claude-tool-call` line up around the
+subagent run; trace OFF → only the model's final `claude-message`,
+nothing else.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1542,7 +1542,65 @@ test('truncates a long tool_use input summary to a bounded length', async () => 
   assert.ok(textPart.text.endsWith('…'), 'truncation marker expected at tail');
 });
 
-test('subagent tool_use under the legacy "Task" name also fires bookends', async () => {
+test('subagent tool_use is silent without traceability opt-in', async () => {
+  // The subagent lifecycle is execution-trace detail (which tool ran,
+  // when it finished) and must ride the traceability extension just
+  // like `claude-tool-call` / `claude-tool-result`. A task that did NOT
+  // request the extension sees only assistant text, never the bookend.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tu_no_trace',
+              name: 'Agent',
+              input: { description: 'No trace allowed' },
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu_no_trace',
+              content: [{ type: 'text', text: 'subagent done' }],
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Final.' }] },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'Final.' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
+  const { emit, frames } = collect();
+  await backend.handle(assign('no trace'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // Only the final assistant-text artifact survives — no
+  // claude-subagent-event, no claude-tool-call, no claude-tool-result.
+  assert.deepEqual(
+    artifacts.map((a) => a.artifact.name),
+    ['claude-message'],
+  );
+  assert.equal(textOf(artifacts[0]), 'Final.');
+});
+
+test('subagent tool_use under the legacy "Task" name also fires the trace bookend', async () => {
   // The wire-level name from `claude -p --output-format stream-json` is
   // `Agent` (verified against claude 2.1.148), but the user-facing
   // surface and historical name is `Task`. We accept both so the
@@ -1582,16 +1640,16 @@ test('subagent tool_use under the legacy "Task" name also fires bookends', async
   });
   const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
   const { emit, frames } = collect();
-  await backend.handle(assign('legacy path'), emit, NEVER);
+  await backend.handle(assignWithTraceability('legacy path'), emit, NEVER);
 
   const events = frames
     .filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact')
-    .map((a) => a.artifact.metadata?.event)
-    .filter(Boolean);
+    .filter((a) => a.artifact.name === 'claude-subagent-event')
+    .map((a) => a.artifact.metadata?.event);
   assert.deepEqual(events, ['subagent-started', 'subagent-completed']);
 });
 
-test('subagent tool_use surfaces start/finish bookend messages without traceability opt-in', async () => {
+test('subagent tool_use surfaces start/finish trace artifacts when traceability is requested', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1632,28 +1690,39 @@ test('subagent tool_use surfaces start/finish bookend messages without traceabil
 
   const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
   const { emit, frames } = collect();
-  // Note: assign() — NO traceability extension.
-  await backend.handle(assign('look into Bson'), emit, NEVER);
+  await backend.handle(assignWithTraceability('look into Bson'), emit, NEVER);
 
   const artifacts = frames.filter(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
   );
-  // Without trace, we get: subagent-started, subagent-completed, then the
-  // final assistant text. No claude-tool-call / claude-tool-result.
+  // Sequence with trace ON: subagent-started, the raw tool-call,
+  // subagent-completed, then the final assistant text. Text-only
+  // tool_result content does not produce a claude-tool-result.
   assert.deepEqual(
     artifacts.map((a) => a.artifact.name),
-    ['claude-message', 'claude-message', 'claude-message'],
+    ['claude-subagent-event', 'claude-tool-call', 'claude-subagent-event', 'claude-message'],
   );
-  assert.equal(textOf(artifacts[0]), 'Task started: Search Bson transaction handlers');
-  assert.equal(artifacts[0].artifact.metadata?.event, 'subagent-started');
-  assert.equal(artifacts[0].artifact.metadata?.toolUseId, 'tu_task_1');
-  assert.equal(textOf(artifacts[1]), 'Task completed: Search Bson transaction handlers');
-  assert.equal(artifacts[1].artifact.metadata?.event, 'subagent-completed');
-  assert.equal(artifacts[1].artifact.metadata?.toolUseId, 'tu_task_1');
-  assert.equal(textOf(artifacts[2]), 'Here is the summary.');
+  const started = artifacts[0];
+  assert.equal(textOf(started), 'Task started: Search Bson transaction handlers');
+  assert.equal(started.artifact.metadata?.event, 'subagent-started');
+  assert.equal(started.artifact.metadata?.traceType, 'subagent-event');
+  assert.equal(started.artifact.metadata?.toolUseId, 'tu_task_1');
+  assert.deepEqual(started.artifact.extensions, [TRACEABILITY_EXTENSION_URI]);
+  const dataPart = started.artifact.parts[1];
+  assert.equal(dataPart.kind, 'data');
+  if (dataPart.kind === 'data') {
+    assert.equal(dataPart.data.event, 'subagent-started');
+    assert.equal(dataPart.data.toolUseId, 'tu_task_1');
+    assert.equal(dataPart.data.description, 'Search Bson transaction handlers');
+  }
+  const completed = artifacts[2];
+  assert.equal(textOf(completed), 'Task completed: Search Bson transaction handlers');
+  assert.equal(completed.artifact.metadata?.event, 'subagent-completed');
+  assert.equal(completed.artifact.metadata?.toolUseId, 'tu_task_1');
+  assert.equal(textOf(artifacts[3]), 'Here is the summary.');
 });
 
-test('Task tool_result with is_error=true emits a "Task failed" bookend', async () => {
+test('subagent tool_result with is_error=true emits a "Task failed" trace bookend', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1691,68 +1760,17 @@ test('Task tool_result with is_error=true emits a "Task failed" bookend', async 
 
   const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
   const { emit, frames } = collect();
-  await backend.handle(assign('try the audit'), emit, NEVER);
+  await backend.handle(assignWithTraceability('try the audit'), emit, NEVER);
 
-  const artifacts = frames.filter(
-    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
-  );
-  const failed = artifacts.find((a) => a.artifact.metadata?.event === 'subagent-failed');
-  assert.ok(failed, 'expected a subagent-failed message');
+  const failed = frames
+    .filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact')
+    .find((a) => a.artifact.metadata?.event === 'subagent-failed');
+  assert.ok(failed, 'expected a subagent-failed trace artifact');
+  assert.equal(failed.artifact.name, 'claude-subagent-event');
   assert.equal(textOf(failed), 'Task failed: Audit migrations');
 });
 
-test('Task bookend messages co-exist with trace artifacts when traceability is requested', async () => {
-  const fake = scriptedSpawn({
-    lines: [
-      JSON.stringify({
-        type: 'assistant',
-        message: {
-          role: 'assistant',
-          content: [
-            {
-              type: 'tool_use',
-              id: 'tu_task_trace',
-              name: 'Agent',
-              input: { description: 'Trace flow' },
-            },
-          ],
-        },
-      }),
-      JSON.stringify({
-        type: 'user',
-        message: {
-          role: 'user',
-          content: [
-            {
-              type: 'tool_result',
-              tool_use_id: 'tu_task_trace',
-              content: [{ type: 'text', text: 'ok' }],
-            },
-          ],
-        },
-      }),
-      JSON.stringify({ type: 'result', subtype: 'success', result: 'done' }),
-    ],
-    exitCode: 0,
-  });
-
-  const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
-  const { emit, frames } = collect();
-  await backend.handle(assignWithTraceability('trace it'), emit, NEVER);
-
-  const artifacts = frames.filter(
-    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
-  );
-  const names = artifacts.map((a) => a.artifact.name);
-  // Sequence: started bookend, tool-call trace, completed bookend.
-  // Text-only tool_result content emits no claude-tool-result (only
-  // image/document blocks do), so we don't expect one for this run.
-  assert.deepEqual(names, ['claude-message', 'claude-tool-call', 'claude-message']);
-  assert.equal(artifacts[0].artifact.metadata?.event, 'subagent-started');
-  assert.equal(artifacts[2].artifact.metadata?.event, 'subagent-completed');
-});
-
-test('Task description falls back to bare "Task" when input.description is missing', async () => {
+test('subagent description falls back to bare "Task" when input.description is missing', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1776,12 +1794,12 @@ test('Task description falls back to bare "Task" when input.description is missi
 
   const backend = createClaudeBackend({ spawn: fake.spawn, heartbeatMs: 0 });
   const { emit, frames } = collect();
-  await backend.handle(assign('go'), emit, NEVER);
+  await backend.handle(assignWithTraceability('go'), emit, NEVER);
 
   const started = frames
     .filter((f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact')
     .find((a) => a.artifact.metadata?.event === 'subagent-started');
-  assert.ok(started, 'expected a subagent-started message even without description');
+  assert.ok(started, 'expected a subagent-started trace artifact even without description');
   assert.equal(textOf(started), 'Task started: Task');
 });
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -831,11 +831,13 @@ interface TaskCompletion {
 }
 
 // Walk a `user`-role event's content array for `tool_result` blocks
-// matching tool_use_ids we previously registered as in-flight Task runs.
-// We surface a bookend message per match so callers see the subagent
-// finished even when the subagent itself emitted no user-visible text
-// (its output is packed into the tool_result fed back to the main
-// agent, not into the assistant stream).
+// matching tool_use_ids we previously registered as in-flight subagent
+// runs. We pair each with a `claude-subagent-event` trace artifact so
+// consumers see the subagent finished even though its output is packed
+// into the tool_result fed back to the main agent rather than the
+// assistant stream — and a text-only subagent result, which would not
+// otherwise produce a `claude-tool-result` trace artifact, still gets
+// a "completed" marker.
 function extractTaskCompletions(
   content: unknown,
   registry: ReadonlyMap<string, string>,
@@ -1560,13 +1562,12 @@ export function createClaudeBackend(
       let aborted = false;
       let settled = false;
       const emitTraceArtifacts = traceabilityRequested(task);
-      // tool_use_id → description for in-flight Task subagent runs.
-      // Populated when a `Task` tool_use is observed; drained when the
-      // matching tool_result returns so we can bookend the long silence
-      // while the subagent is running with a visible "started/completed"
-      // message. Surfaces regardless of the traceability opt-in because
-      // without it callers see ZERO progress between the model's Task
-      // call and its final response.
+      // tool_use_id → description for in-flight subagent runs.
+      // Populated when an `Agent`/`Task` tool_use is observed (and
+      // traceability is opted-in); drained when the matching
+      // tool_result returns so we can pair the start with a
+      // completed/failed bookend in the trace stream. Outside trace
+      // mode it stays empty — see the assistant handler below.
       const activeTaskRuns = new Map<string, string>();
 
       // Register this task with the send_file MCP server (if running) so
@@ -1631,16 +1632,21 @@ export function createClaudeBackend(
         emittedAnyArtifact = true;
       };
 
-      // Surface a subagent lifecycle bookend as a `claude-message`
-      // artifact (NOT a trace artifact) so callers see it without opting
-      // into the traceability extension. The structured event +
-      // toolUseId on `metadata` let smart consumers style/correlate
-      // start↔end, but a plain text reader sees a normal chat message.
+      // Surface a subagent lifecycle event as a `claude-subagent-event`
+      // trace artifact. Mirrors the `claude-tool-call` /
+      // `claude-tool-result` shape (text summary + structured `data`
+      // part + `extensions: [TRACEABILITY_EXTENSION_URI]` +
+      // `metadata.traceType`) so it sits alongside them under the same
+      // opt-in. The lifecycle pair adds value over `claude-tool-call`
+      // alone because text-only subagent results don't otherwise
+      // produce a `claude-tool-result` artifact — without this, trace
+      // consumers see "Agent started" but never a matching "finished".
       const emitSubagentEventArtifact = (
         event: 'subagent-started' | 'subagent-completed' | 'subagent-failed',
         toolUseId: string,
         description: string,
       ): void => {
+        if (!emitTraceArtifacts) return;
         const verb =
           event === 'subagent-started'
             ? 'started'
@@ -1653,9 +1659,13 @@ export function createClaudeBackend(
           taskId: task.taskId,
           artifact: {
             artifactId: randomUUID(),
-            name: 'claude-message',
-            parts: [{ kind: 'text', text: `Task ${verb}: ${label}` }],
-            metadata: { event, toolUseId },
+            name: 'claude-subagent-event',
+            parts: [
+              { kind: 'text', text: `Task ${verb}: ${label}` },
+              { kind: 'data', data: { event, toolUseId, description: label } },
+            ],
+            extensions: [TRACEABILITY_EXTENSION_URI],
+            metadata: { traceType: 'subagent-event', event, toolUseId },
           },
           lastChunk: true,
         });
@@ -1726,13 +1736,20 @@ export function createClaudeBackend(
               child.stdin.write(toolResult + '\n');
               try { child.stdin.end(); } catch { /* best effort */ }
             } else {
-              // Surface subagent starts as user-visible messages
-              // independently of the trace artifact stream — they
-              // bookend the otherwise silent window while the subagent
-              // runs. Trace artifact (if requested) still fires so
-              // trace-aware consumers see the structured tool-call
-              // alongside the human-readable bookend.
-              if (SUBAGENT_TOOL_NAMES.has(tu.toolName) && tu.toolUseId) {
+              // Pair subagent tool_use blocks with their tool_result via
+              // a `claude-subagent-event` lifecycle artifact so trace
+              // consumers see a clean "Agent started / completed"
+              // bookend alongside the raw `claude-tool-call` summary —
+              // text-only subagent results don't fire a
+              // `claude-tool-result`, so without this pair they'd see
+              // "started" with no matching "finished". Both sides ride
+              // the same traceability opt-in; skip registry tracking
+              // entirely when trace is off.
+              if (
+                emitTraceArtifacts &&
+                SUBAGENT_TOOL_NAMES.has(tu.toolName) &&
+                tu.toolUseId
+              ) {
                 const description = extractTaskDescription(tu.input);
                 activeTaskRuns.set(tu.toolUseId, description);
                 emitSubagentEventArtifact('subagent-started', tu.toolUseId, description);
@@ -1743,11 +1760,11 @@ export function createClaudeBackend(
           return;
         }
         if (evt.type === 'user') {
-          // Task completion bookends must fire BEFORE the trace gate —
-          // they are always user-visible, regardless of the traceability
-          // opt-in, to close the loop on the start message we emitted
-          // above. A subagent that errored surfaces as "Task failed: ..."
-          // so the caller can tell their request didn't quietly succeed.
+          // Pair subagent completions back to the start events emitted
+          // above. The registry is only populated when trace is on (see
+          // the assistant handler above), so this loop is a no-op when
+          // trace is off — the size check just avoids walking content
+          // arrays in that path.
           if (activeTaskRuns.size > 0) {
             for (const done of extractTaskCompletions(evt.message?.content, activeTaskRuns)) {
               activeTaskRuns.delete(done.toolUseId);


### PR DESCRIPTION
Follow-up to #274. The bookend added there was unconditionally emitted as a `claude-message`, which (a) leaked execution-trace detail to callers that had not opted into the traceability extension and (b) misused the `claude-message` artifact name (its semantics are "the model's words to the user", not a synthetic lifecycle marker).

## Summary
- Rename the artifact to `claude-subagent-event` and emit it under the same opt-in as `claude-tool-call` / `claude-tool-result`
- `extensions: [traceability/v1]` + `metadata.traceType: "subagent-event"`
- Added a structured `data` part (`{event, toolUseId, description}`) alongside the existing text summary
- Gate the registry write + completion walk on the traceability opt-in — when trace is off the bookend stays silent

The pair still adds value over `claude-tool-call` alone for trace consumers: text-only subagent results don't fire a `claude-tool-result`, so without the explicit "completed" marker trace consumers would see "started" with no matching finish event.

## Test plan
- [x] `pnpm --filter @vicoop-bridge/client typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` (518 pass — 5 subagent-event tests realigned + 1 explicit "silent without trace opt-in" test added)
- [x] E2E trace ON (via curl JSON-RPC `message/stream` with `message.extensions: [traceability/v1]`) → stream contained `claude-subagent-event` started + `claude-tool-call` (Agent) + `claude-subagent-event` completed + final `claude-message`
- [x] E2E trace OFF (via `a2a-wallet a2a stream`) → only the final `claude-message`; no `claude-subagent-event`, no `claude-tool-call`

🤖 Generated with [Claude Code](https://claude.com/claude-code)