### PR TITLE
feat(client)!: split daemon into `start` subcommand

### DIFF
--- a/.changeset/split-daemon-into-start.md
+++ b/.changeset/split-daemon-into-start.md
@@ -1,0 +1,14 @@
+---
+'@vicoop-bridge/client': major
+---
+
+Promote the daemon entrypoint to an explicit `vicoop-client start`
+subcommand and stop treating bare invocation as "start the daemon".
+Running `vicoop-client` with no arguments (or with `--help`) now prints
+the top-level help and exits 0, where previous releases would open the
+bridge WS. Replace any operator scripts / systemd units / docker
+commands that ran `vicoop-client …` with `vicoop-client start …`; the
+flag surface is unchanged. The bundled container entrypoint
+(`container/bundled/entrypoint.sh`) already rewrites the historical
+flags-only / no-args invocation to `vicoop-client start` before
+exec'ing, so `docker run … <image>` keeps working unchanged.

--- a/.changeset/split-daemon-into-start.md
+++ b/.changeset/split-daemon-into-start.md
@@ -1,5 +1,5 @@
 ---
-'@vicoop-bridge/client': major
+'@vicoop-bridge/client': minor
 ---
 
 Promote the daemon entrypoint to an explicit `vicoop-client start`

--- a/.changeset/split-daemon-into-start.md
+++ b/.changeset/split-daemon-into-start.md
@@ -4,11 +4,13 @@
 
 Promote the daemon entrypoint to an explicit `vicoop-client start`
 subcommand and stop treating bare invocation as "start the daemon".
-Running `vicoop-client` with no arguments (or with `--help`) now prints
-the top-level help and exits 0, where previous releases would open the
-bridge WS. Replace any operator scripts / systemd units / docker
+Running `vicoop-client` with no arguments now prints the top-level help
+and exits 0, where previous releases would open the bridge WS. The
+flags-only form (`vicoop-client --backend ...`) also no longer starts
+the daemon — it now fails with a parse error pointing at the missing
+subcommand. Replace any operator scripts / systemd units / docker
 commands that ran `vicoop-client …` with `vicoop-client start …`; the
 flag surface is unchanged. The bundled container entrypoint
-(`container/bundled/entrypoint.sh`) already rewrites the historical
-flags-only / no-args invocation to `vicoop-client start` before
-exec'ing, so `docker run … <image>` keeps working unchanged.
+(`container/bundled/entrypoint.sh`) rewrites the historical flags-only
+/ no-args invocation to `vicoop-client start` before exec'ing, so
+`docker run … <image>` keeps working unchanged.

