### PR TITLE
feat(client): auto-login at container init + fail-fast on daemon start

### DIFF
--- a/.changeset/container-init-auto-login.md
+++ b/.changeset/container-init-auto-login.md
@@ -1,0 +1,13 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+`container init`: when `--from-host` is omitted and stdin is a TTY,
+launch the agent CLI's interactive auth flow (`claude setup-token` /
+`codex login --device-auth`) inside the freshly-installed runtime
+container right after the install + compat check. Non-TTY callers (CI,
+piped input) keep the previous hint-only behavior. The daemon
+(`--runtime container`) now also probes the per-kind creds file at
+startup and exits with the same auth hint when it is missing, instead
+of accepting tasks that would fail at first spawn with a
+backend-specific auth error.

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -22,6 +22,7 @@ import type { Backend } from './backend.js';
 import { RuntimeContainer, DEFAULT_RUNTIME_IMAGE } from './runtime-container.js';
 import { createDockerExecSpawn, type SpawnFn } from './spawn-adapter.js';
 import {
+  assertContainerCredsPresent,
   containerCmd,
   runContainerInitCli,
   runContainerListCli,
@@ -394,6 +395,16 @@ async function resolveRuntime(args: {
     bridgeUrl: args.bridgeUrl,
   });
   await runtime.start();
+  // Fail fast if the operator started the daemon against a runtime that
+  // was initialised without --from-host and has not been authenticated
+  // yet. Without this check the daemon would happily accept tasks until
+  // the first spawn, then surface a backend-specific auth error.
+  try {
+    await assertContainerCredsPresent(runtime.getContainerName(), args.kind);
+  } catch (err) {
+    await runtime.stop();
+    throw err;
+  }
   return {
     runtime,
     spawn: createDockerExecSpawn(runtime),

--- a/packages/client/src/container-init.test.ts
+++ b/packages/client/src/container-init.test.ts
@@ -1,16 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  assertContainerCredsPresent,
   collectClaudeHostCreds,
   collectCodexHostCreds,
+  expectedCredsPath,
   formatRuntimeList,
   formatRuntimeListJson,
   formatRuntimeRemoveJson,
   formatRuntimeRemoveResult,
   listRuntimeContainers,
+  maybeAutoLoginAfterInit,
   removeRuntimeContainer,
 } from './container-init.js';
 import type { DockerResult } from './runtime-container.js';
+import type { Logger } from './logger.js';
 
 // ──────────────────────────────────────────────────────────────────
 // collectClaudeHostCreds
@@ -459,6 +463,163 @@ test('removeRuntimeContainer: unexpected docker failures throw', () => {
     /docker rm -f vicoop-runtime-codex failed/,
   );
 });
