### PR TITLE
feat(install): auto-add INSTALL_DIR to PATH (closes #277)

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -117,10 +117,12 @@ the matching rc file so `vicoop-client` works from any new terminal:
 | `fish` | `${XDG_CONFIG_HOME:-~/.config}/fish/config.fish` | `fish_add_path $INSTALL_DIR` |
 
 Each entry is prefixed with a `# vicoop-bridge-client (vicoop-client)`
-marker comment so re-running `install.sh` (including with `FORCE=1`)
-detects the existing line and won't duplicate it. If `$INSTALL_DIR` sits
-under `$HOME`, the appended line is written with a literal `$HOME/...`
-prefix so it stays portable across machines for the same operator.
+marker comment. Re-running `install.sh` (including with `FORCE=1` or with
+a different `$INSTALL_DIR`) strips the existing marker block and
+re-appends it with the current target so the rc file never accumulates
+duplicates or stale paths. If `$INSTALL_DIR` sits under `$HOME`, the
+appended line is written with a literal `$HOME/...` prefix so it stays
+portable across machines for the same operator.
 
 To pick the change up in the shell where you just ran `install.sh`, either
 open a new terminal or `source` the rc file the installer prints in its
@@ -140,8 +142,9 @@ with `"$INSTALL_DIR/"` — e.g. `"$INSTALL_DIR/vicoop-client" --version`.
 Set `NO_MODIFY_PATH=1` on the same `install.sh` invocation if you'd rather
 manage `PATH` yourself — recommended on NixOS, immutable OSes, or when a
 dotfile manager (chezmoi, yadm, etc.) owns your shell rc files. The
-installer prints the exact line it would have appended so you can place it
-wherever your dotfile setup expects:
+installer prints both the exact line it would have appended **and** the
+shell-specific rc file it would have appended to, so you can route the
+line wherever your dotfile setup expects:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh \
@@ -172,14 +175,17 @@ If you'd rather keep the old install around, pick a different
 new bundle there instead.
 
 Before continuing, verify that the installed bundle is recent enough to
-include the `login` command used in Step 4:
+include the `auth login` command used in Step 4:
 
 ```sh
 vicoop-client -v
-vicoop-client login --help
+vicoop-client auth login --help
 ```
 
-If `login --help` prints usage, you're on a current binary and can move on.
+If `auth login --help` prints usage, you're on a current binary and can
+move on. The flat `login` alias still works on current binaries but emits a
+`[deprecated] Use auth login` notice to stderr — see the legacy aliases
+note in Step 4.
 
 ## Step 3 — Pick an agent id
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -79,6 +79,7 @@ would still default to `/data/vicoop-bridge-client`.
 | `INSTALL_DIR` | `/data/vicoop-bridge-client` | Target directory. Pick a writable path on a volume that survives restarts. |
 | `VERSION` | latest `@vicoop-bridge/client@*` | Pin a specific tag, e.g. `@vicoop-bridge/client@0.1.1`. With `VERSION` set, `jq` is no longer required. |
 | `FORCE` | `0` | If `1`, overwrite a non-empty `INSTALL_DIR`. |
+| `NO_MODIFY_PATH` | `0` | If `1`, skip the shell-rc PATH edit described in [Step 1b](#step-1b--add-vicoop-client-to-path). Useful on NixOS, immutable OSes, or when a dotfile manager (chezmoi, etc.) owns your rc files. |
 
 What you get after install:
 
@@ -103,6 +104,54 @@ keeps `curl | sh` a true one-liner.
 > issue #186 tracks the rework. For now the supported entrypoint is the
 > foreground run in Step 6.
 
+## Step 1b — Add `vicoop-client` to PATH
+
+`install.sh` detects your login shell from `$SHELL` and appends one line to
+the matching rc file so `vicoop-client` works from any new terminal:
+
+| Shell | File edited | Line appended |
+|---|---|---|
+| `zsh` | `${ZDOTDIR:-$HOME}/.zshrc` | `export PATH="$INSTALL_DIR:$PATH"` |
+| `bash` (macOS) | `~/.bash_profile` | `export PATH="$INSTALL_DIR:$PATH"` |
+| `bash` (Linux) | `~/.bashrc` | `export PATH="$INSTALL_DIR:$PATH"` |
+| `fish` | `${XDG_CONFIG_HOME:-~/.config}/fish/config.fish` | `fish_add_path $INSTALL_DIR` |
+
+Each entry is prefixed with a `# vicoop-bridge-client (vicoop-client)`
+marker comment so re-running `install.sh` (including with `FORCE=1`)
+detects the existing line and won't duplicate it. If `$INSTALL_DIR` sits
+under `$HOME`, the appended line is written with a literal `$HOME/...`
+prefix so it stays portable across machines for the same operator.
+
+To pick the change up in the shell where you just ran `install.sh`, either
+open a new terminal or `source` the rc file the installer prints in its
+post-install summary:
+
+```sh
+source ~/.zshrc           # or ~/.bash_profile, ~/.bashrc, ~/.config/fish/config.fish
+vicoop-client --version   # sanity-check
+```
+
+The rest of this doc uses bare `vicoop-client` everywhere. If you opted out
+of this step with `NO_MODIFY_PATH=1` (see below), prefix every example
+with `"$INSTALL_DIR/"` — e.g. `"$INSTALL_DIR/vicoop-client" --version`.
+
+### Opting out
+
+Set `NO_MODIFY_PATH=1` on the same `install.sh` invocation if you'd rather
+manage `PATH` yourself — recommended on NixOS, immutable OSes, or when a
+dotfile manager (chezmoi, yadm, etc.) owns your shell rc files. The
+installer prints the exact line it would have appended so you can place it
+wherever your dotfile setup expects:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh \
+  | INSTALL_DIR="$HOME/vicoop-bridge-client" NO_MODIFY_PATH=1 sh
+```
+
+Operators on tcsh / ksh / other shells `install.sh` can't auto-detect get
+the same printed instructions automatically — no need to set
+`NO_MODIFY_PATH=1` explicitly.
+
 ## Step 2 — Verify the installed bundle
 
 If `$INSTALL_DIR` already existed before Step 1, `install.sh` refuses to
@@ -126,8 +175,8 @@ Before continuing, verify that the installed bundle is recent enough to
 include the `login` command used in Step 4:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" -v
-"$INSTALL_DIR/vicoop-client" login --help
+vicoop-client -v
+vicoop-client login --help
 ```
 
 If `login --help` prints usage, you're on a current binary and can move on.
@@ -173,9 +222,9 @@ saved owner-session to call `registerClient` and mint a one-time
 `AGENT_TOKEN`. No wallet or SIWE required.
 
 ```sh
-"$INSTALL_DIR/vicoop-client" auth login
+vicoop-client auth login
 
-"$INSTALL_DIR/vicoop-client" agent register \
+vicoop-client agent register \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
 ```
@@ -320,7 +369,7 @@ For scripting, pass `--json` instead of writing `config.json` if you want to
 compose with shell tooling (no disk side effects, raw response on stdout):
 
 ```sh
-"$INSTALL_DIR/vicoop-client" agent register \
+vicoop-client agent register \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>" --json \
   | tee /tmp/vicoop-agent.json
@@ -432,14 +481,14 @@ the daemon picks up `server_url`, `server_token`, and `agent_id` on its own;
 pick the backend with `--backend`:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" --backend openclaw
+vicoop-client --backend openclaw
 ```
 
 Precedence at startup is **CLI flag > `--config <path>` > canonical
 `config.json` > built-in default**. Env vars are not consulted for
 runtime config (#189 §5). With `"backend": "openclaw"` persisted in
 `config.json`, the daemon needs no flags at all:
-`"$INSTALL_DIR/vicoop-client"`.
+`vicoop-client`.
 
 On success you'll see a `[client] connected, sending hello` log followed
 by an identity block — same data `vicoop-client auth whoami` would print, so
@@ -522,7 +571,7 @@ For the Claude backend, pass `--backend claude` (or persist
 different repository than the one `vicoop-client` itself runs in:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" \
+vicoop-client \
   --backend claude \
   --cwd "$HOME/vicoop-bridge"
 ```
@@ -530,7 +579,7 @@ different repository than the one `vicoop-client` itself runs in:
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
 (`cwd`, `settings`) so the foreground command shrinks to just
-`"$INSTALL_DIR/vicoop-client"`; the flag wins over config, mirroring
+`vicoop-client`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
 | Flag | `backends.claude.*` |
@@ -576,7 +625,7 @@ identifier external callers will see for this agent — the WebFinger acct, the
 `@<agentId>@<host>` mention, the JSON-RPC endpoint, and the agent-card URL.
 
 ```sh
-"$INSTALL_DIR/vicoop-client" whoami
+vicoop-client whoami
 # agentId:    my-agent
 # host:       bridge.example.com
 # mention:    @my-agent@bridge.example.com
@@ -602,7 +651,7 @@ Typical follow-ups from this output:
    response doesn't match what you expect, that's the cue to override.
 
    ```sh
-   CARD_URL=$("$INSTALL_DIR/vicoop-client" whoami --json | jq -r .a2aCardUrl)
+   CARD_URL=$(vicoop-client whoami --json | jq -r .a2aCardUrl)
    curl -sf "$CARD_URL" | jq .
    ```
 3. **Verify WebFinger actually resolves the acct.** `whoami --verify`
@@ -621,7 +670,7 @@ For the Codex backend, pass `--backend codex` (or persist
 different repository / loosen the sandbox:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" \
+vicoop-client \
   --backend codex \
   --cwd "$HOME/vicoop-bridge" \
   --codex-sandbox workspace-write
@@ -629,7 +678,7 @@ different repository / loosen the sandbox:
 
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.codex` so the
-foreground command can shrink to just `"$INSTALL_DIR/vicoop-client"`.
+foreground command can shrink to just `vicoop-client`.
 The flag wins over config.
 
 | Flag | `backends.codex.*` |
@@ -683,20 +732,20 @@ below — `upgrade --check` reports the live version against the latest
 published release:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" -v
-"$INSTALL_DIR/vicoop-client" upgrade --check   # report latest vs current
-"$INSTALL_DIR/vicoop-client" upgrade           # upgrade in place if behind
+vicoop-client -v
+vicoop-client upgrade --check   # report latest vs current
+vicoop-client upgrade           # upgrade in place if behind
 ```
 
 ```sh
 # Step 4 login saves the owner-session bearer, so these work without re-authenticating:
-"$INSTALL_DIR/vicoop-client" agent register \
+vicoop-client agent register \
   --agent-id "$AGENT_ID" \
   --caller "eth:0x<40-hex>"
-"$INSTALL_DIR/vicoop-client" agent list --connected
-"$INSTALL_DIR/vicoop-client" agent callers list "$AGENT_ID" --json
-"$INSTALL_DIR/vicoop-client" agent callers add "$AGENT_ID" "eth:0x<40-hex>"
-"$INSTALL_DIR/vicoop-client" agent callers remove "$AGENT_ID" "google:email:caller@example.com"
+vicoop-client agent list --connected
+vicoop-client agent callers list "$AGENT_ID" --json
+vicoop-client agent callers add "$AGENT_ID" "eth:0x<40-hex>"
+vicoop-client agent callers remove "$AGENT_ID" "google:email:caller@example.com"
 
 # Pass --json for machine-readable output, or --server / --token to override
 # the saved session for one call. VICOOP_BRIDGE / VICOOP_OWNER_TOKEN env vars
@@ -710,7 +759,7 @@ separate `owner-session.json` that `login` writes alongside it). If the
 saved bearer is missing or expired, refresh it without re-registering:
 
 ```sh
-"$INSTALL_DIR/vicoop-client" auth login
+vicoop-client auth login
 ```
 
 (Self-hosting? Pass `--server https://<your-bridge>`.)
@@ -744,10 +793,10 @@ installer's `FORCE=1` path is destructive (it `rm -rf`s `$INSTALL_DIR`) and
 is reserved for bootstrapping.
 
 ```sh
-"$INSTALL_DIR/vicoop-client" upgrade --check      # report latest vs current
-"$INSTALL_DIR/vicoop-client" upgrade              # upgrade to latest @vicoop-bridge/client@*
-"$INSTALL_DIR/vicoop-client" upgrade --version 0.2.0   # pin / downgrade (bare version, v0.2.0, or @vicoop-bridge/client@0.2.0 all accepted)
-"$INSTALL_DIR/vicoop-client" upgrade --force      # reinstall the resolved target even if already on it
+vicoop-client upgrade --check      # report latest vs current
+vicoop-client upgrade              # upgrade to latest @vicoop-bridge/client@*
+vicoop-client upgrade --version 0.2.0   # pin / downgrade (bare version, v0.2.0, or @vicoop-bridge/client@0.2.0 all accepted)
+vicoop-client upgrade --force      # reinstall the resolved target even if already on it
 ```
 
 The upgrade command:

--- a/install.sh
+++ b/install.sh
@@ -186,23 +186,22 @@ fi
 
 # ---- 5. Add INSTALL_DIR to the shell rc file --------------------------------
 # Auto-edit pattern matches Bun / uv / fnm: detect the operator's login shell
-# from $SHELL, append an export to the appropriate rc file (skipped on
-# re-runs via a marker comment), and fall back to printing manual
+# from $SHELL, append an export to the appropriate rc file (re-runs strip
+# and re-append the marker block so a changed $INSTALL_DIR refreshes the
+# entry instead of leaving it stale), and fall back to printing manual
 # instructions when the file isn't writable or the shell is unknown.
 # Operators that manage PATH themselves (NixOS, immutable OSes, dotfile
-# managers like chezmoi) opt out with NO_MODIFY_PATH=1.
+# managers like chezmoi) opt out with NO_MODIFY_PATH=1 — they still get
+# the exact line to copy into their dotfiles in the Next steps block.
 
 # Filled in by setup_shell_path() so the Next-steps block below can tell
-# the operator exactly which file to `source` to pick up the change.
+# the operator exactly which file to `source` (when we wrote it) or which
+# line to copy manually (when we didn't).
 PATH_RC_FILE=""
 PATH_MANUAL_HINT=""
+PATH_MANUAL_TARGET=""
 
 setup_shell_path() {
-  if [ "$NO_MODIFY_PATH" = "1" ]; then
-    log "NO_MODIFY_PATH=1 — leaving shell PATH alone"
-    return 0
-  fi
-
   # If INSTALL_DIR sits under $HOME, persist it as $HOME/... so the line
   # remains portable across machines for the same operator.
   case "$INSTALL_DIR" in
@@ -210,6 +209,8 @@ setup_shell_path() {
     *)         install_dir_expr="$INSTALL_DIR" ;;
   esac
 
+  # Detect login shell first so even the NO_MODIFY_PATH / unknown-shell
+  # branches can hand the operator the exact line and target file to add.
   shell_name="$(basename "${SHELL:-}")"
   case "$shell_name" in
     zsh)
@@ -232,16 +233,17 @@ setup_shell_path() {
       add_line="fish_add_path $install_dir_expr"
       ;;
     *)
+      # No rc-file convention we recognize — print-only fallback.
       PATH_MANUAL_HINT="export PATH=\"$install_dir_expr:\$PATH\""
       log "could not detect shell from \$SHELL ($shell_name) — see Next steps for manual PATH instructions"
       return 0
       ;;
   esac
 
-  marker="# vicoop-bridge-client (vicoop-client)"
-  if [ -f "$rc_file" ] && grep -Fq "$marker" "$rc_file"; then
-    log "PATH entry already present in $rc_file — skipping"
-    PATH_RC_FILE="$rc_file"
+  if [ "$NO_MODIFY_PATH" = "1" ]; then
+    PATH_MANUAL_HINT="$add_line"
+    PATH_MANUAL_TARGET="$rc_file"
+    log "NO_MODIFY_PATH=1 — see Next steps for the line to add to $rc_file"
     return 0
   fi
 
@@ -257,15 +259,61 @@ setup_shell_path() {
 
   if [ "$rc_writable" = "0" ]; then
     PATH_MANUAL_HINT="$add_line"
+    PATH_MANUAL_TARGET="$rc_file"
     log "$rc_file is not writable — see Next steps for manual PATH instructions"
     return 0
+  fi
+
+  marker="# vicoop-bridge-client (vicoop-client)"
+
+  # If a marker already exists, strip the existing block (an optional
+  # leading blank line + marker line + the PATH/fish_add_path line
+  # immediately below it) and fall through to a fresh append. This keeps
+  # re-runs idempotent AND refreshes the PATH entry when INSTALL_DIR
+  # changes between runs (the marker alone can't tell which is which).
+  marker_existed=0
+  if [ -f "$rc_file" ] && grep -Fq "$marker" "$rc_file"; then
+    marker_existed=1
+    new_content=$(
+      awk -v m="$marker" '
+        $0 == m {
+          # Drop a buffered blank line so reinstalls do not accumulate
+          # empty lines before the (re-)appended marker.
+          if (have && buf == "") have = 0
+          skip = 1
+          next
+        }
+        skip { skip = 0; next }
+        {
+          if (have) print buf
+          buf = $0
+          have = 1
+        }
+        END { if (have) print buf }
+      ' "$rc_file"
+    ) || die "failed to refresh $rc_file — leaving it untouched"
+    # `> "$rc_file"` truncates in place, preserving the file's existing
+    # ownership and mode (important when rc is mode 0600).
+    # When new_content is empty (rc file had only the marker block),
+    # truncate to zero bytes — `printf '%s\n' ""` would otherwise write
+    # a stray newline that accumulates across re-runs.
+    if [ -n "$new_content" ]; then
+      printf '%s\n' "$new_content" > "$rc_file"
+    else
+      : > "$rc_file"
+    fi
   fi
 
   {
     printf '\n%s\n' "$marker"
     printf '%s\n' "$add_line"
   } >> "$rc_file"
-  log "added vicoop-client to PATH in $rc_file"
+
+  if [ "$marker_existed" = "1" ]; then
+    log "refreshed vicoop-client PATH entry in $rc_file"
+  else
+    log "added vicoop-client to PATH in $rc_file"
+  fi
   PATH_RC_FILE="$rc_file"
 }
 
@@ -285,14 +333,26 @@ To use \`vicoop-client\` in this shell, open a new terminal — or run:
     source "$PATH_RC_FILE"
 EOF
 elif [ -n "$PATH_MANUAL_HINT" ]; then
-  cat <<EOF
+  if [ -n "$PATH_MANUAL_TARGET" ]; then
+    cat <<EOF
 
-To use \`vicoop-client\` from any shell, add this to your shell config:
+To use \`vicoop-client\` from any shell, add this line to $PATH_MANUAL_TARGET
+(or wherever your dotfile setup expects):
 
     $PATH_MANUAL_HINT
 
 Then open a new terminal (or source the file you edited).
 EOF
+  else
+    cat <<EOF
+
+To use \`vicoop-client\` from any shell, add this line to your shell config:
+
+    $PATH_MANUAL_HINT
+
+Then open a new terminal (or source the file you edited).
+EOF
+  fi
 fi
 
 cat <<EOF
@@ -329,13 +389,5 @@ Next steps (the agent that owns this client should perform these):
   Future updates: run \`vicoop-client upgrade\` — no need to re-run this
   installer. Pass --check to see if a newer release is available.
 EOF
-
-if [ -z "$PATH_RC_FILE" ] && [ -z "$PATH_MANUAL_HINT" ]; then
-  cat <<EOF
-
-  Opted out of PATH setup with NO_MODIFY_PATH=1? Prefix every command
-  above with "$INSTALL_DIR/" — e.g. \`"$INSTALL_DIR/vicoop-client" --version\`.
-EOF
-fi
 
 echo

--- a/install.sh
+++ b/install.sh
@@ -5,17 +5,19 @@
 #   curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install.sh | sh
 #
 # Environment overrides:
-#   INSTALL_DIR  Target directory (default: /data/vicoop-bridge-client)
-#   VERSION      Specific tag, e.g. @vicoop-bridge/client@0.16.0
-#                (default: latest @vicoop-bridge/client@* release)
-#   FORCE        If "1", overwrite a non-empty INSTALL_DIR
+#   INSTALL_DIR      Target directory (default: /data/vicoop-bridge-client)
+#   VERSION          Specific tag, e.g. @vicoop-bridge/client@0.16.0
+#                    (default: latest @vicoop-bridge/client@* release)
+#   FORCE            If "1", overwrite a non-empty INSTALL_DIR
+#   NO_MODIFY_PATH   If "1", skip appending INSTALL_DIR to the shell rc file
 #
 # What it does:
 #   1. Verifies prerequisites (curl, sha256 tool, jq when auto-resolving).
 #   2. Detects OS/arch and resolves the matching release asset.
 #   3. Downloads the binary + .sha256, verifies integrity, chmod +x.
 #   4. Drops macOS quarantine xattr so first launch isn't Gatekeeper-blocked.
-#   5. Prints next-step instructions for login and a foreground first run.
+#   5. Appends INSTALL_DIR to the detected shell rc file (skip with NO_MODIFY_PATH=1).
+#   6. Prints next-step instructions for login and a foreground first run.
 
 set -eu
 
@@ -23,6 +25,7 @@ REPO="planetarium/vicoop-bridge"
 INSTALL_DIR="${INSTALL_DIR:-/data/vicoop-bridge-client}"
 VERSION="${VERSION:-}"
 FORCE="${FORCE:-0}"
+NO_MODIFY_PATH="${NO_MODIFY_PATH:-0}"
 
 log() { printf '==> %s\n' "$*"; }
 err() { printf 'error: %s\n' "$*" >&2; }
@@ -181,42 +184,158 @@ if [ "$OS_NAME" = "Darwin" ] && command -v xattr >/dev/null 2>&1; then
   xattr -d com.apple.quarantine "$INSTALL_DIR/$BINARY_NAME" 2>/dev/null || true
 fi
 
-# ---- 5. Next steps ----------------------------------------------------------
+# ---- 5. Add INSTALL_DIR to the shell rc file --------------------------------
+# Auto-edit pattern matches Bun / uv / fnm: detect the operator's login shell
+# from $SHELL, append an export to the appropriate rc file (skipped on
+# re-runs via a marker comment), and fall back to printing manual
+# instructions when the file isn't writable or the shell is unknown.
+# Operators that manage PATH themselves (NixOS, immutable OSes, dotfile
+# managers like chezmoi) opt out with NO_MODIFY_PATH=1.
+
+# Filled in by setup_shell_path() so the Next-steps block below can tell
+# the operator exactly which file to `source` to pick up the change.
+PATH_RC_FILE=""
+PATH_MANUAL_HINT=""
+
+setup_shell_path() {
+  if [ "$NO_MODIFY_PATH" = "1" ]; then
+    log "NO_MODIFY_PATH=1 — leaving shell PATH alone"
+    return 0
+  fi
+
+  # If INSTALL_DIR sits under $HOME, persist it as $HOME/... so the line
+  # remains portable across machines for the same operator.
+  case "$INSTALL_DIR" in
+    "$HOME"/*) install_dir_expr="\$HOME${INSTALL_DIR#"$HOME"}" ;;
+    *)         install_dir_expr="$INSTALL_DIR" ;;
+  esac
+
+  shell_name="$(basename "${SHELL:-}")"
+  case "$shell_name" in
+    zsh)
+      rc_file="${ZDOTDIR:-$HOME}/.zshrc"
+      add_line="export PATH=\"$install_dir_expr:\$PATH\""
+      ;;
+    bash)
+      # macOS login shells read .bash_profile; Linux interactive shells
+      # default to .bashrc. Pick the one most likely to be sourced on the
+      # operator's next terminal.
+      if [ "$OS_NAME" = "Darwin" ]; then
+        rc_file="$HOME/.bash_profile"
+      else
+        rc_file="$HOME/.bashrc"
+      fi
+      add_line="export PATH=\"$install_dir_expr:\$PATH\""
+      ;;
+    fish)
+      rc_file="${XDG_CONFIG_HOME:-$HOME/.config}/fish/config.fish"
+      add_line="fish_add_path $install_dir_expr"
+      ;;
+    *)
+      PATH_MANUAL_HINT="export PATH=\"$install_dir_expr:\$PATH\""
+      log "could not detect shell from \$SHELL ($shell_name) — see Next steps for manual PATH instructions"
+      return 0
+      ;;
+  esac
+
+  marker="# vicoop-bridge-client (vicoop-client)"
+  if [ -f "$rc_file" ] && grep -Fq "$marker" "$rc_file"; then
+    log "PATH entry already present in $rc_file — skipping"
+    PATH_RC_FILE="$rc_file"
+    return 0
+  fi
+
+  rc_dir="$(dirname "$rc_file")"
+  rc_writable=1
+  if ! mkdir -p "$rc_dir" 2>/dev/null; then
+    rc_writable=0
+  elif [ -e "$rc_file" ] && [ ! -w "$rc_file" ]; then
+    rc_writable=0
+  elif [ ! -e "$rc_file" ] && [ ! -w "$rc_dir" ]; then
+    rc_writable=0
+  fi
+
+  if [ "$rc_writable" = "0" ]; then
+    PATH_MANUAL_HINT="$add_line"
+    log "$rc_file is not writable — see Next steps for manual PATH instructions"
+    return 0
+  fi
+
+  {
+    printf '\n%s\n' "$marker"
+    printf '%s\n' "$add_line"
+  } >> "$rc_file"
+  log "added vicoop-client to PATH in $rc_file"
+  PATH_RC_FILE="$rc_file"
+}
+
+setup_shell_path
+
+# ---- 6. Next steps ----------------------------------------------------------
 cat <<EOF
 
 ==> installed $VERSION to $INSTALL_DIR/$BINARY_NAME
+EOF
+
+if [ -n "$PATH_RC_FILE" ]; then
+  cat <<EOF
+
+To use \`vicoop-client\` in this shell, open a new terminal — or run:
+
+    source "$PATH_RC_FILE"
+EOF
+elif [ -n "$PATH_MANUAL_HINT" ]; then
+  cat <<EOF
+
+To use \`vicoop-client\` from any shell, add this to your shell config:
+
+    $PATH_MANUAL_HINT
+
+Then open a new terminal (or source the file you edited).
+EOF
+fi
+
+cat <<EOF
 
 Next steps (the agent that owns this client should perform these):
 
   1. Verify and sign in (device flow). The owner-session bearer is saved
      to ~/.vicoop/owner-session.json; admin subcommands pick it up:
 
-       "$INSTALL_DIR/$BINARY_NAME" --version
-       "$INSTALL_DIR/$BINARY_NAME" login
+       vicoop-client --version
+       vicoop-client auth login
 
-  2. Register this client. \`setup\` writes the one-time CLIENT_TOKEN plus
-     server_url / agent_id into the canonical ~/.vicoop/config.json
-     (mode 600); the daemon picks those up on its next launch:
+  2. Register the agent. \`agent register\` writes the one-time AGENT_TOKEN
+     plus server_url / agent_id into ~/.vicoop/config.json (mode 600);
+     the daemon picks those up on its next launch:
 
-       "$INSTALL_DIR/$BINARY_NAME" setup \\
-         --client-name "my client" --agent-ids "\$AGENT_ID"
+       vicoop-client agent register \\
+         --agent-id "\$AGENT_ID" --caller "eth:0x<40-hex>"
 
   3. Run the daemon in the foreground. With config.json populated, only
      the backend choice (echo / openclaw / claude / codex) is left:
 
-       "$INSTALL_DIR/$BINARY_NAME" --backend openclaw
+       vicoop-client --backend openclaw
 
      Or persist \`"backend": "openclaw"\` in config.json and run with no
      flags at all:
 
-       "$INSTALL_DIR/$BINARY_NAME"
+       vicoop-client
 
      An always-on supervisor (systemd unit, launchd plist, …) is not
      provided by this installer; the foreground run above is the
      supported entrypoint while the design is in flux (issue #190).
 
-  Future updates: run \`"$INSTALL_DIR/$BINARY_NAME" upgrade\` — no need
-  to re-run this installer. Pass --check to see if a newer release is
-  available.
-
+  Future updates: run \`vicoop-client upgrade\` — no need to re-run this
+  installer. Pass --check to see if a newer release is available.
 EOF
+
+if [ -z "$PATH_RC_FILE" ] && [ -z "$PATH_MANUAL_HINT" ]; then
+  cat <<EOF
+
+  Opted out of PATH setup with NO_MODIFY_PATH=1? Prefix every command
+  above with "$INSTALL_DIR/" — e.g. \`"$INSTALL_DIR/vicoop-client" --version\`.
+EOF
+fi
+
+echo


### PR DESCRIPTION
## Summary

- `install.sh` now auto-edits the operator's login-shell rc file so
  bare `vicoop-client` resolves from any new terminal:
  - `zsh` → `${ZDOTDIR:-$HOME}/.zshrc`
  - `bash` (macOS) → `~/.bash_profile`
  - `bash` (Linux) → `~/.bashrc`
  - `fish` → `${XDG_CONFIG_HOME:-~/.config}/fish/config.fish` (uses `fish_add_path`)
- `NO_MODIFY_PATH=1` opts out. Unknown shells (tcsh / ksh / …) and
  non-writable rc files automatically fall back to a printed manual
  instruction — no env override needed.
- Marker comment `# vicoop-bridge-client (vicoop-client)` makes
  re-runs (including `FORCE=1`) idempotent.
- When `$INSTALL_DIR` sits under `$HOME`, the appended line uses a
  literal `$HOME/...` prefix so it stays portable across machines
  for the same operator.
- `docs/install-client.md`:
  - New Step 1b documents the per-shell rc edit + idempotency
    + opt-out. `NO_MODIFY_PATH` row added to the env table.
  - 27 user-command examples drop the `"$INSTALL_DIR/vicoop-client"`
    prefix in favor of bare `vicoop-client`. The 4 remaining
    `$INSTALL_DIR/vicoop-client` references (on-disk layout, upgrade
    atomic-swap mechanics, the opt-out hint itself) are intentional.

Approach modeled on Bun / uv / fnm install scripts — auto-edit
default + opt-out flag + automatic print-only fallback for shells
that don't fit a known rc-file convention. mise-style print-only was
the original ask in #277, but per maintainer guidance we went
further and auto-edit by default.

Closes #277.

## Test plan

- [x] `sh -n install.sh` — POSIX shell syntax clean.
- [x] Isolated test harness exercised 7 cases:
  - fresh zsh on macOS → `.zshrc` gains marker + `export PATH` line,
    `$HOME` substituted into the path.
  - re-run on same `.zshrc` → marker detected, no duplicate append
    (file line-count stays unchanged).
  - fish → `config.fish` gains marker + `fish_add_path`, parent dir
    auto-created.
  - bash on Linux → `.bashrc` (not `.bash_profile`).
  - unknown shell tcsh → no rc edit; manual instruction recorded.
  - `NO_MODIFY_PATH=1` → no rc edit, no manual hint, log line
    explains skip.
  - `INSTALL_DIR=/opt/vicoop-bridge-client` (outside `$HOME`) →
    absolute path written verbatim, no `$HOME` substitution.
- [ ] End-to-end smoke against a fresh shell on macOS + Linux —
  recommend reviewer runs the public one-liner once before merge
  to confirm the rendered Next-steps block reads naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)