### PR TITLE
fix(vicoop-codex): order user turn before tool_call_history

### DIFF
--- a/.changeset/vicoop-codex-user-turn-order.md
+++ b/.changeset/vicoop-codex-user-turn-order.md
@@ -1,0 +1,17 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+fix(vicoop-codex): place the current user turn before tool_call_history
+
+The vicoop-codex backend assembled the `vicoop-codex call` body as
+`system → tool_call_history → user`, leaving the current user request after
+every prior assistant/tool round. With a growing multi-turn history,
+gpt-5.3-codex read its own request as a brand-new instruction arriving after
+all that tool activity and restarted from the first tool (e.g. re-calling
+`list_workflows` every turn) instead of progressing to completion.
+
+`buildMessages` now emits `system → user → tool_call_history`, preserving the
+original linear OpenAI conversation order (the user request first, then the
+tool rounds it drove). This matches what the model sees when talking to
+`vicoop-codex serve` directly, eliminating the re-call loop.

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -235,7 +235,7 @@ test('historyToChatCompletionMessages: assistant tool_calls + tool result round-
   assert.equal(msgs[1].content, '{"temp":13}');
 });
 
-test('buildMessages: ordering — system → history → user', () => {
+test('buildMessages: ordering — system → user → history', () => {
   const msgs = buildMessages(
     {
       system: 'be concise',
@@ -251,10 +251,10 @@ test('buildMessages: ordering — system → history → user', () => {
   );
   assert.deepEqual(
     msgs.map((m) => m.role),
-    ['system', 'assistant', 'tool', 'user'],
+    ['system', 'user', 'assistant', 'tool'],
   );
   assert.equal(msgs[0].content, 'be concise');
-  assert.equal(msgs[msgs.length - 1].content, 'current ask');
+  assert.equal(msgs[1].content, 'current ask');
 });
 
 test('buildMessages: no metadata still emits a user message', () => {
@@ -534,11 +534,11 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
     };
     const payload = child.stdinPayload();
     const body = JSON.parse(payload) as Record<string, unknown>;
-    // Messages: system → assistant(tool_calls) → tool → user
+    // Messages: system → user → assistant(tool_calls) → tool
     const messages = body.messages as Array<{ role: string }>;
     assert.deepEqual(
       messages.map((m) => m.role),
-      ['system', 'assistant', 'tool', 'user'],
+      ['system', 'user', 'assistant', 'tool'],
     );
     // Only the existing 4-field schema's `tools` / `tool_choice` are
     // forwarded; the spurious model/reasoning_effort/temperature/max_tokens

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -198,15 +198,9 @@ export function historyToChatCompletionMessages(
   return out;
 }
 
-// Assemble the full `messages` array for the call body. Order, per the
-// doc's "Per-role message JSON examples" section:
-//   1. system (from openai-compat.system; one entry)
-//   2. tool_call_history (assistant → tool round-trips)
-//   3. current user turn (flattened from A2A parts)
-//
-// The user turn comes last so the model sees prior tool results before the
-// new instruction — same convention as claude.ts's `formatToolCallHistory`
-// prepending the block to the user content.
+// Assemble the messages array in linear conversation order: system, the
+// current user turn, then the prior tool_call_history (assistant → tool
+// round-trips).
 export function buildMessages(
   meta: OpenAICompatMetadata | null,
   userContent: string,
@@ -215,12 +209,12 @@ export function buildMessages(
   if (meta?.system) {
     messages.push({ role: 'system', content: meta.system });
   }
+  messages.push({ role: 'user', content: userContent });
   if (meta?.tool_call_history) {
     for (const m of historyToChatCompletionMessages(meta.tool_call_history)) {
       messages.push(m);
     }
   }
-  messages.push({ role: 'user', content: userContent });
   return messages;
 }
 


### PR DESCRIPTION
## Summary
The `vicoop-codex` backend assembled the `vicoop-codex call` body as
`system → tool_call_history → user`, placing the current user request **after**
every prior assistant/tool round. With a growing multi-turn `tool_call_history`,
gpt-5.3-codex read its own request as a brand-new instruction arriving after all
that tool activity and restarted from the first tool — re-calling
`list_workflows` every turn instead of progressing — an infinite tool loop until
the `maxLlmCalls` cap.

`buildMessages` now emits `system → user → tool_call_history`, preserving the
original linear OpenAI conversation order (the user request first, then the tool
rounds it drove). This matches what the model sees when talking to
`vicoop-codex serve` directly, where the loop never occurs.

## Root cause (confirmed via runtime logging)
Before: the role sequence sent to `vicoop-codex call` was
`system → assistant → tool → … → user` (user last), with `historyLen` growing
to 48+ as the same `list_workflows` round repeated.

After: `system → user → assistant → tool → …`, and the agent completes the
normal flow (list → execute → wait → reply).

## Changes
- `buildMessages`: push the user turn before `tool_call_history`.
- Update the two ordering assertions in `vicoop-codex.test.ts`.
- Add a changeset (patch).

## Test plan
- [x] `tsx --test src/backends/vicoop-codex.test.ts` — 17/17 pass
- [x] e2e via `router → bridge → vicoop-codex call`: image generated, no `list_workflows` loop (verified with two prompts)