### PR TITLE
feat(client): stream vicoop-codex backend via long-running serve child

### DIFF
--- a/.changeset/vicoop-codex-http-streaming.md
+++ b/.changeset/vicoop-codex-http-streaming.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Replace the `vicoop-codex` backend's subprocess-per-task model with a long-running `vicoop-codex serve --port 0` child supervised on the bridge side. Each A2A task POSTs `/v1/chat/completions` with `stream: true` and emits token-level artifact deltas, plus a terminal `chat_completion` echo on `task.complete` for OpenAI-compat callers. Requires the `vicoop-codex` CLI release that ships `--port 0` support and the JSON listening banner (planetarium/vicoop-codex-cli#5).

--- a/packages/client/src/backends/vicoop-codex-supervisor.ts
+++ b/packages/client/src/backends/vicoop-codex-supervisor.ts
@@ -1,0 +1,279 @@
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
+import { createLogger, type Logger } from '../logger.js';
+
+// Slim subset of ChildProcess the supervisor uses. Tests inject a fake.
+export interface VicoopCodexChildHandle {
+  readonly stdin: NodeJS.WritableStream | null;
+  readonly stdout: NodeJS.ReadableStream | null;
+  readonly stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(
+    event: 'close',
+    listener: (code: number | null, signal: NodeJS.Signals | null) => void,
+  ): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+}
+
+export interface VicoopCodexSpawnOptions {
+  cwd?: string;
+}
+
+export type VicoopCodexSpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: VicoopCodexSpawnOptions,
+) => VicoopCodexChildHandle;
+
+export interface ServeSupervisorOptions {
+  command?: string;
+  cwd?: string;
+  extraArgs?: readonly string[];
+  spawn?: VicoopCodexSpawnFn;
+  stderrCaptureBytes?: number;
+  startupTimeoutMs?: number;
+  logger?: Logger;
+}
+
+export interface ListeningInfo {
+  host: string;
+  port: number;
+  url: string;
+}
+
+export interface CloseReason {
+  code?: number | null;
+  signal?: NodeJS.Signals | null;
+  error?: unknown;
+}
+
+function defaultSpawn(
+  command: string,
+  args: readonly string[],
+  options: VicoopCodexSpawnOptions,
+): VicoopCodexChildHandle {
+  // Same Windows-shim handling as the legacy subprocess-per-call code.
+  return nodeSpawn(command, Array.from(args), {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    shell: process.platform === 'win32',
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  }) as ChildProcess;
+}
+
+// Long-running `vicoop-codex serve --port 0` child. Spawns once, parses the
+// machine-parseable JSON banner the CLI emits as its first stderr line to
+// discover the bound port, then exposes `getBaseUrl()` for the backend
+// `handle()` to POST against. Modeled on AppServerRpcClient (codex-rpc.ts).
+export class ServeSupervisor {
+  private readonly command: string;
+  private readonly baseArgs: readonly string[];
+  private readonly cwd?: string;
+  private readonly spawnFn: VicoopCodexSpawnFn;
+  private readonly stderrCap: number;
+  private readonly startupTimeoutMs: number;
+  private readonly logger?: Logger;
+
+  private child: VicoopCodexChildHandle | null = null;
+  private stderrTail = '';
+  private stderrBuf = '';
+  private listening: ListeningInfo | null = null;
+  private readyWaiters: Array<{
+    resolve: (info: ListeningInfo) => void;
+    reject: (err: Error) => void;
+  }> = [];
+  private startupTimer: NodeJS.Timeout | null = null;
+  private closed = false;
+  private closeReason: CloseReason | null = null;
+  private readonly closeWaiters = new Set<(reason: CloseReason) => void>();
+
+  constructor(opts: ServeSupervisorOptions = {}) {
+    this.command = opts.command ?? 'vicoop-codex';
+    this.baseArgs = [
+      'serve',
+      '--port',
+      '0',
+      '--host',
+      '127.0.0.1',
+      ...(opts.extraArgs ?? []),
+    ];
+    this.cwd = opts.cwd;
+    this.spawnFn = opts.spawn ?? defaultSpawn;
+    this.stderrCap = opts.stderrCaptureBytes ?? 16 * 1024;
+    this.startupTimeoutMs = opts.startupTimeoutMs ?? 10_000;
+    this.logger = opts.logger;
+  }
+
+  // Spawn the child and arm the stderr listener. Throws synchronously on
+  // spawn(2) failure (ENOENT for a missing binary, etc.).
+  start(): void {
+    if (this.child) throw new Error('ServeSupervisor.start called twice');
+    if (this.closed) throw new Error('ServeSupervisor.start called after close');
+    const child = this.spawnFn(this.command, this.baseArgs, { cwd: this.cwd });
+    this.child = child;
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      this.appendStderr(s);
+      if (!this.listening) this.scanForListening(s);
+    });
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      // `serve` doesn't write to stdout in normal operation. Capture into
+      // stderrTail so unexpected output still surfaces on failure.
+      const s = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      this.appendStderr(s);
+    });
+    child.on('error', (err) => this.handleClose({ error: err }));
+    child.on('close', (code, signal) => this.handleClose({ code, signal }));
+
+    if (this.startupTimeoutMs > 0) {
+      this.startupTimer = setTimeout(() => {
+        if (this.listening || this.closed) return;
+        this.fail(
+          new Error(
+            `vicoop-codex serve failed to report a listening port within ${this.startupTimeoutMs}ms` +
+              (this.stderrTail ? `; stderr tail: ${this.stderrTail.trim()}` : ''),
+          ),
+        );
+      }, this.startupTimeoutMs);
+    }
+  }
+
+  // Resolves once the child has printed its listening banner. Rejects if the
+  // child exits or times out before then.
+  ready(): Promise<ListeningInfo> {
+    if (this.listening) return Promise.resolve(this.listening);
+    if (this.closed) {
+      return Promise.reject(this.closeError('vicoop-codex serve exited before becoming ready'));
+    }
+    return new Promise<ListeningInfo>((resolve, reject) => {
+      this.readyWaiters.push({ resolve, reject });
+    });
+  }
+
+  // Resolves when the child exits. Used by the backend to drop the singleton
+  // and lazily respawn on the next task.
+  waitForClose(): Promise<CloseReason> {
+    if (this.closed) return Promise.resolve(this.closeReason ?? {});
+    return new Promise((resolve) => {
+      this.closeWaiters.add(resolve);
+    });
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  getListening(): ListeningInfo | null {
+    return this.listening;
+  }
+
+  // Last N bytes of stderr+stdout. Surfaced in task.fail messages so an
+  // operator can diagnose without enabling --verbose.
+  getStderrTail(): string {
+    return this.stderrTail;
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): void {
+    if (!this.child || this.closed) return;
+    try {
+      this.child.kill(signal);
+    } catch {
+      // best-effort
+    }
+  }
+
+  private appendStderr(s: string): void {
+    if (this.stderrTail.length >= this.stderrCap) {
+      this.stderrTail = (this.stderrTail + s).slice(-this.stderrCap);
+    } else {
+      this.stderrTail += s;
+      if (this.stderrTail.length > this.stderrCap) {
+        this.stderrTail = this.stderrTail.slice(-this.stderrCap);
+      }
+    }
+  }
+
+  // Buffer stderr line-by-line until we find a JSON object with
+  // `event: "listening"`. The CLI emits this as the FIRST stderr line,
+  // followed by a human banner — we tolerate other lines in case stderr
+  // ordering shifts.
+  private scanForListening(chunk: string): void {
+    this.stderrBuf += chunk;
+    let nl: number;
+    while ((nl = this.stderrBuf.indexOf('\n')) >= 0) {
+      const line = this.stderrBuf.slice(0, nl).trim();
+      this.stderrBuf = this.stderrBuf.slice(nl + 1);
+      if (line.length === 0) continue;
+      if (line.charAt(0) !== '{') continue;
+      try {
+        const parsed = JSON.parse(line) as {
+          event?: string;
+          host?: string;
+          port?: number;
+          url?: string;
+        };
+        if (
+          parsed.event === 'listening' &&
+          typeof parsed.host === 'string' &&
+          typeof parsed.port === 'number' &&
+          typeof parsed.url === 'string'
+        ) {
+          this.markReady({ host: parsed.host, port: parsed.port, url: parsed.url });
+          return;
+        }
+      } catch {
+        // not the line we're looking for
+      }
+    }
+  }
+
+  private markReady(info: ListeningInfo): void {
+    this.listening = info;
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+    const waiters = this.readyWaiters;
+    this.readyWaiters = [];
+    for (const w of waiters) w.resolve(info);
+  }
+
+  private fail(err: Error): void {
+    if (this.closed) return;
+    this.logger?.warn?.(`[vicoop-codex] supervisor failed: ${err.message}`);
+    this.kill();
+    if (!this.closed) {
+      // close handler may not fire on a spawn that never wired stdio; finalize
+      // synchronously so callers don't hang.
+      this.handleClose({ error: err });
+    }
+  }
+
+  private handleClose(reason: CloseReason): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeReason = reason;
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer);
+      this.startupTimer = null;
+    }
+    const waiters = this.readyWaiters;
+    this.readyWaiters = [];
+    const err = this.closeError('vicoop-codex serve exited before becoming ready');
+    for (const w of waiters) w.reject(err);
+    const closeListeners = [...this.closeWaiters];
+    this.closeWaiters.clear();
+    for (const cb of closeListeners) cb(reason);
+  }
+
+  private closeError(prefix: string): Error {
+    const r = this.closeReason;
+    const detail = r?.error
+      ? `: ${(r.error as Error).message ?? String(r.error)}`
+      : r?.code !== undefined && r?.code !== null
+        ? ` (exit ${r.code}${r.signal ? `, signal ${r.signal}` : ''})`
+        : r?.signal
+          ? ` (signal ${r.signal})`
+          : '';
+    const tail = this.stderrTail.trim();
+    return new Error(`${prefix}${detail}${tail ? `; stderr tail: ${tail}` : ''}`);
+  }
+}

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -15,15 +15,20 @@ import {
   historyToChatCompletionMessages,
   parseChatCompletionUsage,
   type ChatCompletionResponse,
+} from './vicoop-codex.js';
+import {
   type VicoopCodexChildHandle,
   type VicoopCodexSpawnFn,
   type VicoopCodexSpawnOptions,
-} from './vicoop-codex.js';
+} from './vicoop-codex-supervisor.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Fake `vicoop-codex` child — collects stdin, scripts stdout/stderr/exit-code
-// to drive integration tests through the backend's `handle()` path without a
-// real subprocess. Mirrors the codex.test.ts FakeChild shape.
+// Fake `vicoop-codex serve` child — emits the JSON listening banner on stderr
+// as the first thing it does (mirroring the real CLI) and otherwise stays
+// alive until `finish()` is called. The backend's supervisor scans stderr for
+// the listening event to learn the bound port, so the banner must arrive
+// after the supervisor attaches its `on('data')` listener — queueMicrotask
+// the emit so it fires post-`start()`.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface FakeChild extends VicoopCodexChildHandle {
@@ -32,9 +37,8 @@ interface FakeChild extends VicoopCodexChildHandle {
   readonly cwd?: string;
   killed: boolean;
   killSignal: NodeJS.Signals | null;
-  stdinPayload: () => string;
-  emitStdout(text: string): void;
   emitStderr(text: string): void;
+  emitStdout(text: string): void;
   finish(code: number | null, sig?: NodeJS.Signals | null): void;
 }
 
