### PR TITLE
fix(client): embed bundled cards so bun --compile ships them

### DIFF
--- a/.changeset/openai-compat-advertise-bundle-cards-fix.md
+++ b/.changeset/openai-compat-advertise-bundle-cards-fix.md
@@ -1,0 +1,24 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Fix the `openai-compat/v1` `params.models` advertise (shipped in 0.23.0)
+not reaching the hello frame from a `vicoop-client upgrade`-installed
+release binary. The bundled card lookup did
+`fileURLToPath(import.meta.url) + '..' + 'cards' + …` and then
+`existsSync`. Under `tsx` (dev) or a Node-run `dist/cli.js` that path
+resolves to a real file, but inside a `bun build --compile` single-file
+binary `import.meta.url` points into Bun's virtual root — the file
+doesn't exist on disk, `existsSync` returns false, the lookup returns
+`null`, and `agentCard` ends up `undefined`. `Client.resolveEffectiveCard`
+short-circuits before `backend.resolveCapabilities()` is even called,
+the daemon ships hello with no inline card, and the server falls back
+to its own canonical card which has no `params.models`. Symptom for
+operators upgrading via `vicoop-client upgrade`: no model advertise
+after relaunch, while `pnpm dev:client` (which runs from disk) worked.
+
+Replace the fs-based lookup with static JSON imports of the five
+bundled cards (`claude` / `codex` / `echo` / `openclaw` /
+`vicoop-codex`) — Bun's `--compile` embeds statically imported JSON
+into the binary, so dev and release paths converge. Operator-supplied
+`--card <path>` stays fs-based.

