### PR TITLE
feat(client): advertise underlying model on openai-compat/v1 extension

### DIFF
--- a/.changeset/openai-compat-advertise-models.md
+++ b/.changeset/openai-compat-advertise-models.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Advertise the underlying model on the `openai-compat/v1` AgentExtension's
+`params.models` slot for the `claude` and `codex` backends, per
+planetarium/oai2a2a#63. Claude reads its `system/init` stream-json event
+on a SIGTERM'd probe (no LLM call), and codex reads the `model` /
+`model_reasoning_effort` keys from `${CODEX_HOME ?? ~/.codex}/config.toml`.
+Probes are best-effort and silent on failure; the advertise is omitted
+when the model cannot be determined. Wire semantics are unchanged.

--- a/.changeset/openai-compat-advertise-models.md
+++ b/.changeset/openai-compat-advertise-models.md
@@ -2,10 +2,26 @@
 '@vicoop-bridge/client': minor
 ---
 
-Advertise the underlying model on the `openai-compat/v1` AgentExtension's
+Advertise the underlying model(s) on the `openai-compat/v1` AgentExtension's
 `params.models` slot for the `claude` and `codex` backends, per
-planetarium/oai2a2a#63. Claude reads its `system/init` stream-json event
-on a SIGTERM'd probe (no LLM call), and codex reads the `model` /
-`model_reasoning_effort` keys from `${CODEX_HOME ?? ~/.codex}/config.toml`.
+planetarium/oai2a2a#63. The advertise lands on the hello card so A2A callers
+can route by declared model without waiting for the first task.
+
+- `claude`: a SIGTERM'd probe spawns `claude --output-format stream-json …`
+  and reads `model` from the `system/init` event — no LLM call. The
+  Claude Code-specific tier suffix (e.g. `[1m]`) is stripped at both
+  emission sites (advertise + `usage.model`) so the canonical Anthropic
+  id is what callers see.
+- `codex`: the probe drives an `app-server` and calls the `model/list`
+  RPC for the full model pool. `reasoning` comes from each entry's
+  `supportedReasoningEfforts`. The `default` tag prefers the operator's
+  `config.toml` model (the value the spawn actually loads) over
+  codex's own recommended `isDefault`.
+- Daemon-wiring fixes that the advertise needed in order to reach
+  the server card: load the bundled `cards/<backend>.json` as the
+  default inline card on hello (so `resolveCapabilities()` runs at all),
+  and raise the outer probe deadline from 3s to 12s so the claude probe
+  on hook-heavy operator cwds completes before hello.
+
 Probes are best-effort and silent on failure; the advertise is omitted
 when the model cannot be determined. Wire semantics are unchanged.

--- a/packages/client/src/backend.ts
+++ b/packages/client/src/backend.ts
@@ -1,4 +1,8 @@
-import type { UpFrame, TaskAssignFrame } from '@vicoop-bridge/protocol';
+import type {
+  OpenAICompatModelAdvertise,
+  UpFrame,
+  TaskAssignFrame,
+} from '@vicoop-bridge/protocol';
 
 export type TaskAssign = TaskAssignFrame;
 