@@ -44,8 +48,18 @@ interface FakeSpawn {
   lastChild: () => FakeChild;
 }
 
-function makeFakeSpawn(): FakeSpawn {
+interface FakeSpawnOptions {
+  // Test seam: skip the auto-emitted listening banner so a test can drive a
+  // startup-failure scenario.
+  suppressListeningBanner?: boolean;
+  // Test seam: override the port reported in the listening banner. Defaults
+  // to a high ephemeral-style value the fake fetch will match on.
+  listeningPort?: number;
+}
+
+function makeFakeSpawn(spawnOpts: FakeSpawnOptions = {}): FakeSpawn {
   const children: FakeChild[] = [];
+  const port = spawnOpts.listeningPort ?? 54321;
   const spawn: VicoopCodexSpawnFn = (
     command,
     args,
@@ -65,47 +79,15 @@ function makeFakeSpawn(): FakeSpawn {
         },
       }) as unknown as NodeJS.ReadableStream;
 
-    const stdinChunks: string[] = [];
-    const stdin: NodeJS.WritableStream = {
-      write(chunk: unknown): boolean {
-        const s =
-          typeof chunk === 'string'
-            ? chunk
-            : Buffer.from(chunk as Buffer).toString('utf8');
-        stdinChunks.push(s);
-        return true;
-      },
-      end(chunk?: unknown) {
-        if (chunk !== undefined) {
-          const s =
-            typeof chunk === 'string'
-              ? chunk
-              : Buffer.from(chunk as Buffer).toString('utf8');
-          stdinChunks.push(s);
-        }
-        return stdin;
-      },
-      on() {
-        return stdin;
-      },
-      once() {
-        return stdin;
-      },
-      emit() {
-        return false;
-      },
-    } as unknown as NodeJS.WritableStream;
-
     const child: FakeChild = {
       command,
       args,
       cwd: options.cwd,
-      stdin,
+      stdin: null,
       stdout: mkReadable(stdoutEmitter),
       stderr: mkReadable(stderrEmitter),
       killed: false,
       killSignal: null,
-      stdinPayload: () => stdinChunks.join(''),
       emitStdout(text) {
         stdoutEmitter.emit('data', Buffer.from(text, 'utf8'));
       },
@@ -113,6 +95,7 @@ function makeFakeSpawn(): FakeSpawn {
         stderrEmitter.emit('data', Buffer.from(text, 'utf8'));
       },
       kill(sig?: NodeJS.Signals) {
+        if (closed) return true;
         this.killed = true;
         this.killSignal = sig ?? 'SIGTERM';
         queueMicrotask(() => {
@@ -140,14 +123,29 @@ function makeFakeSpawn(): FakeSpawn {
       finish(code, sig = null) {
         if (closed) return;
         closed = true;
-        // Schedule async so the backend has a chance to register its
-        // listeners before we synthesise the exit — mirrors real
-        // child_process semantics.
         queueMicrotask(() => {
           for (const l of closeListeners) l(code, sig);
         });
       },
     };
+
+    if (!spawnOpts.suppressListeningBanner) {
+      queueMicrotask(() => {
+        stderrEmitter.emit(
+          'data',
+          Buffer.from(
+            JSON.stringify({
+              event: 'listening',
+              host: '127.0.0.1',
+              port,
+              url: `http://127.0.0.1:${port}`,
+            }) + '\n',
+            'utf8',
+          ),
+        );
+      });
+    }
+
     children.push(child);
     return child;
   };
@@ -159,6 +157,61 @@ function makeFakeSpawn(): FakeSpawn {
       return children[children.length - 1];
     },
   };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fake fetch + SSE response helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FakeFetchCall {
+  url: string;
+  init: RequestInit;
+  body: Record<string, unknown>;
+}
+
+interface FakeFetch {
+  fetch: typeof fetch;
+  calls: FakeFetchCall[];
+}
+
+function makeFakeFetch(
+  handler: (
+    call: FakeFetchCall,
+  ) => Response | Promise<Response>,
+): FakeFetch {
+  const calls: FakeFetchCall[] = [];
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : (input as URL).toString();
+    const i = init ?? {};
+    const body = i.body ? (JSON.parse(i.body as string) as Record<string, unknown>) : {};
+    const call: FakeFetchCall = { url, init: i, body };
+    calls.push(call);
+    return await handler(call);
+  };
+  return { fetch: fetchImpl, calls };
+}
+
+function sseResponse(chunks: Array<Record<string, unknown> | '[DONE]'>, status = 200): Response {
+  const lines = chunks
+    .map((c) => (c === '[DONE]' ? `data: [DONE]\n\n` : `data: ${JSON.stringify(c)}\n\n`))
+    .join('');
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(lines));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function errorResponse(status: number, bodyJson?: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(bodyJson ?? { error: { message: `HTTP ${status}` } }), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
 }
 
 function makeTask(
@@ -177,6 +230,28 @@ function makeTask(
     },
     ...rest,
   };
+}
+
+// Drive backend.handle() to completion against the given fake supervisor +
+// fake fetch, collecting every emitted frame.
+async function runBackend(
+  task: TaskAssignFrame,
+  fakeSpawn: FakeSpawn,
+  fakeFetch: FakeFetch,
+  opts: {
+    abort?: AbortController;
+  } = {},
+): Promise<{ frames: UpFrame[]; bundle: ReturnType<typeof createVicoopCodexBackend> }> {
+  const bundle = createVicoopCodexBackend({
+    spawn: fakeSpawn.spawn,
+    fetchImpl: fakeFetch.fetch,
+    // Short timeout so misconfigured tests fail fast.
+    startupTimeoutMs: 1_000,
+  });
+  const frames: UpFrame[] = [];
+  const ctrl = opts.abort ?? new AbortController();
+  await bundle.backend.handle(task, (f) => frames.push(f), ctrl.signal);
+  return { frames, bundle };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -219,190 +294,99 @@ test('historyToChatCompletionMessages: assistant tool_calls + tool result round-
         },
       ],
     },
-    {
-      role: 'tool',
-      tool_call_id: 'call_1',
-      content: '{"temp":13}',
-      name: 'get_weather',
-    },
+    { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}', name: 'get_weather' },
   ]);
   assert.equal(msgs.length, 2);
   assert.equal(msgs[0].role, 'assistant');
   assert.equal(msgs[0].content, null);
-  assert.equal((msgs[0].tool_calls as unknown[]).length, 1);
+  assert.equal((msgs[0].tool_calls as unknown[])?.length, 1);
   assert.equal(msgs[1].role, 'tool');
   assert.equal(msgs[1].tool_call_id, 'call_1');
   assert.equal(msgs[1].name, 'get_weather');