+
+// ──────────────────────────────────────────────────────────────────
+// assertContainerCredsPresent — daemon-startup fail-fast probe
+// ──────────────────────────────────────────────────────────────────
+
+test('assertContainerCredsPresent: claude path probes /data/creds/claude/.credentials.json', async () => {
+  const calls: Array<readonly string[]> = [];
+  await assertContainerCredsPresent('vicoop-runtime-claude', 'claude', {
+    dockerRun: (args) => {
+      calls.push(args);
+      return ok('');
+    },
+  });
+  assert.deepEqual(calls, [[
+    'exec',
+    'vicoop-runtime-claude',
+    'test',
+    '-f',
+    '/data/creds/claude/.credentials.json',
+  ]]);
+});
+
+test('assertContainerCredsPresent: codex path probes /data/creds/codex/auth.json', async () => {
+  const calls: Array<readonly string[]> = [];
+  await assertContainerCredsPresent('vicoop-runtime-codex', 'codex', {
+    dockerRun: (args) => {
+      calls.push(args);
+      return ok('');
+    },
+  });
+  assert.deepEqual(calls[0], [
+    'exec',
+    'vicoop-runtime-codex',
+    'test',
+    '-f',
+    '/data/creds/codex/auth.json',
+  ]);
+});
+
+test('assertContainerCredsPresent: throws with auth-command hint when probe fails', async () => {
+  await assert.rejects(
+    () =>
+      assertContainerCredsPresent('vicoop-runtime-claude', 'claude', {
+        dockerRun: () => fail('', 1),
+      }),
+    (err: Error) => {
+      assert.match(err.message, /no claude creds at \/data\/creds\/claude\/\.credentials\.json/);
+      assert.match(err.message, /docker exec -it vicoop-runtime-claude claude setup-token/);
+      return true;
+    },
+  );
+});
+
+test('assertContainerCredsPresent: codex hint uses codex login --device-auth', async () => {
+  await assert.rejects(
+    () =>
+      assertContainerCredsPresent('vicoop-runtime-codex', 'codex', {
+        dockerRun: () => fail('', 1),
+      }),
+    /docker exec -it vicoop-runtime-codex codex login --device-auth/,
+  );
+});
+
+test('expectedCredsPath: stable canonical paths per kind', () => {
+  assert.equal(expectedCredsPath('claude'), '/data/creds/claude/.credentials.json');
+  assert.equal(expectedCredsPath('codex'), '/data/creds/codex/auth.json');
+});
+
+// ──────────────────────────────────────────────────────────────────
+// maybeAutoLoginAfterInit — TTY-gated interactive auth at init time
+// ──────────────────────────────────────────────────────────────────
+
+test('maybeAutoLoginAfterInit: TTY off skips interactive auth and prints docker-exec hint', async () => {
+  const log = recordingLogger();
+  const argvs: Array<readonly string[]> = [];
+  const result = await maybeAutoLoginAfterInit('vicoop-runtime-claude', 'claude', log, {
+    isTTY: () => false,
+    runDockerInteractive: async (argv) => {
+      argvs.push(argv);
+      return 0;
+    },
+  });
+  assert.deepEqual(result, { attempted: false, exitCode: 0 });
+  assert.deepEqual(argvs, []);
+  const infos = log.entries.filter((e) => e.level === 'info').map((e) => e.msg);
+  assert.ok(infos.some((m) => /not a TTY/.test(m)));
+  assert.ok(infos.some((m) => /claude setup-token/.test(m)));
+});
+
+test('maybeAutoLoginAfterInit: TTY on runs claude auth via docker exec -it', async () => {
+  const log = recordingLogger();
+  let captured: readonly string[] | null = null;
+  const result = await maybeAutoLoginAfterInit('vicoop-runtime-claude', 'claude', log, {
+    isTTY: () => true,
+    runDockerInteractive: async (argv) => {
+      captured = argv;
+      return 0;
+    },
+  });
+  assert.deepEqual(result, { attempted: true, exitCode: 0 });
+  assert.deepEqual(captured, [
+    'exec',
+    '-it',
+    'vicoop-runtime-claude',
+    'claude',
+    'setup-token',
+  ]);
+});
+
+test('maybeAutoLoginAfterInit: TTY on runs codex auth with --device-auth', async () => {
+  const log = recordingLogger();
+  let captured: readonly string[] | null = null;
+  await maybeAutoLoginAfterInit('vicoop-runtime-codex', 'codex', log, {
+    isTTY: () => true,
+    runDockerInteractive: async (argv) => {
+      captured = argv;
+      return 0;
+    },
+  });
+  assert.deepEqual(captured, [
+    'exec',
+    '-it',
+    'vicoop-runtime-codex',
+    'codex',
+    'login',
+    '--device-auth',
+  ]);
+});
+
+test('maybeAutoLoginAfterInit: failed interactive auth returns exitCode 1 and surfaces retry hint', async () => {
+  const log = recordingLogger();
+  const result = await maybeAutoLoginAfterInit('vicoop-runtime-claude', 'claude', log, {
+    isTTY: () => true,
+    runDockerInteractive: async () => 130,
+  });
+  assert.deepEqual(result, { attempted: true, exitCode: 1 });
+  const errors = log.entries.filter((e) => e.level === 'error').map((e) => e.msg);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /interactive auth exited with code 130/);
+  assert.match(errors[0], /docker exec -it vicoop-runtime-claude claude setup-token/);
+  assert.match(errors[0], /left in place/);
+});
+
+function recordingLogger(): Logger & {
+  entries: Array<{ level: 'error' | 'warn' | 'info' | 'debug'; msg: string }>;
+} {
+  const entries: Array<{ level: 'error' | 'warn' | 'info' | 'debug'; msg: string }> = [];
+  const join = (args: unknown[]) => args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' ');
+  return {
+    level: 'debug',
+    error: (...args) => entries.push({ level: 'error', msg: join(args) }),
+    warn: (...args) => entries.push({ level: 'warn', msg: join(args) }),
+    info: (...args) => entries.push({ level: 'info', msg: join(args) }),
+    debug: (...args) => entries.push({ level: 'debug', msg: join(args) }),
+    entries,
+  };
+}
 
 function ok(stdout = ''): DockerResult {
   return { stdout, stderr: '', exitCode: 0 };

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -6,9 +6,11 @@
 // binary against this client's supportedRange manifest, and
 // (with --from-host) copies the operator's existing agent CLI
 // creds into the container-scoped named volume so the operator can
-// immediately go daemon. Without --from-host the command leaves
-// creds empty and prints the docker-exec incantation for the
-// operator to do an interactive auth flow themselves.
+// immediately go daemon. Without --from-host: if stdin is a TTY,
+// runs the agent CLI's interactive auth (claude setup-token /
+// codex login --device-auth) in the running container right then;
+// otherwise falls back to printing the docker-exec incantation
+// the operator can run themselves.
 //
 // Companion to RuntimeContainer (lifecycle) + SpawnAdapter
 // (per-task spawn). RuntimeContainer is the unit of state that
@@ -59,7 +61,17 @@ export interface ContainerInitOptions {
   // init-firewall.sh. The CLI defaults this to whatever the daemon
   // would use; included as a parameter so tests can override.
   bridgeUrl?: string;
+  // Test seam — inject a stub TTY probe + interactive runner so the
+  // auto-login branch can be exercised without a real terminal /
+  // docker daemon. Production passes nothing; defaults fall through
+  // to process.stdin.isTTY + spawn('docker', argv, {stdio:'inherit'}).
+  authRunner?: Partial<AuthRunner>;
   logger?: Logger;
+}
+
+export interface AuthRunner {
+  isTTY: () => boolean;
+  runDockerInteractive: (argv: readonly string[]) => Promise<number>;
 }
 
 type RuntimeContainerState = 'running' | 'stopped' | 'missing';
@@ -187,10 +199,13 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
         return 1;
       }
     } else {
-      log.info(
-        `--from-host not set: leaving creds empty. To auth inside the container run\n` +
-          `    ${authCommandFor(containerName, opts.kind)}`,
+      const autoLogin = await maybeAutoLoginAfterInit(
+        containerName,
+        opts.kind,
+        log,
+        opts.authRunner,
       );
+      if (autoLogin.exitCode !== 0) return autoLogin.exitCode;
     }
 
     log.info(`runtime container for ${opts.kind} initialized. start daemon with:`);
@@ -208,6 +223,92 @@ function authCommandFor(containerName: string, kind: InstallableBackendKind): st
     `docker start ${containerName} >/dev/null && ` +
     `docker exec -it ${containerName} ${authHintFor(kind)} && ` +
     `docker stop ${containerName} >/dev/null`
+  );
+}
+
+// Decides whether to run the agent CLI's interactive auth flow in
+// the freshly-installed runtime container, and runs it inline when
+// the operator is on an interactive terminal. Non-TTY callers
+// (CI, piped input, automation) fall back to the hint-only path so
+// init stays scriptable. Caller in runContainerInit treats a
+// non-zero exitCode as a fatal init failure but leaves the runtime
+// container in place so the operator can retry the auth without
+// re-running install-backend.sh.
+export async function maybeAutoLoginAfterInit(
+  containerName: string,
+  kind: InstallableBackendKind,
+  log: Logger,
+  runner: Partial<AuthRunner> = {},
+): Promise<{ attempted: boolean; exitCode: number }> {
+  const isTTY = (runner.isTTY ?? defaultIsTTY)();
+  if (!isTTY) {
+    log.info(
+      `--from-host not set and stdin is not a TTY: leaving creds empty. To auth inside the container run\n` +
+        `    ${authCommandFor(containerName, kind)}`,
+    );
+    return { attempted: false, exitCode: 0 };
+  }
+  log.info(
+    `--from-host not set; starting interactive auth (${authHintFor(kind)}) inside ${containerName}...`,
+  );
+  const run = runner.runDockerInteractive ?? defaultRunDockerInteractive;
+  const code = await run(['exec', '-it', containerName, ...authHintFor(kind).split(' ')]);
+  if (code === 0) {
+    log.info(`auth complete for ${kind}.`);
+    return { attempted: true, exitCode: 0 };
+  }
+  log.error(
+    `interactive auth exited with code ${code}. Runtime container '${containerName}' was left in place; ` +
+      `retry with:\n    ${authCommandFor(containerName, kind)}`,
+  );
+  return { attempted: true, exitCode: 1 };
+}
+
+function defaultIsTTY(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function defaultRunDockerInteractive(argv: readonly string[]): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('docker', Array.from(argv), { stdio: 'inherit' });
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code ?? -1));
+  });
+}
+
+// Canonical in-container path of the file the backend will read on
+// first task. Probed by the daemon at startup (assertContainerCredsPresent)
+// so a missing-creds runtime container fails before any task is
+// accepted, instead of failing at first spawn with whatever
+// backend-specific "not authenticated" error the CLI emits.
+export function expectedCredsPath(kind: InstallableBackendKind): string {
+  switch (kind) {
+    case 'claude':
+      return '/data/creds/claude/.credentials.json';
+    case 'codex':
+      return '/data/creds/codex/auth.json';
+  }
+}
+
+// Daemon-startup fail-fast probe. Run after RuntimeContainer.start()
+// has the container running; checks that the per-kind creds file the
+// agent CLI will read actually exists in the creds volume. Throws
+// with the same auth-hint container-init prints when --from-host was
+// omitted, so the operator's recovery path is identical regardless of
+// where they hit the missing-creds case.
+export async function assertContainerCredsPresent(
+  containerName: string,
+  kind: InstallableBackendKind,
+  opts: { dockerRun?: DockerRun } = {},
+): Promise<void> {
+  const dockerRun = opts.dockerRun ?? defaultDockerRun;
+  const path = expectedCredsPath(kind);
+  const r = dockerRun(['exec', containerName, 'test', '-f', path]);
+  if (r.exitCode === 0) return;
+  throw new Error(
+    `runtime container '${containerName}' has no ${kind} creds at ${path}. ` +
+      `Authenticate inside the container, then restart the daemon:\n` +
+      `    ${authCommandFor(containerName, kind)}`,
   );
 }
 