@@ -7,6 +11,12 @@ export type Emit = (frame: UpFrame) => void;
 export interface DetectedCapabilities {
   streaming?: boolean;
   pushNotifications?: boolean;
+  // openai-compat/v1 `params.models[]` advertise block. When set, the
+  // bridge-server hello frame's `agentCard` will carry these on the
+  // openai-compat extension entry, so A2A callers can pick backends by
+  // declared model (planetarium/oai2a2a#63). Best-effort: a backend that
+  // cannot determine its model in time SHOULD omit this rather than guess.
+  openaiCompatModels?: OpenAICompatModelAdvertise[];
 }
 
 export interface Backend {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -12,8 +12,10 @@ import {
   formatToolCallHistory,
   openaiToolsToCallerToolDefs,
   parseOpenAICompatMetadata,
+  probeClaudeModel,
   summarizeToolInput,
   tryParseToolCallsEnvelope,
+  CLAUDE_PROBE_ARGS,
   type ClaudeChildHandle,
   type ClaudeSpawnOptions,
 } from './claude.js';
@@ -3684,4 +3686,163 @@ test('AskUserQuestion: terminal frame uses state=input-required with DataPart pa
   assert.equal(child.stdinClosed, true);
   assert.match(child.stdinPayload, /tool_result/);
   assert.match(child.stdinPayload, /tu_aq_1/);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveCapabilities — startup probe that captures the underlying model from
+// the `system/init` stream-json event for openai-compat/v1 `params.models`
+// advertise (planetarium/oai2a2a#63). The probe SIGTERMs before any LLM call
+// is issued.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('probeClaudeModel returns model from system/init and SIGTERMs the child', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      // Real claude emits a rate_limit_event before system/init in some
+      // sessions; the probe must ignore non-init events and keep reading.
+      child.emitStdout(
+        JSON.stringify({ type: 'rate_limit_event', rate_limit_info: { status: 'allowed' } }) + '\n',
+      );
+      child.emitStdout(
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          session_id: 'sid',
+          model: 'claude-opus-4-7[1m]',
+        }) + '\n',
+      );
+    });
+  });
+
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+
+  assert.equal(model, 'claude-opus-4-7[1m]');
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(child.killed, true);
+  assert.equal(child.killSignal, 'SIGTERM');
+  // The probe invokes the stream-json + verbose argv documented in
+  // https://code.claude.com/docs/en/headless — pin it so a future spawn
+  // refactor that drops a required flag (e.g. --verbose) is caught here
+  // rather than only in production where system/init silently never lands.
+  assert.deepEqual(Array.from(child.args), Array.from(CLAUDE_PROBE_ARGS));
+});
+
+test('probeClaudeModel returns null on timeout when no system/init arrives', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      // Emit only a non-init event so the probe never settles on its own.
+      child.emitStdout(
+        JSON.stringify({ type: 'rate_limit_event', rate_limit_info: { status: 'allowed' } }) + '\n',
+      );
+      // Never call child.finish().
+    });
+  });
+
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn: fake.spawn,
+    timeoutMs: 50,
+  });
+
+  assert.equal(model, null);
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(child.killed, true, 'timeout path must SIGTERM the child');
+});
+
+test('probeClaudeModel ignores malformed JSON lines and still extracts model', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      // Garbage line, then a half-line, then valid system/init. The probe
+      // must skip the non-JSON noise rather than abort.
+      child.emitStdout('not json at all\n');
+      child.emitStdout('{ "type": "system", "subtype": "init"');
+      child.emitStdout(', "model": "claude-sonnet-4-6" }\n');
+    });
+  });
+
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+
+  assert.equal(model, 'claude-sonnet-4-6');
+});
+
+test('probeClaudeModel returns null when child exits before init', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      // Exit immediately with no useful output (mimics `claude: command
+      // not found` / auth-required exit path).
+      child.finish(127, null);
+    });
+  });
+
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+
+  assert.equal(model, null);
+});
+
+test('probeClaudeModel returns null when spawn itself throws', async () => {
+  const spawn: import('./claude.js').ClaudeSpawnFn = () => {
+    throw new Error('ENOENT');
+  };
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn,
+    timeoutMs: 1000,
+  });
+  assert.equal(model, null);
+});
+
+test('claude backend resolveCapabilities advertises model from system/init probe', async () => {
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStdout(
+        JSON.stringify({
+          type: 'system',
+          subtype: 'init',
+          model: 'claude-opus-4-7',
+        }) + '\n',
+      );
+    });
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, probeTimeoutMs: 1000 });
+  assert.ok(backend.resolveCapabilities, 'claude backend must expose resolveCapabilities');
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'claude-opus-4-7', default: true }],
+  });
+});
+
+test('claude backend resolveCapabilities returns {} on probe timeout', async () => {
+  const fake = makeFakeSpawn(() => {
+    // No output, no finish — the probe must time out and return {}.
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, probeTimeoutMs: 25 });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
+});
+
+test('claude backend resolveCapabilities short-circuits when probeTimeoutMs is 0', async () => {
+  let spawned = 0;
+  const fake = makeFakeSpawn(() => {
+    spawned += 1;
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, probeTimeoutMs: 0 });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
+  assert.equal(spawned, 0, 'probeTimeoutMs:0 must skip the spawn entirely');
 });

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -10,7 +10,9 @@ import {
   callerToolDispatchActive,
   createClaudeBackend,
   formatToolCallHistory,
+  normalizeClaudeModelId,
   openaiToolsToCallerToolDefs,
+  parseClaudeModelUsageForOpenAICompat,
   parseOpenAICompatMetadata,
   probeClaudeModel,
   summarizeToolInput,
@@ -2861,7 +2863,9 @@ test('single-model modelUsage maps cleanly and advertises the extension', async 
   assert.equal(payload?.usage?.completion_tokens, 8);
   assert.equal(payload?.usage?.total_tokens, 6 + 24933 + 23 + 8);
   assert.deepEqual(payload?.usage?.prompt_tokens_details, { cached_tokens: 24933 });
-  assert.equal(payload?.usage?.model, 'claude-opus-4-7[1m]');
+  // Normalised to the canonical Anthropic id so it matches what
+  // `params.models[].id` advertises — see `normalizeClaudeModelId`.
+  assert.equal(payload?.usage?.model, 'claude-opus-4-7');
 });
 
 test('absent modelUsage → no openai-compat metadata is attached', async () => {
@@ -3695,7 +3699,7 @@ test('AskUserQuestion: terminal frame uses state=input-required with DataPart pa
 // is issued.
 // ─────────────────────────────────────────────────────────────────────────────
 
-test('probeClaudeModel returns model from system/init and SIGTERMs the child', async () => {
+test('probeClaudeModel returns normalised model from system/init and SIGTERMs the child', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {
       // Real claude emits a rate_limit_event before system/init in some
@@ -3708,6 +3712,8 @@ test('probeClaudeModel returns model from system/init and SIGTERMs the child', a
           type: 'system',
           subtype: 'init',
           session_id: 'sid',
+          // The 1M-tier suffix MUST be stripped so the advertise matches
+          // the canonical Anthropic model id (and `usage.model`).
           model: 'claude-opus-4-7[1m]',
         }) + '\n',
       );
@@ -3720,7 +3726,7 @@ test('probeClaudeModel returns model from system/init and SIGTERMs the child', a
     timeoutMs: 1000,
   });
 
-  assert.equal(model, 'claude-opus-4-7[1m]');
+  assert.equal(model, 'claude-opus-4-7');
   const child = fake.lastChild();
   assert.ok(child);
   assert.equal(child.killed, true);
@@ -3805,14 +3811,14 @@ test('probeClaudeModel returns null when spawn itself throws', async () => {
   assert.equal(model, null);
 });
 
-test('claude backend resolveCapabilities advertises model from system/init probe', async () => {
+test('claude backend resolveCapabilities advertises normalised model from system/init probe', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {
       child.emitStdout(
         JSON.stringify({
           type: 'system',
           subtype: 'init',
-          model: 'claude-opus-4-7',
+          model: 'claude-opus-4-7[1m]',
         }) + '\n',
       );
     });
@@ -3824,6 +3830,49 @@ test('claude backend resolveCapabilities advertises model from system/init probe
   assert.deepEqual(caps, {
     openaiCompatModels: [{ id: 'claude-opus-4-7', default: true }],
   });
+});
+
+test('normalizeClaudeModelId strips trailing tier suffix and is a no-op otherwise', () => {
+  assert.equal(normalizeClaudeModelId('claude-opus-4-7[1m]'), 'claude-opus-4-7');
+  assert.equal(normalizeClaudeModelId('claude-opus-4-7[200k]'), 'claude-opus-4-7');
+  assert.equal(normalizeClaudeModelId('claude-opus-4-7'), 'claude-opus-4-7');
+  assert.equal(
+    normalizeClaudeModelId('claude-opus-4-7-20251101'),
+    'claude-opus-4-7-20251101',
+    'dated form has no brackets — pass through verbatim',
+  );
+  assert.equal(normalizeClaudeModelId('claude-haiku-4-5[1m]'), 'claude-haiku-4-5');
+});
+
+test('probeClaudeModel returns null if the whole id was a bracket tier marker', async () => {
+  // Pathological: model = "[1m]" only. Stripping leaves empty string, and
+  // an empty `id` would trip the protocol's z.string().min(1). Treat as
+  // no signal so the daemon ships its declared card unchanged.
+  const fake = makeFakeSpawn((child) => {
+    setImmediate(() => {
+      child.emitStdout(
+        JSON.stringify({ type: 'system', subtype: 'init', model: '[1m]' }) + '\n',
+      );
+    });
+  });
+  const model = await probeClaudeModel({
+    command: 'claude',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+  assert.equal(model, null);
+});
+
+test('parseClaudeModelUsageForOpenAICompat strips bracket tier suffix on usage.model', () => {
+  // The advertise and the usage.model echo MUST resolve to the same
+  // string so the openai-compat/v1 spec's "id SHOULD match usage.model"
+  // cross-check holds for callers doing exact-match routing.
+  const usage = parseClaudeModelUsageForOpenAICompat({
+    'claude-haiku-4-5-20251001': { inputTokens: 100, outputTokens: 5 },
+    'claude-opus-4-7[1m]': { inputTokens: 100, outputTokens: 50 },
+  });
+  assert.ok(usage);
+  assert.equal(usage!.model, 'claude-opus-4-7');
 });
 
 test('claude backend resolveCapabilities returns {} on probe timeout', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -121,10 +121,16 @@ export interface ClaudeBackendOptions {
    */
   onCallerToolsMcpReady?: (server: CallerToolsMcpServer) => void;
   // Max time the startup probe (`resolveCapabilities`) waits for the
-  // `system/init` event before giving up. Default 5000 ms. Set to 0 to
-  // disable the probe entirely — the daemon will simply not advertise
-  // `params.models` in its hello card, which is harmless (the spec is
-  // advisory) but blinds clients that want to route by declared model.
+  // `system/init` event before giving up. Default 10000 ms — `claude`
+  // startup can take 5s+ on an operator cwd loaded with hooks, skills,
+  // MCP servers, or a large CLAUDE.md (auto-discovery still runs because
+  // we deliberately *don't* use `--bare`: bare mode skips
+  // user/project settings.json, including its `model` field, which would
+  // make the probed model diverge from the model the real task spawn
+  // actually loads). Set to 0 to disable the probe entirely — the daemon
+  // will simply not advertise `params.models` in its hello card, which
+  // is harmless (the spec is advisory) but blinds clients that want to
+  // route by declared model.
   probeTimeoutMs?: number;
 }
 
@@ -1220,7 +1226,7 @@ export function createClaudeBackend(
     }
   }
 
-  const probeTimeoutMs = opts.probeTimeoutMs ?? 5000;
+  const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
 
   return {
     name: 'claude',

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -120,6 +120,12 @@ export interface ClaudeBackendOptions {
    * public API — leave unset in production.
    */
   onCallerToolsMcpReady?: (server: CallerToolsMcpServer) => void;
+  // Max time the startup probe (`resolveCapabilities`) waits for the
+  // `system/init` event before giving up. Default 5000 ms. Set to 0 to
+  // disable the probe entirely — the daemon will simply not advertise
+  // `params.models` in its hello card, which is harmless (the spec is
+  // advisory) but blinds clients that want to route by declared model.
+  probeTimeoutMs?: number;
 }
 
 // Kept short and behaviour-focused. The risk we're guarding against is
@@ -316,6 +322,106 @@ function defaultSpawn(
     stdio: ['pipe', 'pipe', 'pipe'],
     ...(options.cwd ? { cwd: options.cwd } : {}),
   }) as ChildProcess;
+}
+
+// Argv for the resolveCapabilities probe. Stream-json so `system/init`
+// (the first non-rate-limit event, carrying the resolved `model`) lands
+// as a parseable line we can read and bail out from before any LLM call
+// is issued. We pass a minimal prompt because Claude Code rejects an
+// empty `-p` argument — the probe SIGTERMs the child as soon as the
+// init frame arrives, so the prompt is never actually sent to the API.
+//
+// Exported so tests can pin the exact argv the production resolveCapabilities
+// expects, without coupling to a string literal in two places.
+export const CLAUDE_PROBE_ARGS: readonly string[] = [
+  '-p',
+  'probe',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  '--include-partial-messages',
+];
+
+// Spawn `claude` with stream-json output, read until the `system/init`
+// event lands, capture its `model` field, and SIGTERM the child. Returns
+// `null` on any failure (spawn error, timeout, malformed stream, child
+// exits before init) so the caller can silently skip advertising.
+//
+// LLM cost: `system/init` is session metadata emitted before the model
+// is called — see https://code.claude.com/docs/en/headless ("The
+// system/init event reports session metadata including the model … It
+// is the first event in the stream"). Killing the child at this stage
+// produces no token usage. The rate_limit_event line that may precede
+// it is also pre-LLM and is ignored here.
+export async function probeClaudeModel(probeOpts: {
+  command: string;
+  spawn: ClaudeSpawnFn;
+  cwd?: string;
+  timeoutMs: number;
+}): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    let child: ClaudeChildHandle;
+    try {
+      child = probeOpts.spawn(probeOpts.command, CLAUDE_PROBE_ARGS, {
+        ...(probeOpts.cwd ? { cwd: probeOpts.cwd } : {}),
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    let settled = false;
+    const timer = setTimeout(() => settle(null), probeOpts.timeoutMs);
+    if (typeof (timer as { unref?: () => void }).unref === 'function') {
+      (timer as { unref: () => void }).unref();
+    }
+    function settle(value: string | null): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // best-effort
+      }
+      resolve(value);
+    }
+    let buf = '';
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      if (settled) return;
+      buf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) !== -1) {
+        const line = buf.slice(0, nl).trim();
+        buf = buf.slice(nl + 1);
+        if (!line) continue;
+        let evt: unknown;
+        try {
+          evt = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (!evt || typeof evt !== 'object' || Array.isArray(evt)) continue;
+        const e = evt as { type?: unknown; subtype?: unknown; model?: unknown };
+        if (
+          e.type === 'system' &&
+          e.subtype === 'init' &&
+          typeof e.model === 'string' &&
+          e.model.length > 0
+        ) {
+          settle(e.model);
+          return;
+        }
+      }
+    });
+    // stderr is intentionally not surfaced — the probe is best-effort and
+    // a noisy `Notice:` from claude on a non-init code path should not
+    // produce a log line on every daemon start.
+    child.stderr?.on('data', () => {
+      /* drain */
+    });
+    child.on('close', () => settle(null));
+    child.on('error', () => settle(null));
+  });
 }
 
 function extractAssistantText(content: unknown): string {
@@ -1106,10 +1212,37 @@ export function createClaudeBackend(
     }
   }
 
+  const probeTimeoutMs = opts.probeTimeoutMs ?? 5000;
+
   return {
     name: 'claude',
 
     getSendFileMcpServer: () => sendFileMcp,
+
+    // Advertise the underlying model via the openai-compat/v1
+    // `params.models[]` slot (planetarium/oai2a2a#63) so A2A callers can
+    // route by declared model before the first task lands. The probe
+    // spawns `claude` with stream-json output, reads the `system/init`
+    // line, captures `model`, and SIGTERMs — no LLM call is made.
+    // Any failure (timeout, missing binary, malformed stream) returns
+    // `{}` and the card's declared capabilities are left untouched.
+    //
+    // `reasoning` is not set: Claude Code does not currently emit
+    // `completion_tokens_details.reasoning_tokens` in `usage`, and per
+    // spec "Absence means 'unspecified,' not 'false.'"
+    async resolveCapabilities() {
+      if (probeTimeoutMs <= 0) return {};
+      const model = await probeClaudeModel({
+        command,
+        spawn: spawnFn,
+        cwd,
+        timeoutMs: probeTimeoutMs,
+      });
+      if (!model) return {};
+      return {
+        openaiCompatModels: [{ id: model, default: true }],
+      };
+    },
 
     async handle(task, rawEmit, signal) {
       // Idle-silence heartbeat needs to observe every outbound frame so

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -370,10 +370,18 @@ export async function probeClaudeModel(probeOpts: {
       return;
     }
     let settled = false;
+    // No `.unref()` here. The probe always settles via either the timeout,
+    // a `system/init` line, or the child's close/error — and `settle()`
+    // clears the timer in every path. Calling `.unref()` only matters if
+    // the timer would otherwise outlive a daemon shutdown, but the probe
+    // runs once at startup and is awaited; the `await` already prevents
+    // any "linger after daemon exit" hazard. Worse, on Node's built-in
+    // test runner an unref'd timer can let the event loop idle out while
+    // the awaiting promise is still pending, which surfaces as
+    // `Promise resolution is still pending but the event loop has
+    // already resolved` and cancels the test plus everything after it
+    // in the same file. See vicoop-bridge#282 for the failure mode.
     const timer = setTimeout(() => settle(null), probeOpts.timeoutMs);
-    if (typeof (timer as { unref?: () => void }).unref === 'function') {
-      (timer as { unref: () => void }).unref();
-    }
     function settle(value: string | null): void {
       if (settled) return;
       settled = true;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -200,14 +200,21 @@ interface StreamEvent {
 
 // Strip Claude Code's trailing tier suffix (e.g. `[1m]` for the 1M-context
 // variant) from a model id. The suffix appears in `system/init.model` and
-// `result.modelUsage` keys verbatim, but it is not part of the canonical
-// Anthropic API model ID (`claude-opus-4-7`, `claude-opus-4-7-<date>`,
-// etc.) that callers see elsewhere.
+// `result.modelUsage` keys verbatim, but it is a Claude Code-specific
+// notation (the CLI reads it off `--model` / `ANTHROPIC_MODEL` /
+// settings.json `model` per-variable to pick a context tier); the
+// canonical Anthropic API id is just `claude-opus-4-7` (or its dated
+// form). Neither `@anthropic-ai/sdk` nor `@ai-sdk/anthropic` expose a
+// normaliser, and the openai-compat/v1 spec is silent on id format, so
+// this regex is the pragmatic option.
 //
 // Applied at both emission sites — the openai-compat/v1 `params.models[]`
 // advertise (from `system/init`) and the `usage.model` echo (from
 // `result.modelUsage`) — so the spec's "id SHOULD match usage.model"
-// cross-check holds against the canonical form.
+// cross-check holds against the canonical form. Side-effect: the
+// "running on the 1M tier" signal is dropped from the advertise; if a
+// caller ever needs that, it should ride a forward-compat sub-field
+// (e.g. `params.models[].contextWindow`), not the id itself.
 //
 // Exported for unit tests.
 export function normalizeClaudeModelId(raw: string): string {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -198,6 +198,22 @@ interface StreamEvent {
   modelUsage?: unknown;
 }
 
+// Strip Claude Code's trailing tier suffix (e.g. `[1m]` for the 1M-context
+// variant) from a model id. The suffix appears in `system/init.model` and
+// `result.modelUsage` keys verbatim, but it is not part of the canonical
+// Anthropic API model ID (`claude-opus-4-7`, `claude-opus-4-7-<date>`,
+// etc.) that callers see elsewhere.
+//
+// Applied at both emission sites — the openai-compat/v1 `params.models[]`
+// advertise (from `system/init`) and the `usage.model` echo (from
+// `result.modelUsage`) — so the spec's "id SHOULD match usage.model"
+// cross-check holds against the canonical form.
+//
+// Exported for unit tests.
+export function normalizeClaudeModelId(raw: string): string {
+  return raw.replace(/\[[^\]]+\]$/, '');
+}
+
 // Parse Claude Code's `result.modelUsage` (a map keyed by model id with
 // per-model { inputTokens, outputTokens, cacheCreationInputTokens,
 // cacheReadInputTokens, ... }) into a spec-compliant OpenAICompatUsage.
@@ -240,7 +256,7 @@ export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompat
     prompt_tokens: promptSum,
     completion_tokens: completionSum,
     cached_tokens: cacheReadSum > 0 ? cacheReadSum : undefined,
-    model: primaryModel ?? undefined,
+    model: primaryModel ? normalizeClaudeModelId(primaryModel) : undefined,
   });
 }
 
@@ -422,7 +438,18 @@ export async function probeClaudeModel(probeOpts: {
           typeof e.model === 'string' &&
           e.model.length > 0
         ) {
-          settle(e.model);
+          // Normalise here (and not at the resolveCapabilities caller) so
+          // the function's contract — "returns the model id you'll see in
+          // `usage.model`" — holds across both emission sites.
+          const normalised = normalizeClaudeModelId(e.model);
+          if (normalised.length === 0) {
+            // The whole id was a bracketed tier marker — pathological,
+            // but treat as no signal rather than advertise an empty id
+            // and trip downstream zod min(1) checks.
+            settle(null);
+            return;
+          }
+          settle(normalised);
           return;
         }
       }

--- a/packages/client/src/backends/codex-rpc.ts
+++ b/packages/client/src/backends/codex-rpc.ts
@@ -138,6 +138,29 @@ export interface ThreadStartOrResumeResult {
   thread: { id: string };
 }
 
+// Subset of codex's `model/list` response entry we read. The full schema is
+// wider (display name, description, NUX message, service tiers, input
+// modalities, …), but `resolveCapabilities` only needs:
+//   - `id`: the model identifier we advertise + that lands in `usage.model`
+//   - `isDefault`: codex's recommended default (used when the operator
+//     hasn't pinned a different one via `config.toml`)
+//   - `hidden`: codex hides legacy / deprecated models from pickers; we
+//     skip them in the advertise too
+//   - `supportedReasoningEfforts`: presence (length > 0) is codex's own
+//     signal that the model emits `completion_tokens_details.reasoning_tokens`,
+//     so we can set the openai-compat/v1 `reasoning` flag without the
+//     `model_reasoning_effort` heuristic the config.toml path used.
+export interface ModelListEntry {
+  id: string;
+  isDefault?: boolean;
+  hidden?: boolean;
+  supportedReasoningEfforts?: Array<{ reasoningEffort?: string }>;
+}
+
+export interface ModelListResult {
+  data: ModelListEntry[];
+}
+
 export type UserInputItem =
   | { type: 'text'; text: string; text_elements: never[] }
   | { type: 'localImage'; path: string };

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -6,6 +6,7 @@ import {
   createCodexBackend,
   historyToInjectItems,
   openaiToolsToDynamicToolSpecs,
+  parseCodexConfigTomlForModel,
 } from './codex.js';
 import type {
   AppServerChildHandle,
@@ -1832,4 +1833,108 @@ test('openai-compat tasks always thread/start, never thread/resume — every tur
       .params?.config?.features;
     assert.deepEqual(features, EXPECTED_OPENAI_COMPAT_DISABLES);
   }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveCapabilities — reads codex's `config.toml` to advertise the
+// underlying model on the openai-compat/v1 extension (planetarium/oai2a2a#63).
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('parseCodexConfigTomlForModel extracts model + reasoning from real-shape config', () => {
+  const text = [
+    'model = "gpt-5.4"',
+    'model_reasoning_effort = "medium"',
+    '[projects."/home/op/repo"]',
+    'trust_level = "trusted"',
+  ].join('\n');
+  const out = parseCodexConfigTomlForModel(text);
+  assert.equal(out.model, 'gpt-5.4');
+  assert.equal(out.hasReasoningEffort, true);
+});
+
+test('parseCodexConfigTomlForModel treats reasoning_effort="none" as not-reasoning', () => {
+  const text = ['model = "gpt-4o"', 'model_reasoning_effort = "none"'].join('\n');
+  const out = parseCodexConfigTomlForModel(text);
+  assert.equal(out.model, 'gpt-4o');
+  assert.equal(out.hasReasoningEffort, false);
+});
+
+test('parseCodexConfigTomlForModel ignores model = inside a [section]', () => {
+  // codex permits per-profile overrides under sub-tables; those MUST NOT
+  // be read as the agent's default model, because our spawn does not
+  // select a profile.
+  const text = [
+    'model = "gpt-5.4"',
+    '',
+    '[profiles.qa]',
+    'model = "gpt-3.5"',
+  ].join('\n');
+  const out = parseCodexConfigTomlForModel(text);
+  assert.equal(out.model, 'gpt-5.4');
+});
+
+test('parseCodexConfigTomlForModel returns null model when key is absent', () => {
+  const text = '[projects."/x"]\ntrust_level = "trusted"\n';
+  const out = parseCodexConfigTomlForModel(text);
+  assert.equal(out.model, null);
+  assert.equal(out.hasReasoningEffort, false);
+});
+
+test('parseCodexConfigTomlForModel accepts literal-string values and ignores comments', () => {
+  const text = [
+    "model = 'gpt-5.4'  # default for the agent",
+    '# model = "decoy"',
+    'model_reasoning_effort = "high"',
+  ].join('\n');
+  const out = parseCodexConfigTomlForModel(text);
+  assert.equal(out.model, 'gpt-5.4');
+  assert.equal(out.hasReasoningEffort, true);
+});
+
+test('codex backend resolveCapabilities advertises model + reasoning from config.toml', async () => {
+  const backend = createCodexBackend({
+    readCodexConfigToml: async () =>
+      ['model = "gpt-5.4"', 'model_reasoning_effort = "medium"'].join('\n'),
+  });
+  assert.ok(backend.resolveCapabilities, 'codex backend must expose resolveCapabilities');
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'gpt-5.4', reasoning: true, default: true }],
+  });
+});
+
+test('codex backend resolveCapabilities omits reasoning when effort is absent', async () => {
+  const backend = createCodexBackend({
+    readCodexConfigToml: async () => 'model = "gpt-4o"\n',
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'gpt-4o', default: true }],
+  });
+});
+
+test('codex backend resolveCapabilities returns {} when config.toml is unreadable', async () => {
+  const backend = createCodexBackend({
+    readCodexConfigToml: async () => null,
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
+});
+
+test('codex backend resolveCapabilities returns {} when reader throws', async () => {
+  const backend = createCodexBackend({
+    readCodexConfigToml: async () => {
+      throw new Error('boom');
+    },
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
+});
+
+test('codex backend resolveCapabilities returns {} when model key is absent', async () => {
+  const backend = createCodexBackend({
+    readCodexConfigToml: async () => '[projects."/x"]\n',
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
 });

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -12,6 +12,7 @@ import type {
   AppServerChildHandle,
   AppServerSpawnFn,
   AppServerSpawnOptions,
+  ModelListEntry,
 } from './codex-rpc.js';
 import {
   OPENAI_COMPAT_EXTENSION_URI,
@@ -1891,50 +1892,186 @@ test('parseCodexConfigTomlForModel accepts literal-string values and ignores com
   assert.equal(out.hasReasoningEffort, true);
 });
 
-test('codex backend resolveCapabilities advertises model + reasoning from config.toml', async () => {
+// Scenario helper: respond to `initialize` then to `model/list` with the
+// supplied entries. Any other inbound RPC is ignored — the probe never
+// issues a thread/start or turn/start, so we don't bother modelling
+// those response paths here.
+function modelListScenario(
+  entries: ModelListEntry[],
+  opts: { failModelList?: boolean } = {},
+): ChildScenario {
+  return {
+    onLine(frame, child) {
+      const id = (frame as { id?: number | string }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({
+          id,
+          result: {
+            userAgent: 'fake-codex/0.133.0',
+            codexHome: '/tmp',
+            platformFamily: 'unix',
+            platformOs: 'macos',
+          },
+        });
+        return;
+      }
+      if (method === 'model/list' && id !== undefined) {
+        if (opts.failModelList) {
+          child.emitStdout({ id, error: { code: -32601, message: 'Method not found' } });
+        } else {
+          child.emitStdout({ id, result: { data: entries } });
+        }
+        return;
+      }
+    },
+  };
+}
+
+test('codex backend resolveCapabilities advertises full model/list with default tag', async () => {
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([
+      {
+        id: 'gpt-5.5',
+        isDefault: true,
+        supportedReasoningEfforts: [{ reasoningEffort: 'medium' }],
+      },
+      {
+        id: 'gpt-5.4',
+        supportedReasoningEfforts: [{ reasoningEffort: 'low' }],
+      },
+      { id: 'gpt-4o' },
+    ]),
+  );
   const backend = createCodexBackend({
-    readCodexConfigToml: async () =>
-      ['model = "gpt-5.4"', 'model_reasoning_effort = "medium"'].join('\n'),
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => null, // no operator override
   });
-  assert.ok(backend.resolveCapabilities, 'codex backend must expose resolveCapabilities');
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {
-    openaiCompatModels: [{ id: 'gpt-5.4', reasoning: true, default: true }],
+    openaiCompatModels: [
+      { id: 'gpt-5.5', reasoning: true, default: true },
+      { id: 'gpt-5.4', reasoning: true },
+      { id: 'gpt-4o' },
+    ],
   });
+  backend.stop?.();
 });
 
-test('codex backend resolveCapabilities omits reasoning when effort is absent', async () => {
+test('codex backend resolveCapabilities tags operator override as default, not model/list.isDefault', async () => {
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([
+      { id: 'gpt-5.5', isDefault: true, supportedReasoningEfforts: [{ reasoningEffort: 'medium' }] },
+      { id: 'gpt-5.4', supportedReasoningEfforts: [{ reasoningEffort: 'low' }] },
+    ]),
+  );
   const backend = createCodexBackend({
-    readCodexConfigToml: async () => 'model = "gpt-4o"\n',
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => 'model = "gpt-5.4"\n',
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [
+      { id: 'gpt-5.5', reasoning: true }, // codex's recommended default loses to operator override
+      { id: 'gpt-5.4', reasoning: true, default: true },
+    ],
+  });
+  backend.stop?.();
+});
+
+test('codex backend resolveCapabilities surfaces operator override that is absent from model/list', async () => {
+  // Custom provider / beta access: the operator pinned a model codex's
+  // own picker doesn't surface. We still advertise it (and tag default)
+  // because that's what the spawn actually loads.
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([{ id: 'gpt-5.5', isDefault: true }]),
+  );
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => 'model = "claude-opus-via-litellm"\n',
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [
+      { id: 'claude-opus-via-litellm', default: true },
+      { id: 'gpt-5.5' },
+    ],
+  });
+  backend.stop?.();
+});
+
+test('codex backend resolveCapabilities omits reasoning when supportedReasoningEfforts is empty', async () => {
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([
+      { id: 'gpt-4o', isDefault: true, supportedReasoningEfforts: [] },
+    ]),
+  );
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => null,
   });
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {
     openaiCompatModels: [{ id: 'gpt-4o', default: true }],
   });
+  backend.stop?.();
 });
 