-  assert.equal(msgs[1].content, '{"temp":13}');
-});
-
-test('historyToChatCompletionMessages: prior user/assistant text turns round-trip', () => {
-  // New chat_history shape carries every prior turn — plain text turns
-  // map 1:1 to Chat Completions messages.
-  const msgs = historyToChatCompletionMessages([
-    { role: 'user', content: 'hi' },
-    { role: 'assistant', content: 'hello' },
-  ]);
-  assert.equal(msgs.length, 2);
-  assert.equal(msgs[0].role, 'user');
-  assert.equal(msgs[0].content, 'hi');
-  assert.equal(msgs[1].role, 'assistant');
-  assert.equal(msgs[1].content, 'hello');
 });
 
 test('buildMessages: ordering — system → history → user', () => {
-  const msgs = buildMessages(
+  const out = buildMessages(
     {
-      system: 'be concise',
+      system: 'reply in korean',
       chat_history: [
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'result' },
+        { role: 'user', content: 'prior' },
+        { role: 'assistant', content: 'prior reply' },
       ],
     },
-    'current ask',
+    'now',
   );
   assert.deepEqual(
-    msgs.map((m) => m.role),
-    ['system', 'assistant', 'tool', 'user'],
+    out.map((m) => m.role),
+    ['system', 'user', 'assistant', 'user'],
   );
-  assert.equal(msgs[0].content, 'be concise');
-  assert.equal(msgs[msgs.length - 1].content, 'current ask');
-});
-
-test('buildMessages: multi-turn tool-loop scenario from PR #289 keeps opening user at the head', () => {
-  // Regression guard for the gpt-5.3-codex re-call loop fixed by
-  // PR #289 (fix/vicoop-codex-user-turn-order). On the old
-  // `tool_call_history` wire that PR worked against, the prior tool
-  // round-trips were the only entries in metadata and the originating
-  // user request was nowhere in the assembled `messages` — so the
-  // model saw `[system, asst.tc, tool, asst.tc, tool, …, user]` and
-  // re-interpreted the trailing user as a fresh imperative, restarting
-  // from `list_workflows` on every turn.
-  //
-  // The new `chat_history` wire fixes this at the source: the gateway
-  // includes EVERY prior turn except the trailing user (so the
-  // originating user request is the first history entry). With
-  // `buildMessages` emitting `system → chat_history → trailing_user`,
-  // the assembled messages preserve the linear OpenAI conversation
-  // order automatically — no manual re-ordering needed.
-  //
-  // This test pins that invariant: the originating user request MUST
-  // be at index 1 (right after system), and the trailing user MUST be
-  // last, regardless of how many tool round-trips sit between them.
-  const msgs = buildMessages(
-    {
-      system: 'be concise',
-      chat_history: [
-        { role: 'user', content: 'list workflows then run X' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'list_workflows', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: '[…]' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c2', function: { name: 'execute', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c2', content: 'started' },
-      ],
-    },
-    'how is it going?',
-  );
-  assert.deepEqual(
-    msgs.map((m) => m.role),
-    ['system', 'user', 'assistant', 'tool', 'assistant', 'tool', 'user'],
-  );
-  // Opening user at index 1 — the original request the tool rounds were
-  // driven by. The model needs to see this BEFORE any tool activity or
-  // it loses the thread and re-emits the first call.
-  assert.equal(msgs[1].content, 'list workflows then run X');
-  // Trailing user at the tail — the new question on this turn.
-  assert.equal(msgs[msgs.length - 1].content, 'how is it going?');
+  assert.equal(out[out.length - 1].content, 'now');
 });
 
 test('buildMessages: tool-continuation (null userContent) skips trailing user', () => {
-  // openai-compat spec edge case: when A2A parts is the empty
-  // placeholder, the caller passes null userContent and chat_history
-  // carries the full conversation including the trailing tool result.
-  const msgs = buildMessages(
+  const out = buildMessages(
     {
       chat_history: [
-        { role: 'user', content: 'kick off' },
+        { role: 'user', content: 'q' },
         {
           role: 'assistant',
           content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
+          tool_calls: [
+            {
+              id: 'c1',
+              type: 'function',
+              function: { name: 'f', arguments: '{}' },
+            },
+          ],
         },
-        { role: 'tool', tool_call_id: 'c1', content: 'result' },
+        { role: 'tool', tool_call_id: 'c1', content: 'r' },
       ],
     },
     null,
   );
   assert.deepEqual(
-    msgs.map((m) => m.role),
+    out.map((m) => m.role),
     ['user', 'assistant', 'tool'],
   );
 });
 
 test('buildMessages: no metadata still emits a user message', () => {
-  const msgs = buildMessages(null, 'hi');
-  assert.deepEqual(msgs, [{ role: 'user', content: 'hi' }]);
+  const out = buildMessages(null, 'hi');
+  assert.deepEqual(out, [{ role: 'user', content: 'hi' }]);
 });
 
 test('buildCallBody: forwards only tools / tool_choice from the existing 4-field schema', () => {
-  const body = buildCallBody(
+  const out = buildCallBody(
     {
-      system: 'sys',
-      tools: [{ type: 'function', function: { name: 'x' } }],
-      tool_choice: 'auto',
-      chat_history: [
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'r' },
-      ],
+      tools: [{ type: 'function', function: { name: 'f' } }],
+      tool_choice: { type: 'function', function: { name: 'f' } },
     },
-    [{ role: 'user', content: 'q' }],
+    [{ role: 'user', content: 'hi' }],
   );
-  assert.deepEqual(body.tools, [{ type: 'function', function: { name: 'x' } }]);
-  assert.equal(body.tool_choice, 'auto');
-  assert.deepEqual(body.messages, [{ role: 'user', content: 'q' }]);
-  // Nothing else lands on the body — no model, no reasoning_effort, no
-  // Group B / Group C fields.
-  assert.equal(Object.keys(body).sort().join(','), 'messages,tool_choice,tools');
+  assert.equal(out.stream, true);
+  assert.deepEqual(out.stream_options, { include_usage: true });
+  assert.deepEqual(out.tools, [{ type: 'function', function: { name: 'f' } }]);
+  assert.deepEqual(out.tool_choice, { type: 'function', function: { name: 'f' } });
 });
 
-test('buildCallBody: no metadata yields messages-only body', () => {
-  const body = buildCallBody(null, [{ role: 'user', content: 'q' }]);
-  assert.deepEqual(body, { messages: [{ role: 'user', content: 'q' }] });
+test('buildCallBody: no metadata yields messages + stream + stream_options', () => {
+  const out = buildCallBody(null, [{ role: 'user', content: 'hi' }]);
+  assert.deepEqual(out.messages, [{ role: 'user', content: 'hi' }]);
+  assert.equal(out.stream, true);
+  assert.deepEqual(out.stream_options, { include_usage: true });
+  assert.equal(out.tools, undefined);
+  assert.equal(out.tool_choice, undefined);
 });
 
 test('parseChatCompletionUsage: enforces total = prompt + completion', () => {
   const u = parseChatCompletionUsage(
-    {
-      prompt_tokens: 17,
-      completion_tokens: 5,
-      total_tokens: 999,
-      prompt_tokens_details: { cached_tokens: 3 },
-      completion_tokens_details: { reasoning_tokens: 2 },
-    },
+    { prompt_tokens: 7, completion_tokens: 3, total_tokens: 9999 },
     'gpt-5.4',
   );
   assert.ok(u);
-  assert.equal(u!.prompt_tokens, 17);
-  assert.equal(u!.completion_tokens, 5);
-  assert.equal(u!.total_tokens, 22);
-  assert.equal(u!.model, 'gpt-5.4');
-  assert.equal(u!.prompt_tokens_details?.cached_tokens, 3);
-  assert.equal(u!.completion_tokens_details?.reasoning_tokens, 2);
+  assert.equal(u!.prompt_tokens, 7);
+  assert.equal(u!.completion_tokens, 3);
+  assert.equal(u!.total_tokens, 10);
 });
 
 test('parseChatCompletionUsage: missing primary counts yields null', () => {
@@ -441,77 +425,54 @@ test('buildResponseMetadata: includes both usage and chat_completion echo', () =
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// End-to-end Backend.handle() tests via the fake spawn surface
+// Backend.handle() integration tests (mock supervisor + mock fetch)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function runBackend(
-  task: TaskAssignFrame,
-  driveChild: (child: FakeChild) => void,
-): Promise<UpFrame[]> {
-  const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
-  const frames: UpFrame[] = [];
-  const ctrl = new AbortController();
-  const done = backend.handle(task, (f) => frames.push(f), ctrl.signal);
-  // Wait one microtask so the backend has spawned its child before we drive
-  // it. The fake spawn is synchronous, so a single queueMicrotask suffices.
-  return new Promise((resolve, reject) => {
-    queueMicrotask(() => {
-      try {
-        driveChild(fake.lastChild());
-      } catch (err) {
-        reject(err);
-        return;
-      }
-      done.then(() => resolve(frames), reject);
-    });
-  });
-}
+test('handle: streams text deltas as appended artifacts and emits complete with metadata', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch((_call) =>
+    sseResponse([
+      { id: 'chatcmpl-1', model: 'gpt-5.4', created: 1700000000, choices: [{ index: 0, delta: { role: 'assistant' } }] },
+      { id: 'chatcmpl-1', choices: [{ index: 0, delta: { content: 'Hello' } }] },
+      { id: 'chatcmpl-1', choices: [{ index: 0, delta: { content: ' world' } }] },
+      { id: 'chatcmpl-1', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      { id: 'chatcmpl-1', usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 }, choices: [] },
+      '[DONE]',
+    ]),
+  );
 
-test('handle: success path — text response → artifact + complete with metadata', async () => {
-  const task = makeTask({
-    metadata: {
-      [OPENAI_COMPAT_EXTENSION_URI]: {
-        system: 'be concise',
-      },
-    },
-  });
-  const frames = await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
-      id: 'chatcmpl-1',
-      object: 'chat.completion',
-      created: 1700000000,
-      model: 'gpt-5.4',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content: 'ok' },
-          finish_reason: 'stop',
-        },
-      ],
-      usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
-    };
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
-  });
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch);
+  await bundle.shutdown();
 
-  const statuses = frames.filter((f) => f.type === 'task.status');
   const artifacts = frames.filter((f) => f.type === 'task.artifact');
+  assert.ok(artifacts.length >= 3, `expected at least 3 artifact frames, got ${artifacts.length}`);
+  // First delta: append unset, lastChunk false.
+  const first = artifacts[0];
+  if (first.type !== 'task.artifact') throw new Error('unreachable');
+  assert.equal(first.append, undefined);
+  assert.equal(first.lastChunk, false);
+  if (first.artifact.parts[0].kind !== 'text') throw new Error('unreachable');
+  assert.equal(first.artifact.parts[0].text, 'Hello');
+  // Subsequent deltas share the artifactId and set append:true.
+  const second = artifacts[1];
+  if (second.type !== 'task.artifact') throw new Error('unreachable');
+  assert.equal(second.append, true);
+  assert.equal(second.lastChunk, false);
+  assert.equal(second.artifact.artifactId, first.artifact.artifactId);
+  // Final artifact carries lastChunk:true.
+  const last = artifacts[artifacts.length - 1];
+  if (last.type !== 'task.artifact') throw new Error('unreachable');
+  assert.equal(last.lastChunk, true);
+  assert.equal(last.artifact.artifactId, first.artifact.artifactId);
+
   const completes = frames.filter((f) => f.type === 'task.complete');
-  assert.equal(statuses.length, 1);
-  assert.equal(statuses[0].status.state, 'working');
-  assert.equal(artifacts.length, 1);
-  const artifact = artifacts[0];
-  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].kind, 'text');
-  if (artifact.artifact.parts[0].kind !== 'text') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].text, 'ok');
   assert.equal(completes.length, 1);
-  const completeFrame = completes[0];
-  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
-  assert.equal(completeFrame.status.state, 'completed');
-  const msg = completeFrame.status.message!;
-  assert.ok(msg.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+  const c = completes[0];
+  if (c.type !== 'task.complete') throw new Error('unreachable');
+  assert.equal(c.status.state, 'completed');
+  const msg = c.status.message!;
+  if (msg.parts[0].kind !== 'text') throw new Error('unreachable');
+  assert.equal(msg.parts[0].text, 'Hello world');
   const ext = (msg.metadata as Record<string, Record<string, unknown>>)[
     OPENAI_COMPAT_EXTENSION_URI
   ];
@@ -521,61 +482,99 @@ test('handle: success path — text response → artifact + complete with metada
   assert.equal(echo.model, 'gpt-5.4');
 });
 
-test('handle: tool_calls response → data artifact + no text in status message', async () => {
-  const task = makeTask({
-    metadata: {
-      [OPENAI_COMPAT_EXTENSION_URI]: {
-        tools: [{ type: 'function', function: { name: 'list_files' } }],
+test('handle: tool_calls streamed across deltas → assembled, data artifact, no text in complete', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch((_call) =>
+    sseResponse([
+      {
+        id: 'chatcmpl-2',
+        model: 'gpt-5.3-codex',
+        created: 1700000001,
+        choices: [{ index: 0, delta: { role: 'assistant' } }],
       },
-    },
-  });
-  const frames = await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
-      id: 'chatcmpl-2',
-      object: 'chat.completion',
-      created: 1700000001,
-      model: 'gpt-5.3-codex',
-      choices: [
-        {
-          index: 0,
-          message: {
-            role: 'assistant',
-            content: null,
-            tool_calls: [
-              {
-                id: 'call_xyz',
-                type: 'function',
-                function: { name: 'list_files', arguments: '{"path":"."}' },
-              },
-            ],
+      {
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_xyz',
+                  type: 'function',
+                  function: { name: 'list_files', arguments: '{"path"' },
+                },
+              ],
+            },
           },
-          finish_reason: 'tool_calls',
+        ],
+      },
+      {
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [{ index: 0, function: { arguments: ':"."}' } }] },
+          },
+        ],
+      },
+      { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+      { usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 }, choices: [] },
+      '[DONE]',
+    ]),
+  );
+
+  const { frames, bundle } = await runBackend(
+    makeTask({
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          tools: [{ type: 'function', function: { name: 'list_files' } }],
         },
-      ],
-      usage: { prompt_tokens: 4, completion_tokens: 6, total_tokens: 10 },
-    };
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
-  });
+      },
+    }),
+    fakeSpawn,
+    fakeFetch,
+  );
+  await bundle.shutdown();
+
   const artifacts = frames.filter((f) => f.type === 'task.artifact');
   assert.equal(artifacts.length, 1);
