### PR TITLE
[codex] Emit incremental artifact chunks

### DIFF
--- a/.changeset/fresh-needles-stream.md
+++ b/.changeset/fresh-needles-stream.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Emit incremental artifact chunks for Claude and Codex streaming responses.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -272,6 +272,46 @@ test('streams cumulative Claude partial messages as append deltas on one artifac
   assert.deepEqual(artifacts.map((a) => a.append), [true, true, true]);
 });
 
+test('streams Claude stream_event text deltas as append chunks', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'one' },
+        },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: ' two' },
+        },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one two' }] },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'one two' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 2);
+  assert.deepEqual(artifacts.map(textOf), ['one', ' two']);
+  assert.equal(new Set(artifacts.map((a) => a.artifact.artifactId)).size, 1);
+  assert.deepEqual(artifacts.map((a) => a.append), [true, true]);
+});
+
 test('falls back to result artifact when streaming produced nothing', async () => {
   const fake = scriptedSpawn({
     lines: [

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -227,11 +227,49 @@ test('streams each assistant message as its own artifact and completes with fina
   assert.equal(textOf(artifacts[0]), 'hi there');
   assert.equal(textOf(artifacts[1]), 'second turn');
   assert.notEqual(artifacts[0].artifact.artifactId, artifacts[1].artifact.artifactId);
-  assert.equal(artifacts[0].lastChunk, true);
+  assert.equal(artifacts[0].append, true);
+  assert.equal(artifacts[0].lastChunk, false);
 
   const complete = frames.at(-1) as Extract<UpFrame, { type: 'task.complete' }>;
   assert.equal(complete.status.state, 'completed');
   assert.equal(textOf(complete), 'second turn');
+});
+
+test('streams cumulative Claude partial messages as append deltas on one artifact', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one two' }] },
+      }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'one two three' }] },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'one two three' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child?.args.includes('--include-partial-messages'));
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 3);
+  assert.deepEqual(artifacts.map(textOf), ['one', ' two', ' three']);
+  assert.equal(new Set(artifacts.map((a) => a.artifact.artifactId)).size, 1);
+  assert.deepEqual(artifacts.map((a) => a.append), [true, true, true]);
 });
 
 test('falls back to result artifact when streaming produced nothing', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1479,6 +1479,7 @@ export function createClaudeBackend(
         ...openaiCompatArgs,
         ...disableBuiltinToolArgs,
         ...nativeTurnCapArgs,
+        '--include-partial-messages',
         ...settingsArgs,
         ...extraArgs,
       ];
@@ -1566,6 +1567,8 @@ export function createClaudeBackend(
       } | null = null;
       let finalText: string | null = null;
       let finalUsage: OpenAICompatUsage | null = null;
+      let responseArtifactId: string | null = null;
+      let streamedResponseText = '';
       let sawCompletedResult = false;
       let sawErrorResult = false;
       let stdoutTail = '';
@@ -1580,6 +1583,7 @@ export function createClaudeBackend(
       // completed/failed bookend in the trace stream. Outside trace
       // mode it stays empty — see the assistant handler below.
       const activeTaskRuns = new Map<string, string>();
+      const seenAssistantToolUseIds = new Set<string>();
 
       // Register this task with the send_file MCP server (if running) so
       // tool calls landing during this run resolve to this task's emit().
@@ -1603,8 +1607,9 @@ export function createClaudeBackend(
         sendFileRelease = handle.release;
       }
 
-      const emitAssistantArtifact = (text: string): void => {
+      const emitAssistantArtifact = (text: string, append = false, lastChunk = true): void => {
         if (!text) return;
+        responseArtifactId ??= randomUUID();
         // openai-compat caller tools land as a `tool_calls` data artifact
         // through the caller-tools MCP onInvoke handler above, NOT via
         // any text-shape parsing. Assistant-text turns (natural-language
@@ -1614,15 +1619,32 @@ export function createClaudeBackend(
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
-            artifactId: randomUUID(),
+            artifactId: responseArtifactId,
             name: 'claude-message',
             parts: [{ kind: 'text', text }],
           },
-          // Each assistant message is a complete artifact on its own (same
-          // shape openclaw uses for session.message streaming).
-          lastChunk: true,
+          ...(append ? { append: true } : {}),
+          lastChunk,
         });
         emittedAnyArtifact = true;
+      };
+
+      const emitAssistantTextUpdate = (text: string): void => {
+        if (!text) return;
+        if (!streamedResponseText) {
+          streamedResponseText = text;
+          emitAssistantArtifact(text, true, false);
+          return;
+        }
+        if (text.startsWith(streamedResponseText)) {
+          const delta = text.slice(streamedResponseText.length);
+          streamedResponseText = text;
+          emitAssistantArtifact(delta, true, false);
+          return;
+        }
+        responseArtifactId = null;
+        streamedResponseText = text;
+        emitAssistantArtifact(text, false, true);
       };
 
       const emitToolResultMedia = (parts: Part[]): void => {
@@ -1716,10 +1738,14 @@ export function createClaudeBackend(
           // model said" before "what tools it then called", matching the
           // visible CLI ordering inside that turn.
           if (!emittedAskUserQuestion) {
-            emitAssistantArtifact(extractAssistantText(evt.message.content));
+            emitAssistantTextUpdate(extractAssistantText(evt.message.content));
           }
           if (emittedAskUserQuestion) return;
           for (const tu of extractAssistantToolUses(evt.message.content)) {
+            if (tu.toolUseId) {
+              if (seenAssistantToolUseIds.has(tu.toolUseId)) continue;
+              seenAssistantToolUseIds.add(tu.toolUseId);
+            }
             if (tu.toolName === 'AskUserQuestion' && tu.toolUseId && child.stdin) {
               // Stash for input-required terminal frame (A2A spec §9.4).
               // Placeholder tool_result + stdin.end() flushes CC's session state
@@ -2051,6 +2077,8 @@ export function createClaudeBackend(
           },
           lastChunk: true,
         });
+      } else if (streamedResponseText && completeText.startsWith(streamedResponseText)) {
+        emitAssistantArtifact(completeText.slice(streamedResponseText.length), true, true);
       }
 
       // Attach the openai-compat/v1 `usage` payload to the final A2A

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -198,6 +198,7 @@ interface StreamEvent {
     role?: unknown;
     content?: unknown;
   };
+  event?: unknown;
   result?: unknown;
   terminal_reason?: unknown;
   is_error?: unknown;
@@ -493,6 +494,22 @@ function extractAssistantText(content: unknown): string {
     if (b.type === 'text' && typeof b.text === 'string') out += b.text;
   }
   return out;
+}
+
+function extractClaudeStreamTextDelta(evt: StreamEvent): string {
+  if (evt.type !== 'stream_event') return '';
+  const event = evt.event;
+  if (!event || typeof event !== 'object') return '';
+  const e = event as { type?: unknown; delta?: unknown; content_block?: unknown };
+  if (e.type === 'content_block_delta' && e.delta && typeof e.delta === 'object') {
+    const delta = e.delta as { type?: unknown; text?: unknown };
+    if (delta.type === 'text_delta' && typeof delta.text === 'string') return delta.text;
+  }
+  if (e.type === 'content_block_start' && e.content_block && typeof e.content_block === 'object') {
+    const block = e.content_block as { type?: unknown; text?: unknown };
+    if (block.type === 'text' && typeof block.text === 'string') return block.text;
+  }
+  return '';
 }
 
 interface ToolUseBlock {
@@ -1730,6 +1747,29 @@ export function createClaudeBackend(
 
       const handleEvent = (evt: StreamEvent): void => {
         if (settled) return;
+        if (openaiCompatTrace) {
+          const textLen =
+            evt.type === 'assistant'
+              ? extractAssistantText(evt.message?.content).length
+              : evt.type === 'stream_event'
+                ? extractClaudeStreamTextDelta(evt).length
+              : evt.type === 'result' && typeof evt.result === 'string'
+                ? evt.result.length
+                : undefined;
+          console.error(
+            `[openai-compat trace] claude event type=${evt.type}` +
+              (textLen !== undefined ? ` textLen=${textLen}` : ''),
+          );
+        }
+        if (evt.type === 'stream_event') {
+          const delta = extractClaudeStreamTextDelta(evt);
+          if (delta && !emittedAskUserQuestion) {
+            recorder.mark('firstAssistant');
+            streamedResponseText += delta;
+            emitAssistantArtifact(delta, true, false);
+          }
+          return;
+        }
         if (evt.type === 'assistant') {
           if (evt.message?.role !== 'assistant') return;
           recorder.mark('firstAssistant');

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -220,6 +220,7 @@ interface HappyPathOptions {
   agentMessageText?: string;
   threadId?: string;
   turnId?: string;
+  tokenUsage?: unknown;
   /**
    * After how many `turn/start` requests we should pretend the agent
    * emitted a `commandExecution` item before completing. Default 0.
@@ -299,6 +300,16 @@ function happyPath(opts: HappyPathOptions = {}): ChildScenario {
                   exitCode: 0,
                   aggregatedOutput: 'foo\nbar\n',
                 },
+              },
+            });
+          }
+          if (opts.tokenUsage) {
+            child.emitStdout({
+              method: 'thread/tokenUsage/updated',
+              params: {
+                threadId: activeThreadId,
+                turnId: localTurnId,
+                tokenUsage: opts.tokenUsage,
               },
             });
           }
@@ -1962,6 +1973,47 @@ test('openai-compat tasks always thread/start, never thread/resume — every tur
       .params?.config?.features;
     assert.deepEqual(features, EXPECTED_OPENAI_COMPAT_DISABLES);
   }
+});
+
+test('thread/tokenUsage/updated is forwarded as openai-compat usage metadata', async () => {
+  const fake = makeFakeSpawn(() =>
+    happyPath({
+      agentMessageText: 'usage ok',
+      tokenUsage: {
+        total: {
+          totalTokens: 200,
+          inputTokens: 160,
+          cachedInputTokens: 96,
+          outputTokens: 40,
+          reasoningOutputTokens: 12,
+        },
+        last: {
+          totalTokens: 200,
+          inputTokens: 160,
+          cachedInputTokens: 96,
+          outputTokens: 40,
+          reasoningOutputTokens: 12,
+        },
+        modelContextWindow: 258400,
+      },
+    }),
+  );
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('hi'), emit, NEVER);
+
+  const complete = frames.find((f) => f.type === 'task.complete');
+  assert.ok(complete && complete.type === 'task.complete');
+  assert.deepEqual(complete.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+  const payload = complete.status.message?.metadata?.[OPENAI_COMPAT_EXTENSION_URI] as {
+    usage?: Record<string, unknown>;
+  };
+  assert.equal(payload?.usage?.prompt_tokens, 160);
+  assert.equal(payload?.usage?.completion_tokens, 40);
+  assert.equal(payload?.usage?.total_tokens, 200);
+  assert.deepEqual(payload?.usage?.prompt_tokens_details, { cached_tokens: 96 });
+  assert.deepEqual(payload?.usage?.completion_tokens_details, { reasoning_tokens: 12 });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -346,6 +346,11 @@ function collect(): { emit: (f: UpFrame) => void; frames: UpFrame[] } {
   return { emit: (f) => frames.push(f), frames };
 }
 
+function artifactText(frame: Extract<UpFrame, { type: 'task.artifact' }>): string {
+  const part = frame.artifact.parts[0];
+  return part?.kind === 'text' ? part.text : '';
+}
+
 function findRequest(frames: unknown[], method: string): Record<string, unknown> | null {
   for (const f of frames) {
     if (f === null || typeof f !== 'object') continue;
@@ -415,6 +420,72 @@ test('first task runs initialize + thread/start + turn/start and emits agent art
   const last = frames.at(-1);
   assert.equal(last?.type, 'task.complete');
   assert.equal(last?.type === 'task.complete' && last.status.state, 'completed');
+});
+
+test('agentMessage deltas stream as append artifact chunks without duplicating final text', async () => {
+  const fake = makeFakeSpawn(() => {
+    let localTurnId = '';
+    return {
+      onLine(frame, child) {
+        const id = (frame as { id?: number | string }).id;
+        const method = (frame as { method?: string }).method;
+        if (method === 'initialize' && id !== undefined) {
+          child.emitStdout({
+            id,
+            result: {
+              userAgent: 'fake-codex/0.130.0',
+              codexHome: '/tmp',
+              platformFamily: 'unix',
+              platformOs: 'macos',
+            },
+          });
+          return;
+        }
+        if (method === 'thread/start' && id !== undefined) {
+          child.emitStdout({ id, result: { thread: { id: 'thr-1' } } });
+          return;
+        }
+        if (method === 'turn/start' && id !== undefined) {
+          localTurnId = 'turn-1';
+          child.emitStdout({ id, result: { turn: { id: localTurnId } } });
+          queueMicrotask(() => {
+            child.emitStdout({
+              method: 'item/agentMessage/delta',
+              params: { itemId: 'item-1', delta: 'one', turnId: localTurnId },
+            });
+            child.emitStdout({
+              method: 'item/agentMessage/delta',
+              params: { itemId: 'item-1', delta: ' two', turnId: localTurnId },
+            });
+            child.emitStdout({
+              method: 'item/completed',
+              params: {
+                turnId: localTurnId,
+                item: { type: 'agentMessage', id: 'item-1', text: 'one two' },
+              },
+            });
+            child.emitStdout({
+              method: 'turn/completed',
+              params: { turn: { id: localTurnId, status: 'completed' } },
+            });
+          });
+        }
+      },
+    };
+  });
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  assert.equal(artifacts.length, 2);
+  assert.deepEqual(artifacts.map(artifactText), ['one', ' two']);
+  assert.equal(new Set(artifacts.map((a) => a.artifact.artifactId)).size, 1);
+  assert.deepEqual(artifacts.map((a) => a.append), [true, true]);
+  assert.equal(frames.at(-1)?.type, 'task.complete');
 });
 
 test('backend.stop() sends SIGTERM to the long-lived app-server child (#186)', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -319,33 +319,35 @@ export async function mapPartsToCodexInput(
   return { ok: true, prompt, imageFiles, tempDir };
 }
 
-// Parse codex `turn.completed.usage` (or any equivalent shape codex
-// app-server emits on the terminal turn notification) into a spec-compliant
-// OpenAICompatUsage payload.
+// Parse codex `thread/tokenUsage/updated.tokenUsage.last` into a
+// spec-compliant OpenAICompatUsage payload.
 //
-// Native shape (codex 0.130+):
-//   { input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens }
+// Native shape (codex app-server 0.134+):
+//   { totalTokens, inputTokens, cachedInputTokens, outputTokens, reasoningOutputTokens }
 //
 // Mapping per the openai-compat/v1 native-fields appendix:
-//   prompt_tokens                              = input_tokens
-//                                                (cached_input_tokens is ALREADY
-//                                                 included in input_tokens; do not
+//   prompt_tokens                              = inputTokens
+//                                                (cachedInputTokens is ALREADY
+//                                                 included in inputTokens; do not
 //                                                 add again)
-//   prompt_tokens_details.cached_tokens        = cached_input_tokens
-//   completion_tokens                          = output_tokens
-//                                                (reasoning_output_tokens is a
-//                                                 breakdown of output_tokens, not
+//   prompt_tokens_details.cached_tokens        = cachedInputTokens
+//   completion_tokens                          = outputTokens
+//                                                (reasoningOutputTokens is a
+//                                                 breakdown of outputTokens, not
 //                                                 additive)
-//   completion_tokens_details.reasoning_tokens = reasoning_output_tokens
-export function parseCodexTurnUsageForOpenAICompat(raw: unknown): OpenAICompatUsage | null {
+//   completion_tokens_details.reasoning_tokens = reasoningOutputTokens
+export function parseCodexTokenUsageForOpenAICompat(raw: unknown): OpenAICompatUsage | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-  const u = raw as Record<string, unknown>;
-  const input = typeof u.input_tokens === 'number' ? u.input_tokens : null;
-  const output = typeof u.output_tokens === 'number' ? u.output_tokens : null;
+  const tokenUsage = raw as Record<string, unknown>;
+  const last = tokenUsage.last;
+  if (!last || typeof last !== 'object' || Array.isArray(last)) return null;
+  const u = last as Record<string, unknown>;
+  const input = typeof u.inputTokens === 'number' ? u.inputTokens : null;
+  const output = typeof u.outputTokens === 'number' ? u.outputTokens : null;
   if (input === null || output === null) return null;
-  const cached = typeof u.cached_input_tokens === 'number' ? u.cached_input_tokens : undefined;
+  const cached = typeof u.cachedInputTokens === 'number' ? u.cachedInputTokens : undefined;
   const reasoning =
-    typeof u.reasoning_output_tokens === 'number' ? u.reasoning_output_tokens : undefined;
+    typeof u.reasoningOutputTokens === 'number' ? u.reasoningOutputTokens : undefined;
   return buildOpenAICompatUsage({
     prompt_tokens: input,
     completion_tokens: output,
@@ -1424,6 +1426,25 @@ export function createCodexBackend(
             };
 
             const cleanupNotifications = client.onNotification((method, params) => {
+              if (method === 'thread/tokenUsage/updated') {
+                const p = params as
+                  | {
+                      threadId?: string;
+                      turnId?: string;
+                      tokenUsage?: unknown;
+                    }
+                  | undefined;
+                if (activeTurnId && p?.turnId !== activeTurnId) return;
+                const parsed = parseCodexTokenUsageForOpenAICompat(p?.tokenUsage);
+                if (openaiCompatTrace) {
+                  console.error(
+                    `[openai-compat trace] codex tokenUsage raw=${JSON.stringify(p?.tokenUsage ?? null)} ` +
+                      `parsed=${JSON.stringify(parsed)}`,
+                  );
+                }
+                if (parsed) finalUsage = parsed;
+                return;
+              }
               if (method === 'item/completed') {
                 const p = params as { item?: ThreadItem; turnId?: string } | undefined;
                 if (activeTurnId && p?.turnId !== activeTurnId) return;
@@ -1472,15 +1493,6 @@ export function createCodexBackend(
                   | undefined;
                 const t = p?.turn;
                 if (activeTurnId && t?.id !== activeTurnId) return;
-                // openai-compat/v1 response-side usage. Best-effort: codex
-                // 0.130+ flat usage object on `turn.usage` (or `params.usage`,
-                // depending on app-server schema version). A malformed shape
-                // leaves finalUsage null and the gateway falls back to its
-                // own estimate.
-                const parsed =
-                  parseCodexTurnUsageForOpenAICompat(t?.usage) ??
-                  parseCodexTurnUsageForOpenAICompat(p?.usage);
-                if (parsed) finalUsage = parsed;
                 if (t?.status === 'completed') {
                   finish({ status: 'completed', finalText });
                 } else if (t?.status === 'interrupted') {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -576,6 +576,19 @@ interface TurnRunOutcome {
   finalText: string | null;
 }
 
+function extractAgentMessageDelta(params: unknown): string {
+  if (!params || typeof params !== 'object') return '';
+  const p = params as Record<string, unknown>;
+  if (typeof p.delta === 'string') return p.delta;
+  if (p.delta && typeof p.delta === 'object') {
+    const d = p.delta as Record<string, unknown>;
+    if (typeof d.text === 'string') return d.text;
+    if (typeof d.content === 'string') return d.content;
+  }
+  if (typeof p.text === 'string') return p.text;
+  return '';
+}
+
 export function createCodexBackend(
   opts: CodexBackendOptions = {},
 ): Backend {
@@ -1347,17 +1360,22 @@ export function createCodexBackend(
             });
           }
 
-          const emitAgentArtifact = (text: string): void => {
+          let responseArtifactId: string | null = null;
+          let streamedResponseText = '';
+
+          const emitAgentArtifact = (text: string, append = false, lastChunk = true): void => {
             if (!text) return;
+            responseArtifactId ??= randomUUID();
             emit({
               type: 'task.artifact',
               taskId: task.taskId,
               artifact: {
-                artifactId: randomUUID(),
+                artifactId: responseArtifactId,
                 name: 'codex-message',
                 parts: [{ kind: 'text', text }],
               },
-              lastChunk: true,
+              ...(append ? { append: true } : {}),
+              lastChunk,
             });
             emittedAnyArtifact = true;
           };
@@ -1414,7 +1432,14 @@ export function createCodexBackend(
                 if (item.type === 'agentMessage' && typeof item.text === 'string') {
                   recorder.mark('firstFinal');
                   finalText = item.text;
-                  emitAgentArtifact(item.text);
+                  if (streamedResponseText) {
+                    const tail = item.text.startsWith(streamedResponseText)
+                      ? item.text.slice(streamedResponseText.length)
+                      : '';
+                    emitAgentArtifact(tail, true, true);
+                  } else {
+                    emitAgentArtifact(item.text);
+                  }
                   return;
                 }
                 if (item.type === 'commandExecution') {
@@ -1426,6 +1451,11 @@ export function createCodexBackend(
                 const p = params as { turnId?: string } | undefined;
                 if (activeTurnId && p?.turnId !== activeTurnId) return;
                 recorder.mark('firstDelta');
+                const delta = extractAgentMessageDelta(params);
+                if (delta) {
+                  streamedResponseText += delta;
+                  emitAgentArtifact(delta, true, false);
+                }
                 return;
               }
               if (method === 'turn/completed') {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -206,6 +206,7 @@ export const TaskArtifactFrame = z.object({
   type: z.literal('task.artifact'),
   taskId: z.string(),
   artifact: Artifact,
+  append: z.boolean().optional(),
   lastChunk: z.boolean().optional(),
 });
 

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
-import { TaskState, type Message, type Task, type TaskStore } from '@a2x/sdk';
+import { TaskState, type Artifact, type Message, type Task, type TaskStore } from '@a2x/sdk';
 import { parseDownFrame, type AgentCard } from '@vicoop-bridge/protocol';
 import { Registry, type ClientConnection } from './registry.js';
 import {
@@ -350,6 +350,64 @@ test('executor persists inbound and agent status messages in task history', asyn
     task.history?.map((m) => m.messageId),
     ['m-4', 'agent-working', 'agent-done'],
   );
+});
+
+test('executor merges appended artifact chunks before persisting task artifacts', async () => {
+  const { ws } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'a-artifact',
+    clientId: 'c-artifact',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const taskStore = captureTaskStore();
+  const executor = new WSForwardingExecutor('a-artifact', registry, taskStore);
+  const task = {
+    id: 't-artifact',
+    contextId: 'ctx-artifact',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-artifact',
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  const firstEvent = gen.next();
+  const binding = registry.getBinding('t-artifact')!;
+
+  binding.sink.pushArtifact({
+    taskId: 't-artifact',
+    contextId: 'ctx-artifact',
+    append: true,
+    artifact: { artifactId: 'response', parts: [{ text: 'one' }] },
+  });
+  binding.sink.pushArtifact({
+    taskId: 't-artifact',
+    contextId: 'ctx-artifact',
+    append: true,
+    artifact: { artifactId: 'response', parts: [{ text: ' two' }] },
+  });
+  binding.sink.pushStatus({
+    taskId: 't-artifact',
+    contextId: 'ctx-artifact',
+    final: true,
+    status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+  });
+  binding.sink.finish();
+
+  await firstEvent;
+  for await (const _event of gen) void _event;
+
+  assert.equal(task.artifacts?.length, 1);
+  assert.deepEqual(task.artifacts?.[0]?.parts, [{ text: 'one two' }]);
+  const update = taskStore.updates.at(-1) as { artifacts?: Artifact[] };
+  assert.deepEqual(update.artifacts?.[0]?.parts, [{ text: 'one two' }]);
 });
 
 test('executor persists history when agent is unreachable', async () => {

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -36,6 +36,35 @@ const NOOP_RUNNER = new InMemoryRunner({
   appName: 'vicoop-bridge-noop',
 });
 
+function appendArtifactChunk(accumulated: Artifact[], event: TaskArtifactUpdateEvent): void {
+  if (event.append !== true) {
+    accumulated.push(event.artifact);
+    return;
+  }
+
+  const existing = accumulated.find((a) => a.artifactId === event.artifact.artifactId);
+  if (!existing) {
+    accumulated.push(event.artifact);
+    return;
+  }
+
+  existing.parts = mergeArtifactParts(existing.parts, event.artifact.parts);
+  existing.name = event.artifact.name ?? existing.name;
+  existing.metadata = event.artifact.metadata ?? existing.metadata;
+  existing.extensions = event.artifact.extensions ?? existing.extensions;
+}
+
+function mergeArtifactParts(existing: Artifact['parts'], chunk: Artifact['parts']): Artifact['parts'] {
+  if (existing.length === 1 && chunk.length === 1) {
+    const current = existing[0] as Record<string, unknown>;
+    const next = chunk[0] as Record<string, unknown>;
+    if (typeof current.text === 'string' && typeof next.text === 'string') {
+      return [{ ...current, text: current.text + next.text }] as Artifact['parts'];
+    }
+  }
+  return [...existing, ...chunk];
+}
+
 /**
  * Drop server-internal `_`-prefixed metadata keys (e.g. `_principalId`)
  * before forwarding a message to the connected client. The convention is
@@ -203,7 +232,7 @@ export class WSForwardingExecutor extends AgentExecutor {
           // post-stream `getTask()` path (push notifications, sync
           // `message/send`) sees the same artifacts the streaming
           // consumers received.
-          accumulatedArtifacts.push(event.artifact);
+          appendArtifactChunk(accumulatedArtifacts, event);
           yield event;
           continue;
         }

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -243,6 +243,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
             // Wire-shape parts; see wireMessageToA2X for the shape note.
             parts: frame.artifact.parts as unknown as Part[] as never,
           },
+          append: frame.append,
           lastChunk: frame.lastChunk,
         });
         break;


### PR DESCRIPTION
## Summary

- carry `append` through the bridge client/server artifact frame path
- stream Claude partial messages, Claude `stream_event` text deltas, and Codex `agentMessage` deltas as appended response artifacts
- merge appended artifact chunks before persisting task artifacts for non-streaming reads
- forward Codex `thread/tokenUsage/updated` into OpenAI-compat response usage metadata

## Why

Issue #293 showed Claude and Codex advertising streaming but buffering the complete response into one artifact. The OpenAI-compat gateway already maps `append: true` artifact updates to SSE deltas, so the bridge needs to emit and forward those incremental chunks.

While testing the Codex backend, `turn/completed.usage` was empty in current app-server output; usage is emitted through `thread/tokenUsage/updated`, so the client now maps that event to the OpenAI-compat usage extension.

Claude CLI also emits native streaming text through `stream_event` before the final assistant/result events. The Claude backend now forwards those text deltas immediately and avoids duplicating the final message.

## Validation

- `pnpm -r typecheck`
- `pnpm --filter @vicoop-bridge/client test -- --test-name-pattern='thread/tokenUsage/updated|streams Claude stream_event|streams cumulative Claude partial'`\n- previous validation: `pnpm --filter @vicoop-bridge/server test -- --test-name-pattern='executor merges appended artifact chunks'`\n- live check with `a2a-wallet a2a stream` against the Claude backend confirmed multiple `artifact-update` chunks and usage metadata