--- a/container/bundled/entrypoint.sh
+++ b/container/bundled/entrypoint.sh
@@ -321,6 +321,12 @@ wizard() {
 # `info`, `upgrade`, `auth login` are passed through unchanged — operators
 # need them to work whether or not config has been bootstrapped yet (e.g.
 # `docker run ... vicoop-client info` for compat checks from outside).
+#
+# The bridge client itself no longer treats bare argv as "start the
+# daemon" — empty argv now prints help and exits 0. The entrypoint
+# preserves the historical `docker run … <image>` ergonomics by
+# translating the daemon-shaped invocations (no args / flags-only) into
+# explicit `vicoop-client start "$@"` before the final exec.
 is_daemon_invocation() {
     [[ $# -eq 0 ]] && return 0
     case "$1" in
@@ -351,9 +357,11 @@ if is_daemon_invocation "$@"; then
         compat_check
     fi
     maybe_init_firewall
+    # exec replaces this shell so signals from tini reach vicoop-client
+    # directly (no double-process orphaning of agent CLI children).
+    exec vicoop-client start "$@"
 fi
 
-# Hand off to the bridge client. exec replaces this shell so signals from
-# tini reach vicoop-client directly (no double-process orphaning of agent
-# CLI children).
+# Non-daemon subcommand: pass through unchanged so `docker run … <image>
+# info` / `… auth login` still work.
 exec vicoop-client "$@"

--- a/docs/container.md
+++ b/docs/container.md
@@ -77,7 +77,7 @@ On first start the entrypoint:
 2. Installs the backend CLI into `/data/agents/<kind>/` (claude / codex
    via npm; openclaw is no-op because the gateway runs out-of-process).
 3. Applies the outbound-allowlist firewall (if `NET_ADMIN` was granted).
-4. Hands off to `vicoop-client` daemon mode.
+4. Hands off to `vicoop-client start` (daemon mode).
 
 On every subsequent start the entrypoint skips bootstrap and just
 re-runs the firewall + compatibility check.

--- a/docs/design.md
+++ b/docs/design.md
@@ -69,23 +69,23 @@ vicoop-bridge/
 
 ```bash
 # OpenClaw (native integration)
-vicoop-client \
+vicoop-client start \
   --server wss://bridge.vicoop.xyz \
   --token $TOKEN \
   --backend openclaw
 
 # Claude Code
-vicoop-client \
+vicoop-client start \
   --backend claude
   # internally: `claude -p --session-id <ctx> --resume ...`
 
 # Codex CLI
-vicoop-client \
+vicoop-client start \
   --backend codex
   # internally: `codex app-server` (one persistent JSON-RPC over stdio process)
 
 # Generic webhook
-vicoop-client \
+vicoop-client start \
   --backend webhook \
   --backend-url http://localhost:8080/agent \
   --card ./cards/custom.json

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -482,19 +482,25 @@ JSON
 
 ## Step 6 — Run the client
 
-Run the client in the foreground first. With `config.json` written by Step 4,
-the daemon picks up `server_url`, `server_token`, and `agent_id` on its own;
+Run the client in the foreground first. The daemon entrypoint is the
+explicit `start` subcommand. With `config.json` written by Step 4 the
+daemon picks up `server_url`, `server_token`, and `agent_id` on its own;
 pick the backend with `--backend`:
 
 ```sh
-vicoop-client --backend openclaw
+vicoop-client start --backend openclaw
 ```
 
 Precedence at startup is **CLI flag > `--config <path>` > canonical
 `config.json` > built-in default**. Env vars are not consulted for
 runtime config (#189 §5). With `"backend": "openclaw"` persisted in
 `config.json`, the daemon needs no flags at all:
-`vicoop-client`.
+`vicoop-client start`.
+
+> Bare `vicoop-client` (no subcommand) prints the top-level help and
+> exits 0; it no longer starts the daemon. Earlier releases booted the
+> daemon on empty argv, which would silently open the WS when an
+> operator only meant to run `--help`.
 
 On success you'll see a `[client] connected, sending hello` log followed
 by an identity block — same data `vicoop-client auth whoami` would print, so
@@ -577,7 +583,7 @@ For the Claude backend, pass `--backend claude` (or persist
 different repository than the one `vicoop-client` itself runs in:
 
 ```sh
-vicoop-client \
+vicoop-client start \
   --backend claude \
   --cwd "$HOME/vicoop-bridge"
 ```
@@ -585,7 +591,7 @@ vicoop-client \
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
 (`cwd`, `settings`) so the foreground command shrinks to just
-`vicoop-client`; the flag wins over config, mirroring
+`vicoop-client start`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
 | Flag | `backends.claude.*` |
@@ -676,7 +682,7 @@ For the Codex backend, pass `--backend codex` (or persist
 different repository / loosen the sandbox:
 
 ```sh
-vicoop-client \
+vicoop-client start \
   --backend codex \
   --cwd "$HOME/vicoop-bridge" \
   --codex-sandbox workspace-write
@@ -684,7 +690,7 @@ vicoop-client \
 
 Both knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.codex` so the
-foreground command can shrink to just `vicoop-client`.
+foreground command can shrink to just `vicoop-client start`.
 The flag wins over config.
 
 | Flag | `backends.codex.*` |

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -499,8 +499,10 @@ runtime config (#189 §5). With `"backend": "openclaw"` persisted in
 
 > Bare `vicoop-client` (no subcommand) prints the top-level help and
 > exits 0; it no longer starts the daemon. Earlier releases booted the
-> daemon on empty argv, which would silently open the WS when an
-> operator only meant to run `--help`.
+> daemon on empty argv, which made an operator who just wanted to see
+> the help inadvertently open the WS. The flags-only form
+> (`vicoop-client --backend ...`) is rejected with a parse error now —
+> use `vicoop-client start --backend ...` instead.
 
 On success you'll see a `[client] connected, sending hello` log followed
 by an identity block — same data `vicoop-client auth whoami` would print, so

--- a/install.sh
+++ b/install.sh
@@ -375,12 +375,12 @@ Next steps (the agent that owns this client should perform these):
   3. Run the daemon in the foreground. With config.json populated, only
      the backend choice (echo / openclaw / claude / codex) is left:
 
-       vicoop-client --backend openclaw
+       vicoop-client start --backend openclaw
 
-     Or persist \`"backend": "openclaw"\` in config.json and run with no
+     Or persist \`"backend": "openclaw"\` in config.json and start with no
      flags at all:
 
-       vicoop-client
+       vicoop-client start
 
      An always-on supervisor (systemd unit, launchd plist, …) is not
      provided by this installer; the foreground run above is the

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -34,7 +34,8 @@ const sharedFlags = {
 // ----- New `agent <sub>` command group (#218) --------------------------------
 // `agent` is the operator-facing primary resource. The legacy `list-agents` /
 // `list-clients` / `revoke-client` / `{add,remove,list}-caller` commands below
-// remain as deprecated aliases (see DEPRECATION_HINTS).
+// remain as deprecated aliases; each handler calls `warnDeprecated` before
+// dispatching to the new shape.
 
 const agentListSubCmd = command(
   'list',

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -132,6 +132,12 @@ export type AgentCallersAddArgs = Extract<AgentCliArgs, { action: 'agent-callers
 export type AgentCallersRemoveArgs = Extract<AgentCliArgs, { action: 'agent-callers-remove' }>;
 
 // ----- Legacy flat commands (deprecated, kept as aliases) --------------------
+//
+// `hidden: 'help'` drops these from both the Usage: block and the brief
+// listing at top-level help, while keeping scoped help
+// (`vicoop-client add-caller --help`) and "did you mean?" suggestions —
+// so operators still on the old form discover the deprecation warning
+// from runtime stderr and from the per-command help page.
 
 export const addCallerCmd = command(
   'add-caller',
@@ -144,6 +150,7 @@ export const addCallerCmd = command(
   {
     brief: message`[deprecated] Use \`agent callers add\`.`,
     description: message`Deprecated alias for \`vicoop-client agent callers add\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 
@@ -158,6 +165,7 @@ export const removeCallerCmd = command(
   {
     brief: message`[deprecated] Use \`agent callers remove\`.`,
     description: message`Deprecated alias for \`vicoop-client agent callers remove\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 
@@ -171,6 +179,7 @@ export const listCallersCmd = command(
   {
     brief: message`[deprecated] Use \`agent callers list\`.`,
     description: message`Deprecated alias for \`vicoop-client agent callers list\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 
@@ -183,6 +192,7 @@ export const listAgentsCmd = command(
   {
     brief: message`[deprecated] Use \`agent list --connected\`.`,
     description: message`Deprecated alias for \`vicoop-client agent list --connected\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 
@@ -195,6 +205,7 @@ export const listClientsCmd = command(
   {
     brief: message`[deprecated] Use \`agent list\`.`,
     description: message`Deprecated alias for \`vicoop-client agent list\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 
@@ -208,6 +219,7 @@ export const revokeClientCmd = command(
   {
     brief: message`[deprecated] Use \`agent delete\`.`,
     description: message`Deprecated alias for \`vicoop-client agent delete\`. Hard-deletes the agent (renamed from revoke). Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -121,6 +121,7 @@ export const agentCmd = command(
   {
     brief: message`Manage agent registrations and their allowed callers.`,
     description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`delete\`, \`callers {list,add,remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+    hidden: 'usage',
   },
 );
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -111,23 +111,25 @@ const infoCmd = command(
   },
 );
 
-// Daemon mode is the bare invocation (no subcommand). `constant('daemon')`
-// gives the dispatch switch a discriminator alongside the named commands.
+// `vicoop-client start`: the long-running daemon entrypoint. Promoted to an
+// explicit subcommand so bare `vicoop-client` no longer connects to the
+// bridge — an operator running `vicoop-client` to grep for help should not
+// silently boot a network process. The action discriminator stays
+// `'daemon'` so runDaemon and the dispatch switch don't need to change.
 // `daemonFlagsFields` is the raw parser-field map exported from cli-args.ts
 // so we can splice it in here without losing per-field types.
-const daemonCmd = object({
-  action: constant('daemon' as const),
-  ...daemonFlagsFields,
-});
+const startCmd = command(
+  'start',
+  object({
+    action: constant('daemon' as const),
+    ...daemonFlagsFields,
+  }),
+  {
+    brief: message`Start the bridge client daemon.`,
+    description: message`Connects to the bridge server, advertises the chosen backend's agent card, and runs until interrupted. With \`config.json\` populated by \`agent register\`, this needs no flags. Precedence over the canonical \`config.json\` is the same as documented in \`docs/install-client.md\` (CLI flag > \`--config\` overlay > canonical config > built-in default).`,
+  },
+);
 
-// All subcommands + the bare daemon-mode parser in one parser. We use
-// `longestMatch` (not `or`) so that bare invocation — `vicoop-client` with
-// no tokens — falls through to `daemonCmd`, which consumes zero tokens
-// successfully via all-optional fields. `or()` requires at least one
-// branch to consume something, so it would reject empty argv even though
-// daemonCmd structurally matches. With longestMatch, subcommand branches
-// win whenever their keyword is present (longer match), and daemonCmd
-// wins otherwise.
 // Owner-session umbrella. Mirrors the `agent` umbrella from #218: both new
 // subcommands sit under their topic, the flat versions stay as deprecated
 // aliases.
@@ -152,6 +154,9 @@ const legacyAdminCmds = longestMatch(
   revokeClientCmd,
 );
 
+// All subcommands in one parser. `longestMatch` (rather than `or`) keeps
+// behavior stable as more sibling commands are added — branches with a
+// keyword match consume more tokens and win deterministically.
 const cli = longestMatch(
   authCmd,
   loginCmd,
@@ -163,7 +168,7 @@ const cli = longestMatch(
   containerCmd,
   legacyAdminCmds,
   whoamiCmd,
-  daemonCmd,
+  startCmd,
 );
 
 type CliArgs = InferValue<typeof cli>;
@@ -550,9 +555,18 @@ async function runUpgradeCmd(args: Extract<CliArgs, { action: 'upgrade' }>): Pro
 }
 
 async function main(): Promise<void> {
+  // Bare invocation prints help and exits 0. Pre-`start`-subcommand
+  // releases booted the daemon on empty argv; that surprised operators
+  // who ran `vicoop-client` expecting --help, and the daemon would
+  // happily open the WS until they noticed. Injecting `--help` lets
+  // optique render its own usage page and exit cleanly rather than
+  // surfacing the "no subcommand" parse failure as a non-zero exit.
+  if (process.argv.length <= 2) {
+    process.argv.push('--help');
+  }
   // Optique handles --help, --version, parse errors, and "did you mean?"
   // suggestions inside `run()`. Anything that reaches the switch is a
-  // successfully-parsed subcommand or daemon-mode payload.
+  // successfully-parsed subcommand.
   const parsed = run(cli, {
     programName: 'vicoop-client',
     brief: message`A2A bridge client daemon. Connects a local backend (echo, openclaw, claude, codex) to a deployed vicoop-bridge server.`,

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -2,7 +2,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { AgentCard } from '@vicoop-bridge/protocol';
 import { resolveBundledCard } from './bundled-cards.js';
-import { longestMatch, object } from '@optique/core/constructs';
+import { group, longestMatch, object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
 import { command, constant, flag, option } from '@optique/core/primitives';
 import { message } from '@optique/core/message';
@@ -156,19 +156,21 @@ const legacyAdminCmds = longestMatch(
 
 // All subcommands in one parser. `longestMatch` (rather than `or`) keeps
 // behavior stable as more sibling commands are added — branches with a
-// keyword match consume more tokens and win deterministically.
+// keyword match consume more tokens and win deterministically. `group()`
+// gives optique's help renderer section headers so the top-level help
+// scans as an operator workflow rather than a 17-line wall.
 const cli = longestMatch(
-  authCmd,
+  group('Run the daemon', startCmd),
+  group('Identity', authCmd),
+  group('Agents', longestMatch(agentCmd, setupCmd)),
+  group('Runtime containers', containerCmd),
+  group('Maintenance', longestMatch(upgradeCmd, infoCmd)),
+  // Hidden by `hidden: 'help'` on each command; kept in the parser tree
+  // for back-compat and "did you mean?" suggestions.
   loginCmd,
   logoutCmd,
-  setupCmd,
-  upgradeCmd,
-  infoCmd,
-  agentCmd,
-  containerCmd,
   legacyAdminCmds,
   whoamiCmd,
-  startCmd,
 );
 
 type CliArgs = InferValue<typeof cli>;

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -90,6 +90,10 @@ const upgradeCmd = command(
   {
     brief: message`Upgrade the installed client bundle in place.`,
     description: message`Downloads the latest \`@vicoop-bridge/client@*\` release (or the pinned --version), verifies its sha256, extracts into a sibling directory, healthchecks, and atomically swaps it into place. Operator-added cards / files under \$INSTALL_DIR are preserved across the swap; \`~/.vicoop/config.json\` and \`~/.vicoop/owner-session.json\` are never touched.`,
+    // Drop from the top-level Usage: block — per-command details are
+    // already a `vicoop-client upgrade --help` away. Keeps the brief
+    // listing entry (under the "Maintenance" group header).
+    hidden: 'usage',
   },
 );
 
@@ -108,6 +112,7 @@ const infoCmd = command(
   {
     brief: message`Print client / image / backend metadata as JSON.`,
     description: message`Emits a single JSON object with this client's version, the bundled image's version (if running inside one — \`VICOOP_BRIDGE_IMAGE\` env), and the backend compat manifest.`,
+    hidden: 'usage',
   },
 );
 
@@ -127,6 +132,7 @@ const startCmd = command(
   {
     brief: message`Start the bridge client daemon.`,
     description: message`Connects to the bridge server, advertises the chosen backend's agent card, and runs until interrupted. With \`config.json\` populated by \`agent register\`, this needs no flags. Precedence over the canonical \`config.json\` is the same as documented in \`docs/install-client.md\` (CLI flag > \`--config\` overlay > canonical config > built-in default).`,
+    hidden: 'usage',
   },
 );
 
@@ -139,6 +145,7 @@ const authCmd = command(
   {
     brief: message`Manage owner-session and identity (sign in / out / whoami).`,
     description: message`Operator-facing umbrella for owner-session and agent-identity. Subcommands: \`login\`, \`logout\`, \`whoami\`. Replaces the older flat \`login\` / \`logout\` / \`whoami\` commands, which remain as deprecated aliases.`,
+    hidden: 'usage',
   },
 );
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -149,9 +149,10 @@ const authCmd = command(
   },
 );
 
-// Deprecated flat aliases — kept for backward-compat (DEPRECATION_HINTS
-// in admin-cli.ts) but folded into one slot so optique's longestMatch
-// overload table doesn't blow up as we keep adding top-level commands.
+// Deprecated flat aliases — kept for backward-compat (each handler in
+// admin-cli.ts calls `warnDeprecated` before dispatching to the new
+// shape) but folded into one slot so optique's longestMatch overload
+// table doesn't blow up as we keep adding top-level commands.
 const legacyAdminCmds = longestMatch(
   addCallerCmd,
   removeCallerCmd,
@@ -169,15 +170,17 @@ const legacyAdminCmds = longestMatch(
 const cli = longestMatch(
   group('Run the daemon', startCmd),
   group('Identity', authCmd),
-  group('Agents', longestMatch(agentCmd, setupCmd)),
+  group('Agents', agentCmd),
   group('Runtime containers', containerCmd),
   group('Maintenance', longestMatch(upgradeCmd, infoCmd)),
   // Hidden by `hidden: 'help'` on each command; kept in the parser tree
-  // for back-compat and "did you mean?" suggestions.
+  // for back-compat and "did you mean?" suggestions. Sit outside the
+  // group() wrappers so they don't appear under any section header.
   loginCmd,
   logoutCmd,
-  legacyAdminCmds,
+  setupCmd,
   whoamiCmd,
+  legacyAdminCmds,
 );
 
 type CliArgs = InferValue<typeof cli>;
@@ -565,11 +568,11 @@ async function runUpgradeCmd(args: Extract<CliArgs, { action: 'upgrade' }>): Pro
 
 async function main(): Promise<void> {
   // Bare invocation prints help and exits 0. Pre-`start`-subcommand
-  // releases booted the daemon on empty argv; that surprised operators
-  // who ran `vicoop-client` expecting --help, and the daemon would
-  // happily open the WS until they noticed. Injecting `--help` lets
-  // optique render its own usage page and exit cleanly rather than
-  // surfacing the "no subcommand" parse failure as a non-zero exit.
+  // releases booted the daemon on empty argv; an operator who typed
+  // `vicoop-client` to see what was available would silently open the WS
+  // until they noticed. Injecting `--help` lets optique render its own
+  // usage page and exit cleanly rather than surfacing the "no subcommand"
+  // parse failure as a non-zero exit.
   if (process.argv.length <= 2) {
     process.argv.push('--help');
   }

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -980,6 +980,7 @@ export const containerCmd = command(
   {
     brief: message`Manage per-backend runtime containers.`,
     description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container and volumes by name). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    hidden: 'usage',
   },
 );
 

--- a/packages/client/src/login.ts
+++ b/packages/client/src/login.ts
@@ -65,6 +65,10 @@ export const loginCmd = command(
   {
     brief: message`[deprecated] Use \`auth login\`.`,
     description: message`Deprecated alias for \`vicoop-client auth login\`. Will be removed in a future release.`,
+    // Drops out of the top-level usage + brief listing; `vicoop-client login
+    // --help` and typo suggestions still resolve so the runtime deprecation
+    // warning is discoverable.
+    hidden: 'help',
   },
 );
 

--- a/packages/client/src/logout.ts
+++ b/packages/client/src/logout.ts
@@ -72,6 +72,7 @@ export const logoutCmd = command(
   {
     brief: message`[deprecated] Use \`auth logout\`.`,
     description: message`Deprecated alias for \`vicoop-client auth logout\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -57,6 +57,7 @@ export const setupCmd = command(
   {
     brief: message`[deprecated] Use \`agent register\`.`,
     description: message`Deprecated alias for \`vicoop-client agent register\`. Calls the bridge's \`registerClient\` GraphQL mutation, persists daemon credentials to \`~/.vicoop/config.json\`, and supports \`--write-env-file\` for an optional shell-sourceable env file. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 

--- a/packages/client/src/whoami.ts
+++ b/packages/client/src/whoami.ts
@@ -77,6 +77,7 @@ export const whoamiCmd = command(
   {
     brief: message`[deprecated] Use \`auth whoami\`.`,
     description: message`Deprecated alias for \`vicoop-client auth whoami\`. Will be removed in a future release.`,
+    hidden: 'help',
   },
 );
 


### PR DESCRIPTION
## Summary

- Bare `vicoop-client` no longer boots the bridge daemon — it prints the top-level help and exits 0. The daemon entrypoint is now the explicit `vicoop-client start [--flags]` subcommand.
- Previous releases would silently open the WS when an operator only meant to grep for help; the new shape forces an explicit opt-in (and surfaces `start` in the help listing).
- The bundled container entrypoint (`container/bundled/entrypoint.sh`) rewrites the historical flags-only / no-args invocations to `vicoop-client start "$@"` before exec'ing, so `docker run … <image> [--flags]` keeps working unchanged.
- Docs + `install.sh` post-install hints + `docs/design.md` examples updated to recommend `vicoop-client start`.
- Major-bump changeset included (`.changeset/split-daemon-into-start.md`).

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @vicoop-bridge/client test` — 572 pass, 0 fail
- [x] `pnpm --filter @vicoop-bridge/server test` — 183 pass / 39 skip, 0 fail
- [x] Smoke: `node packages/client/dist/cli.js` → help, exit 0
- [x] Smoke: `node packages/client/dist/cli.js start --help` → start-subcommand help, exit 0
- [x] Smoke: `node packages/client/dist/cli.js --backend echo` (old flags-only form) → help + "Unexpected option: --backend", exit 1
- [ ] Manual: `docker run … <image>` with no args / flags-only still launches the daemon via the entrypoint rewrite (not exercised in CI; depends on a bundled-image rebuild from this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)