-  const artifact = artifacts[0];
-  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].kind, 'data');
-  if (artifact.artifact.parts[0].kind !== 'data') throw new Error('unreachable');
-  const data = artifact.artifact.parts[0].data as { tool_calls: unknown[] };
+  const a = artifacts[0];
+  if (a.type !== 'task.artifact') throw new Error('unreachable');
+  if (a.artifact.parts[0].kind !== 'data') throw new Error('unreachable');
+  const data = a.artifact.parts[0].data as {
+    tool_calls: Array<{ id: string; function: { name: string; arguments: string } }>;
+  };
   assert.equal(data.tool_calls.length, 1);
-  assert.ok(artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
-  const completes = frames.filter((f) => f.type === 'task.complete');
-  assert.equal(completes.length, 1);
-  const completeFrame = completes[0];
-  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
-  // status.message exists but parts must be empty so we don't re-stamp the
-  // tool_calls envelope onto the message.
-  assert.deepEqual(completeFrame.status.message!.parts, []);
+  assert.equal(data.tool_calls[0].id, 'call_xyz');
+  assert.equal(data.tool_calls[0].function.name, 'list_files');
+  // Arguments concatenated across deltas.
+  assert.equal(data.tool_calls[0].function.arguments, '{"path":"."}');
+  assert.ok(a.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+
+  const c = frames.find((f) => f.type === 'task.complete');
+  if (!c || c.type !== 'task.complete') throw new Error('unreachable');
+  // No text duplicated into the completion message.
+  assert.deepEqual(c.status.message!.parts, []);
+  const ext = (c.status.message!.metadata as Record<
+    string,
+    Record<string, unknown>
+  >)[OPENAI_COMPAT_EXTENSION_URI];
+  const echo = ext.chat_completion as Record<string, unknown>;
+  const choice = (echo.choices as Array<{ finish_reason?: string }>)[0];
+  assert.equal(choice.finish_reason, 'tool_calls');
 });
 
-test('handle: stdin body carries only system/tools/tool_choice/history-derived messages', async () => {
+test('handle: POST body carries stream:true + only system/tools/tool_choice/history-derived messages', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch((_call) =>
+    sseResponse([
+      { id: 'chatcmpl-3', model: 'gpt-5.5', created: 1, choices: [{ index: 0, delta: { content: 'ok' } }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      { usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }, choices: [] },
+      '[DONE]',
+    ]),
+  );
+
   const task = makeTask({
     message: {
       role: 'user',
@@ -583,7 +582,6 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
       parts: [{ kind: 'text', text: 'current question' }],
       metadata: {
         [OPENAI_COMPAT_EXTENSION_URI]: {
-          // The 4-field schema only.
           system: 'reply in korean',
           tools: [{ type: 'function', function: { name: 'get_weather' } }],
           tool_choice: { type: 'function', function: { name: 'get_weather' } },
@@ -601,8 +599,7 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
             },
             { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
           ],
-          // Unknown extension keys must NOT reach the call body — they
-          // aren't part of the openai-compat 4-field schema.
+          // Unknown extension keys must NOT reach the call body.
           model: 'gpt-5.5',
           reasoning_effort: 'high',
           temperature: 0.7,
@@ -612,116 +609,202 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
     },
   });
 
-  await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
-      id: 'chatcmpl-3',
-      object: 'chat.completion',
-      created: 1,
-      model: 'gpt-5.5',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content: 'ok' },
-          finish_reason: 'stop',
-        },
-      ],
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-    };
-    const payload = child.stdinPayload();
-    const body = JSON.parse(payload) as Record<string, unknown>;
-    // Messages: system → chat_history (assistant(tool_calls) → tool) →
-    // trailing user. Per the new openai-compat chat_history wire, the
-    // trailing user (the current A2A `parts` turn) sits AFTER the
-    // history slice, mirroring how OpenAI Chat Completions arranges
-    // `[..., assistant.tool_calls, tool, user]` for a follow-up.
-    const messages = body.messages as Array<{ role: string }>;
-    assert.deepEqual(
-      messages.map((m) => m.role),
-      ['system', 'assistant', 'tool', 'user'],
-    );
-    // Only the existing 4-field schema's `tools` / `tool_choice` are
-    // forwarded; the spurious model/reasoning_effort/temperature/max_tokens
-    // entries are dropped at the metadata reader.
-    assert.deepEqual(body.tools, [
-      { type: 'function', function: { name: 'get_weather' } },
-    ]);
-    assert.deepEqual(body.tool_choice, {
-      type: 'function',
-      function: { name: 'get_weather' },
-    });
-    assert.equal(body.model, undefined);
-    assert.equal(body.reasoning_effort, undefined);
-    assert.equal(body.temperature, undefined);
-    assert.equal(body.max_tokens, undefined);
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
+  const { bundle } = await runBackend(task, fakeSpawn, fakeFetch);
+  await bundle.shutdown();
+
+  assert.equal(fakeFetch.calls.length, 1);
+  const sent = fakeFetch.calls[0];
+  assert.equal(sent.url.endsWith('/v1/chat/completions'), true);
+  assert.equal(sent.body.stream, true);
+  assert.deepEqual(sent.body.stream_options, { include_usage: true });
+  const messages = sent.body.messages as Array<{ role: string }>;
+  assert.deepEqual(
+    messages.map((m) => m.role),
+    ['system', 'assistant', 'tool', 'user'],
+  );
+  assert.deepEqual(sent.body.tools, [
+    { type: 'function', function: { name: 'get_weather' } },
+  ]);
+  assert.deepEqual(sent.body.tool_choice, {
+    type: 'function',
+    function: { name: 'get_weather' },
   });
+  assert.equal(sent.body.model, undefined);
+  assert.equal(sent.body.reasoning_effort, undefined);
+  assert.equal(sent.body.temperature, undefined);
+  assert.equal(sent.body.max_tokens, undefined);
 });
 
-test('handle: empty prompt → task.fail with empty_prompt code', async () => {
-  const task = makeTask({
-    message: {
-      role: 'user',
-      messageId: 'msg',
-      parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: 'xx' } }],
-    },
+test('handle: empty prompt → task.fail with empty_prompt code, no fetch made', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() => {
+    throw new Error('fetch should not be called');
   });
-  const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
-  const frames: UpFrame[] = [];
-  await backend.handle(task, (f) => frames.push(f), new AbortController().signal);
-  assert.equal(fake.children.length, 0);
+  const { frames, bundle } = await runBackend(
+    makeTask({
+      message: {
+        role: 'user',
+        messageId: 'msg',
+        parts: [{ kind: 'file', file: { mimeType: 'image/png', bytes: 'xx' } }],
+      },
+    }),
+    fakeSpawn,
+    fakeFetch,
+  );
+  await bundle.shutdown();
   const fails = frames.filter((f) => f.type === 'task.fail');
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
   assert.equal(failFrame.error.code, 'empty_prompt');
+  // Supervisor never spawned because we bailed before ensureSupervisor.
+  assert.equal(fakeSpawn.children.length, 0);
 });
 
-test('handle: non-zero exit maps to documented exit-code error codes', async () => {
-  const exitCases: Array<{ code: number; expected: string }> = [
-    { code: 2, expected: 'invalid_input' },
-    { code: 3, expected: 'login_required' },
-    { code: 4, expected: 'upstream_error' },
-    { code: 5, expected: 'network_error' },
-    { code: 99, expected: 'vicoop_codex_failed' },
-  ];
-  for (const { code, expected } of exitCases) {
-    const frames = await runBackend(makeTask(), (child) => {
-      child.emitStderr('Error: simulated');
-      child.finish(code);
-    });
-    const fails = frames.filter((f) => f.type === 'task.fail');
-    assert.equal(fails.length, 1, `exit code ${code}`);
-    const failFrame = fails[0];
-    if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-    assert.equal(failFrame.error.code, expected, `exit code ${code} → ${expected}`);
-    assert.ok(failFrame.error.message.includes('simulated'));
-  }
-});
-
-test('handle: malformed JSON stdout → parse_failed', async () => {
-  const frames = await runBackend(makeTask(), (child) => {
-    child.emitStdout('not json at all');
-    child.finish(0);
-  });
+test('handle: upstream HTTP 401 → login_required', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() =>
+    errorResponse(401, { error: { message: 'not signed in' } }),
+  );
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch);
+  await bundle.shutdown();
   const fails = frames.filter((f) => f.type === 'task.fail');
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-  assert.equal(failFrame.error.code, 'parse_failed');
+  assert.equal(failFrame.error.code, 'login_required');
+  assert.ok(failFrame.error.message.includes('not signed in'));
 });
 
-test('handle: cancel before spawn → task.complete with canceled', async () => {
-  const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
-  const frames: UpFrame[] = [];
+test('handle: upstream HTTP 429 → rate_limited', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() =>
+    errorResponse(429, { error: { message: 'slow down' } }),
+  );
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch);
+  await bundle.shutdown();
+  const failFrame = frames.find((f) => f.type === 'task.fail');
+  if (!failFrame || failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'rate_limited');
+});
+
+test('handle: upstream HTTP 502 → upstream_http_502', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() => errorResponse(502, { error: { message: 'bad gateway' } }));
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch);
+  await bundle.shutdown();
+  const failFrame = frames.find((f) => f.type === 'task.fail');
+  if (!failFrame || failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'upstream_http_502');
+});
+
+test('handle: mid-stream error event → stream_error', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() =>
+    sseResponse([
+      { id: 'chatcmpl-x', choices: [{ index: 0, delta: { content: 'partial' } }] },
+      { error: { message: 'upstream went away' } },
+    ]),
+  );
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch);
+  await bundle.shutdown();
+  const failFrame = frames.find((f) => f.type === 'task.fail');
+  if (!failFrame || failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'stream_error');
+  assert.ok(failFrame.error.message.includes('upstream went away'));
+});
+
+test('handle: cancel before spawn → task.complete with canceled, no child', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() => {
+    throw new Error('fetch should not be called');
+  });
   const ctrl = new AbortController();
   ctrl.abort();
