### PR TITLE
[codex] start fork skill daemon

### DIFF
--- a/skills/fork-into-container/SKILL.md
+++ b/skills/fork-into-container/SKILL.md
@@ -89,6 +89,20 @@ Optional env overrides:
 | Var | Meaning |
 |---|---|
 | `VICOOP_FORK_KIND` | force `claude` or `codex` (only needed when invoked from outside a skill tree with both config dirs present) |
+| `VICOOP_FORK_DAEMON` | daemon handling mode: `start` (default), `manual`, `restart`, or `stop` |
+| `VICOOP_FORK_STATE_DIR` | override pid/log directory (default: `$XDG_STATE_HOME/vicoop-fork-into-container` or `~/.local/state/vicoop-fork-into-container`) |
+
+Daemon modes:
+
+- `start`: after injecting the harness, start
+  `vicoop-client --backend <kind> --runtime container --runtime-name <kind>`
+  in the background unless the skill's pidfile already points at a
+  matching live process.
+- `manual`: preserve the old behavior and only print the daemon command.
+- `restart`: terminate the skill-owned daemon if present, then start it
+  again.
+- `stop`: terminate the skill-owned daemon and exit without touching the
+  runtime container or harness.
 
 ## What the script does
 
@@ -109,16 +123,24 @@ Optional env overrides:
 5. `tar -C $STAGE --no-xattrs -cf - . | docker exec -i -u node $CONTAINER bash -c "tar -C /data/creds/<kind> -xf -"`.
    Tar-pipe (not `docker cp`) so the extract runs as the `node` user
    and the agent CLI can traverse the files immediately.
-6. Print the daemon-start command:
-   `vicoop-client --backend <kind> --runtime container --runtime-name <kind>`
-7. Emit `{container, runtime_name, kind, injected_into}` JSON for the
-   parent agent to chain off of.
+6. Restore the runtime container to its original stopped/running state
+   after the inject window.
+7. Start, restart, stop, or skip the bridge daemon according to
+   `VICOOP_FORK_DAEMON`. Background daemon output is appended to the
+   per-kind log file in the state dir.
+8. Emit `{container, runtime_name, kind, injected_into, daemon_mode,
+   daemon_pid, daemon_log}` JSON for the parent agent to chain off of.
 
 ## What this skill does NOT do
 
-- **Start the daemon.** The bridge client is a long-running process;
-  the operator launches it in their own shell after this skill
-  finishes. (Auto-starting from inside a skill is awkward and racy.)
+- **Claim ownership of arbitrary daemons.** It only reuses or stops a
+  process whose pidfile still points at a live `vicoop-client` command
+  with the expected backend/runtime flags. Anything the operator started
+  by hand is left alone.
+- **Guarantee session-end cleanup.** Agent runtimes differ in whether
+  they expose a reliable session-end hook. Use
+  `VICOOP_FORK_DAEMON=stop` from such a hook if you want automatic
+  teardown; otherwise the next skill run will reuse the existing daemon.
 - **Re-inject on every call.** Tar-extract overlays existing files;
   re-running the skill refreshes the harness in place. Removed files
   on the host stay in the container until the operator wipes the

--- a/skills/fork-into-container/fork.sh
+++ b/skills/fork-into-container/fork.sh
@@ -17,6 +17,87 @@ set -euo pipefail
 log() { printf '[fork] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
 
+DAEMON_MODE="${VICOOP_FORK_DAEMON:-start}"
+case "$DAEMON_MODE" in
+    start|manual|stop|restart) ;;
+    *) die "unsupported VICOOP_FORK_DAEMON='$DAEMON_MODE' (expected start|manual|stop|restart)" ;;
+esac
+
+STATE_DIR="${VICOOP_FORK_STATE_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/vicoop-fork-into-container}"
+mkdir -p "$STATE_DIR"
+
+daemon_pid_file() { printf '%s/vicoop-%s.pid' "$STATE_DIR" "$KIND"; }
+daemon_log_file() { printf '%s/vicoop-%s.log' "$STATE_DIR" "$KIND"; }
+
+daemon_command_matches() {
+    local pid="$1"
+    ps -p "$pid" -o command= 2>/dev/null \
+        | grep -Eq "vicoop-client .*--backend[ =]$KIND( |$).*--runtime[ =]container( |$).*--runtime-name[ =]$KIND( |$)"
+}
+
+daemon_running_pid() {
+    local pid_file pid
+    pid_file="$(daemon_pid_file)"
+    [[ -f "$pid_file" ]] || return 1
+    pid="$(cat "$pid_file" 2>/dev/null || true)"
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    daemon_command_matches "$pid" || return 1
+    printf '%s\n' "$pid"
+}
+
+stop_daemon() {
+    local pid_file pid
+    pid_file="$(daemon_pid_file)"
+    pid="$(daemon_running_pid 2>/dev/null || true)"
+    if [[ -z "$pid" ]]; then
+        [[ -f "$pid_file" ]] && rm -f "$pid_file"
+        log "daemon not running for $KIND"
+        return 0
+    fi
+
+    log "stopping daemon pid $pid"
+    kill -TERM "$pid" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+        kill -0 "$pid" 2>/dev/null || break
+        sleep 1
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+        log "daemon pid $pid did not exit after SIGTERM; sending SIGKILL"
+        kill -KILL "$pid" 2>/dev/null || true
+    fi
+    rm -f "$pid_file"
+}
+
+start_daemon() {
+    local pid pid_file log_file
+    pid_file="$(daemon_pid_file)"
+    log_file="$(daemon_log_file)"
+
+    pid="$(daemon_running_pid 2>/dev/null || true)"
+    if [[ -n "$pid" ]]; then
+        log "daemon already running for $KIND (pid $pid)"
+        log "log: $log_file"
+        printf '%s\n' "$pid"
+        return 0
+    fi
+    [[ -f "$pid_file" ]] && rm -f "$pid_file"
+
+    log "starting bridge daemon in background"
+    log "log: $log_file"
+    nohup vicoop-client --backend "$KIND" --runtime container --runtime-name "$KIND" \
+        >>"$log_file" 2>&1 &
+    pid="$!"
+    echo "$pid" > "$pid_file"
+    sleep 1
+    if ! kill -0 "$pid" 2>/dev/null; then
+        rm -f "$pid_file"
+        die "daemon exited during startup; inspect $log_file"
+    fi
+    log "daemon pid: $pid"
+    printf '%s\n' "$pid"
+}
+
 # ── detect parent kind ────────────────────────────────────────────────────
 # Priority (strongest signal first):
 #   1) VICOOP_FORK_KIND env override                     (caller handles)