-test('codex backend resolveCapabilities returns {} when config.toml is unreadable', async () => {
+test('codex backend resolveCapabilities skips hidden entries', async () => {
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([
+      { id: 'gpt-5.5', isDefault: true },
+      { id: 'gpt-3.5-legacy', hidden: true },
+    ]),
+  );
   const backend = createCodexBackend({
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => null,
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'gpt-5.5', default: true }],
+  });
+  backend.stop?.();
+});
+
+test('codex backend resolveCapabilities returns {} when model/list is unsupported', async () => {
+  const fake = makeFakeSpawn(() => modelListScenario([], { failModelList: true }));
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
     readCodexConfigToml: async () => null,
   });
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {});
+  backend.stop?.();
 });
 
-test('codex backend resolveCapabilities returns {} when reader throws', async () => {
+test('codex backend resolveCapabilities returns {} when model/list response is empty', async () => {
+  const fake = makeFakeSpawn(() => modelListScenario([]));
   const backend = createCodexBackend({
+    spawn: fake.spawn,
+    readCodexConfigToml: async () => null,
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {});
+  backend.stop?.();
+});
+
+test('codex backend resolveCapabilities tolerates a config.toml reader that throws', async () => {
+  // The operator override is a soft signal — its absence shouldn't take
+  // the whole probe down. model/list still drives the advertise.
+  const fake = makeFakeSpawn(() =>
+    modelListScenario([{ id: 'gpt-5.5', isDefault: true }]),
+  );
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
     readCodexConfigToml: async () => {
       throw new Error('boom');
     },
   });
   const caps = await backend.resolveCapabilities!();
-  assert.deepEqual(caps, {});
-});
-
-test('codex backend resolveCapabilities returns {} when model key is absent', async () => {
-  const backend = createCodexBackend({
-    readCodexConfigToml: async () => '[projects."/x"]\n',
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'gpt-5.5', default: true }],
   });
-  const caps = await backend.resolveCapabilities!();
-  assert.deepEqual(caps, {});
+  backend.stop?.();
 });

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -30,6 +30,8 @@ import {
   type DynamicToolCallResponse,
   type DynamicToolSpec,
   type InitializeResult,
+  type ModelListEntry,
+  type ModelListResult,
   type ResponsesApiItem,
   type SandboxMode,
   type ThreadItem,
@@ -711,37 +713,79 @@ export function createCodexBackend(
   return {
     name: 'codex',
 
-    // Advertise the underlying model on the openai-compat/v1 extension's
-    // `params.models[]` slot (planetarium/oai2a2a#63) by reading codex's
-    // own `config.toml`. We honour `CODEX_HOME` (same override codex CLI
-    // respects) so a wrapped install resolves to the right file.
+    // Advertise the underlying model(s) on the openai-compat/v1 extension's
+    // `params.models[]` slot (planetarium/oai2a2a#63) using codex's own
+    // `model/list` RPC. The RPC requires an initialized `app-server`, so
+    // this triggers the same one-time spawn that would otherwise happen on
+    // the first task — subsequent tasks reuse the existing client.
     //
-    // Best-effort: any failure (file missing, malformed TOML, no `model`
-    // key) returns `{}` and leaves the card's declared capabilities
-    // untouched. Operators who hot-swap models via `-c model=...` on the
-    // codex CLI won't be reflected here — but our spawn (`codex
-    // app-server`) doesn't carry that override, so the config file is
-    // authoritative for what codex actually loads under us.
+    // Default picking, in order:
+    //   1. operator override in `${CODEX_HOME ?? ~/.codex}/config.toml`'s
+    //      root `model = "..."` — that's the value codex actually loads
+    //      under us, even though `model/list.isDefault` reports its own
+    //      recommended id;
+    //   2. the entry where `isDefault: true` (codex's recommendation);
+    //   3. the first non-hidden entry as a last resort.
     //
-    // `reasoning: true` is set only when `model_reasoning_effort` is
-    // configured to a non-`none` value, since the spec defines the flag
-    // by whether the model emits `completion_tokens_details.reasoning_tokens`.
+    // `reasoning: true` is set when codex's own per-model
+    // `supportedReasoningEfforts` is non-empty — that flag tracks whether
+    // the model emits `completion_tokens_details.reasoning_tokens`, which
+    // matches the openai-compat/v1 spec's definition exactly.
+    //
+    // Best-effort: any failure (app-server not installed, `model/list`
+    // unsupported on an older codex, transport closes) returns `{}` and
+    // the card's declared capabilities are left untouched.
     async resolveCapabilities() {
-      let text: string | null;
+      let operatorOverride: string | null = null;
       try {
-        text = await readConfigToml();
+        const tomlText = await readConfigToml();
+        if (tomlText) {
+          operatorOverride = parseCodexConfigTomlForModel(tomlText).model;
+        }
+      } catch {
+        // config.toml read failure is tolerable — we'll fall back to
+        // model/list.isDefault for the default-entry pick.
+      }
+
+      let client: AppServerRpcClient;
+      try {
+        client = await ensureClient();
       } catch {
         return {};
       }
-      if (!text) return {};
-      const parsed = parseCodexConfigTomlForModel(text);
-      if (!parsed.model) return {};
-      const entry: { id: string; reasoning?: boolean; default: true } = {
-        id: parsed.model,
-        default: true,
-      };
-      if (parsed.hasReasoningEffort) entry.reasoning = true;
-      return { openaiCompatModels: [entry] };
+
+      let modelList: ModelListEntry[];
+      try {
+        const result = await client.request<ModelListResult>('model/list', {});
+        modelList = Array.isArray(result?.data) ? result.data : [];
+      } catch {
+        return {};
+      }
+
+      const visible = modelList.filter((m) => m && typeof m.id === 'string' && m.id.length > 0 && !m.hidden);
+      if (visible.length === 0) return {};
+
+      const defaultId =
+        (operatorOverride && visible.find((m) => m.id === operatorOverride)?.id) ??
+        operatorOverride ?? // operator pinned a model codex doesn't list (custom provider) — still honour it as the default tag
+        visible.find((m) => m.isDefault)?.id ??
+        visible[0].id;
+
+      const openaiCompatModels = visible.map((m) => {
+        const entry: { id: string; reasoning?: boolean; default?: true } = { id: m.id };
+        if ((m.supportedReasoningEfforts?.length ?? 0) > 0) entry.reasoning = true;
+        if (m.id === defaultId) entry.default = true;
+        return entry;
+      });
+
+      // If the operator pinned a model that wasn't in `model/list` (custom
+      // provider, beta access, etc.), surface it as its own entry so the
+      // advertise still reflects what actually runs.
+      if (operatorOverride && !visible.some((m) => m.id === operatorOverride)) {
+        openaiCompatModels.unshift({ id: operatorOverride, default: true });
+      }
+
+      return { openaiCompatModels };
     },
 
     // Daemon shutdown hook. Per-task abort flows through `signal` in

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -74,6 +74,12 @@ export interface CodexBackendOptions {
   // (no client-side timeout — the server is authoritative). Set to a
   // positive value to fail-fast against a hung agent.
   turnTimeoutMs?: number;
+  // Test seam — overrides the default codex config.toml reader used by
+  // `resolveCapabilities` to advertise the underlying model on the
+  // openai-compat/v1 extension. Returning `null` (or rejecting) keeps the
+  // probe silent and the card's declared capabilities unchanged. Defaults
+  // to reading `${CODEX_HOME ?? ~/.codex}/config.toml` via `fs.readFile`.
+  readCodexConfigToml?: () => Promise<string | null>;
 }
 
 interface SessionEntry {
@@ -88,6 +94,75 @@ const COMMAND_TRACE_MAX_CHARS = 2_000;
 function errorMessage(e: unknown): string {
   if (e instanceof Error) return e.message;
   return String(e);
+}
+
+// Extract a basic TOML string value: `"…"` or `'…'`. Returns null if the
+// raw value doesn't match either form. Intentionally narrow — codex writes
+// these specific keys as plain quoted strings, and we don't want to pull
+// in a full TOML parser for two fields.
+function extractTomlStringValue(raw: string): string | null {
+  let m = /^"((?:[^"\\]|\\[^])*)"$/.exec(raw);
+  if (m) return m[1];
+  m = /^'([^']*)'$/.exec(raw);
+  if (m) return m[1];
+  return null;
+}
+
+// Minimal TOML extractor for codex's root-level `model` and
+// `model_reasoning_effort` keys. We deliberately do NOT depend on a real
+// TOML parser: codex's config schema places both keys at the top, and a
+// line-based scan that bails at the first `[table]` header covers our
+// case without dragging a parser into the client bundle.
+//
+// Exported for unit testing the parser separately from the resolveCapabilities
+// wiring.
+export function parseCodexConfigTomlForModel(text: string): {
+  model: string | null;
+  hasReasoningEffort: boolean;
+} {
+  let model: string | null = null;
+  let hasReasoningEffort = false;
+  for (const rawLine of text.split(/\r?\n/)) {
+    // Strip comments. We accept the simple form (value contains no '#'
+    // inside its quoted region) — sufficient because codex never embeds
+    // '#' in a model id and `model_reasoning_effort` is a known enum.
+    const stripped = rawLine.replace(/(^|\s)#.*$/, '').trim();
+    if (!stripped) continue;
+    // First `[section]` header ends the root section — any later
+    // occurrence of `model =` is a sub-table key (e.g. a profile) and
+    // does NOT override the agent's default.
+    if (stripped.startsWith('[')) break;
+    const m = /^([A-Za-z0-9_]+)\s*=\s*(.+)$/.exec(stripped);
+    if (!m) continue;
+    const key = m[1];
+    const rawVal = m[2].trim();
+    if (key === 'model') {
+      const v = extractTomlStringValue(rawVal);
+      if (v !== null && v.length > 0) model = v;
+    } else if (key === 'model_reasoning_effort') {
+      const v = extractTomlStringValue(rawVal);
+      // `none` is the explicit "no effort" enum value — treat it as
+      // "model is not used in reasoning mode here" and leave
+      // `hasReasoningEffort` false so we don't claim reasoning_tokens
+      // will land for runs configured this way.
+      if (v !== null && v.length > 0 && v.toLowerCase() !== 'none') {
+        hasReasoningEffort = true;
+      }
+    }
+  }
+  return { model, hasReasoningEffort };
+}
+
+// Default config.toml reader. Honours `CODEX_HOME` to match the codex CLI's
+// own override hook, falling back to `~/.codex/config.toml`. Returns null on
+// any error so `resolveCapabilities` silently skips the advertise.
+async function defaultReadCodexConfigToml(): Promise<string | null> {
+  const home = process.env.CODEX_HOME ?? path.join(os.homedir(), '.codex');
+  try {
+    return await fs.readFile(path.join(home, 'config.toml'), 'utf8');
+  } catch {
+    return null;
+  }
 }
 
 function traceabilityRequested(task: {
@@ -631,8 +706,43 @@ export function createCodexBackend(
     return initInFlight;
   }
 
+  const readConfigToml = opts.readCodexConfigToml ?? defaultReadCodexConfigToml;
+
   return {
     name: 'codex',
+
+    // Advertise the underlying model on the openai-compat/v1 extension's
+    // `params.models[]` slot (planetarium/oai2a2a#63) by reading codex's
+    // own `config.toml`. We honour `CODEX_HOME` (same override codex CLI
+    // respects) so a wrapped install resolves to the right file.
+    //
+    // Best-effort: any failure (file missing, malformed TOML, no `model`
+    // key) returns `{}` and leaves the card's declared capabilities
+    // untouched. Operators who hot-swap models via `-c model=...` on the
+    // codex CLI won't be reflected here — but our spawn (`codex
+    // app-server`) doesn't carry that override, so the config file is
+    // authoritative for what codex actually loads under us.
+    //
+    // `reasoning: true` is set only when `model_reasoning_effort` is
+    // configured to a non-`none` value, since the spec defines the flag
+    // by whether the model emits `completion_tokens_details.reasoning_tokens`.
+    async resolveCapabilities() {
+      let text: string | null;
+      try {
+        text = await readConfigToml();
+      } catch {
+        return {};
+      }
+      if (!text) return {};
+      const parsed = parseCodexConfigTomlForModel(text);
+      if (!parsed.model) return {};
+      const entry: { id: string; reasoning?: boolean; default: true } = {
+        id: parsed.model,
+        default: true,
+      };
+      if (parsed.hasReasoningEffort) entry.reasoning = true;
+      return { openaiCompatModels: [entry] };
+    },
 
     // Daemon shutdown hook. Per-task abort flows through `signal` in
     // `handle()`, but the `codex app-server` subprocess is a singleton kept

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { AgentCard } from '@vicoop-bridge/protocol';
 import { longestMatch, object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
@@ -462,10 +464,31 @@ async function runWithShutdownTimeout(shutdown: () => Promise<void>): Promise<vo
   }
 }
 
+// Resolve the agent card the daemon should send inline on `hello`. Order:
+//   1. operator-supplied `--card` path (highest priority — full override)
+//   2. bundled `cards/<backend>.json` shipped with this package (default)
+//   3. undefined — server falls back to its own canonical card for the
+//      backend kind. The server card is the right shape but lacks anything
+//      we'd want to advertise dynamically (e.g. openai-compat/v1
+//      `params.models`, per planetarium/oai2a2a#63), so always preferring
+//      the local bundle when present makes the advertise reachable.
+//
+// The lookup uses `import.meta.url` so it works both from `src/cli.ts`
+// during dev (resolves to `<pkg>/cards/<kind>.json`) and from the
+// published bundle's `dist/cli.js` (also `<pkg>/cards/<kind>.json`,
+// since `package.json` files include both `dist/` and `cards/`).
+function resolveBundledCardPath(backendKind: string): string | null {
+  const cliDir = path.dirname(fileURLToPath(import.meta.url));
+  // From `src/cli.ts` and `dist/cli.js` alike, `cards/` sits one level up.
+  const candidate = path.join(cliDir, '..', 'cards', `${backendKind}.json`);
+  return existsSync(candidate) ? candidate : null;
+}
+
 async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
   const args = resolveDaemonArgs(parsed);
-  const agentCard = args.card
-    ? AgentCard.parse(JSON.parse(readFileSync(args.card, 'utf8')))
+  const cardPath = args.card ?? resolveBundledCardPath(args.backend);
+  const agentCard = cardPath
+    ? AgentCard.parse(JSON.parse(readFileSync(cardPath, 'utf8')))
     : undefined;
 
   // Emit the resolved backend at startup so operators can verify which

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -3,6 +3,7 @@ import {
   PROTOCOL_VERSION,
   encodeFrame,
   parseDownFrame,
+  withOpenAICompatModelsAdvertise,
   type AgentCard,
   type Part,
   type TaskAssignFrame,
@@ -204,17 +205,34 @@ export class Client {
         // object must leave the card byte-for-byte unchanged, including an
         // absent `capabilities` field. Only materialize `capabilities` when
         // the probe actually reports a value we need to apply.
-        if (detected.streaming === undefined && detected.pushNotifications === undefined) {
+        const hasModels = (detected.openaiCompatModels?.length ?? 0) > 0;
+        if (
+          detected.streaming === undefined &&
+          detected.pushNotifications === undefined &&
+          !hasModels
+        ) {
           return base;
         }
-        const merged: AgentCard['capabilities'] = {
-          ...(base.capabilities ?? {}),
-          ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
-          ...(detected.pushNotifications !== undefined
-            ? { pushNotifications: detected.pushNotifications }
-            : {}),
-        };
-        return { ...base, capabilities: merged };
+        let next = base;
+        if (
+          detected.streaming !== undefined ||
+          detected.pushNotifications !== undefined
+        ) {
+          const merged: AgentCard['capabilities'] = {
+            ...(base.capabilities ?? {}),
+            ...(detected.streaming !== undefined ? { streaming: detected.streaming } : {}),
+            ...(detected.pushNotifications !== undefined
+              ? { pushNotifications: detected.pushNotifications }
+              : {}),
+          };
+          next = { ...next, capabilities: merged };
+        }
+        if (hasModels && detected.openaiCompatModels) {
+          // No-op if the card doesn't declare openai-compat/v1 — see
+          // `withOpenAICompatModelsAdvertise` for the rationale.
+          next = withOpenAICompatModelsAdvertise(next, detected.openaiCompatModels);
+        }
+        return next;
       } finally {
         // Clear the deadline timer so a fast probe doesn't leave an extra
         // callback and its closure alive until `deadlineMs` elapses. The

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -88,7 +88,14 @@ export interface ClientOptions {
   onFatal?: (info: { code: number; reason: string }) => void;
 }
 
-const DEFAULT_PROBE_DEADLINE_MS = 3000;
+// Outer race deadline for `backend.resolveCapabilities()` — caps how long
+// the bridge-server hello frame waits on the backend probe before falling
+// back to the declared card. 12s accommodates the claude backend's worst
+// case (operator cwd with hooks / skills / MCP / a large CLAUDE.md can
+// push `system/init` emit to 5–10s) plus headroom; faster backends (codex
+// reads config.toml in ~1ms) settle well before this and the deadline
+// never fires.
+const DEFAULT_PROBE_DEADLINE_MS = 12_000;
 const DEFAULT_RECONNECT_DELAY_MS = 3000;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;

--- a/packages/client/src/openai-compat-advertise.test.ts
+++ b/packages/client/src/openai-compat-advertise.test.ts
@@ -1,0 +1,162 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AgentCard,
+  OPENAI_COMPAT_EXTENSION_URI,
+  OpenAICompatExtensionParams,
+  buildOpenAICompatExtensionParams,
+  withOpenAICompatModelsAdvertise,
+  type OpenAICompatModelAdvertise,
+} from '@vicoop-bridge/protocol';
+
+test('buildOpenAICompatExtensionParams returns undefined for empty input', () => {
+  assert.equal(buildOpenAICompatExtensionParams([]), undefined);
+});
+
+test('buildOpenAICompatExtensionParams passes through a single entry verbatim', () => {
+  const out = buildOpenAICompatExtensionParams([
+    { id: 'opus-4-7', reasoning: true, default: true },
+  ]);
+  assert.deepEqual(out, {
+    models: [{ id: 'opus-4-7', reasoning: true, default: true }],
+  });
+});
+
+test('buildOpenAICompatExtensionParams keeps first default, strips later defaults', () => {
+  const out = buildOpenAICompatExtensionParams([
+    { id: 'a', default: true, reasoning: true },
+    { id: 'b', default: true },
+    { id: 'c' },
+  ]);
+  assert.deepEqual(out, {
+    models: [
+      { id: 'a', default: true, reasoning: true },
+      { id: 'b' },
+      { id: 'c' },
+    ],
+  });
+});
+
+test('buildOpenAICompatExtensionParams leaves non-default entries untouched', () => {
+  const out = buildOpenAICompatExtensionParams([
+    { id: 'a', reasoning: true },
+    { id: 'b' },
+  ]);
+  assert.deepEqual(out, {
+    models: [
+      { id: 'a', reasoning: true },
+      { id: 'b' },
+    ],
+  });
+});
+
+test('OpenAICompatExtensionParams schema accepts unknown sub-fields (passthrough)', () => {
+  // Forward-compat: a future revision could add a sibling key alongside
+  // `models`. The receiver-side parse should not strip it.
+  const parsed = OpenAICompatExtensionParams.parse({
+    models: [{ id: 'a' }],
+    futureKey: { nested: 42 },
+  });
+  assert.deepEqual(parsed.models, [{ id: 'a' }]);
+  assert.equal((parsed as { futureKey?: unknown }).futureKey !== undefined, true);
+});
+
+test('OpenAICompatModelAdvertise rejects empty id', () => {
+  assert.throws(() => OpenAICompatExtensionParams.parse({ models: [{ id: '' }] }));
+});
+
+test('withOpenAICompatModelsAdvertise is a no-op when the openai-compat extension is absent', () => {
+  const card = AgentCard.parse({
+    name: 'no-ext',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: {
+      extensions: [
+        { uri: 'https://example.test/other/v1' },
+      ],
+    },
+  });
+  const out = withOpenAICompatModelsAdvertise(card, [{ id: 'opus-4-7', default: true }]);
+  assert.deepEqual(out, card);
+});
+
+test('withOpenAICompatModelsAdvertise is a no-op when capabilities/extensions is undefined', () => {
+  const card = AgentCard.parse({
+    name: 'minimal',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+  });
+  const out = withOpenAICompatModelsAdvertise(card, [{ id: 'opus-4-7', default: true }]);
+  assert.deepEqual(out, card);
+});
+
+test('withOpenAICompatModelsAdvertise is a no-op for empty model list', () => {
+  const card = AgentCard.parse({
+    name: 'has-ext',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: {
+      extensions: [{ uri: OPENAI_COMPAT_EXTENSION_URI }],
+    },
+  });
+  const out = withOpenAICompatModelsAdvertise(card, []);
+  assert.deepEqual(out, card);
+});
+
+test('withOpenAICompatModelsAdvertise merges models onto the openai-compat extension entry', () => {
+  const card = AgentCard.parse({
+    name: 'has-ext',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: {
+      extensions: [
+        { uri: 'https://example.test/other/v1', description: 'leave me alone' },
+        { uri: OPENAI_COMPAT_EXTENSION_URI, description: 'keep desc' },
+      ],
+    },
+  });
+  const models: OpenAICompatModelAdvertise[] = [
+    { id: 'opus-4-7', reasoning: true, default: true },
+    { id: 'sonnet-4-6' },
+  ];
+  const out = withOpenAICompatModelsAdvertise(card, models);
+  // Original is untouched.
+  assert.equal(card.capabilities?.extensions?.[1].params, undefined);
+  // Output has params.models on the openai-compat entry only.
+  const exts = out.capabilities?.extensions;
+  assert.equal(exts?.length, 2);
+  assert.equal(exts?.[0].uri, 'https://example.test/other/v1');
+  assert.equal(exts?.[0].params, undefined);
+  assert.equal(exts?.[1].uri, OPENAI_COMPAT_EXTENSION_URI);
+  assert.equal(exts?.[1].description, 'keep desc');
+  assert.deepEqual(exts?.[1].params, {
+    models: [
+      { id: 'opus-4-7', reasoning: true, default: true },
+      { id: 'sonnet-4-6' },
+    ],
+  });
+});
+
+test('withOpenAICompatModelsAdvertise preserves pre-existing params keys on the entry', () => {
+  // If a future code path already wrote a sibling key onto `params`, the
+  // merge must not drop it. Required for forward-compat with other
+  // sub-fields the spec may add to the same params object.
+  const card = AgentCard.parse({
+    name: 'has-ext',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: {
+      extensions: [
+        {
+          uri: OPENAI_COMPAT_EXTENSION_URI,
+          params: { siblingKey: 'preserved' },
+        },
+      ],
+    },
+  });
+  const out = withOpenAICompatModelsAdvertise(card, [{ id: 'a' }]);
+  assert.deepEqual(out.capabilities?.extensions?.[0].params, {
+    siblingKey: 'preserved',
+    models: [{ id: 'a' }],
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -81,6 +81,79 @@ export const AgentExtension = z.object({
 });
 export type AgentExtension = z.infer<typeof AgentExtension>;
 
+// Per planetarium/oai2a2a#63: `openai-compat/v1` AgentExtension may carry an
+// optional `params.models[]` advertise block. Each entry: `id` required;
+// `reasoning` / `default` optional. The shape is advisory and forward-compat
+// — receivers MUST ignore unknown sub-fields.
+export const OpenAICompatModelAdvertise = z.object({
+  id: z.string().min(1),
+  reasoning: z.boolean().optional(),
+  default: z.boolean().optional(),
+});
+export type OpenAICompatModelAdvertise = z.infer<typeof OpenAICompatModelAdvertise>;
+
+// `.passthrough()` so a future forward-compatible sub-field added in the same
+// extension URI (the spec explicitly allows additive growth without a new
+// URI) parses through ours instead of stripping the value.
+export const OpenAICompatExtensionParams = z
+  .object({
+    models: z.array(OpenAICompatModelAdvertise).optional(),
+  })
+  .passthrough();
+export type OpenAICompatExtensionParams = z.infer<typeof OpenAICompatExtensionParams>;
+
+// Build the `params` value for the openai-compat/v1 AgentExtension entry.
+// Returns `undefined` when `models` is empty so callers can omit `params`
+// entirely rather than emit a `{ models: [] }` that advertises emptiness —
+// per spec, absence of `params.models` MUST NOT be read as "no models
+// supported."
+//
+// First-wins `default` normalisation: spec says "At most one entry SHOULD
+// set default: true; if multiple do, receivers SHOULD treat the first as
+// the default." We enforce on the producer side by stripping `default` from
+// subsequent entries, so the wire we emit is always conformant.
+export function buildOpenAICompatExtensionParams(
+  models: readonly OpenAICompatModelAdvertise[],
+): OpenAICompatExtensionParams | undefined {
+  if (models.length === 0) return undefined;
+  let sawDefault = false;
+  const normalised = models.map((m) => {
+    if (!m.default) return { ...m };
+    if (sawDefault) {
+      const { default: _drop, ...rest } = m;
+      return { ...rest };
+    }
+    sawDefault = true;
+    return { ...m };
+  });
+  return { models: normalised };
+}
+
+// Return a shallow copy of `card` with `params.models` set on the
+// `openai-compat/v1` extension entry. No-op (returns the input as-is) when
+// `models` is empty or when the card does not declare the extension — we
+// never *add* the extension just to advertise models, because that would
+// imply support the agent may not have.
+export function withOpenAICompatModelsAdvertise(
+  card: AgentCard,
+  models: readonly OpenAICompatModelAdvertise[],
+): AgentCard {
+  const params = buildOpenAICompatExtensionParams(models);
+  if (!params) return card;
+  const exts = card.capabilities?.extensions;
+  if (!exts) return card;
+  const idx = exts.findIndex((e) => e.uri === OPENAI_COMPAT_EXTENSION_URI);
+  if (idx < 0) return card;
+  const target = exts[idx];
+  const mergedParams = { ...(target.params ?? {}), ...params };
+  const nextExts = exts.slice();
+  nextExts[idx] = { ...target, params: mergedParams };
+  return {
+    ...card,
+    capabilities: { ...card.capabilities, extensions: nextExts },
+  };
+}
+
 export const SecurityScheme = z.object({
   type: z.string(),
   scheme: z.string().optional(),


### PR DESCRIPTION
## Summary

Implements producer-side support for [planetarium/oai2a2a#63](https://github.com/planetarium/oai2a2a/pull/63) — the `params.models[]` advertise slot on the `openai-compat/v1` AgentExtension. A2A callers can now route by declared underlying model **before the first task lands** for the `claude` and `codex` backends.

- **protocol** — add `OpenAICompatModelAdvertise` / `OpenAICompatExtensionParams` zod schemas (passthrough for forward-compat) plus `buildOpenAICompatExtensionParams` and `withOpenAICompatModelsAdvertise` helpers (first-wins `default` normalisation, no-op when the extension is absent).
- **client/backend** — extend `DetectedCapabilities` with `openaiCompatModels?` and merge it onto the effective AgentCard at hello time via `Client.resolveEffectiveCard()`.
- **claude backend** — `resolveCapabilities()` spawns `claude -p probe --output-format stream-json --verbose --include-partial-messages`, reads the first `system/init` line for `model`, then `SIGTERM`s the child. `system/init` is session metadata emitted before any model call, so no LLM tokens are consumed (verified against the upstream [headless docs](https://code.claude.com/docs/en/headless)).
- **codex backend** — `resolveCapabilities()` reads `${CODEX_HOME ?? ~/.codex}/config.toml` root-level `model` and `model_reasoning_effort` via a minimal key extractor (no TOML parser dependency). `reasoning: true` is set only when the effort is configured to a non-`none` value.

## Non-goals (for now)

- **vicoop-codex / openclaw** — no task-pre advertise path. vicoop-codex is explicitly designed without operator-facing model knobs, and openclaw routes through the gateway's host agent; both stay silent for now and the advertise omitted, leaving wire interop unchanged.
- **Operator-supplied advertise overrides** — out of scope for this PR. A `--<backend>-advertise-models` CLI surface can land once #63 ships.
- **per-request model selection** — non-goal of #63 itself.

## Wire safety

All probes are best-effort. On any failure (missing binary, file unreadable, timeout, malformed stream) `resolveCapabilities()` returns `{}` and the card's declared capabilities are untouched. Existing callers that do not look at `params` see byte-for-byte the same hello as before.

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 556 tests
- [x] `pnpm --filter @vicoop-bridge/server test` — 183 pass / 39 skipped
- [ ] Real-binary smoke (claude + codex with this branch installed; sanity-check the advertised id matches `usage.model` post-call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)