-  await backend.handle(makeTask(), (f) => frames.push(f), ctrl.signal);
-  assert.equal(fake.children.length, 0);
+  const { frames, bundle } = await runBackend(makeTask(), fakeSpawn, fakeFetch, { abort: ctrl });
+  await bundle.shutdown();
+  assert.equal(fakeSpawn.children.length, 0);
   assert.equal(frames.length, 1);
   const frame = frames[0];
   if (frame.type !== 'task.complete') throw new Error('unreachable');
   assert.equal(frame.status.state, 'canceled');
+});
+
+test('handle: supervisor that never emits listening banner → cli_unavailable on startup timeout', async () => {
+  const fakeSpawn = makeFakeSpawn({ suppressListeningBanner: true });
+  const fakeFetch = makeFakeFetch(() => {
+    throw new Error('fetch should not be called');
+  });
+  const bundle = createVicoopCodexBackend({
+    spawn: fakeSpawn.spawn,
+    fetchImpl: fakeFetch.fetch,
+    startupTimeoutMs: 50,
+  });
+  const frames: UpFrame[] = [];
+  await bundle.backend.handle(makeTask(), (f) => frames.push(f), new AbortController().signal);
+  await bundle.shutdown();
+  const failFrame = frames.find((f) => f.type === 'task.fail');
+  if (!failFrame || failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'cli_unavailable');
+});
+
+test('handle: second task reuses the same supervisor child', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  let callIdx = 0;
+  const fakeFetch = makeFakeFetch(() => {
+    callIdx++;
+    return sseResponse([
+      { id: `chatcmpl-${callIdx}`, choices: [{ index: 0, delta: { content: 'ok' } }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      { usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }, choices: [] },
+      '[DONE]',
+    ]);
+  });
+
+  const bundle = createVicoopCodexBackend({
+    spawn: fakeSpawn.spawn,
+    fetchImpl: fakeFetch.fetch,
+    startupTimeoutMs: 1_000,
+  });
+  await bundle.backend.handle(makeTask(), () => {}, new AbortController().signal);
+  await bundle.backend.handle(
+    makeTask({ taskId: 'task-2' }),
+    () => {},
+    new AbortController().signal,
+  );
+  await bundle.shutdown();
+
+  assert.equal(fakeSpawn.children.length, 1);
+  assert.equal(fakeFetch.calls.length, 2);
+});
+
+test('handle: supervisor that died between tasks is respawned on next task', async () => {
+  const fakeSpawn = makeFakeSpawn();
+  const fakeFetch = makeFakeFetch(() =>
+    sseResponse([
+      { id: 'x', choices: [{ index: 0, delta: { content: 'ok' } }] },
+      { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+      { usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }, choices: [] },
+      '[DONE]',
+    ]),
+  );
+
+  const bundle = createVicoopCodexBackend({
+    spawn: fakeSpawn.spawn,
+    fetchImpl: fakeFetch.fetch,
+    startupTimeoutMs: 1_000,
+  });
+  await bundle.backend.handle(makeTask(), () => {}, new AbortController().signal);
+  // Kill the supervisor child.
+  fakeSpawn.lastChild().finish(0);
+  // Wait for the close handler to nullify the singleton.
+  await new Promise((r) => setImmediate(r));
+  await bundle.backend.handle(
+    makeTask({ taskId: 'task-2' }),
+    () => {},
+    new AbortController().signal,
+  );
+  await bundle.shutdown();
+
+  assert.equal(fakeSpawn.children.length, 2);
 });

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -1,4 +1,3 @@
-import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import {
   OPENAI_COMPAT_EXTENSION_URI,
@@ -17,77 +16,61 @@ import {
   buildOpenAICompatUsage,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
+import {
+  ServeSupervisor,
+  type ServeSupervisorOptions,
+  type VicoopCodexChildHandle,
+  type VicoopCodexSpawnFn,
+  type VicoopCodexSpawnOptions,
+} from './vicoop-codex-supervisor.js';
 
-// Slim subset of ChildProcess the backend actually uses. Tests inject a
-// fake that satisfies this without wiring up a real OS process.
-export interface VicoopCodexChildHandle {
-  readonly stdin: NodeJS.WritableStream | null;
-  readonly stdout: NodeJS.ReadableStream | null;
-  readonly stderr: NodeJS.ReadableStream | null;
-  kill(signal?: NodeJS.Signals): boolean;
-  on(event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
-  on(event: 'error', listener: (err: Error) => void): void;
-}
-
-export interface VicoopCodexSpawnOptions {
-  cwd?: string;
-}
-
-export type VicoopCodexSpawnFn = (
-  command: string,
-  args: readonly string[],
-  options: VicoopCodexSpawnOptions,
-) => VicoopCodexChildHandle;
+export type {
+  VicoopCodexChildHandle,
+  VicoopCodexSpawnFn,
+  VicoopCodexSpawnOptions,
+};
 
 export interface VicoopCodexBackendOptions {
   // Test seams only — the production CLI calls `createVicoopCodexBackend()`
-  // with no arguments. We don't expose operator-facing knobs here because
-  // anything an operator could set would have to ride through the existing
-  // CLI / config surface, and we are not extending that surface for this
-  // backend. Defaults below cover the production path; tests inject
-  // `spawn` / `logger` / timing overrides.
+  // with no arguments. The supervisor accepts a `spawn` override for tests
+  // and a `fetchImpl` override for tests that script HTTP/SSE responses;
+  // both default to Node's host implementations.
   command?: string;
   cwd?: string;
   extraArgs?: readonly string[];
   spawn?: VicoopCodexSpawnFn;
+  fetchImpl?: typeof fetch;
   stderrCaptureBytes?: number;
-  callTimeoutMs?: number;
+  startupTimeoutMs?: number;
   logger?: Logger;
   // When true, dump A2A `parts` shape + metadata keys + raw
   // `chat_history` to stderr on every task. Operator diagnostic exposed
-  // via `--openai-compat-trace`. Leave off in production.
+  // via `--openai-compat-trace`.
   openaiCompatTrace?: boolean;
 }
 
-// `vicoop-codex call` body shape — only the fields this backend actually
-// emits. The openai-compat A2A extension defines `system` / `tools` /
-// `tool_choice` / `chat_history`, of which `system` and
-// `chat_history` fold into `messages`; the remaining two ride out
-// verbatim. Everything else (model, reasoning_effort, parallel_tool_calls,
-// the Group B / Group C parameters from the call command's input doc) is
-// intentionally not on this shape because no input surface we currently
-// read carries them. The binary applies its own defaults.
+// `vicoop-codex serve`'s `/v1/chat/completions` request body. Same shape the
+// previous subprocess-per-call code built — `serve` reuses the exact same
+// `chatCompletionsToUpstream` translator the `call` subcommand did.
 export interface VicoopCodexCallBody {
   messages: ChatCompletionMessage[];
   tools?: unknown[];
   tool_choice?: unknown;
+  stream: true;
+  stream_options?: { include_usage?: boolean };
 }
 
 export interface ChatCompletionMessage {
   role: 'system' | 'developer' | 'user' | 'assistant' | 'tool' | 'function';
-  // OpenAI permits string or content-parts. We emit a string for system /
-  // developer / user / tool messages and `null` for assistant tool-call-only
-  // messages, mirroring the doc's worked examples.
   content?: string | null;
   tool_calls?: unknown[];
   tool_call_id?: string;
   name?: string;
 }
 
-// Parsed OpenAI Chat Completions non-streaming response (the shape
-// `vicoop-codex call` prints to stdout). All optional / nullable
-// per OpenAI — the binary always emits `id` / `object` / `model` / `choices`
-// but we tolerate missing fields rather than crash on a future schema bump.
+// Reconstructed equivalent of the previous non-streaming
+// ChatCompletionResponse, assembled from streamed deltas. Kept exported
+// because `buildResponseMetadata` and `parseChatCompletionUsage` consume it.
 export interface ChatCompletionResponse {
   id?: string;
   object?: string;
@@ -142,18 +125,12 @@ function serializeDataPart(data: Record<string, unknown>): string {
   return `<context kind="application/json">\n${body}\n</context>`;
 }
 
-// Extract the user turn from A2A `Message.parts`. The vicoop-codex `call`
-// command's `messages[].content` is string-or-multimodal-parts, but the
-// binary only consumes text parts (image / audio are dropped per the doc's
-// "Known limitations" section); we therefore flatten everything to a single
-// string here. DataParts are folded in as `<context>`-tagged JSON so the
-// model sees them as auxiliary structured input — same convention the
-// codex / claude backends already use.
-//
-// Returns null when the message carries no text and no data, signalling the
-// caller to fail the task with `empty_prompt` rather than send an empty
-// user message upstream (which the binary would reject as
-// `'messages' is required and must be a non-empty array`).
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers — unchanged from the prior subprocess-per-call implementation.
+// The translation surface (A2A parts ↔ OpenAI Chat Completions messages) is
+// independent of how we deliver the request to the CLI.
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function flattenA2AUserContent(parts: readonly Part[]): string | null {
   const sections: string[] = [];
   for (const p of parts) {
@@ -166,28 +143,11 @@ export function flattenA2AUserContent(parts: readonly Part[]): string | null {
       if (serialized) sections.push(serialized);
       continue;
     }
-    // FilePart: deliberately dropped. The doc states images/audio are not
-    // forwarded; surfacing a partial picture would be worse than a clear
-    // "this backend is text-only" contract on the artifact side. Operators
-    // that need vision/audio should use the `codex` or `claude` backends.
   }
   if (sections.length === 0) return null;
   return sections.join('\n\n');
 }
 
-// Render `chat_history` entries as OpenAI Chat Completions messages
-// one-for-one — this backend speaks Chat Completions natively, so the
-// mapping is the identity:
-//   - role:"user"                       → user message (content string)
-//   - role:"assistant" (plain text)     → assistant message with the text content
-//   - role:"assistant" (text + tool_calls) → assistant message with BOTH the text
-//                                            content AND the tool_calls array
-//                                            (OpenAI Chat Completions allows the
-//                                            hybrid shape)
-//   - role:"assistant" (no text + tool_calls) → assistant message with
-//                                                content:null + tool_calls
-//   - role:"tool"                        → tool message with tool_call_id +
-//                                          (optional) name + content
 export function historyToChatCompletionMessages(
   history: OpenAICompatHistoryEntry[],
 ): ChatCompletionMessage[] {
@@ -229,11 +189,6 @@ export function historyToChatCompletionMessages(
   return out;
 }
 
-// vicoop-codex's `call` binary accepts string-or-multimodal-parts on
-// `messages[].content` but the binary's "Known limitations" section
-// states only text is forwarded — image / audio parts are silently
-// dropped. Flatten multimodal arrays to plain text here so the
-// downstream binary sees the shape it actually consumes.
 function openAIMessageContentToString(
   content: OpenAICompatMessageContent,
 ): string {
@@ -244,24 +199,10 @@ function openAIMessageContentToString(
       const text = (part as { text?: unknown }).text;
       if (typeof text === 'string' && text.length > 0) sections.push(text);
     }
-    // image_url / unknown content-part types: dropped, mirroring the
-    // backend's documented text-only limitation.
   }
   return sections.join('\n\n');
 }
 
-// Assemble the full `messages` array for the call body. Order, per the
-// doc's "Per-role message JSON examples" section:
-//   1. system (from openai-compat.system; one entry)
-//   2. chat_history entries (prior user / assistant text turns + tool
-//      round-trips) mapped 1:1 to OpenAI Chat Completions messages
-//   3. current user turn (flattened from A2A parts)
-//
-// The user turn comes last so the model sees prior context before the
-// new instruction. When `userContent` is null (tool-continuation edge
-// case: A2A parts is the placeholder `[{text:""}]`), the trailing user
-// is omitted — the chat_history's last entry is the tool result the
-// model should respond to.
 export function buildMessages(
   meta: OpenAICompatMetadata | null,
   userContent: string | null,
@@ -281,57 +222,30 @@ export function buildMessages(
   return messages;
 }
 
-// Assemble the call body from the existing openai-compat A2A extension:
-//   - `tools` / `tool_choice` (read by the existing `parseOpenAICompatMetadata`)
-//   - the assembled `messages` array (from `system` + `chat_history`
-//     + current user turn — the other two fields of the extension)
-//
-// Nothing else is forwarded. The openai-compat A2A extension only defines
-// those four fields, and we read no other A2A or operator-side input on
-// behalf of this backend. `model`, `reasoning_effort`, `parallel_tool_calls`,
-// and every Group B / Group C parameter from the call command's input doc
-// are left unset — the vicoop-codex binary applies its own defaults.
 export function buildCallBody(
   meta: OpenAICompatMetadata | null,
   messages: ChatCompletionMessage[],
 ): VicoopCodexCallBody {
-  const body: VicoopCodexCallBody = { messages };
+  const body: VicoopCodexCallBody = {
+    messages,
+    stream: true,
+    // Always request usage in the terminal chunk — the openai-compat
+    // extension's `usage` metadata depends on it.
+    stream_options: { include_usage: true },
+  };
   if (meta?.tools) body.tools = meta.tools;
   if (meta?.tool_choice !== undefined) body.tool_choice = meta.tool_choice;
   return body;
 }
 
-// Map `vicoop-codex call` exit codes (doc's "Exit codes" section) to A2A
-// task.fail error codes. Anything outside the documented set surfaces as
-// `vicoop_codex_failed` so an operator can grep stderr without needing to
-// memorise the table.
-function exitCodeToA2ACode(code: number | null): string {
-  switch (code) {
-    case 2:
-      return 'invalid_input';
-    case 3:
-      return 'login_required';
-    case 4:
-      return 'upstream_error';
-    case 5:
-      return 'network_error';
-    default:
-      return 'vicoop_codex_failed';
-  }
-}
-
-// Convert the parsed `usage` block to a spec-compliant OpenAICompatUsage.
-// vicoop-codex prints the standard OpenAI shape so the mapping is direct;
-// total_tokens is recomputed by `buildOpenAICompatUsage` to enforce the
-// `total === prompt + completion` invariant regardless of what the binary
-// reported.
 export function parseChatCompletionUsage(
   raw: ChatCompletionResponse['usage'],
   model: string | undefined,
 ): OpenAICompatUsage | null {
   if (!raw) return null;
   const prompt = typeof raw.prompt_tokens === 'number' ? raw.prompt_tokens : null;
-  const completion = typeof raw.completion_tokens === 'number' ? raw.completion_tokens : null;
+  const completion =
+    typeof raw.completion_tokens === 'number' ? raw.completion_tokens : null;
   if (prompt === null || completion === null) return null;
   const cached =
     typeof raw.prompt_tokens_details?.cached_tokens === 'number'
@@ -350,23 +264,12 @@ export function parseChatCompletionUsage(
   });
 }
 
-// Build the metadata payload spread onto the final A2A message under
-// `OPENAI_COMPAT_EXTENSION_URI`. Includes the spec's `usage` field plus a
-// `chat_completion` echo of the binary's response envelope (id / model /
-// created / choices / finish_reason) so callers that need the full OpenAI
-// response shape (e.g. an oai2a2a gateway) can recover it from a single
-// metadata block instead of reconstructing from the text artifact.
 export function buildResponseMetadata(
   response: ChatCompletionResponse,
   usage: OpenAICompatUsage | null,
 ): Record<string, unknown> {
   const payload: Record<string, unknown> = {};
   if (usage) payload.usage = usage;
-  // Echo the upstream response envelope so callers downstream get the
-  // complete OpenAI Chat Completions shape (id / object / created / model /
-  // choices) without having to round-trip through the text artifact. Empty
-  // `choices` arrays still ride along — a malformed-but-non-fatal upstream
-  // payload is more useful to surface than to silently drop.
   const echo: Record<string, unknown> = {};
   if (response.id) echo.id = response.id;
   if (response.object) echo.object = response.object;
@@ -378,175 +281,132 @@ export function buildResponseMetadata(
   return { [OPENAI_COMPAT_EXTENSION_URI]: payload };
 }
 
-function defaultSpawn(
-  command: string,
-  args: readonly string[],
-  options: VicoopCodexSpawnOptions,
-): VicoopCodexChildHandle {
-  // On Windows npm installs the `vicoop-codex` bin as a `.cmd` shim; bare
-  // `spawn('vicoop-codex', …)` without `shell:true` doesn't pick up the
-  // extension and fails with ENOENT. Route through the shell on win32 so
-  // the shim resolves. Safe here because `command` and `args` are fully
-  // determined by this module — no user-supplied tokens enter the argv.
-  return nodeSpawn(command, Array.from(args), {
-    stdio: ['pipe', 'pipe', 'pipe'],
-    shell: process.platform === 'win32',
-    ...(options.cwd ? { cwd: options.cwd } : {}),
-  }) as ChildProcess;
+// ─────────────────────────────────────────────────────────────────────────────
+// SSE consumption + chunk → A2A artifact translation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AccumulatedToolCall {
+  id?: string;
+  name?: string;
+  arguments: string;
 }
 
-// Internal record of the binary's exit + collected streams. Returned by
-// `runVicoopCodexCall` so `handle()` can branch on exit code without
-// re-parsing the stderr / stdout itself.
-interface CallResult {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
+// Walk a fetch ReadableStream of `text/event-stream` bytes and yield each
+// event's `data:` payload as a string. Stops on stream end. Tolerates `\r\n`
+// line endings and multi-line data fields (joined with `\n`).
+async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let buf = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = findEventBoundary(buf)) >= 0) {
+      const raw = buf.slice(0, idx);
+      buf = buf.slice(idx).replace(/^\r?\n\r?\n/, '');
+      const data = extractDataField(raw);
+      if (data !== null) yield data;
+    }
+  }
+  buf += decoder.decode();
+  if (buf.length > 0) {
+    const data = extractDataField(buf);
+    if (data !== null) yield data;
+  }
 }
 
-// Spawn `vicoop-codex call`, write the JSON body on stdin, and collect
-// the result. Honours abort/cancel via `signal` — on abort we SIGTERM the
-// child so the daemon doesn't wait on a stale subprocess after the
-// caller's A2A `tasks/cancel` lands. Stderr is captured in full (no cap)
-// because vicoop-codex's user-facing error guidance lives there and the
-// task.fail message is operator-visible.
-async function runVicoopCodexCall(
-  body: string,
-  opts: {
-    command: string;
-    args: readonly string[];
-    cwd?: string;
-    spawn: VicoopCodexSpawnFn;
-    timeoutMs: number;
-    signal: AbortSignal;
-    stderrCap: number;
-    logger?: Logger;
-  },
-): Promise<CallResult> {
-  return await new Promise<CallResult>((resolve, reject) => {
-    let child: VicoopCodexChildHandle;
-    try {
-      child = opts.spawn(opts.command, opts.args, { cwd: opts.cwd });
-    } catch (err) {
-      reject(err);
-      return;
-    }
-
-    let stdout = '';
-    let stderr = '';
-    let timer: NodeJS.Timeout | null = null;
-    let aborted = false;
-    let settled = false;
-
-    const finish = (result: CallResult): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      opts.signal.removeEventListener('abort', onAbort);
-      resolve(result);
-    };
-
-    const fail = (err: Error): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      opts.signal.removeEventListener('abort', onAbort);
-      reject(err);
-    };
-
-    const onAbort = (): void => {
-      aborted = true;
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // best-effort
-      }
-    };
-    if (opts.signal.aborted) {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // best-effort
-      }
-    } else {
-      opts.signal.addEventListener('abort', onAbort);
-    }
-
-    if (opts.timeoutMs > 0) {
-      timer = setTimeout(() => {
-        if (settled) return;
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // best-effort
-        }
-        fail(new Error(`vicoop-codex call timed out after ${opts.timeoutMs}ms`));
-      }, opts.timeoutMs);
-    }
-
-    if (child.stdout) {
-      child.stdout.on('data', (chunk: Buffer | string) => {
-        stdout += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-      });
-    }
-    if (child.stderr) {
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        const piece = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        if (stderr.length < opts.stderrCap) {
-          const remaining = opts.stderrCap - stderr.length;
-          stderr += piece.length > remaining ? piece.slice(0, remaining) : piece;
-        }
-      });
-    }
-
-    child.on('error', (err) => {
-      fail(err);
-    });
-    child.on('close', (code, signal) => {
-      finish({
-        code: aborted ? null : code,
-        signal,
-        stdout,
-        stderr,
-      });
-    });
-
-    if (child.stdin) {
-      child.stdin.on('error', (err: NodeJS.ErrnoException) => {
-        // EPIPE on early exit is expected (e.g. exit code 2 before reading
-        // the body) — surface it as a normal close, not a hard error.
-        if (err.code !== 'EPIPE') {
-          opts.logger?.warn?.(`[vicoop-codex] stdin error: ${errorMessage(err)}`);
-        }
-      });
-      try {
-        child.stdin.write(body);
-        child.stdin.end();
-      } catch (err) {
-        opts.logger?.warn?.(`[vicoop-codex] failed to write stdin: ${errorMessage(err)}`);
-      }
-    }
-  });
+function findEventBoundary(buf: string): number {
+  const a = buf.indexOf('\n\n');
+  const b = buf.indexOf('\r\n\r\n');
+  if (a < 0) return b;
+  if (b < 0) return a;
+  return Math.min(a, b);
 }
 