--- a/packages/client/src/bundled-cards.test.ts
+++ b/packages/client/src/bundled-cards.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { AgentCard, OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { BUNDLED_CARDS, resolveBundledCard } from './bundled-cards.js';
+
+// Locks in the invariant the openai-compat/v1 `params.models` advertise
+// relies on: bundled cards must be embedded (not fs-resolved) so they
+// reach `Client.resolveEffectiveCard` from inside a `bun --compile`
+// single-file binary, and the openai-compat extension must already be
+// declared on every probe-capable backend's card — `withOpenAICompatModelsAdvertise`
+// intentionally no-ops when the URI isn't already present.
+const PROBE_CAPABLE_BACKENDS = ['claude', 'codex'] as const;
+
+for (const kind of Object.keys(BUNDLED_CARDS)) {
+  test(`bundled card for "${kind}" parses as an AgentCard`, () => {
+    const raw = resolveBundledCard(kind);
+    assert.ok(raw, `expected BUNDLED_CARDS["${kind}"] to be defined`);
+    assert.doesNotThrow(() => AgentCard.parse(raw));
+  });
+}
+
+for (const kind of PROBE_CAPABLE_BACKENDS) {
+  test(`bundled card for "${kind}" declares the openai-compat extension`, () => {
+    const card = AgentCard.parse(resolveBundledCard(kind));
+    const exts = card.capabilities?.extensions ?? [];
+    const hit = exts.find((e) => e.uri === OPENAI_COMPAT_EXTENSION_URI);
+    assert.ok(
+      hit,
+      `card for "${kind}" must declare ${OPENAI_COMPAT_EXTENSION_URI} so the resolveCapabilities advertise has a merge target`,
+    );
+  });
+}
+
+test('resolveBundledCard returns null for an unknown backend kind', () => {
+  assert.equal(resolveBundledCard('does-not-exist'), null);
+});

--- a/packages/client/src/bundled-cards.ts
+++ b/packages/client/src/bundled-cards.ts
@@ -1,0 +1,25 @@
+import claudeCard from '../cards/claude.json' with { type: 'json' };
+import codexCard from '../cards/codex.json' with { type: 'json' };
+import echoCard from '../cards/echo.json' with { type: 'json' };
+import openclawCard from '../cards/openclaw.json' with { type: 'json' };
+import vicoopCodexCard from '../cards/vicoop-codex.json' with { type: 'json' };
+
+// Cards bundled with this package, keyed by backend kind. Static imports
+// (instead of an `import.meta.url`-relative fs read) so `bun build --compile`
+// embeds the JSON into the single-file release binary — an fs lookup against
+// Bun's virtual root returns nothing once compiled, leaving the daemon's
+// hello frame without an inline `agentCard` and silently defeating the
+// openai-compat/v1 `params.models` advertise (planetarium/oai2a2a#63) the
+// hello-time merge would otherwise apply. Operator-supplied `--card <path>`
+// stays fs-based — that's an explicit runtime path.
+export const BUNDLED_CARDS: Record<string, unknown> = {
+  claude: claudeCard,
+  codex: codexCard,
+  echo: echoCard,
+  openclaw: openclawCard,
+  'vicoop-codex': vicoopCodexCard,
+};
+
+export function resolveBundledCard(backendKind: string): unknown | null {
+  return BUNDLED_CARDS[backendKind] ?? null;
+}

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 import { existsSync, readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { AgentCard } from '@vicoop-bridge/protocol';
+import { resolveBundledCard } from './bundled-cards.js';
 import { longestMatch, object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
 import { command, constant, flag, option } from '@optique/core/primitives';
@@ -466,30 +465,18 @@ async function runWithShutdownTimeout(shutdown: () => Promise<void>): Promise<vo
 
 // Resolve the agent card the daemon should send inline on `hello`. Order:
 //   1. operator-supplied `--card` path (highest priority — full override)
-//   2. bundled `cards/<backend>.json` shipped with this package (default)
+//   2. embedded `BUNDLED_CARDS[backend]` shipped with this package (default)
 //   3. undefined — server falls back to its own canonical card for the
 //      backend kind. The server card is the right shape but lacks anything
 //      we'd want to advertise dynamically (e.g. openai-compat/v1
 //      `params.models`, per planetarium/oai2a2a#63), so always preferring
 //      the local bundle when present makes the advertise reachable.
-//
-// The lookup uses `import.meta.url` so it works both from `src/cli.ts`
-// during dev (resolves to `<pkg>/cards/<kind>.json`) and from the
-// published bundle's `dist/cli.js` (also `<pkg>/cards/<kind>.json`,
-// since `package.json` files include both `dist/` and `cards/`).
-function resolveBundledCardPath(backendKind: string): string | null {
-  const cliDir = path.dirname(fileURLToPath(import.meta.url));
-  // From `src/cli.ts` and `dist/cli.js` alike, `cards/` sits one level up.
-  const candidate = path.join(cliDir, '..', 'cards', `${backendKind}.json`);
-  return existsSync(candidate) ? candidate : null;
-}
-
 async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
   const args = resolveDaemonArgs(parsed);
-  const cardPath = args.card ?? resolveBundledCardPath(args.backend);
-  const agentCard = cardPath
-    ? AgentCard.parse(JSON.parse(readFileSync(cardPath, 'utf8')))
-    : undefined;
+  const raw = args.card
+    ? JSON.parse(readFileSync(args.card, 'utf8'))
+    : resolveBundledCard(args.backend);
+  const agentCard = raw ? AgentCard.parse(raw) : undefined;
 
   // Emit the resolved backend at startup so operators can verify which
   // backend the precedence chain picked (flag vs. config vs. default


### PR DESCRIPTION
## Summary

- Bug shipped in 0.23.0 (`openai-compat/v1` advertise feature, commit 7f17aa9). The bundled card lookup used `fileURLToPath(import.meta.url) + '..' + 'cards' + …` + `existsSync`. Under `tsx` (dev) or a Node-run `dist/cli.js` that resolves to a real file, but in a `bun build --compile` release binary `import.meta.url` points into Bun's virtual root — `existsSync` returns false, the lookup returns `null`, and the daemon ships hello with no inline `agentCard`. `Client.resolveEffectiveCard` short-circuits before `resolveCapabilities()` runs, the server falls back to its canonical card, and the `params.models` advertise is silently dropped.
- Replace the fs lookup with static JSON imports of the five bundled cards (`claude` / `codex` / `echo` / `openclaw` / `vicoop-codex`) in a new `bundled-cards.ts` module — Bun's `--compile` embeds statically imported JSON into the binary, so dev (`pnpm dev:client`) and release (`vicoop-client upgrade`) paths converge. Operator-supplied `--card <path>` stays fs-based.
- The new module isolates the helpers from `cli.ts`'s top-level `main()` so `bundled-cards.test.ts` can import them without side effects.
- Patch changeset — fixing already-released 0.23.0 behavior.

## Test plan

- [x] `pnpm -r typecheck` — clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 572 tests pass (8 new in `bundled-cards.test.ts`: every bundled card parses through `AgentCard.parse`; the probe-capable cards declare the `openai-compat/v1` extension; unknown backend returns `null`)
- [ ] Manual: build a release binary via `scripts/package-client-release.sh`, run with no `--card`, verify hello's `agentCard.capabilities.extensions[<openai-compat/v1>].params.models` is populated after the claude / codex probe completes
- [ ] Manual: confirm `pnpm dev:client` still picks up edits to `packages/client/cards/*.json` (it does — static imports re-resolve every dev process start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)