### PR TITLE
fix(container): clean up install/wizard output

### DIFF
--- a/container/bundled/entrypoint.sh
+++ b/container/bundled/entrypoint.sh
@@ -242,11 +242,11 @@ wizard() {
 
     log ""
     log "Available backends:"
-    # bash `select` does the keystroke loop + invalid-input retry on
-    # its own. We render two parallel arrays — `descriptions` is what
-    # operators see, `kinds` is what we feed to install-backend.sh and
-    # write into config.json. REPLY (set by select to the chosen 1-based
-    # index) ties the two.
+    # We render two parallel arrays — `options` is what operators see,
+    # `kinds` is what we feed to install-backend.sh and write into
+    # config.json. Hand-rolled rather than `select` because bash's
+    # builtin reflows long labels into multiple columns, which mangles
+    # the alignment we want here.
     local options=(
         "claude       - Anthropic Claude Code CLI"
         "codex        - OpenAI Codex CLI"
@@ -255,16 +255,21 @@ wizard() {
         "vicoop-codex - codex via vicoop's traceability bridge"
     )
     local kinds=(claude codex echo openclaw vicoop-codex)
-    local backend="" choice
-    PS3="  Pick a backend (number): "
-    select choice in "${options[@]}"; do
-        if [[ -n "$choice" ]]; then
-            backend="${kinds[$((REPLY - 1))]}"
+    local i
+    for i in "${!options[@]}"; do
+        printf '  %d) %s\n' "$((i + 1))" "${options[$i]}" >&2
+    done
+    printf '\n' >&2
+
+    local backend="" reply
+    while true; do
+        read -rp "  Pick a backend [1-${#options[@]}]: " reply
+        if [[ "$reply" =~ ^[0-9]+$ ]] && (( reply >= 1 && reply <= ${#options[@]} )); then
+            backend="${kinds[$((reply - 1))]}"
             break
         fi
         log "  Invalid; enter a number from 1 to ${#options[@]}."
     done
-    unset PS3
 
     log ""
     vicoop-client agent register --agent-id "$agent_id" \

--- a/install-container.sh
+++ b/install-container.sh
@@ -33,6 +33,11 @@ WORKSPACE_VOLUME="${VICOOP_BRIDGE_WORKSPACE_VOLUME:-vicoop-bridge-workspace}"
 
 log()  { printf '[install] %s\n' "$*" >&2; }
 die()  { log "ERROR: $*"; exit 1; }
+# `log` prefixes every line with `[install] ` so the script's chatter is
+# easy to distinguish from the container's output. For shell snippets we
+# want the operator to copy verbatim, that prefix is a hazard — emit
+# those through `snippet` instead, which writes raw lines to stderr.
+snippet() { printf '%s\n' "$@" >&2; }
 
 # ── Preflight ────────────────────────────────────────────────────
 command -v docker >/dev/null 2>&1 \
@@ -43,8 +48,9 @@ if [[ ! -t 0 || ! -t 1 ]]; then
     log "If you ran it via \`curl … | bash\` (which redirects stdin to the pipe),"
     log "download the script first and re-run it directly:"
     log ""
-    log "  curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install-container.sh -o install-container.sh"
-    log "  bash install-container.sh"
+    snippet \
+        "  curl -fsSL https://raw.githubusercontent.com/planetarium/vicoop-bridge/main/install-container.sh -o install-container.sh" \
+        "  bash install-container.sh"
     exit 1
 fi
 
@@ -67,7 +73,7 @@ existing_id="$(docker ps -a --filter "name=^${NAME}$" --format '{{.ID}}')"
 if [[ -n "$existing_id" ]]; then
     log "ERROR: a container named '$NAME' already exists ($existing_id)."
     log "If you're sure it's stale, remove it first:"
-    log "  docker rm -f $NAME"
+    snippet "  docker rm -f $NAME"
     log "Otherwise pass a different name via VICOOP_BRIDGE_CONTAINER=…"
     exit 1
 fi
@@ -98,10 +104,12 @@ log ""
 log "Container exited (status $exit_code)."
 log ""
 log "To start the daemon again later (background, restart-on-host-reboot):"
-log "  docker run -d --restart unless-stopped --name $NAME \\"
-log "    -v $STATE_VOLUME:/data \\"
-log "    -v $WORKSPACE_VOLUME:/home/node/work \\"
-log "    $IMAGE"
+log ""
+snippet \
+    "  docker run -d --restart unless-stopped --name $NAME \\" \
+    "    -v $STATE_VOLUME:/data \\" \
+    "    -v $WORKSPACE_VOLUME:/home/node/work \\" \
+    "    $IMAGE"
 log ""
 log "Your config, credentials, and installed backend CLIs are on the"
 log "'$STATE_VOLUME' volume; subsequent"


### PR DESCRIPTION
## Summary

Two adjacent cosmetic fixes to the container's first-run output, both surfaced while walking through `install-container.sh`:

### 1. Backend picker rendered as a clean vertical list

The bundled-image first-run wizard used bash's `select` builtin for the backend picker. With long labels (`vicoop-codex - codex via vicoop's traceability bridge`), bash reflowed the five options into a cramped two-column block that broke alignment.

Replaced `select` with a hand-rolled `printf` loop + `read` so options always render one per line with consistent indentation, and the prompt explicitly shows the valid range (`[1-5]`).

**Before**

```
[entrypoint] Available backends:
1) claude       - Anthropic Claude Code CLI               3) echo         - in-process echo (testing only; no LLM)  5) vicoop-codex - codex via vicoop's traceability bridge
2) codex        - OpenAI Codex CLI                        4) openclaw     - external OpenClaw gateway
  Pick a backend (number):