-// Construct the A2A Backend. The handler turns each task into a single
-// non-streaming `vicoop-codex call` invocation: read the existing
-// openai-compat extension metadata → assemble messages → invoke →
-// translate response to A2A artifacts + final message metadata.
+function extractDataField(raw: string): string | null {
+  const lines = raw.split(/\r?\n/);
+  const data: string[] = [];
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    if (line.charAt(0) === ':') continue;
+    if (line.startsWith('data:')) {
+      const v = line.slice(5);
+      data.push(v.startsWith(' ') ? v.slice(1) : v);
+    }
+  }
+  if (data.length === 0) return null;
+  return data.join('\n');
+}
+
+function httpStatusToA2ACode(status: number): string {
+  if (status === 401 || status === 403) return 'login_required';
+  if (status === 429) return 'rate_limited';
+  if (status >= 400) return `upstream_http_${status}`;
+  return 'upstream_error';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backend factory.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface VicoopCodexBackendBundle {
+  backend: Backend;
+  // Bridge cli.ts unwraps this and calls it on shutdown so the long-running
+  // `vicoop-codex serve` child gets reaped along with the daemon.
+  shutdown: () => Promise<void>;
+}
+
 export function createVicoopCodexBackend(
   opts: VicoopCodexBackendOptions = {},
-): Backend {
-  const command = opts.command ?? 'vicoop-codex';
-  const baseArgs: readonly string[] = ['call', ...(opts.extraArgs ?? [])];
-  const cwd = opts.cwd;
-  const spawnFn = opts.spawn ?? defaultSpawn;
-  const stderrCap = opts.stderrCaptureBytes ?? 16 * 1024;
-  const callTimeoutMs = opts.callTimeoutMs ?? 0;
+): VicoopCodexBackendBundle {
+  const supervisorOpts: ServeSupervisorOptions = {
+    command: opts.command,
+    cwd: opts.cwd,
+    extraArgs: opts.extraArgs,
+    spawn: opts.spawn,
+    stderrCaptureBytes: opts.stderrCaptureBytes,
+    startupTimeoutMs: opts.startupTimeoutMs,
+    logger: opts.logger ?? createLogger(),
+  };
+  const fetchImpl: typeof fetch = opts.fetchImpl ?? fetch;
   const logger = opts.logger ?? createLogger();
   const openaiCompatTrace = opts.openaiCompatTrace === true;
 
-  return {
+  let supervisor: ServeSupervisor | null = null;
+  let initInFlight: Promise<ServeSupervisor> | null = null;
+
+  async function ensureSupervisor(): Promise<ServeSupervisor> {
+    if (supervisor && !supervisor.isClosed()) return supervisor;
+    if (initInFlight) return initInFlight;
+    initInFlight = (async () => {
+      const s = new ServeSupervisor(supervisorOpts);
+      try {
+        s.start();
+      } catch (err) {
+        initInFlight = null;
+        throw err;
+      }
+      void s.waitForClose().then(() => {
+        if (supervisor === s) supervisor = null;
+      });
+      try {
+        await s.ready();
+      } catch (err) {
+        initInFlight = null;
+        throw err;
+      }
+      supervisor = s;
+      initInFlight = null;
+      return s;
+    })();
+    return initInFlight;
+  }
+
+  const backend: Backend = {
     name: 'vicoop-codex',
 
     async handle(task, emit, signal) {
@@ -559,12 +419,6 @@ export function createVicoopCodexBackend(
         return;
       }
 
-      // Use the existing openai-compat A2A extension reader (claude.ts).
-      // It returns the 4-field schema { system, tools, tool_choice,
-      // chat_history } — the canonical surface every backend in this
-      // package already speaks. We do NOT define additional reader fields
-      // here: extending the extension schema unilaterally would risk
-      // breaking the contract other backends rely on.
       const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
       if (openaiCompatTrace) {
         dumpOpenAICompatTaskWire(
@@ -577,10 +431,6 @@ export function createVicoopCodexBackend(
       }
 
       const userContent = flattenA2AUserContent(task.message.parts);
-      // Tool-continuation edge case (openai-compat spec): A2A parts is the
-      // placeholder `[{text:""}]` and the conversation lives in
-      // chat_history. Skip the empty_prompt check when chat_history will
-      // supply the user-side content via the prior-turns sequence.
       const hasHistory = (openaiCompat?.chat_history?.length ?? 0) > 0;
       if (userContent === null && !hasHistory) {
         emit({
@@ -588,7 +438,8 @@ export function createVicoopCodexBackend(
           taskId: task.taskId,
           error: {
             code: 'empty_prompt',
-            message: 'vicoop-codex backend received no text or data content in the user message',
+            message:
+              'vicoop-codex backend received no text or data content in the user message',
           },
         });
         return;
@@ -617,19 +468,49 @@ export function createVicoopCodexBackend(
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
 
-      let result: CallResult;
+      let sv: ServeSupervisor;
       try {
-        result = await runVicoopCodexCall(serialized, {
-          command,
-          args: baseArgs,
-          cwd,
-          spawn: spawnFn,
-          timeoutMs: callTimeoutMs,
-          signal,
-          stderrCap,
-          logger,
+        sv = await ensureSupervisor();
+      } catch (err) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'cli_unavailable',
+            message: `vicoop-codex serve failed to start: ${errorMessage(err)}`,
+          },
+        });
+        return;
+      }
+
+      const listening = sv.getListening();
+      if (!listening) {
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: {
+            code: 'cli_unavailable',
+            message: 'vicoop-codex serve became ready without a listening port',
+          },
+        });
+        return;
+      }
+
+      const controller = new AbortController();
+      const onAbort = (): void => controller.abort();
+      if (signal.aborted) controller.abort();
+      else signal.addEventListener('abort', onAbort, { once: true });
+
+      let res: Response;
+      try {
+        res = await fetchImpl(`${listening.url}/v1/chat/completions`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: serialized,
+          signal: controller.signal,
         });
       } catch (err) {
+        signal.removeEventListener('abort', onAbort);
         if (signal.aborted) {
           emit({
             type: 'task.complete',
@@ -642,79 +523,177 @@ export function createVicoopCodexBackend(
           type: 'task.fail',
           taskId: task.taskId,
           error: {
-            code: 'spawn_failed',
-            message: `failed to spawn vicoop-codex: ${errorMessage(err)}`,
+            code: 'cli_unavailable',
+            message: `failed to reach vicoop-codex serve at ${listening.url}: ${errorMessage(err)}`,
           },
         });
         return;
       }
 
-      // Aborted mid-flight — caller already pulled the plug, surface as
-      // canceled regardless of what the subprocess did before SIGTERM
-      // delivered.
-      if (signal.aborted) {
-        emit({
-          type: 'task.complete',
-          taskId: task.taskId,
-          status: { state: 'canceled', timestamp: new Date().toISOString() },
-        });
-        return;
-      }
-
-      if (result.code !== 0) {
-        const trimmedStderr = result.stderr.trim();
-        const message =
-          trimmedStderr.length > 0
-            ? trimmedStderr
-            : `vicoop-codex exited with code ${result.code}`;
+      if (!res.ok || !res.body) {
+        signal.removeEventListener('abort', onAbort);
+        let detail = '';
+        try {
+          detail = await res.text();
+        } catch {
+          // ignore
+        }
+        let message = detail || `vicoop-codex serve returned HTTP ${res.status}`;
+        try {
+          const parsed = JSON.parse(detail) as {
+            error?: { message?: string };
+            detail?: string;
+          };
+          message = parsed.error?.message ?? parsed.detail ?? message;
+        } catch {
+          // not JSON
+        }
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: {
-            code: exitCodeToA2ACode(result.code),
-            message,
-          },
+          error: { code: httpStatusToA2ACode(res.status), message },
         });
         return;
       }
 
-      // Parse the stdout payload. A malformed (non-JSON) stdout shouldn't
-      // crash the backend — surface as `parse_failed` with the head of
-      // the output so the operator can diagnose without `--verbose`.
-      let response: ChatCompletionResponse;
+      // Streaming state.
+      let chatcmplId: string | undefined;
+      let model: string | undefined;
+      let created: number | undefined;
+      let accumulatedText = '';
+      const toolCallsByIndex = new Map<number, AccumulatedToolCall>();
+      let finishReason: string | undefined;
+      let usage: ChatCompletionResponse['usage'];
+      let responseArtifactId: string | null = null;
+      let emittedTextDelta = false;
+
+      const emitTextDelta = (delta: string, lastChunk: boolean): void => {
+        if (delta.length === 0 && !lastChunk) return;
+        responseArtifactId ??= randomUUID();
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: responseArtifactId,
+            name: 'vicoop-codex-message',
+            parts: [{ kind: 'text', text: delta }],
+          },
+          ...(emittedTextDelta ? { append: true } : {}),
+          lastChunk,
+        });
+        emittedTextDelta = true;
+      };
+
       try {
-        response = JSON.parse(result.stdout) as ChatCompletionResponse;
+        for await (const data of parseSseStream(res.body)) {
+          if (data === '[DONE]') continue;
+          let chunk: ChatCompletionStreamChunk;
+          try {
+            chunk = JSON.parse(data) as ChatCompletionStreamChunk;
+          } catch {
+            continue;
+          }
+          if (chunk.error) {
+            throw new Error(chunk.error.message ?? 'vicoop-codex stream error');
+          }
+          if (typeof chunk.id === 'string') chatcmplId = chunk.id;
+          if (typeof chunk.model === 'string') model = chunk.model;
+          if (typeof chunk.created === 'number') created = chunk.created;
+          if (chunk.usage) usage = chunk.usage;
+          const choice = chunk.choices?.[0];
+          if (!choice) continue;
+          const delta = choice.delta;
+          if (delta?.content && typeof delta.content === 'string') {
+            accumulatedText += delta.content;
+            emitTextDelta(delta.content, false);
+          }
+          if (Array.isArray(delta?.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+              if (!tc || typeof tc.index !== 'number') continue;
+              const slot = toolCallsByIndex.get(tc.index) ?? { arguments: '' };
+              if (typeof tc.id === 'string' && tc.id.length > 0) slot.id = tc.id;
+              if (tc.function) {
+                if (
+                  typeof tc.function.name === 'string' &&
+                  tc.function.name.length > 0
+                ) {
+                  slot.name = tc.function.name;
+                }
+                if (typeof tc.function.arguments === 'string') {
+                  slot.arguments += tc.function.arguments;
+                }
+              }
+              toolCallsByIndex.set(tc.index, slot);
+            }
+          }
+          if (typeof choice.finish_reason === 'string') {
+            finishReason = choice.finish_reason;
+          }
+        }
       } catch (err) {
-        const head = result.stdout.slice(0, 256);
+        signal.removeEventListener('abort', onAbort);
+        if (signal.aborted) {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
         emit({
           type: 'task.fail',
           taskId: task.taskId,
           error: {
-            code: 'parse_failed',
-            message: `failed to parse vicoop-codex stdout as JSON: ${errorMessage(err)}; head: ${JSON.stringify(head)}`,
+            code: 'stream_error',
+            message: `vicoop-codex stream failed: ${errorMessage(err)}`,
           },
         });
         return;
       }
+      signal.removeEventListener('abort', onAbort);
 
-      // Doc invariants: `choices` is always length 1, n>1 is unsupported.
-      // Tolerate variants regardless (future schema bump) but always read
-      // index 0 — anything else would silently lose data.
-      const choice = response.choices?.[0];
-      const messagePayload = choice?.message;
-      const contentText =
-        typeof messagePayload?.content === 'string' ? messagePayload.content : '';
-      const toolCalls = Array.isArray(messagePayload?.tool_calls)
-        ? messagePayload.tool_calls
-        : [];
-      const finishReason = typeof choice?.finish_reason === 'string' ? choice.finish_reason : '';
+      // Materialize a ChatCompletionResponse equivalent for buildResponseMetadata
+      // so the openai-compat extension's `chat_completion` echo carries the
+      // same fields callers see from the non-streaming path.
+      const toolCalls = [...toolCallsByIndex.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([, slot]) => ({
+          id: slot.id ?? `call_${randomUUID().replace(/-/g, '').slice(0, 16)}`,
+          type: 'function' as const,
+          function: { name: slot.name ?? '', arguments: slot.arguments },
+        }));
 
-      // When the model emitted a `tool_calls` envelope we mirror codex.ts's
-      // native dispatch artifact shape: a `data` part carrying the
-      // `tool_calls` array under the OPENAI_COMPAT_EXTENSION_URI. Callers
-      // downstream (oai2a2a) special-case this artifact to recover the
-      // OpenAI Chat Completions wire shape on the way out.
+      const messagePayload =
+        toolCalls.length > 0
+          ? {
+              role: 'assistant',
+              content: accumulatedText.length > 0 ? accumulatedText : null,
+              tool_calls: toolCalls,
+            }
+          : { role: 'assistant', content: accumulatedText };
+
+      const reconstructed: ChatCompletionResponse = {
+        id: chatcmplId,
+        object: 'chat.completion',
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: messagePayload,
+            finish_reason:
+              finishReason ?? (toolCalls.length > 0 ? 'tool_calls' : 'stop'),
+          },
+        ],
+        usage,
+      };
+
       if (toolCalls.length > 0) {
+        // Mirror the legacy backend: surface the tool_calls envelope as a
+        // dedicated `data` artifact so the oai2a2a gateway can recover the
+        // OpenAI wire shape. If we also streamed text earlier (rare but
+        // possible — hybrid response), close the text artifact first.
+        if (emittedTextDelta) emitTextDelta('', true);
         emit({
           type: 'task.artifact',
           taskId: task.taskId,
@@ -726,33 +705,35 @@ export function createVicoopCodexBackend(
           },
           lastChunk: true,
         });
-      } else if (contentText) {
+      } else if (emittedTextDelta) {
+        // Terminal empty chunk so consumers know the text artifact is final.
+        emitTextDelta('', true);
+      } else if (accumulatedText.length > 0) {
+        // No deltas observed (e.g. upstream concatenated everything in the
+        // final chunk) — emit a single artifact.
+        responseArtifactId ??= randomUUID();
         emit({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
-            artifactId: randomUUID(),
+            artifactId: responseArtifactId,
             name: 'vicoop-codex-message',
-            parts: [{ kind: 'text', text: contentText }],
+            parts: [{ kind: 'text', text: accumulatedText }],
           },
           lastChunk: true,
         });
       }
 
-      const usage = parseChatCompletionUsage(response.usage, response.model);
-      const responseMetadata = buildResponseMetadata(response, usage);
+      const parsedUsage = parseChatCompletionUsage(
+        reconstructed.usage,
+        reconstructed.model,
+      );
+      const responseMetadata = buildResponseMetadata(reconstructed, parsedUsage);
 
-      // The final `task.complete` message mirrors codex.ts's pattern:
-      //   - `parts`: the assistant's text content (omitted on the tool-call
-      //     path so we don't double-stamp the tool_calls envelope onto the
-      //     status message).
-      //   - `metadata[OPENAI_COMPAT_EXTENSION_URI]`: usage + the full
-      //     chat_completion echo. Always emitted so the caller has access
-      //     to id / model / created / choices / finish_reason without
-      //     parsing the artifact.
-      //   - `extensions`: the OPENAI_COMPAT_EXTENSION_URI marker.
-      const parts: Part[] =
-        toolCalls.length === 0 && contentText ? [{ kind: 'text', text: contentText }] : [];
+      const finalParts: Part[] =
+        toolCalls.length === 0 && accumulatedText.length > 0
+          ? [{ kind: 'text', text: accumulatedText }]
+          : [];
       emit({
         type: 'task.complete',
         taskId: task.taskId,
@@ -762,18 +743,51 @@ export function createVicoopCodexBackend(
           message: {
             role: 'agent',
             messageId: randomUUID(),
-            parts,
+            parts: finalParts,
             metadata: responseMetadata,
             extensions: [OPENAI_COMPAT_EXTENSION_URI],
           },
         },
       });
-      // finish_reason is informational; surfaced only via the metadata
-      // echo above. The A2A `task.complete` state is always `completed`
-      // (incl. `finish_reason: "tool_calls"`) because the tool-call round
-      // is a successful turn from the bridge's perspective — the next A2A
-      // turn brings back the tool result via `chat_history`.
-      void finishReason;
     },
   };