@@ -336,14 +437,14 @@ export function collectClaudeHostCreds(
       return [];
     }
     if (!token || token.length === 0) return [];
-    return [{ target: '/data/creds/claude/.credentials.json', data: Buffer.from(`${token}\n`) }];
+    return [{ target: expectedCredsPath('claude'), data: Buffer.from(`${token}\n`) }];
   }
   const home = (env.homedir ?? homedir)();
   const existsFn = env.existsSync ?? existsSync;
   const readFn = env.readFileSync ?? readFileSync;
   const linuxPath = join(home, '.claude', '.credentials.json');
   if (existsFn(linuxPath)) {
-    return [{ target: '/data/creds/claude/.credentials.json', data: readFn(linuxPath) }];
+    return [{ target: expectedCredsPath('claude'), data: readFn(linuxPath) }];
   }
   return [];
 }
@@ -362,7 +463,7 @@ export function collectCodexHostCreds(
   const out: Array<{ target: string; data: Buffer }> = [];
   const authPath = join(home, '.codex', 'auth.json');
   if (existsFn(authPath)) {
-    out.push({ target: '/data/creds/codex/auth.json', data: readFn(authPath) });
+    out.push({ target: expectedCredsPath('codex'), data: readFn(authPath) });
   }
   const configPath = join(home, '.codex', 'config.toml');
   if (existsFn(configPath)) {


### PR DESCRIPTION
## Summary

- `container init` without `--from-host`: when stdin is a TTY, runs the agent CLI's interactive auth (`claude setup-token` / `codex login --device-auth`) inside the freshly-installed runtime container in-line. Non-TTY callers (CI, piped input) keep the previous hint-only behavior; failed interactive auth leaves the runtime container in place with a retry hint.
- Daemon (`--runtime container`): probes the per-kind creds file inside the container right after `RuntimeContainer.start()`; missing creds now exits the daemon with the same auth hint, before any task is accepted. Previously the daemon would happily accept tasks until the first spawn surfaced a backend-specific auth error.
- Introduces a shared `expectedCredsPath(kind)` so the probe path and the `--from-host` copy target stay in lockstep.

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 527 pass (4 new tests for `maybeAutoLoginAfterInit` covering TTY-off / TTY-on claude / TTY-on codex / failure; 4 new tests for `assertContainerCredsPresent` + `expectedCredsPath`)
- [ ] Manual: `vicoop-client container init claude` on a TTY → drops into `claude setup-token` automatically
- [ ] Manual: `vicoop-client container init claude < /dev/null` → falls back to hint-only path
- [ ] Manual: start daemon against a runtime with empty creds → exits with the docker-exec retry hint instead of accepting tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)