```

**After**

```
[entrypoint] Available backends:
  1) claude       - Anthropic Claude Code CLI
  2) codex        - OpenAI Codex CLI
  3) echo         - in-process echo (testing only; no LLM)
  4) openclaw     - external OpenClaw gateway
  5) vicoop-codex - codex via vicoop's traceability bridge

  Pick a backend [1-5]:
```

### 2. Suggested shell snippets are now copy-paste-able

`install-container.sh` printed every line through `log()`, which prefixes with `[install] `. That's fine for chatter, but the post-install "to restart later" docker-run block (and a couple of other suggested commands) became unselect-and-pasteable — copying the multi-line block carried the prefix along.

Added a `snippet()` helper that writes raw lines to stderr, and routed the three copy-paste blocks (curl/bash retry path, `docker rm -f` cleanup, final daemon docker-run) through it. Surrounding chatter still uses `log()`.

**Before** (final block)

```
[install] To start the daemon again later (background, restart-on-host-reboot):
[install]   docker run -d --restart unless-stopped --name vicoop-bridge \
[install]     -v vicoop-bridge-state:/data \
[install]     -v vicoop-bridge-workspace:/home/node/work \
[install]     ghcr.io/planetarium/vicoop-bridge-client:latest
```

**After**

```
[install] To start the daemon again later (background, restart-on-host-reboot):
[install]
  docker run -d --restart unless-stopped --name vicoop-bridge \
    -v vicoop-bridge-state:/data \
    -v vicoop-bridge-workspace:/home/node/work \
    ghcr.io/planetarium/vicoop-bridge-client:latest
```

No changeset: `container/bundled/` and `install-container.sh` ship via `release-bundled.yml` / direct curl, not the `@vicoop-bridge/client` pipeline.

## Test plan

- [x] `bash -n` passes on both files
- [x] `shellcheck` clean on both files
- [ ] Manual: run `bash install-container.sh`, confirm the wizard's backend picker renders one option per line, and the final "to restart later" docker-run block can be selected and pasted as a single runnable command

🤖 Generated with [Claude Code](https://claude.com/claude-code)