@@ -60,13 +141,20 @@ esac
 [[ -d "$SRC_DIR" ]] || die "source config dir not found: $SRC_DIR"
 log "source: $SRC_DIR"
 
+CONTAINER="vicoop-runtime-$KIND"
+TARGET="/data/creds/$KIND"
+
+if [[ "$DAEMON_MODE" == "stop" ]]; then
+    stop_daemon
+    printf '{"container":"%s","runtime_name":"%s","kind":"%s","daemon_mode":"stop","daemon_pid":null,"daemon_log":"%s"}\n' \
+        "$CONTAINER" "$KIND" "$KIND" "$(daemon_log_file)"
+    exit 0
+fi
+
 # ── preflight ─────────────────────────────────────────────────────────────
 command -v docker         >/dev/null 2>&1 || die "docker not found in PATH"
 command -v vicoop-client  >/dev/null 2>&1 || die "vicoop-client not found in PATH (install: https://github.com/planetarium/vicoop-bridge)"
 docker info >/dev/null 2>&1 || die "docker daemon not reachable"
-
-CONTAINER="vicoop-runtime-$KIND"
-TARGET="/data/creds/$KIND"
 
 # ── ensure runtime container exists (delegates auth + image + volume) ──────
 if docker inspect "$CONTAINER" >/dev/null 2>&1; then
@@ -215,9 +303,31 @@ else
     log "nothing to inject (source has no skills/agents/commands/$MEMORY_FILE)"
 fi
 
-log ""
-log "done. start the bridge daemon (in another shell) with:"
-log "    vicoop-client --backend $KIND --runtime container --runtime-name $KIND"
+# Restore the runtime container before starting the daemon. That avoids
+# racing the short-lived inject window cleanup against RuntimeContainer.start().
+cleanup
+trap - EXIT
 
-printf '{"container":"%s","runtime_name":"%s","kind":"%s","injected_into":"%s"}\n' \
-    "$CONTAINER" "$KIND" "$KIND" "$TARGET"
+DAEMON_PID=""
+case "$DAEMON_MODE" in
+    manual)
+        log ""
+        log "done. start the bridge daemon (in another shell) with:"
+        log "    vicoop-client --backend $KIND --runtime container --runtime-name $KIND"
+        ;;
+    restart)
+        stop_daemon
+        DAEMON_PID="$(start_daemon)"
+        ;;
+    start)
+        DAEMON_PID="$(start_daemon)"
+        ;;
+esac
+
+if [[ -n "$DAEMON_PID" ]]; then
+    printf '{"container":"%s","runtime_name":"%s","kind":"%s","injected_into":"%s","daemon_mode":"%s","daemon_pid":%s,"daemon_log":"%s"}\n' \
+        "$CONTAINER" "$KIND" "$KIND" "$TARGET" "$DAEMON_MODE" "$DAEMON_PID" "$(daemon_log_file)"
+else
+    printf '{"container":"%s","runtime_name":"%s","kind":"%s","injected_into":"%s","daemon_mode":"%s","daemon_pid":null,"daemon_log":"%s"}\n' \
+        "$CONTAINER" "$KIND" "$KIND" "$TARGET" "$DAEMON_MODE" "$(daemon_log_file)"
+fi


### PR DESCRIPTION
## What changed

- The fork-into-container skill now starts the matching `vicoop-client --runtime container` daemon in the background by default after harness injection.
- Added pid/log tracking under a per-kind state directory, with reuse for an already-live skill-owned daemon.
- Added `VICOOP_FORK_DAEMON=manual|start|restart|stop` and `VICOOP_FORK_STATE_DIR` controls.
- Updated skill docs to describe daemon ownership, logs, and the limits around session-end cleanup.

## Why

Forking into a container is easier to use when the bridge daemon is already running after the skill finishes. The implementation keeps the ownership boundary narrow: it only stops or reuses a pidfile-backed process whose command line matches the expected backend/runtime flags.

## Validation

- `bash -n skills/fork-into-container/fork.sh`
- `shellcheck skills/fork-into-container/fork.sh`
- `VICOOP_FORK_KIND=codex VICOOP_FORK_DAEMON=stop VICOOP_FORK_STATE_DIR=$(mktemp -d -t vicoop-fork-test.XXXXXX) bash skills/fork-into-container/fork.sh`
- `git diff --check -- skills/fork-into-container/fork.sh skills/fork-into-container/SKILL.md`