+
+  const shutdown = async (): Promise<void> => {
+    const s = supervisor;
+    if (!s) return;
+    s.kill();
+    try {
+      await s.waitForClose();
+    } catch {
+      // best-effort
+    }
+    logger.info?.('[vicoop-codex] serve child reaped on shutdown');
+  };
+
+  return { backend, shutdown };
+}
+
+// Minimal projection of an OpenAI Chat Completions streaming chunk — only the
+// fields this backend consumes. Tolerates unknown/missing fields rather than
+// asserting a schema, so a future upstream version bump doesn't crash us.
+interface ChatCompletionStreamChunk {
+  id?: string;
+  model?: string;
+  created?: number;
+  usage?: ChatCompletionResponse['usage'];
+  error?: { message?: string };
+  choices?: Array<{
+    index?: number;
+    delta?: {
+      role?: string;
+      content?: string | null;
+      tool_calls?: Array<{
+        index?: number;
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason?: string | null;
+  }>;
 }

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -380,12 +380,12 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       });
       return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };
     }
-    case 'vicoop-codex':
-      return {
-        backend: createVicoopCodexBackend({
-          openaiCompatTrace: args.openaiCompatTrace,
-        }),
-      };
+    case 'vicoop-codex': {
+      const { backend, shutdown } = createVicoopCodexBackend({
+        openaiCompatTrace: args.openaiCompatTrace,
+      });
+      return { backend, shutdown };
+    }
     default:
       throw new Error(
         `unknown backend: ${name} (supported: echo, openclaw, claude, codex, vicoop-codex)`,


### PR DESCRIPTION
## Summary

- Replace the `vicoop-codex` backend's subprocess-per-task model with a long-running `vicoop-codex serve --port 0` child supervised on the bridge side.
- New `ServeChildSupervisor` (modeled on `AppServerRpcClient`): spawn once, parse the JSON listening banner the CLI prints on its first stderr line to discover the bound port, lazy spawn / crash respawn via `waitForClose`, killed on shutdown through the `cli.ts` hook.
- Each A2A task POSTs `/v1/chat/completions` with `stream: true`; SSE chunks are translated to token-level `task.artifact` frames (`append: true`, terminated with `lastChunk: true`).
- Tool-call deltas are accumulated across chunks (name on first delta, arguments concatenated across the rest) and emitted as a single `data` artifact under the openai-compat extension URI — same wire shape as before so the oai2a2a gateway keeps decoding it.
- Terminal `task.complete` carries the same `chat_completion` echo + `usage` metadata the previous non-streaming path produced.

## Dependency

Requires the `vicoop-codex` CLI release that supports `--port 0` and emits the JSON listening banner — planetarium/vicoop-codex-cli#5. Until that ships, `vicoop-codex` ≥ the version from that PR must be installed locally (`npm link` works for dev).

## Why

Issue planetarium/vicoop-codex-cli#4 — bridge's previous `vicoop-codex call` path buffered the full Chat Completions response and emitted one final artifact, so OpenAI-compat clients couldn't receive incremental SSE chunks. After the CLI option-comparison thread (#4 comments), `serve` came out the simpler path: streaming was already implemented there, and the bridge already had a long-running-subprocess supervisor pattern (codex's `app-server`) to model on.

## Test plan

- [x] 23 tests pass (`node --import tsx --test src/backends/vicoop-codex.test.ts`) — pure helpers (`flattenA2AUserContent`, `buildMessages`, `buildCallBody`, `parseChatCompletionUsage`, `buildResponseMetadata`) plus integration tests covering text streaming, tool_calls assembly across deltas, body shape, HTTP 401 / 429 / 502 mapping, mid-stream `error` event, cancel-before-spawn, startup timeout, supervisor reuse across tasks, and crash respawn.
- [x] `pnpm -r typecheck` clean.
- [x] End-to-end against real ChatGPT (via `npm link`-installed CLI from planetarium/vicoop-codex-cli#5): a 5-token prompt streamed 10 artifact frames (first delta +2916ms, subsequent ~50ms gaps, terminal `lastChunk:true` frame, `task.complete` with `chat_completion` metadata echo).
- [ ] Multi-turn tool-loop scenario validated against a real backend (covered by unit tests; smoke-tested manually with a single-turn synthetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)