### PR TITLE
feat(client): add --backend to `agent register`

### DIFF
--- a/.changeset/agent-register-backend-flag.md
+++ b/.changeset/agent-register-backend-flag.md
@@ -1,0 +1,12 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add `--backend` to `vicoop-client agent register`. When supplied (one of
+`echo` / `openclaw` / `claude` / `codex` / `vicoop-codex`), the chosen
+backend is persisted into `config.json` alongside the just-minted
+credentials so the daemon picks it up on next start without the
+entrypoint wizard or a separate `--backend` daemon flag. Omitting
+`--backend` leaves any pre-existing `backend` field intact, so
+re-running register to rotate a token does not clobber an operator's
+prior backend choice.

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -28,7 +28,7 @@ export const DEFAULT_BRIDGE_HTTPS_URL = 'https://vicoop-bridge-server.fly.dev';
 const SANDBOX_MODES = ['read-only', 'workspace-write', 'danger-full-access'] as const;
 export type CodexSandboxMode = (typeof SANDBOX_MODES)[number];
 
-const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex', 'vicoop-codex'] as const;
+export const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex', 'vicoop-codex'] as const;
 export type BackendKind = (typeof BACKEND_KINDS)[number];
 
 const BACKEND_RUNTIMES = ['host', 'container'] as const;

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
 import test, { type TestContext } from 'node:test';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { saveOwnerSession } from './owner-session.js';
 import { runAgentRegister, runSetup, type AgentRegisterArgs, type SetupArgs } from './setup.js';
 import { readConfig } from './config.js';
@@ -901,12 +901,13 @@ function agentRegisterArgs(
 ): AgentRegisterArgs {
   const {
     agentId,
-    callers = [], envFile, envFileAlias, server, token, json = false,
+    callers = [], backend, envFile, envFileAlias, server, token, json = false,
   } = p;
   return {
     action: 'agent-register',
     agentId,
     callers,
+    backend,
     envFile,
     envFileAlias,
     server,
@@ -1086,6 +1087,43 @@ test('agent register configures callers when --caller is passed', async (t) => {
     fix.calls[1].url,
     'https://bridge.test/admin-api/agents/codex-Mac/callers',
   );
+});
+
+test('agent register --backend persists the backend choice into config.json', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    agentId: 'codex-Mac', backend: 'codex',
+  }));
+
+  assert.equal(code, 0);
+  const config = readConfig(join(fix.tmpHome, '.vicoop', 'config.json'));
+  assert.deepEqual(config, {
+    server_url: 'wss://bridge.test',
+    server_token: 'agent-token-1',
+    agent_id: 'codex-Mac',
+    backend: 'codex',
+  });
+});
+
+test('agent register without --backend leaves the existing backend field intact', async (t) => {
+  const fix = installAgentRegisterFixture(t);
+
+  // Pre-seed an operator-edited config.json with a backend choice already set,
+  // then run register without --backend. The backend field must survive the
+  // credential rewrite so re-running register to rotate a token doesn't wipe
+  // the operator's prior setup.
+  const configPath = join(fix.tmpHome, '.vicoop', 'config.json');
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify({ backend: 'claude' }, null, 2));
+
+  const code = await runAgentRegister(agentRegisterArgs({
+    agentId: 'codex-Mac',
+  }));
+
+  assert.equal(code, 0);
+  const config = readConfig(configPath);
+  assert.equal(config?.backend, 'claude');
 });
 
 // ---- Legacy `setup` alias: deprecation warning -----------------------------

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -9,8 +9,9 @@ import { map, multiple, optional, withDefault } from '@optique/core/modifiers';
 import { command, constant, flag, option } from '@optique/core/primitives';
 import { message } from '@optique/core/message';
 import type { InferValue } from '@optique/core/parser';
-import { string } from '@optique/core/valueparser';
+import { choice, string } from '@optique/core/valueparser';
 import { atomicWriteFile, resolveOwnerSession } from './owner-session.js';
+import { BACKEND_KINDS, type BackendKind } from './cli-args.js';
 import {
   defaultConfigPath,
   readConfigRaw,
@@ -70,6 +71,9 @@ export const agentRegisterCmd = command(
     }),
     callers: multiple(option('--caller', string({ metavar: 'PRINCIPAL' }), {
       description: message`Principal allowed to call this agent. Repeatable; comma-separated lists also accepted within a single occurrence.`,
+    })),
+    backend: optional(option('--backend', choice([...BACKEND_KINDS]), {
+      description: message`Persist this backend choice into config.json so the daemon picks it up on next start. Without this flag, the daemon falls back to the existing \`backend\` field (or the entrypoint wizard).`,
     })),
     envFile: optional(option('--write-env-file', string({ metavar: 'PATH' }), {
       description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars; the file is purely an operator-side credentials backup / scripting hook.`,
@@ -169,7 +173,11 @@ function writeClientEnvFile(path: string, success: ClientRegisterSuccess, bridge
 // response. Failing here is safer than silently overwriting a populated
 // `agent_id` in config.json with `""`, which would break the daemon on
 // next start with no obvious cause.
-function writeConfigForSetup(success: ClientRegisterSuccess, bridgeUrl: string): string {
+function writeConfigForSetup(
+  success: ClientRegisterSuccess,
+  bridgeUrl: string,
+  backend: BackendKind | null,
+): string {
   const firstAgentId = success.allowed_agent_ids[0];
   if (!firstAgentId) {
     throw new Error(
@@ -202,6 +210,7 @@ function writeConfigForSetup(success: ClientRegisterSuccess, bridgeUrl: string):
   existing.server_url = wsUrlFromBridge(bridgeUrl);
   existing.server_token = success.client_token;
   existing.agent_id = firstAgentId;
+  if (backend) existing.backend = backend;
   writeConfig(path, existing);
   return path;
 }
@@ -214,7 +223,7 @@ function writeConfigForSetup(success: ClientRegisterSuccess, bridgeUrl: string):
 // here; see `writeOptionalEnvFile` for that path's separate failure
 // handling.
 function persistCanonical(
-  args: { json: boolean },
+  args: { json: boolean; backend: BackendKind | null },
   success: ClientRegisterSuccess,
   bridgeUrl: string,
 ): string | null {
@@ -224,7 +233,7 @@ function persistCanonical(
     process.stdout.write(`${JSON.stringify(success, null, 2)}\n`);
     return null;
   }
-  const configPath = writeConfigForSetup(success, bridgeUrl);
+  const configPath = writeConfigForSetup(success, bridgeUrl, args.backend);
   process.stderr.write(`Wrote ${configPath} (mode 600).\n`);
   return configPath;
 }
@@ -357,6 +366,10 @@ interface ExecuteRegistrationOpts {
   // rename); kept as `server` here to match the args field name.
   server: string | null;
   token: string | null;
+  // Backend choice to persist into config.json (top-level `backend` field).
+  // null means "leave whatever is already there"; the daemon's existing
+  // precedence (CLI flag > env > config > default 'echo') still applies.
+  backend: BackendKind | null;
   json: boolean;
   labels: RegistrationLabels;
 }
@@ -441,7 +454,11 @@ async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<numbe
   // recovery hatch.
   let canonicalPath: string | null;
   try {
-    canonicalPath = persistCanonical({ json: opts.json }, success, bridge);
+    canonicalPath = persistCanonical(
+      { json: opts.json, backend: opts.backend },
+      success,
+      bridge,
+    );
   } catch (e) {
     process.stderr.write(`${(e as Error).message}\n`);
     process.stderr.write(
@@ -551,6 +568,7 @@ export async function runSetup(args: SetupArgs): Promise<number> {
     envFile: args.envFile ?? args.envFileAlias ?? null,
     server: args.server ?? null,
     token: args.token ?? null,
+    backend: null,
     json: args.json,
     labels: {
       cmdName: 'setup',
@@ -579,6 +597,7 @@ export async function runAgentRegister(args: AgentRegisterArgs): Promise<number>
     envFile: args.envFile ?? args.envFileAlias ?? null,
     server: args.server ?? null,
     token: args.token ?? null,
+    backend: args.backend ?? null,
     json: args.json,
     labels: {
       cmdName: 'agent register',


### PR DESCRIPTION
## Summary

- Adds `--backend` to `vicoop-client agent register`. Valid values: `echo` / `openclaw` / `claude` / `codex` / `vicoop-codex` (validated against the same enum the daemon uses).
- When supplied, the chosen backend is persisted into `config.json` alongside `server_url` / `server_token` / `agent_id`, so the daemon picks it up on next start without the entrypoint wizard or a separate `--backend` daemon flag.
- Omitting `--backend` leaves any pre-existing `backend` field intact — re-running register to rotate a token does not clobber operator setup.
- The deprecated `setup` alias is wired to pass `null` so its behavior is unchanged.

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 529 / 529 pass, including two new coverage tests:
  - `agent register --backend persists the backend choice into config.json`
  - `agent register without --backend leaves the existing backend field intact`
- [ ] Manual: `vicoop-client agent register --agent-id foo --backend codex` writes `"backend": "codex"` into `~/.vicoop/config.json`.
- [ ] Manual: re-running without `--backend` keeps the prior value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)