### PR TITLE
feat(client)!: emit complete ChatCompletion echo for openai-compat

### DIFF
--- a/.changeset/issue-80-envelope-emit.md
+++ b/.changeset/issue-80-envelope-emit.md
@@ -1,0 +1,19 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Align with the **symmetric envelope contract** for the `openai-compat/v1` A2A extension (companion to planetarium/oai2a2a#80 / planetarium/oai2a2a#81).
+
+**Wire-breaking** for advertising agents (client major bump expected once the project crosses 1.0; using minor under the 0.x convention).
+
+Response side: codex (app-server), vicoop-codex (CLI), and claude backends now emit a spec-complete `chat_completion` envelope on the terminal A2A status message metadata: `id` / `object` / `created` / `model` / `choices[].{message, finish_reason, logprobs}` / `usage`. Tool calls surface exclusively via `chat_completion.choices[0].message.tool_calls`; the legacy data-part `tool_calls` artifact is no longer emitted from any of the three supported backends.
+
+A new shared helper `packages/client/src/backends/openai-compat-usage.ts` (`buildOpenAICompatResponseMetadata`, `buildOpenAICompatUsage`) is the single source of truth so the supported backends cannot drift on envelope shape. Each backend synthesizes a stable `id` keyed off the A2A task id (`chatcmpl-codex-…`, `chatcmpl-vicoop-codex-…`, `chatcmpl-claude-…`).
+
+For codex (app-server) specifically: tool-call-only turns (where codex's `thread/tokenUsage/updated` notification doesn't fire because the turn is interrupted) emit a `{0, 0, 0}` placeholder for `chat_completion.usage` rather than omit the field — the placeholder honestly signals "runtime did not report" while satisfying the new strict usage MUST on the gateway side.
+
+Request side: `parseOpenAICompatMetadata` now reads `metadata[URI].chat_completions_request` (the envelope) and decomposes it into the existing 4-field `OpenAICompatMetadata` view that backends already consume. The 4 backends (claude / codex / vicoop-codex / openclaw) keep their existing parameter-reading code — the parser is the seam. Legacy decomposed shape (`{system, tools, tool_choice, chat_history}`) still accepted as a transitional compat shim during gateway migration.
+
+`openclaw` backend is **not** updated to emit the response envelope — out of scope per the supported-backend set (`vicoop-codex` / `codex` / `claude`). openclaw can continue to emit data-part `tool_calls` but is no longer reachable through advertising-agent code paths on the new gateway.
+
+Also includes a follow-up race fix: claude's post-exit trailing-flush handler now runs before the `settled = true` cleanup so an orphan terminal `result` event (no trailing newline) is not silently dropped. Previously, claude exiting 1 immediately after a multi-tool turn could trip a spurious `claude_exit_nonzero` failure even when claude reported `terminal_reason: "completed"` in stdout.

--- a/packages/client/cards/claude.json
+++ b/packages/client/cards/claude.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/client/cards/codex.json
+++ b/packages/client/cards/codex.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/client/cards/vicoop-codex.json
+++ b/packages/client/cards/vicoop-codex.json
@@ -8,7 +8,7 @@
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / tool_call_history) to assemble the call body; emits OpenAI Chat Completions tool_calls back as an A2A data part and the full response envelope on the final message metadata.",
+        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / chat_history) to assemble the call body; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/client/cards/vicoop-codex.json
+++ b/packages/client/cards/vicoop-codex.json
@@ -1,6 +1,6 @@
 {
   "name": "vicoop-codex",
-  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion echo on the final message metadata.",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": {

--- a/packages/client/cards/vicoop-codex.json
+++ b/packages/client/cards/vicoop-codex.json
@@ -8,7 +8,7 @@
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / chat_history) to assemble the call body; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
+        "description": "Reads the full OpenAI Chat Completions request envelope (chat_completions_request) from the openai-compat A2A metadata and forwards it to the vicoop-codex CLI; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
 import {
+  buildClaudeChatCompletionEnvelope,
   buildOpenAICompatNativeSystemPrompt,
   createClaudeBackend,
   normalizeClaudeModelId,
@@ -3668,10 +3669,11 @@ test('argv: --allowedTools covers all registered MCP servers (#235)', async () =
 
 // End-to-end (with test seam): the model "invokes" the caller tool via
 // the MCP server's `invokeForTest` while claude is mid-run; the bridge
-// emits a `tool_calls` data artifact with the OpenAI wire shape and
-// suppresses any subsequent agent text from `status.message.parts` on
-// completion. Same invariant codex backend enforces under #212.
-test('native dispatch: tool invocation emits tool_calls artifact + suppresses final text (#213)', async () => {
+// surfaces the call on the terminal `chat_completion` envelope metadata
+// (oai2a2a#80) and suppresses any subsequent agent text from
+// `status.message.parts` on completion. Same invariant codex backend
+// enforces under #212.
+test('native dispatch: tool invocation → chat_completion envelope on terminal status + suppresses final text (#213, oai2a2a#80)', async () => {
   // Drive claude's stream-json from outside so we can interleave the
   // MCP invocation. The fake child stays alive until `finish()` so the
   // bridge can route the artifact emit through the live `emit` capture.
@@ -3757,33 +3759,24 @@ test('native dispatch: tool invocation emits tool_calls artifact + suppresses fi
     NEVER,
   );
 
-  // Locate the tool_calls artifact (data part with the OPENAI_COMPAT
-  // extension). Bridge emits it as soon as onInvoke fires.
-  const toolCallsArtifact = frames.find(
+  // Envelope contract (oai2a2a#80): no data-part `tool_calls` artifact.
+  // The model's function_call is delivered exclusively on the terminal
+  // status message metadata as `chat_completion.choices[0].message.tool_calls`.
+  const dataArtifacts = frames.filter(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
       f.type === 'task.artifact' &&
       f.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI) === true &&
       f.artifact.parts[0]?.kind === 'data',
   );
-  assert.ok(toolCallsArtifact, 'tool_calls data artifact emitted under openai-compat extension');
-  if (toolCallsArtifact) {
-    const data = (toolCallsArtifact.artifact.parts[0] as { data: unknown }).data as {
-      tool_calls?: Array<{
-        id?: string;
-        function?: { name?: string; arguments?: unknown };
-      }>;
-    };
-    assert.equal(data.tool_calls?.length, 1);
-    assert.equal(data.tool_calls?.[0]?.id, 'call_xyz');
-    assert.equal(data.tool_calls?.[0]?.function?.name, 'fetch');
-    assert.deepEqual(data.tool_calls?.[0]?.function?.arguments, {
-      url: 'https://example.com',
-    });
-  }
+  assert.equal(
+    dataArtifacts.length,
+    0,
+    'no data-part tool_calls artifact under the envelope contract',
+  );
 
   // Terminal frame: state=completed, NO text in status.message.parts.
-  // The tool_calls artifact is the complete output; any wrap-up text the
-  // model emitted ("OK, calling that for you.") is reasoning preamble
+  // The chat_completion envelope is the complete output; any wrap-up text
+  // the model emitted ("OK, calling that for you.") is reasoning preamble
   // and is dropped on completion to avoid the #200-style double-emit
   // downstream gateways would otherwise produce.
   const complete = frames.find(
@@ -3794,16 +3787,60 @@ test('native dispatch: tool invocation emits tool_calls artifact + suppresses fi
   const parts = complete?.status.message?.parts ?? [];
   const hasText = parts.some((p) => p.kind === 'text');
   assert.equal(hasText, false, 'no text in status.message.parts when tool was captured');
+
+  // Envelope verification: the terminal status message metadata carries the
+  // complete OpenAI ChatCompletion envelope with tool_calls.
+  if (complete && complete.type === 'task.complete') {
+    const metadata = complete.status.message?.metadata as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
+    assert.ok(ext, 'openai-compat metadata present on terminal message');
+    const envelope = ext.chat_completion as Record<string, unknown> | undefined;
+    assert.ok(envelope, 'chat_completion envelope present');
+    assert.equal(typeof envelope.id, 'string');
+    assert.ok((envelope.id as string).startsWith('chatcmpl-claude-'));
+    assert.equal(envelope.object, 'chat.completion');
+    assert.equal(typeof envelope.created, 'number');
+    assert.equal(typeof envelope.model, 'string');
+    const choices = envelope.choices as Array<Record<string, unknown>>;
+    assert.equal(choices.length, 1);
+    const choice = choices[0];
+    assert.equal(choice.finish_reason, 'tool_calls');
+    assert.equal(choice.logprobs, null);
+    const message = choice.message as {
+      role: string;
+      content: unknown;
+      tool_calls?: Array<{
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: unknown };
+      }>;
+    };
+    assert.equal(message.role, 'assistant');
+    assert.equal(message.content, null);
+    assert.equal(message.tool_calls?.length, 1);
+    assert.equal(message.tool_calls?.[0]?.id, 'call_xyz');
+    assert.equal(message.tool_calls?.[0]?.type, 'function');
+    assert.equal(message.tool_calls?.[0]?.function?.name, 'fetch');
+    // OpenAI spec requires `arguments` to be a JSON-encoded string.
+    const argsRaw = message.tool_calls?.[0]?.function?.arguments;
+    assert.equal(typeof argsRaw, 'string');
+    assert.deepEqual(JSON.parse(argsRaw as string), {
+      url: 'https://example.com',
+    });
+  }
 });
 
 // `--max-turns 1` + exit-code-1 mapping (#213): with native dispatch active,
 // claude code hits the turn cap immediately after the model emits its
 // tool_use(s) and exits with code 1. The bridge MUST map that exit to a
-// successful task.complete when a tool call was captured (the `tool_calls`
-// artifact is the complete output for this turn — same invariant codex
-// backend enforces under PR #212). Without this mapping every native
-// tool-using task would surface as task.fail to the caller, breaking the
-// OpenAI Chat Completions `finish_reason: "tool_calls"` round-trip.
+// successful task.complete when a tool call was captured (the
+// `chat_completion` envelope on the terminal status message IS the complete
+// output for this turn — same invariant codex backend enforces under PR
+// #212). Without this mapping every native tool-using task would surface
+// as task.fail to the caller, breaking the OpenAI Chat Completions
+// `finish_reason: "tool_calls"` round-trip.
 test('native dispatch: --max-turns 1 exits with code 1; bridge maps to completed when tool captured (#213)', async () => {
   const fake = makeFakeSpawn((child) => {
     setImmediate(() => {
@@ -3874,12 +3911,30 @@ test('native dispatch: --max-turns 1 exits with code 1; bridge maps to completed
   const failFrame = frames.find((f) => f.type === 'task.fail');
   assert.equal(failFrame, undefined, 'task.fail must not be emitted');
 
-  // The tool_calls artifact is still on the wire.
+  // Envelope contract (oai2a2a#80): no data-part `tool_calls` artifact;
+  // the tool_calls ride exclusively on the terminal status message's
+  // chat_completion envelope. Verify the envelope is present with
+  // finish_reason: 'tool_calls' and the captured call.
   const dataArt = frames.find(
     (f): f is Extract<UpFrame, { type: 'task.artifact' }> =>
       f.type === 'task.artifact' && f.artifact.parts[0]?.kind === 'data',
   );
-  assert.ok(dataArt, 'tool_calls artifact emitted before exit');
+  assert.equal(dataArt, undefined, 'no data-part tool_calls artifact under the envelope contract');
+
+  if (terminal?.type === 'task.complete') {
+    const metadata = terminal.status.message?.metadata as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const envelope = metadata?.[OPENAI_COMPAT_EXTENSION_URI]?.chat_completion as
+      | Record<string, unknown>
+      | undefined;
+    assert.ok(envelope, 'chat_completion envelope present on terminal status');
+    const choices = envelope.choices as Array<Record<string, unknown>>;
+    assert.equal(choices[0]?.finish_reason, 'tool_calls');
+    const msg = choices[0]?.message as { tool_calls?: Array<{ id?: string }> };
+    assert.equal(msg.tool_calls?.length, 1);
+    assert.equal(msg.tool_calls?.[0]?.id, 'call_xyz');
+  }
 });
 
 // Inverse: claude exits non-zero WITHOUT any tool capture (e.g., a real
@@ -4285,6 +4340,95 @@ test('parseClaudeModelUsageForOpenAICompat strips bracket tier suffix on usage.m
   assert.ok(usage);
   assert.equal(usage!.model, 'claude-opus-4-7');
 });
+
+// Envelope shape: text-only turn (no tool calls, with usage) produces a
+// spec-compliant ChatCompletion envelope — id synthesized from taskId,
+// object/created/model defaults, logprobs:null on the choice, content as
+// the assistant text, and finish_reason:'stop'.
+test('buildClaudeChatCompletionEnvelope: text-only turn shape with synthesized defaults (oai2a2a#80)', () => {
+  const usage = buildOpenAICompatUsageFromInputs(120, 30, 'claude-opus-4-7');
+  const envelope = buildClaudeChatCompletionEnvelope({
+    taskId: 't-abc',
+    model: 'claude-opus-4-7',
+    content: 'hello there',
+    toolCalls: undefined,
+    finishReason: 'stop',
+    usage,
+  });
+  assert.equal(envelope.id, 'chatcmpl-claude-t-abc');
+  assert.equal(envelope.object, 'chat.completion');
+  assert.equal(typeof envelope.created, 'number');
+  assert.equal(envelope.model, 'claude-opus-4-7');
+  const choices = envelope.choices as Array<Record<string, unknown>>;
+  assert.equal(choices.length, 1);
+  assert.equal(choices[0]?.index, 0);
+  assert.equal(choices[0]?.finish_reason, 'stop');
+  assert.equal(choices[0]?.logprobs, null);
+  const message = choices[0]?.message as { role: string; content: unknown; tool_calls?: unknown };
+  assert.equal(message.role, 'assistant');
+  assert.equal(message.content, 'hello there');
+  assert.equal('tool_calls' in message, false);
+  // Usage rides inside the envelope.
+  const envUsage = envelope.usage as { prompt_tokens?: number; total_tokens?: number; model?: string };
+  assert.equal(envUsage.prompt_tokens, 120);
+  assert.equal(envUsage.total_tokens, 150);
+  assert.equal(envUsage.model, 'claude-opus-4-7');
+});
+
+// Defensive defaults: when claude never surfaced a model id (e.g. the run
+// failed before any modelUsage frame landed), the envelope still satisfies
+// the spec's "model is required" obligation via the placeholder fallback.
+// Tool-call envelopes carry `content: null` and a populated tool_calls
+// array; finish_reason flips to 'tool_calls'.
+test('buildClaudeChatCompletionEnvelope: tool-call envelope with model fallback (oai2a2a#80)', () => {
+  const envelope = buildClaudeChatCompletionEnvelope({
+    taskId: 'task-xyz',
+    model: undefined,
+    content: null,
+    toolCalls: [
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'fetch', arguments: '{"url":"https://example.com"}' },
+      },
+    ],
+    finishReason: 'tool_calls',
+    usage: null,
+  });
+  assert.equal(envelope.id, 'chatcmpl-claude-task-xyz');
+  assert.equal(envelope.model, 'claude');
+  assert.equal('usage' in envelope, false, 'usage omitted when not reported');
+  const choices = envelope.choices as Array<Record<string, unknown>>;
+  assert.equal(choices[0]?.finish_reason, 'tool_calls');
+  assert.equal(choices[0]?.logprobs, null);
+  const message = choices[0]?.message as {
+    role: string;
+    content: unknown;
+    tool_calls?: Array<{ id?: string; type?: string; function?: { arguments?: unknown } }>;
+  };
+  assert.equal(message.role, 'assistant');
+  assert.equal(message.content, null);
+  assert.equal(message.tool_calls?.length, 1);
+  assert.equal(message.tool_calls?.[0]?.id, 'call_1');
+  assert.equal(message.tool_calls?.[0]?.type, 'function');
+  // `arguments` MUST be a JSON-encoded string per OpenAI Chat Completions.
+  assert.equal(typeof message.tool_calls?.[0]?.function?.arguments, 'string');
+});
+
+// Local helper — keeps the envelope test self-contained without leaning on
+// internal usage-builder import.
+function buildOpenAICompatUsageFromInputs(
+  prompt: number,
+  completion: number,
+  model: string,
+): { prompt_tokens: number; completion_tokens: number; total_tokens: number; model: string } {
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+    model,
+  };
+}
 
 test('claude backend resolveCapabilities returns {} on probe timeout', async () => {
   const fake = makeFakeSpawn(() => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2312,6 +2312,93 @@ test('parseOpenAICompatMetadata: picks up system / tools / tool_choice and drops
   assert.equal(m2.tools?.length, 1);
 });
 
+test('parseOpenAICompatMetadata: envelope path decomposes chat_completions_request into system/history', () => {
+  // Symmetric envelope contract (oai2a2a#80): the full inbound OpenAI
+  // ChatCompletionsRequest body rides under `chat_completions_request`.
+  // The parser decomposes it into the same {system, tools, tool_choice,
+  // chat_history} projection backends already consume — so existing
+  // backend code paths keep working unchanged.
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      chat_completions_request: {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'system', content: 'You are concise.' },
+          { role: 'developer', content: 'Reply in english.' },
+          { role: 'user', content: 'Will it rain in Seoul?' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{}' } },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: 'sunny' },
+          { role: 'user', content: 'Thanks.' },
+        ],
+        tools: SAMPLE_TOOLS,
+        tool_choice: 'auto',
+      },
+    },
+  });
+  assert.ok(m);
+  // system + developer joined with \n.
+  assert.equal(m.system, 'You are concise.\nReply in english.');
+  assert.equal(m.tool_choice, 'auto');
+  assert.equal(m.tools?.length, 1);
+  // chat_history excludes the trailing user turn (it rides A2A parts) and
+  // the system / developer entries (they go through the system channel).
+  assert.equal(m.chat_history?.length, 3);
+  assert.equal((m.chat_history![0] as { role: string }).role, 'user');
+  assert.equal((m.chat_history![1] as { role: string }).role, 'assistant');
+  assert.equal((m.chat_history![2] as { role: string }).role, 'tool');
+});
+
+test('parseOpenAICompatMetadata: envelope tool-continuation keeps the full transcript in chat_history', () => {
+  // When the inbound messages[] does not end with a user turn the gateway
+  // emits A2A parts as the empty placeholder; the agent should see the
+  // whole sequence in chat_history.
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      chat_completions_request: {
+        model: 'gpt-4o',
+        messages: [
+          { role: 'user', content: 'Will it rain in Seoul?' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              { id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '{}' } },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: 'sunny' },
+        ],
+      },
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.chat_history?.length, 3);
+  assert.equal((m.chat_history![2] as { role: string }).role, 'tool');
+});
+
+test('parseOpenAICompatMetadata: envelope path with only a trailing user turn yields no chat_history', () => {
+  // Plain single-turn request: nothing for chat_history to carry — every
+  // entry would either be the trailing user (split off into parts) or
+  // a system entry (split off into the system channel).
+  const m = parseOpenAICompatMetadata({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      chat_completions_request: {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: SAMPLE_TOOLS,
+      },
+    },
+  });
+  assert.ok(m);
+  assert.equal(m.chat_history, undefined);
+  assert.equal(m.tools?.length, 1);
+});
+
 test('buildOpenAICompatSystemPrompt: includes tools JSON and tool_choice line when tools present', () => {
   const prompt = buildOpenAICompatSystemPrompt({
     system: 'You are concise.',

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -8,8 +8,8 @@ import {
 import type { Backend } from '../backend.js';
 import { formatAcct, formatMention, type AgentIdentity } from '../identity.js';
 import {
+  buildOpenAICompatResponseMetadata,
   buildOpenAICompatUsage,
-  makeOpenAICompatUsageMetadata,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
 import {
@@ -278,6 +278,56 @@ export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompat
     cached_tokens: cacheReadSum > 0 ? cacheReadSum : undefined,
     model: primaryModel ? normalizeClaudeModelId(primaryModel) : undefined,
   });
+}
+
+// Assemble a complete OpenAI ChatCompletion envelope for the openai-compat/v1
+// envelope contract (oai2a2a#80). The codec on the gateway unwraps this
+// verbatim, so we own every required field — id / object / created / model /
+// choices / finish_reason / logprobs / usage. `id` is synthesized from the
+// A2A task id (Claude Code does not expose a stable response id we can
+// forward); `model` falls back to a placeholder when the run never reported
+// modelUsage (e.g. an early-exit failure before any LLM round-trip). Mirrors
+// `buildCodexChatCompletionEnvelope` in codex.ts so the two backends cannot
+// drift on the response shape.
+//
+// `finishReason` is constrained to the values Claude Code can produce on this
+// path: `tool_calls` when the model invoked a caller-side function tool,
+// otherwise `stop`. Claude does not surface `length` or `refusal` through the
+// stream-json transcript today, so we don't synthesize either — passing
+// through whatever the SDK exposes when it gains the field is a future
+// extension.
+//
+// Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
+export function buildClaudeChatCompletionEnvelope(args: {
+  taskId: string;
+  model: string | undefined;
+  content: string | null;
+  toolCalls:
+    | Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }>
+    | undefined;
+  finishReason: 'stop' | 'tool_calls';
+  usage: OpenAICompatUsage | null;
+}): Record<string, unknown> {
+  const message: Record<string, unknown> = { role: 'assistant', content: args.content };
+  if (args.toolCalls && args.toolCalls.length > 0) {
+    message.tool_calls = args.toolCalls;
+  }
+  const envelope: Record<string, unknown> = {
+    id: `chatcmpl-claude-${args.taskId}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: args.model ?? 'claude',
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: args.finishReason,
+        logprobs: null,
+      },
+    ],
+  };
+  if (args.usage) envelope.usage = args.usage;
+  return envelope;
 }
 
 // Anthropic-shaped content block we send on stdin.
@@ -1134,9 +1184,10 @@ export function createClaudeBackend(
 
       // Detect the openai-compat extension payload once per task so the
       // result feeds both the spawn argv (--append-system-prompt) and the
-      // assistant artifact path (tool_calls JSON → data part). Absent or
-      // malformed metadata leaves the run on the original non-extension code
-      // path with no envelope-detection cost.
+      // terminal `chat_completion` envelope (oai2a2a#80) on
+      // `status.message.metadata`. Absent or malformed metadata leaves the
+      // run on the original non-extension code path with no envelope-
+      // detection cost.
       const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
       if (openaiCompatTrace) {
         dumpOpenAICompatTaskWire(
@@ -1294,11 +1345,22 @@ export function createClaudeBackend(
       // Flag flipped by the `caller-tools-mcp` invocation handler when the
       // model invokes a caller-supplied tool. Read in the terminal block
       // below to suppress re-stamping the model's wrap-up text on
-      // `status.message.parts` — the `tool_calls` data artifact is the
-      // complete output for this turn, matching OpenAI Chat Completions'
-      // `finish_reason: "tool_calls"` semantics (the same invariant codex
-      // backend enforces on its native path, see #212).
+      // `status.message.parts` — the terminal `chat_completion` envelope
+      // (oai2a2a#80) is the complete output for this turn, matching OpenAI
+      // Chat Completions' `finish_reason: "tool_calls"` semantics (the same
+      // invariant codex backend enforces on its native path, see #212).
       let capturedToolCall = false;
+      // OpenAI Chat Completions tool_calls accumulated from caller-tools MCP
+      // invocations during this turn. Surfaced to the gateway via the
+      // terminal `chat_completion` envelope on
+      // `status.message.metadata[OPENAI_COMPAT_EXTENSION_URI]` per the
+      // openai-compat/v1 envelope contract (oai2a2a#80). Replaces the legacy
+      // data-part `tool_calls` artifact this backend used to emit.
+      const capturedToolCalls: Array<{
+        id: string;
+        type: 'function';
+        function: { name: string; arguments: string };
+      }> = [];
 
       // Caller-side function tools, exposed as native MCP tools. Per-task
       // lifecycle: stood up here BEFORE the spawn (so we know the URL to
@@ -1332,31 +1394,26 @@ export function createClaudeBackend(
             skipHttp: opts.onCallerToolsMcpReady !== undefined,
             tools: callerToolDefs,
             onInvoke: (invocation: CallerToolInvocation) => {
-              // Same OpenAI wire shape the envelope path emits — downstream
-              // gateways (oai2a2a) see no difference between native and
-              // envelope output, so this dispatch swap is invisible above
-              // the bridge layer.
-              const envelope = {
-                tool_calls: [
-                  {
-                    id: invocation.callId,
-                    function: {
-                      name: invocation.toolName,
-                      arguments: invocation.arguments,
-                    },
-                  },
-                ],
-              };
-              emit({
-                type: 'task.artifact',
-                taskId: task.taskId,
-                artifact: {
-                  artifactId: randomUUID(),
-                  name: 'claude-message',
-                  parts: [{ kind: 'data', data: envelope }],
-                  extensions: [OPENAI_COMPAT_EXTENSION_URI],
+              // Envelope contract (oai2a2a#80): tool_calls flow exclusively
+              // through the terminal `chat_completion` envelope metadata —
+              // NOT as a data-part artifact. Accumulate here; the terminal
+              // block below builds the envelope from `capturedToolCalls` and
+              // stamps it on `status.message.metadata`. OpenAI Chat
+              // Completions requires `arguments` as a JSON-encoded string;
+              // the MCP transport hands us a parsed JSON value, so we
+              // stringify here for spec compliance (mirrors codex.ts's
+              // capture path).
+              const argsString =
+                typeof invocation.arguments === 'string'
+                  ? invocation.arguments
+                  : JSON.stringify(invocation.arguments ?? {});
+              capturedToolCalls.push({
+                id: invocation.callId,
+                type: 'function',
+                function: {
+                  name: invocation.toolName,
+                  arguments: argsString,
                 },
-                lastChunk: true,
               });
               capturedToolCall = true;
               // The actual tool result is the caller's job — it arrives on
@@ -1583,7 +1640,13 @@ export function createClaudeBackend(
         input: unknown
       } | null = null;
       let finalText: string | null = null;
-      let finalUsage: OpenAICompatUsage | null = null;
+      // Explicit widening type — without this TS infers a too-narrow type
+      // through the `if (parsed) finalUsage = parsed;` assignment when
+      // `parseClaudeModelUsageForOpenAICompat` returns `OpenAICompatUsage | null`,
+      // because the only assignment site narrows out the `null` branch and
+      // later flow analysis collapses the type. Mirrors codex.ts's
+      // `finalUsage` declaration for the same reason.
+      let finalUsage: OpenAICompatUsage | null = null as OpenAICompatUsage | null;
       let responseArtifactId: string | null = null;
       let streamedResponseText = '';
       let sawCompletedResult = false;
@@ -1627,11 +1690,12 @@ export function createClaudeBackend(
       const emitAssistantArtifact = (text: string, append = false, lastChunk = true): void => {
         if (!text) return;
         responseArtifactId ??= randomUUID();
-        // openai-compat caller tools land as a `tool_calls` data artifact
-        // through the caller-tools MCP onInvoke handler above, NOT via
-        // any text-shape parsing. Assistant-text turns (natural-language
-        // answers, or any turn from a task that didn't request the
-        // extension) are emitted unchanged as a `text` part artifact.
+        // openai-compat caller tools surface via the terminal
+        // `chat_completion` envelope (oai2a2a#80) on the final A2A status
+        // message, NOT as any in-stream artifact. Assistant-text turns
+        // (natural-language answers, or any turn from a task that didn't
+        // request the extension) are emitted unchanged as a `text` part
+        // artifact for A2A debuggability and non-OpenAI consumers.
         emit({
           type: 'task.artifact',
           taskId: task.taskId,
@@ -2092,13 +2156,13 @@ export function createClaudeBackend(
 
       const completeText = finalText ?? '';
       // Native MCP dispatch (#213): when the model invoked a caller tool,
-      // the `tool_calls` data artifact (emitted via the MCP onInvoke
-      // handler above) is the complete task output. Any wrap-up text the
-      // model produced before exiting the turn (the system-prompt
-      // directive tells it to stop, but models occasionally emit a brief
-      // acknowledgement anyway) is reasoning preamble and must NOT be
-      // re-stamped on `status.message.parts` — same invariant codex
-      // backend enforces under PR #212, same root-cause concern as #200.
+      // the terminal `chat_completion` envelope (assembled below) is the
+      // complete task output. Any wrap-up text the model produced before
+      // exiting the turn (the system-prompt directive tells it to stop, but
+      // models occasionally emit a brief acknowledgement anyway) is
+      // reasoning preamble and must NOT be re-stamped on
+      // `status.message.parts` — same invariant codex backend enforces
+      // under PR #212, same root-cause concern as #200.
       const parts: Part[] = !capturedToolCall && completeText
         ? [{ kind: 'text', text: completeText }]
         : [];
@@ -2121,15 +2185,38 @@ export function createClaudeBackend(
         emitAssistantArtifact(completeText.slice(streamedResponseText.length), true, true);
       }
 
-      // Attach the openai-compat/v1 `usage` payload to the final A2A
-      // message of this turn when the underlying claude run reported it.
-      // Per spec the carrier is `Task.status.message.metadata[<URI>].usage`,
-      // so when usage is present but there is no completion text we still
-      // emit a message frame (with empty parts) to carry the metadata.
-      const hasMessage = parts.length > 0 || finalUsage !== null;
-      const messageMetadata = finalUsage
-        ? makeOpenAICompatUsageMetadata(finalUsage)
+      // Envelope response contract (oai2a2a#80): emit a complete OpenAI
+      // ChatCompletion envelope under
+      // `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completion` on the final
+      // A2A message of this turn. The codec unwraps the envelope verbatim,
+      // so we own id / created / model / choices / usage. The legacy
+      // top-level `usage` field is also emitted (via the shared metadata
+      // builder) for back-compat with codecs that read it as a fallback
+      // when the envelope lacks `usage`. When the openai-compat extension
+      // wasn't on the request at all we skip the envelope (no advertising
+      // consumer to feed it) but still emit the bare `usage` payload when
+      // claude reported one — preserves the pre-envelope behaviour for
+      // plain claude tasks. Mirrors codex.ts's emit pattern via the shared
+      // `buildOpenAICompatResponseMetadata` helper so claude and codex
+      // cannot drift on the wire shape.
+      const finishReason: 'tool_calls' | 'stop' =
+        capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
+      const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
+      const envelope = openaiCompat
+        ? buildClaudeChatCompletionEnvelope({
+            taskId: task.taskId,
+            model: finalUsage?.model,
+            content: assistantContent,
+            toolCalls: capturedToolCalls.length > 0 ? capturedToolCalls : undefined,
+            finishReason,
+            usage: finalUsage,
+          })
         : undefined;
+
+      const messageMetadata = buildOpenAICompatResponseMetadata(envelope, finalUsage);
+      // When parts is empty but we have envelope/usage to convey, still
+      // emit the message frame so the metadata reaches the gateway.
+      const hasMessage = parts.length > 0 || messageMetadata !== undefined;
       emit({
         type: 'task.complete',
         taskId: task.taskId,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2041,6 +2041,24 @@ export function createClaudeBackend(
       );
 
       signal.removeEventListener('abort', onAbort);
+
+      // Flush any trailing line without a newline. claude normally terminates
+      // each event with \n but recent CC builds can flush the final `result`
+      // event without a trailing newline and exit. This MUST run before
+      // `settled = true` — `handleEvent` returns early when `settled` is
+      // set, and a swallowed trailing `result` event leaves
+      // `sawCompletedResult` false, which then collapses the otherwise-
+      // legitimate "exit 1 after completed result" case into a
+      // `claude_exit_nonzero` failure.
+      const trailing = stdoutBuf.trim();
+      if (trailing) {
+        try {
+          handleEvent(JSON.parse(trailing) as StreamEvent);
+        } catch {
+          // ignore
+        }
+      }
+
       settled = true;
       sendFileRelease?.();
       // Caller-tools MCP is per-task; release it as soon as claude has
@@ -2052,17 +2070,6 @@ export function createClaudeBackend(
       // we're guaranteed claude has already disconnected.
       await closeCallerToolsMcp();
       if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
-
-      // Flush any trailing line without a newline. claude normally terminates
-      // each event with \n but a crash mid-write could leave one orphan.
-      const trailing = stdoutBuf.trim();
-      if (trailing) {
-        try {
-          handleEvent(JSON.parse(trailing) as StreamEvent);
-        } catch {
-          // ignore
-        }
-      }
 
       if (aborted) {
         emit({

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1308,14 +1308,15 @@ test('turn/start RPC error surfaces task.fail with turn_failed', async () => {
   assert.equal(last?.type === 'task.fail' && last.error.code, 'turn_failed');
 });
 
-// Native function-call surface (#209): codex sends `item/tool/call` as a
-// server request when the model invokes a caller-supplied dynamicTool. The
-// bridge captures it, emits an OpenAI-shaped `tool_calls` artifact, and
+// Native function-call surface (#209) + echo-only response contract
+// (oai2a2a#80): codex sends `item/tool/call` as a server request when the
+// model invokes a caller-supplied dynamicTool. The bridge captures it,
+// surfaces it on the terminal `chat_completion` echo metadata, and
 // interrupts the turn so codex unwinds — the caller delivers the result on
-// the next A2A turn via `chat_history` (existing path). A2A surfaces
-// the task as `completed` (not `canceled`) so OpenAI Chat Completions
-// callers see `finish_reason: "tool_calls"` semantics.
-test('openai-compat dynamicTools: item/tool/call → tool_calls artifact + completed task (#209)', async () => {
+// the next A2A turn via `chat_history` (existing path). A2A surfaces the
+// task as `completed` (not `canceled`) so OpenAI Chat Completions callers
+// see `finish_reason: "tool_calls"` semantics.
+test('openai-compat dynamicTools: item/tool/call → chat_completion echo on terminal status + completed task (#209, oai2a2a#80)', async () => {
   const fake = makeFakeSpawn(() => ({
     onLine(frame, child) {
       const id = (frame as { id?: number | string }).id;
@@ -1410,32 +1411,19 @@ test('openai-compat dynamicTools: item/tool/call → tool_calls artifact + compl
     NEVER,
   );
 
-  // The artifact must carry the OpenAI `tool_calls` envelope as a `data`
-  // part — same wire shape PR #208 already emitted on the legacy envelope
-  // path, so downstream gateways see no difference.
-  const artifact = frames.find((f) => f.type === 'task.artifact');
-  assert.ok(artifact, 'tool_calls artifact emitted');
-  if (artifact?.type === 'task.artifact') {
-    const p = artifact.artifact.parts[0];
-    assert.equal(p.kind, 'data');
-    assert.ok(
-      artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI),
-    );
-    if (p.kind === 'data') {
-      const data = p.data as {
-        tool_calls?: Array<{
-          id?: string;
-          function?: { name?: string; arguments?: unknown };
-        }>;
-      };
-      assert.equal(data.tool_calls?.length, 1);
-      assert.equal(data.tool_calls?.[0]?.id, 'call_xyz');
-      assert.equal(data.tool_calls?.[0]?.function?.name, 'fetch');
-      assert.deepEqual(data.tool_calls?.[0]?.function?.arguments, {
-        url: 'https://example.com',
-      });
-    }
-  }
+  // Echo-only contract (oai2a2a#80): no data-part `tool_calls` artifact.
+  // The model's function_call is delivered exclusively on the terminal
+  // status message metadata as `chat_completion.choices[0].message.tool_calls`.
+  const dataArtifacts = frames.filter(
+    (f) =>
+      f.type === 'task.artifact' &&
+      (f.artifact.parts[0] as { kind?: string })?.kind === 'data',
+  );
+  assert.equal(
+    dataArtifacts.length,
+    0,
+    'no data-part tool_calls artifact under the echo-only contract',
+  );
 
   // Despite the underlying turn ending in `interrupted`, the A2A task must
   // surface as `completed` because the model invoked a tool (caller asked
@@ -1443,6 +1431,47 @@ test('openai-compat dynamicTools: item/tool/call → tool_calls artifact + compl
   const complete = frames.find((f) => f.type === 'task.complete');
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
+
+  // Echo verification: the terminal status message metadata carries the
+  // complete OpenAI ChatCompletion envelope with tool_calls.
+  if (complete && complete.type === 'task.complete') {
+    const metadata = complete.status.message?.metadata as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
+    assert.ok(ext, 'openai-compat metadata present on terminal message');
+    const echo = ext.chat_completion as Record<string, unknown> | undefined;
+    assert.ok(echo, 'chat_completion echo present');
+    assert.equal(typeof echo.id, 'string');
+    assert.equal(echo.object, 'chat.completion');
+    assert.equal(typeof echo.created, 'number');
+    assert.equal(typeof echo.model, 'string');
+    const choices = echo.choices as Array<Record<string, unknown>>;
+    assert.equal(choices.length, 1);
+    const choice = choices[0];
+    assert.equal(choice.finish_reason, 'tool_calls');
+    const message = choice.message as {
+      role: string;
+      content: unknown;
+      tool_calls?: Array<{
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: unknown };
+      }>;
+    };
+    assert.equal(message.role, 'assistant');
+    assert.equal(message.content, null);
+    assert.equal(message.tool_calls?.length, 1);
+    assert.equal(message.tool_calls?.[0]?.id, 'call_xyz');
+    assert.equal(message.tool_calls?.[0]?.type, 'function');
+    assert.equal(message.tool_calls?.[0]?.function?.name, 'fetch');
+    // OpenAI spec requires `arguments` to be a JSON-encoded string.
+    const argsRaw = message.tool_calls?.[0]?.function?.arguments;
+    assert.equal(typeof argsRaw, 'string');
+    assert.deepEqual(JSON.parse(argsRaw as string), {
+      url: 'https://example.com',
+    });
+  }
 
   // Bridge must have sent `turn/interrupt` for our turn — that, plus
   // codex's terminal `turn/completed` notification, is what unwinds the
@@ -1694,7 +1723,8 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
 
   // Turn 2: same contextId still does thread/start (no reuse under
   // openai-compat). The handler must register on the new thread id so the
-  // model's tool_call surfaces as a `tool_calls` artifact.
+  // model's tool_call surfaces on the terminal chat_completion echo
+  // (echo-only contract, oai2a2a#80).
   const { emit, frames } = collect();
   await backend.handle(
     assign('second', 'ctx-no-resume', {
@@ -1709,16 +1739,29 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
     NEVER,
   );
 
-  const artifact = frames.find((f) => f.type === 'task.artifact');
-  assert.ok(artifact, 'tool_calls artifact emitted on the second turn');
-  if (artifact?.type === 'task.artifact') {
-    assert.ok(
-      artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI),
-    );
-  }
   const complete = frames.find((f) => f.type === 'task.complete');
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
+
+  // Echo verification: terminal status message metadata carries the
+  // chat_completion envelope with tool_calls — no data-part artifact.
+  const dataArtifacts = frames.filter(
+    (f) =>
+      f.type === 'task.artifact' &&
+      (f.artifact.parts[0] as { kind?: string })?.kind === 'data',
+  );
+  assert.equal(dataArtifacts.length, 0);
+  if (complete && complete.type === 'task.complete') {
+    const metadata = complete.status.message?.metadata as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
+    assert.ok(ext, 'openai-compat metadata present on second turn terminal message');
+    const echo = ext.chat_completion as { choices?: Array<{ message?: { tool_calls?: unknown[] } }> } | undefined;
+    assert.ok(echo, 'chat_completion echo present on second turn');
+    const calls = echo.choices?.[0]?.message?.tool_calls;
+    assert.ok(Array.isArray(calls) && calls.length === 1);
+  }
 
   // Both turns went through thread/start; thread/resume is never used for
   // openai-compat tasks (#233 session-reuse guard).

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1308,15 +1308,15 @@ test('turn/start RPC error surfaces task.fail with turn_failed', async () => {
   assert.equal(last?.type === 'task.fail' && last.error.code, 'turn_failed');
 });
 
-// Native function-call surface (#209) + echo-only response contract
+// Native function-call surface (#209) + envelope response contract
 // (oai2a2a#80): codex sends `item/tool/call` as a server request when the
 // model invokes a caller-supplied dynamicTool. The bridge captures it,
-// surfaces it on the terminal `chat_completion` echo metadata, and
+// surfaces it on the terminal `chat_completion` envelope metadata, and
 // interrupts the turn so codex unwinds — the caller delivers the result on
 // the next A2A turn via `chat_history` (existing path). A2A surfaces the
 // task as `completed` (not `canceled`) so OpenAI Chat Completions callers
 // see `finish_reason: "tool_calls"` semantics.
-test('openai-compat dynamicTools: item/tool/call → chat_completion echo on terminal status + completed task (#209, oai2a2a#80)', async () => {
+test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on terminal status + completed task (#209, oai2a2a#80)', async () => {
   const fake = makeFakeSpawn(() => ({
     onLine(frame, child) {
       const id = (frame as { id?: number | string }).id;
@@ -1411,7 +1411,7 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion echo on ter
     NEVER,
   );
 
-  // Echo-only contract (oai2a2a#80): no data-part `tool_calls` artifact.
+  // Envelope contract (oai2a2a#80): no data-part `tool_calls` artifact.
   // The model's function_call is delivered exclusively on the terminal
   // status message metadata as `chat_completion.choices[0].message.tool_calls`.
   const dataArtifacts = frames.filter(
@@ -1422,7 +1422,7 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion echo on ter
   assert.equal(
     dataArtifacts.length,
     0,
-    'no data-part tool_calls artifact under the echo-only contract',
+    'no data-part tool_calls artifact under the envelope contract',
   );
 
   // Despite the underlying turn ending in `interrupted`, the A2A task must
@@ -1432,7 +1432,7 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion echo on ter
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
 
-  // Echo verification: the terminal status message metadata carries the
+  // Envelope verification: the terminal status message metadata carries the
   // complete OpenAI ChatCompletion envelope with tool_calls.
   if (complete && complete.type === 'task.complete') {
     const metadata = complete.status.message?.metadata as
@@ -1440,13 +1440,13 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion echo on ter
       | undefined;
     const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
     assert.ok(ext, 'openai-compat metadata present on terminal message');
-    const echo = ext.chat_completion as Record<string, unknown> | undefined;
-    assert.ok(echo, 'chat_completion echo present');
-    assert.equal(typeof echo.id, 'string');
-    assert.equal(echo.object, 'chat.completion');
-    assert.equal(typeof echo.created, 'number');
-    assert.equal(typeof echo.model, 'string');
-    const choices = echo.choices as Array<Record<string, unknown>>;
+    const envelope = ext.chat_completion as Record<string, unknown> | undefined;
+    assert.ok(envelope, 'chat_completion envelope present');
+    assert.equal(typeof envelope.id, 'string');
+    assert.equal(envelope.object, 'chat.completion');
+    assert.equal(typeof envelope.created, 'number');
+    assert.equal(typeof envelope.model, 'string');
+    const choices = envelope.choices as Array<Record<string, unknown>>;
     assert.equal(choices.length, 1);
     const choice = choices[0];
     assert.equal(choice.finish_reason, 'tool_calls');
@@ -1723,8 +1723,8 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
 
   // Turn 2: same contextId still does thread/start (no reuse under
   // openai-compat). The handler must register on the new thread id so the
-  // model's tool_call surfaces on the terminal chat_completion echo
-  // (echo-only contract, oai2a2a#80).
+  // model's tool_call surfaces on the terminal chat_completion envelope
+  // (envelope contract, oai2a2a#80).
   const { emit, frames } = collect();
   await backend.handle(
     assign('second', 'ctx-no-resume', {
@@ -1743,7 +1743,7 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
 
-  // Echo verification: terminal status message metadata carries the
+  // Envelope verification: terminal status message metadata carries the
   // chat_completion envelope with tool_calls — no data-part artifact.
   const dataArtifacts = frames.filter(
     (f) =>
@@ -1757,9 +1757,9 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
       | undefined;
     const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
     assert.ok(ext, 'openai-compat metadata present on second turn terminal message');
-    const echo = ext.chat_completion as { choices?: Array<{ message?: { tool_calls?: unknown[] } }> } | undefined;
-    assert.ok(echo, 'chat_completion echo present on second turn');
-    const calls = echo.choices?.[0]?.message?.tool_calls;
+    const envelope = ext.chat_completion as { choices?: Array<{ message?: { tool_calls?: unknown[] } }> } | undefined;
+    assert.ok(envelope, 'chat_completion envelope present on second turn');
+    const calls = envelope.choices?.[0]?.message?.tool_calls;
     assert.ok(Array.isArray(calls) && calls.length === 1);
   }
 

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -357,7 +357,7 @@ export function parseCodexTokenUsageForOpenAICompat(raw: unknown): OpenAICompatU
 }
 
 // Assemble a complete OpenAI ChatCompletion envelope for the openai-compat/v1
-// echo-only contract. The codec on the gateway unwraps this verbatim, so we
+// envelope contract. The codec on the gateway unwraps this verbatim, so we
 // own every required field — id / object / created / model / choices /
 // finish_reason / logprobs / usage. `id` is synthesized from the A2A task id
 // (codex's app-server doesn't expose a stable response id we can forward);
@@ -365,7 +365,7 @@ export function parseCodexTokenUsageForOpenAICompat(raw: unknown): OpenAICompatU
 // tokenUsage.
 //
 // Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
-export function buildCodexChatCompletionEcho(args: {
+export function buildCodexChatCompletionEnvelope(args: {
   taskId: string;
   model: string | undefined;
   content: string | null;
@@ -1343,9 +1343,9 @@ export function createCodexBackend(
           let capturedToolCall = false;
           // OpenAI Chat Completions tool_calls accumulated from codex's
           // server-initiated `item/tool/call` events. Surfaced to the gateway
-          // via the terminal `chat_completion` echo on
+          // via the terminal `chat_completion` envelope on
           // `status.message.metadata[OPENAI_COMPAT_EXTENSION_URI]` per the
-          // openai-compat/v1 echo-only contract (oai2a2a#80).
+          // openai-compat/v1 envelope contract (oai2a2a#80).
           const capturedToolCalls: Array<{
             id: string;
             type: 'function';
@@ -1367,8 +1367,8 @@ export function createCodexBackend(
               // OpenAI Chat Completions requires `arguments` as a JSON-encoded
               // string; codex hands us a parsed JSON value, so we stringify
               // here for spec compliance. The captured call rides out via the
-              // terminal chat_completion echo (no data-part artifact under the
-              // echo-only contract — oai2a2a#80).
+              // terminal chat_completion envelope (no data-part artifact under
+              // the envelope contract — oai2a2a#80).
               const argsString =
                 typeof p.arguments === 'string'
                   ? p.arguments
@@ -1693,7 +1693,7 @@ export function createCodexBackend(
           // preamble and not re-stamped on `status.message.parts`. Stamping
           // it violates A2A's "Messages SHOULD NOT be used to deliver task
           // outputs"; the model's final answer in that turn IS the
-          // function_call which now rides via the chat_completion echo
+          // function_call which now rides via the chat_completion envelope
           // (oai2a2a#80).
           const parts: Part[] = !capturedToolCall && completeText
             ? [{ kind: 'text', text: completeText }]
@@ -1711,21 +1711,21 @@ export function createCodexBackend(
             });
           }
 
-          // Echo-only response contract (oai2a2a#80): emit a complete OpenAI
+          // Envelope response contract (oai2a2a#80): emit a complete OpenAI
           // ChatCompletion envelope under
           // `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completion` on the
           // final A2A message of this turn. The codec unwraps the envelope
           // verbatim, so we own id / created / model / choices / usage. The
           // legacy top-level `usage` field is also emitted for back-compat
-          // with codecs that read it as a fallback when the echo lacks
+          // with codecs that read it as a fallback when the envelope lacks
           // `usage`. When the openai-compat extension wasn't on the request
-          // at all we skip the echo (no advertising consumer to feed it).
+          // at all we skip the envelope (no advertising consumer to feed it).
           const finishReason: 'tool_calls' | 'stop' =
             capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
           const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
           const finalUsageSnapshot: OpenAICompatUsage | null = finalUsage;
-          const echo = openaiCompat
-            ? buildCodexChatCompletionEcho({
+          const envelope = openaiCompat
+            ? buildCodexChatCompletionEnvelope({
                 taskId: task.taskId,
                 model: finalUsageSnapshot?.model,
                 content: assistantContent,
@@ -1735,9 +1735,9 @@ export function createCodexBackend(
               })
             : undefined;
 
-          const messageMetadata = buildOpenAICompatResponseMetadata(echo, finalUsage);
-          // When parts is empty but we have echo/usage to convey, still emit
-          // the message frame so the metadata reaches the gateway.
+          const messageMetadata = buildOpenAICompatResponseMetadata(envelope, finalUsage);
+          // When parts is empty but we have envelope/usage to convey, still
+          // emit the message frame so the metadata reaches the gateway.
           const hasMessage = parts.length > 0 || messageMetadata !== undefined;
           emit({
             type: 'task.complete',

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -1525,36 +1525,11 @@ export function createCodexBackend(
                         id?: string;
                         status?: string;
                         error?: { message?: string } | null;
-                        usage?: unknown;
                       };
-                      usage?: unknown;
                     }
                   | undefined;
                 const t = p?.turn;
                 if (activeTurnId && t?.id !== activeTurnId) return;
-                // Tool-call-only turns sometimes don't get a
-                // `thread/tokenUsage/updated` notification (or it arrives
-                // after `turn/completed`). Try to pull usage off the
-                // `turn/completed.turn.usage` payload as a fallback so the
-                // openai-compat/v1 envelope's strict usage MUST stays
-                // satisfied. We accept both shapes the app-server has used
-                // in practice: the wrapper `{ last: {...} }` or the inner
-                // `last`-shaped object directly.
-                if (!finalUsage && (t?.usage !== undefined || p?.usage !== undefined)) {
-                  const candidate = t?.usage ?? p?.usage;
-                  const direct = parseCodexTokenUsageForOpenAICompat(candidate);
-                  const wrapped = direct
-                    ? null
-                    : parseCodexTokenUsageForOpenAICompat({ last: candidate });
-                  const parsed = direct ?? wrapped;
-                  if (openaiCompatTrace) {
-                    console.error(
-                      `[openai-compat trace] codex turn.usage fallback raw=${JSON.stringify(candidate ?? null)} ` +
-                        `parsed=${JSON.stringify(parsed)}`,
-                    );
-                  }
-                  if (parsed) finalUsage = parsed;
-                }
                 if (t?.status === 'completed') {
                   finish({ status: 'completed', finalText });
                 } else if (t?.status === 'interrupted') {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -15,8 +15,8 @@ import {
   parseOpenAICompatMetadata,
 } from './openai-compat.js';
 import {
+  buildOpenAICompatResponseMetadata,
   buildOpenAICompatUsage,
-  makeOpenAICompatUsageMetadata,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
 import { INPUT_FILE_MAX_BYTES, INPUT_IMAGE_MIME } from './fetch-uri-file.js';
@@ -354,6 +354,45 @@ export function parseCodexTokenUsageForOpenAICompat(raw: unknown): OpenAICompatU
     cached_tokens: cached,
     reasoning_tokens: reasoning,
   });
+}
+
+// Assemble a complete OpenAI ChatCompletion envelope for the openai-compat/v1
+// echo-only contract. The codec on the gateway unwraps this verbatim, so we
+// own every required field — id / object / created / model / choices /
+// finish_reason / logprobs / usage. `id` is synthesized from the A2A task id
+// (codex's app-server doesn't expose a stable response id we can forward);
+// `model` falls back to a placeholder when codex didn't surface it via
+// tokenUsage.
+//
+// Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
+export function buildCodexChatCompletionEcho(args: {
+  taskId: string;
+  model: string | undefined;
+  content: string | null;
+  toolCalls: Array<{ id: string; type: 'function'; function: { name: string; arguments: string } }> | undefined;
+  finishReason: 'stop' | 'tool_calls';
+  usage: OpenAICompatUsage | null;
+}): Record<string, unknown> {
+  const message: Record<string, unknown> = { role: 'assistant', content: args.content };
+  if (args.toolCalls && args.toolCalls.length > 0) {
+    message.tool_calls = args.toolCalls;
+  }
+  const envelope: Record<string, unknown> = {
+    id: `chatcmpl-codex-${args.taskId}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: args.model ?? 'codex',
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: args.finishReason,
+        logprobs: null,
+      },
+    ],
+  };
+  if (args.usage) envelope.usage = args.usage;
+  return envelope;
 }
 
 // app-server `commandExecution` item summary.
@@ -1287,7 +1326,12 @@ export function createCodexBackend(
           // ignore turn-level events (no turn of ours is yet on the wire).
           let activeTurnId: string | null = null;
           let finalText: string | null = null;
-          let finalUsage: OpenAICompatUsage | null = null;
+          // Explicit widening type — without this TS infers a too-narrow type
+          // through the `if (parsed) finalUsage = parsed;` assignment when
+          // `parseCodexTokenUsageForOpenAICompat` returns `OpenAICompatUsage | null`,
+          // because the only assignment site narrows out the `null` branch and
+          // later flow analysis collapses the type.
+          let finalUsage: OpenAICompatUsage | null = null as OpenAICompatUsage | null;
           let emittedAnyArtifact = false;
           // Set when an `item/tool/call` lands for this turn — the model
           // invoked a caller-side tool, we emitted a `tool_calls` artifact,
@@ -1297,6 +1341,16 @@ export function createCodexBackend(
           // `tool_calls` artifact, matching OpenAI Chat Completions'
           // `finish_reason: "tool_calls"` semantics.
           let capturedToolCall = false;
+          // OpenAI Chat Completions tool_calls accumulated from codex's
+          // server-initiated `item/tool/call` events. Surfaced to the gateway
+          // via the terminal `chat_completion` echo on
+          // `status.message.metadata[OPENAI_COMPAT_EXTENSION_URI]` per the
+          // openai-compat/v1 echo-only contract (oai2a2a#80).
+          const capturedToolCalls: Array<{
+            id: string;
+            type: 'function';
+            function: { name: string; arguments: string };
+          }> = [];
           const emitTraceArtifacts = traceabilityRequested(task);
 
           // Register the per-thread `item/tool/call` handler for the
@@ -1310,35 +1364,20 @@ export function createCodexBackend(
             registeredThreadId = threadId;
             toolCallHandlers.set(threadId, async (p) => {
               capturedToolCall = true;
-              // The OpenAI Chat Completions wire shape callers expect.
-              // codex hands us `arguments` already parsed as a JSON value;
-              // the envelope path historically forwarded the parsed object
-              // verbatim, so the artifact stays byte-compatible with PR
-              // #208's output and downstream gateways (oai2a2a) don't have
-              // to special-case the source.
-              const envelope = {
-                tool_calls: [
-                  {
-                    id: p.callId,
-                    function: {
-                      name: p.tool,
-                      arguments: p.arguments,
-                    },
-                  },
-                ],
-              };
-              emit({
-                type: 'task.artifact',
-                taskId: task.taskId,
-                artifact: {
-                  artifactId: randomUUID(),
-                  name: 'codex-message',
-                  parts: [{ kind: 'data', data: envelope }],
-                  extensions: [OPENAI_COMPAT_EXTENSION_URI],
-                },
-                lastChunk: true,
+              // OpenAI Chat Completions requires `arguments` as a JSON-encoded
+              // string; codex hands us a parsed JSON value, so we stringify
+              // here for spec compliance. The captured call rides out via the
+              // terminal chat_completion echo (no data-part artifact under the
+              // echo-only contract — oai2a2a#80).
+              const argsString =
+                typeof p.arguments === 'string'
+                  ? p.arguments
+                  : JSON.stringify(p.arguments ?? {});
+              capturedToolCalls.push({
+                id: p.callId,
+                type: 'function',
+                function: { name: p.tool, arguments: argsString },
               });
-              emittedAnyArtifact = true;
               // Best-effort `turn/interrupt` so codex unwinds the turn —
               // the model's function_call is already surfaced upstream and
               // we don't want it generating further text or chaining into
@@ -1649,14 +1688,13 @@ export function createCodexBackend(
           }
 
           const completeText = outcome.finalText ?? '';
-          // When the model invoked a caller tool, the `tool_calls` artifact
-          // is the complete task output: any agent text codex streamed
-          // before the function_call is best treated as reasoning preamble
-          // and not re-stamped on `status.message.parts`. Re-stamping
-          // violates A2A's "Messages SHOULD NOT be used to deliver task
-          // outputs" and, downstream, caused gateways (oai2a2a) to
-          // double-emit `tool_calls` on the envelope path (#200) — keep
-          // the same invariant on the native path.
+          // When the model invoked a caller tool, the assistant text codex
+          // streamed before the function_call is best treated as reasoning
+          // preamble and not re-stamped on `status.message.parts`. Stamping
+          // it violates A2A's "Messages SHOULD NOT be used to deliver task
+          // outputs"; the model's final answer in that turn IS the
+          // function_call which now rides via the chat_completion echo
+          // (oai2a2a#80).
           const parts: Part[] = !capturedToolCall && completeText
             ? [{ kind: 'text', text: completeText }]
             : [];
@@ -1673,14 +1711,34 @@ export function createCodexBackend(
             });
           }
 
-          // Attach the openai-compat/v1 `usage` payload to the final A2A
-          // message of this turn when codex reported it on turn/completed.
-          // When usage is present but there are no parts we still emit the
-          // message frame (with empty parts) to carry the metadata.
-          const hasMessage = parts.length > 0 || finalUsage !== null;
-          const messageMetadata = finalUsage
-            ? makeOpenAICompatUsageMetadata(finalUsage)
+          // Echo-only response contract (oai2a2a#80): emit a complete OpenAI
+          // ChatCompletion envelope under
+          // `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completion` on the
+          // final A2A message of this turn. The codec unwraps the envelope
+          // verbatim, so we own id / created / model / choices / usage. The
+          // legacy top-level `usage` field is also emitted for back-compat
+          // with codecs that read it as a fallback when the echo lacks
+          // `usage`. When the openai-compat extension wasn't on the request
+          // at all we skip the echo (no advertising consumer to feed it).
+          const finishReason: 'tool_calls' | 'stop' =
+            capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
+          const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
+          const finalUsageSnapshot: OpenAICompatUsage | null = finalUsage;
+          const echo = openaiCompat
+            ? buildCodexChatCompletionEcho({
+                taskId: task.taskId,
+                model: finalUsageSnapshot?.model,
+                content: assistantContent,
+                toolCalls: capturedToolCalls.length > 0 ? capturedToolCalls : undefined,
+                finishReason,
+                usage: finalUsageSnapshot,
+              })
             : undefined;
+
+          const messageMetadata = buildOpenAICompatResponseMetadata(echo, finalUsage);
+          // When parts is empty but we have echo/usage to convey, still emit
+          // the message frame so the metadata reaches the gateway.
+          const hasMessage = parts.length > 0 || messageMetadata !== undefined;
           emit({
             type: 'task.complete',
             taskId: task.taskId,

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -1532,6 +1532,29 @@ export function createCodexBackend(
                   | undefined;
                 const t = p?.turn;
                 if (activeTurnId && t?.id !== activeTurnId) return;
+                // Tool-call-only turns sometimes don't get a
+                // `thread/tokenUsage/updated` notification (or it arrives
+                // after `turn/completed`). Try to pull usage off the
+                // `turn/completed.turn.usage` payload as a fallback so the
+                // openai-compat/v1 envelope's strict usage MUST stays
+                // satisfied. We accept both shapes the app-server has used
+                // in practice: the wrapper `{ last: {...} }` or the inner
+                // `last`-shaped object directly.
+                if (!finalUsage && (t?.usage !== undefined || p?.usage !== undefined)) {
+                  const candidate = t?.usage ?? p?.usage;
+                  const direct = parseCodexTokenUsageForOpenAICompat(candidate);
+                  const wrapped = direct
+                    ? null
+                    : parseCodexTokenUsageForOpenAICompat({ last: candidate });
+                  const parsed = direct ?? wrapped;
+                  if (openaiCompatTrace) {
+                    console.error(
+                      `[openai-compat trace] codex turn.usage fallback raw=${JSON.stringify(candidate ?? null)} ` +
+                        `parsed=${JSON.stringify(parsed)}`,
+                    );
+                  }
+                  if (parsed) finalUsage = parsed;
+                }
                 if (t?.status === 'completed') {
                   finish({ status: 'completed', finalText });
                 } else if (t?.status === 'interrupted') {
@@ -1723,7 +1746,22 @@ export function createCodexBackend(
           const finishReason: 'tool_calls' | 'stop' =
             capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
           const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
-          const finalUsageSnapshot: OpenAICompatUsage | null = finalUsage;
+          // Placeholder fallback for codex app-server's known limitation:
+          // `thread/tokenUsage/updated` does not fire on tool-call-only
+          // (interrupted) turns, and `turn/completed` carries no usage
+          // payload for those turns either. The openai-compat/v1 envelope
+          // contract requires `usage` to be present — when codex genuinely
+          // didn't surface it, emit `{0,0,0}` as a placeholder rather than
+          // omit the field (which would trip the gateway's strict
+          // missing_usage 502). The zeros honestly signal "runtime did
+          // not report" rather than fabricating a tokenizer estimate the
+          // codex runtime never produced.
+          const finalUsageSnapshot: OpenAICompatUsage | null = openaiCompat && !finalUsage
+            ? buildOpenAICompatUsage({
+                prompt_tokens: 0,
+                completion_tokens: 0,
+              })
+            : finalUsage;
           const envelope = openaiCompat
             ? buildCodexChatCompletionEnvelope({
                 taskId: task.taskId,

--- a/packages/client/src/backends/openai-compat-usage.ts
+++ b/packages/client/src/backends/openai-compat-usage.ts
@@ -61,10 +61,10 @@ export function makeOpenAICompatUsageMetadata(usage: OpenAICompatUsage): Record<
 
 // Build the `Message.metadata` payload to attach to the terminal A2A
 // message under the openai-compat extension URI. Bundles the
-// `chat_completion` envelope (echo-only contract per oai2a2a#80 — the
+// `chat_completion` envelope (envelope contract per oai2a2a#80 — the
 // codec on the gateway unwraps this verbatim) with a transitional
 // top-level `usage` sibling for back-compat with codecs that read it as a
-// fallback when the echo lacks `usage`.
+// fallback when the envelope lacks `usage`.
 //
 // Both backends (codex.ts, vicoop-codex.ts) emit the same metadata shape;
 // this helper exists so the wire stays consistent and neither backend
@@ -73,13 +73,13 @@ export function makeOpenAICompatUsageMetadata(usage: OpenAICompatUsage): Record<
 //
 // Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
 export function buildOpenAICompatResponseMetadata(
-  echo: Record<string, unknown> | undefined,
+  envelope: Record<string, unknown> | undefined,
   usage: OpenAICompatUsage | null,
 ): Record<string, unknown> | undefined {
-  if (!echo && !usage) return undefined;
+  if (!envelope && !usage) return undefined;
   const payload: Record<string, unknown> = {};
   if (usage) payload.usage = usage;
-  if (echo) payload.chat_completion = echo;
+  if (envelope) payload.chat_completion = envelope;
   return { [OPENAI_COMPAT_EXTENSION_URI]: payload };
 }
 

--- a/packages/client/src/backends/openai-compat-usage.ts
+++ b/packages/client/src/backends/openai-compat-usage.ts
@@ -59,6 +59,30 @@ export function makeOpenAICompatUsageMetadata(usage: OpenAICompatUsage): Record<
   return { [OPENAI_COMPAT_EXTENSION_URI]: { usage } };
 }
 
+// Build the `Message.metadata` payload to attach to the terminal A2A
+// message under the openai-compat extension URI. Bundles the
+// `chat_completion` envelope (echo-only contract per oai2a2a#80 — the
+// codec on the gateway unwraps this verbatim) with a transitional
+// top-level `usage` sibling for back-compat with codecs that read it as a
+// fallback when the echo lacks `usage`.
+//
+// Both backends (codex.ts, vicoop-codex.ts) emit the same metadata shape;
+// this helper exists so the wire stays consistent and neither backend
+// silently drifts. Returns `undefined` when neither field has content so
+// callers don't stamp an empty extension block onto the message.
+//
+// Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
+export function buildOpenAICompatResponseMetadata(
+  echo: Record<string, unknown> | undefined,
+  usage: OpenAICompatUsage | null,
+): Record<string, unknown> | undefined {
+  if (!echo && !usage) return undefined;
+  const payload: Record<string, unknown> = {};
+  if (usage) payload.usage = usage;
+  if (echo) payload.chat_completion = echo;
+  return { [OPENAI_COMPAT_EXTENSION_URI]: payload };
+}
+
 function isCount(n: unknown): n is number {
   return typeof n === 'number' && Number.isFinite(n) && n >= 0 && Number.isInteger(n);
 }

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -70,14 +70,37 @@ export type OpenAICompatHistoryEntry =
   | OpenAICompatHistoryAssistantToolCalls
   | OpenAICompatHistoryTool;
 
-// Payload of the openai-compat A2A extension as carried under
-// `Message.metadata[OPENAI_COMPAT_EXTENSION_URI]`. Each field is optional and
-// is forwarded verbatim from the OpenAI-shaped originating request.
+// Decomposed view of the openai-compat A2A extension. The wire payload
+// under `Message.metadata[OPENAI_COMPAT_EXTENSION_URI]` carries the
+// *complete* OpenAI Chat Completions request body inside
+// `chat_completions_request` (envelope contract, oai2a2a#80 symmetric
+// envelope completion). This struct is the parser's decomposed view of
+// that envelope — it splits the body into the four logical channels every
+// backend in this package has historically consumed (system text, tools,
+// tool_choice, prior conversation turns) so backend code does not have to
+// re-walk `messages[]` itself. The decomposition is lossy by design (the
+// gateway-internal `a2a` field is dropped, `system`/`developer` messages
+// are concatenated, the trailing user turn is split off into A2A `parts`);
+// for the raw envelope, read the metadata key directly.
 export interface OpenAICompatMetadata {
   system?: string;
   tools?: unknown[];
   tool_choice?: unknown;
   chat_history?: OpenAICompatHistoryEntry[];
+}
+
+// Top-level shape of the openai-compat extension wire payload. The full
+// inbound OpenAI Chat Completions request body lives under
+// `chat_completions_request` — forwarded verbatim by the gateway with at
+// most codec-internal transport fields stripped.
+//
+// Spec: extensions/openai-compat/v1/README.md#request-metadata-payload-gateway--agent
+export interface OpenAICompatRequestEnvelope {
+  model?: unknown;
+  messages?: unknown;
+  tools?: unknown;
+  tool_choice?: unknown;
+  [key: string]: unknown;
 }
 
 // Validate a single content-part item from a `user` / `assistant` `content`
@@ -125,13 +148,116 @@ function parseUserOrAssistantContent(raw: unknown): OpenAICompatMessageContent |
   return parts;
 }
 
-// Whole-array validator for `chat_history`. Returns null (caller drops the
-// field) on ANY malformed entry rather than skipping it — order and
-// id-pairings between `assistant.tool_calls` and `role:"tool"` results
-// matter, so dropping a middle entry would silently break the model's view
-// of the prior conversation. Strict-or-nothing is safer than
-// forgiving-with-holes.
-function parseChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
+
+// True when the caller has supplied tool definitions AND has not explicitly
+// disabled tool use (`tool_choice === "none"`). Backends consult this to
+// decide whether to suppress agent-side built-in tools that would otherwise
+// bypass the envelope-emit contract — see #175 for the codex case (built-in
+// shell/exec executed `ls` directly instead of emitting a `tool_calls`
+// envelope for the caller's `bash` definition) and #178 for the same
+// pattern in claude (built-in Read/Glob/Bash served a `ls` request without
+// surfacing the caller's `List`). The condition mirrors `hasTools` in
+// `buildOpenAICompatSystemPrompt` so the gate that enables the envelope
+// contract in the prompt is the same gate that disables the conflicting
+// built-ins.
+export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boolean {
+  if (!meta) return false;
+  if (meta.tools === undefined) return false;
+  return meta.tool_choice !== 'none';
+}
+
+// Extract and shape-check the openai-compat extension metadata. Reads the
+// `chat_completions_request` envelope (the symmetric envelope contract —
+// oai2a2a#80 — places the full inbound OpenAI Chat Completions request
+// body under that key) and decomposes it into the four logical channels
+// every backend in this package consumes:
+//
+//   - `system`: concatenation of every `messages[i].role in {system,
+//     developer}` entry's text content, `\n`-joined.
+//   - `tools`: the envelope's `tools[]` verbatim (when non-empty).
+//   - `tool_choice`: the envelope's `tool_choice` verbatim.
+//   - `chat_history`: every non-system / non-developer entry of `messages[]`
+//     *except* the trailing user turn (which rides A2A `parts` for
+//     non-extension-aware consumers and is already in the envelope itself).
+//
+// Returns null when the envelope key is absent, malformed, or
+// decomposes to no actionable content, so callers can branch on
+// truthiness without per-field null checks.
+export function parseOpenAICompatMetadata(
+  metadata: Record<string, unknown> | undefined,
+): OpenAICompatMetadata | null {
+  if (!metadata) return null;
+  const raw = metadata[OPENAI_COMPAT_EXTENSION_URI];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+
+  // Envelope contract (oai2a2a#80 symmetric): the full inbound
+  // ChatCompletionsRequest body lives under `chat_completions_request`.
+  if (r.chat_completions_request && typeof r.chat_completions_request === 'object') {
+    return parseEnvelope(r.chat_completions_request as OpenAICompatRequestEnvelope);
+  }
+
+  // Legacy / direct-decomposed shape: pre-envelope gateways and unit-test
+  // fixtures place `{system, tools, tool_choice, chat_history}` directly
+  // under the URI key. The parser still accepts this for transitional
+  // compatibility — the envelope path above is the production wire shape.
+  return parseLegacyDecomposed(r);
+}
+
+function parseEnvelope(envelope: OpenAICompatRequestEnvelope): OpenAICompatMetadata | null {
+  const out: OpenAICompatMetadata = {};
+
+  const system = collectSystemFromMessages(envelope.messages);
+  if (system) out.system = system;
+
+  if (Array.isArray(envelope.tools) && envelope.tools.length > 0) {
+    out.tools = envelope.tools;
+  }
+  if (envelope.tool_choice !== undefined && envelope.tool_choice !== null) {
+    out.tool_choice = envelope.tool_choice;
+  }
+
+  if (Array.isArray(envelope.messages)) {
+    const history = chatHistoryFromMessages(envelope.messages);
+    if (history) out.chat_history = history;
+  }
+
+  if (
+    out.system === undefined &&
+    out.tools === undefined &&
+    out.tool_choice === undefined &&
+    out.chat_history === undefined
+  ) {
+    return null;
+  }
+  return out;
+}
+
+function parseLegacyDecomposed(r: Record<string, unknown>): OpenAICompatMetadata | null {
+  const out: OpenAICompatMetadata = {};
+  if (typeof r.system === 'string' && r.system.length > 0) out.system = r.system;
+  if (Array.isArray(r.tools) && r.tools.length > 0) out.tools = r.tools;
+  if (r.tool_choice !== undefined && r.tool_choice !== null) out.tool_choice = r.tool_choice;
+  if (Array.isArray(r.chat_history)) {
+    const history = parseLegacyChatHistory(r.chat_history);
+    if (history) out.chat_history = history;
+  }
+  if (
+    out.system === undefined &&
+    out.tools === undefined &&
+    out.tool_choice === undefined &&
+    out.chat_history === undefined
+  ) {
+    return null;
+  }
+  return out;
+}
+
+// Strict-or-nothing parser for the legacy `chat_history` field. Mirrors
+// the pre-envelope gateway behaviour exactly (e.g. tool entries require
+// `content` to be a plain string — no normalisation) — used only by the
+// legacy shape path and existing test fixtures.
+function parseLegacyChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
   if (raw.length === 0) return null;
   const out: OpenAICompatHistoryEntry[] = [];
   for (const entry of raw) {
@@ -144,20 +270,8 @@ function parseChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
       continue;
     }
     if (e.role === 'assistant') {
-      // Discriminate by `tool_calls` presence: assistant turns may be
-      // plain text, a pure tool-call envelope, or a hybrid (text +
-      // tool_calls — the model emits a brief explanation before
-      // calling). All three shapes are valid OpenAI Chat Completions.
       if (Array.isArray(e.tool_calls) && e.tool_calls.length > 0) {
-        // No-text variants (`null` / missing field / `""`) normalise to
-        // `null`. Any other shape is parsed as message content and
-        // preserved alongside the tool_calls so downstream backends can
-        // re-emit the explanation before the function calls.
-        if (
-          e.content === null ||
-          e.content === undefined ||
-          e.content === ''
-        ) {
+        if (e.content === null || e.content === undefined || e.content === '') {
           out.push({ role: 'assistant', content: null, tool_calls: e.tool_calls });
           continue;
         }
@@ -177,13 +291,13 @@ function parseChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
       e.tool_call_id.length > 0 &&
       typeof e.content === 'string'
     ) {
-      const toolEntry: OpenAICompatHistoryTool = {
+      const tool: OpenAICompatHistoryTool = {
         role: 'tool',
         tool_call_id: e.tool_call_id,
         content: e.content,
       };
-      if (typeof e.name === 'string' && e.name.length > 0) toolEntry.name = e.name;
-      out.push(toolEntry);
+      if (typeof e.name === 'string' && e.name.length > 0) tool.name = e.name;
+      out.push(tool);
       continue;
     }
     return null;
@@ -191,51 +305,162 @@ function parseChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | null {
   return out;
 }
 
-// True when the caller has supplied tool definitions AND has not explicitly
-// disabled tool use (`tool_choice === "none"`). Backends consult this to
-// decide whether to suppress agent-side built-in tools that would otherwise
-// bypass the envelope-emit contract — see #175 for the codex case (built-in
-// shell/exec executed `ls` directly instead of emitting a `tool_calls`
-// envelope for the caller's `bash` definition) and #178 for the same
-// pattern in claude (built-in Read/Glob/Bash served a `ls` request without
-// surfacing the caller's `List`). The condition mirrors `hasTools` in
-// `buildOpenAICompatSystemPrompt` so the gate that enables the envelope
-// contract in the prompt is the same gate that disables the conflicting
-// built-ins.
-export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boolean {
-  if (!meta) return false;
-  if (meta.tools === undefined) return false;
-  return meta.tool_choice !== 'none';
+// Concatenate every `system`/`developer` role entry's text content from
+// the inbound OpenAI `messages[]`, joined with `\n`. Returns undefined
+// when no such content exists (so callers can omit the system channel
+// entirely instead of pushing an empty prompt).
+//
+// Accepts both string content and OpenAI content-part arrays (the
+// `[{type:"text", text:"..."}, ...]` shape used by structured system
+// prompts). Non-text parts (image_url etc.) in a system message are
+// silently dropped — system channels are text-only on every supported
+// backend.
+function collectSystemFromMessages(messages: unknown): string | undefined {
+  if (!Array.isArray(messages)) return undefined;
+  const parts: string[] = [];
+  for (const entry of messages) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    if (e.role !== 'system' && e.role !== 'developer') continue;
+    const content = e.content;
+    if (typeof content === 'string') {
+      if (content.trim()) parts.push(content);
+      continue;
+    }
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        if (
+          item &&
+          typeof item === 'object' &&
+          (item as { type?: unknown }).type === 'text' &&
+          typeof (item as { text?: unknown }).text === 'string' &&
+          (item as { text: string }).text.trim()
+        ) {
+          parts.push((item as { text: string }).text);
+        }
+      }
+    }
+  }
+  return parts.length > 0 ? parts.join('\n') : undefined;
 }
 
-// Extract and shape-check the openai-compat metadata key. Returns null when
-// the metadata key is absent, malformed, or actionably empty (all four
-// fields missing or trivial) so the caller can fall back to its non-extension
-// path without conditional null-checks on every read.
-export function parseOpenAICompatMetadata(
-  metadata: Record<string, unknown> | undefined,
-): OpenAICompatMetadata | null {
-  if (!metadata) return null;
-  const raw = metadata[OPENAI_COMPAT_EXTENSION_URI];
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-  const r = raw as Record<string, unknown>;
-  const out: OpenAICompatMetadata = {};
-  if (typeof r.system === 'string' && r.system.length > 0) out.system = r.system;
-  if (Array.isArray(r.tools) && r.tools.length > 0) out.tools = r.tools;
-  if (r.tool_choice !== undefined && r.tool_choice !== null) out.tool_choice = r.tool_choice;
-  if (Array.isArray(r.chat_history)) {
-    const history = parseChatHistory(r.chat_history);
-    if (history) out.chat_history = history;
+// Convert the envelope's `messages[]` into the `chat_history` projection:
+// every user/assistant/tool entry in original order, *except* the trailing
+// user turn (it rides A2A `parts`; including it here would duplicate the
+// turn against backends that prepend the formatted history to the parts
+// text). System / developer entries are filtered out — they go through
+// the `system` channel.
+//
+// Returns null when the projection is empty (e.g. a single-turn
+// trailing-user-only request) so callers can omit history-replay code
+// paths cleanly.
+function chatHistoryFromMessages(
+  messages: unknown[],
+): OpenAICompatHistoryEntry[] | null {
+  // Find the index of the trailing user turn. Per spec it is split into
+  // A2A `parts`, so we exclude it from the decomposed chat_history view.
+  let trailingUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const entry = messages[i];
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      (entry as Record<string, unknown>).role === 'user'
+    ) {
+      trailingUserIndex = i;
+      break;
+    }
+    // Stop at the first non-trailing role — if the trailing entry isn't
+    // a user (tool-continuation), the parts placeholder is empty and the
+    // full conversation belongs in chat_history.
+    break;
   }
-  if (
-    out.system === undefined &&
-    out.tools === undefined &&
-    out.tool_choice === undefined &&
-    out.chat_history === undefined
-  ) {
-    return null;
+
+  const out: OpenAICompatHistoryEntry[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (i === trailingUserIndex) continue;
+    const entry = messages[i];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    const e = entry as Record<string, unknown>;
+    if (e.role === 'system' || e.role === 'developer') continue;
+
+    const parsed = parseHistoryEntry(e);
+    if (!parsed) {
+      // Strict-or-nothing: a single malformed history entry breaks the
+      // ordering / id-pairing the model relies on, so drop the whole
+      // history projection rather than silently skip the entry.
+      return null;
+    }
+    out.push(parsed);
   }
-  return out;
+  return out.length > 0 ? out : null;
+}
+
+// Parse a single envelope `messages[]` entry into the chat_history
+// projection. Mirrors the historic on-wire shapes — string-or-content-part
+// `content`, assistant with optional `tool_calls`, tool result strings —
+// while normalising the no-text-with-tool_calls variants to `content: null`
+// so downstream backends only have to handle one shape.
+function parseHistoryEntry(e: Record<string, unknown>): OpenAICompatHistoryEntry | null {
+  if (e.role === 'user') {
+    const content = parseUserOrAssistantContent(e.content);
+    if (content === null) return null;
+    return { role: 'user', content };
+  }
+  if (e.role === 'assistant') {
+    if (Array.isArray(e.tool_calls) && e.tool_calls.length > 0) {
+      if (e.content === null || e.content === undefined || e.content === '') {
+        return { role: 'assistant', content: null, tool_calls: e.tool_calls };
+      }
+      const content = parseUserOrAssistantContent(e.content);
+      if (content === null) return null;
+      return { role: 'assistant', content, tool_calls: e.tool_calls };
+    }
+    const content = parseUserOrAssistantContent(e.content);
+    if (content === null) return null;
+    return { role: 'assistant', content };
+  }
+  if (e.role === 'tool' && typeof e.tool_call_id === 'string' && e.tool_call_id.length > 0) {
+    // OpenAI permits string or content-parts for tool result content; the
+    // envelope forwards verbatim, so normalise here for backends that
+    // assume a plain string.
+    const content = normalizeToolResultContent(e.content);
+    const tool: OpenAICompatHistoryTool = {
+      role: 'tool',
+      tool_call_id: e.tool_call_id,
+      content,
+    };
+    if (typeof e.name === 'string' && e.name.length > 0) tool.name = e.name;
+    return tool;
+  }
+  return null;
+}
+
+// Flatten an arbitrary tool-result `content` (string, content-parts, or
+// raw object) into the plain string every backend expects. Mirrors the
+// pre-envelope gateway behaviour so the parser can absorb any of the
+// shapes OpenAI Chat Completions accepts.
+function normalizeToolResultContent(raw: unknown): string {
+  if (raw === undefined || raw === null) return '';
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw)) {
+    const sections: string[] = [];
+    for (const item of raw) {
+      if (item && typeof item === 'object' && 'text' in (item as Record<string, unknown>)) {
+        const text = (item as { text?: unknown }).text;
+        if (typeof text === 'string') sections.push(text);
+        continue;
+      }
+      if (typeof item === 'string') sections.push(item);
+    }
+    return sections.join('\n');
+  }
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return String(raw);
+  }
 }
 
 // Translate an OpenAI `tool_choice` value into a one-line directive the
@@ -467,15 +692,36 @@ export function dumpOpenAICompatTaskWire(
       }
     }
 
+    // Raw envelope dump: surface the inbound conversation so operators can
+    // diff what the gateway sent vs. what the backend ended up using. The
+    // decomposed `parsed` view above already shows the chat_history
+    // projection — this section is the raw shape pre-decomposition.
+    //
+    // Reads `chat_completions_request.messages[]` (envelope contract,
+    // oai2a2a#80) when present; falls back to the legacy `chat_history`
+    // shape so pre-envelope gateways still produce a useful trace.
     const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
     if (ext && typeof ext === 'object') {
-      const rawHist = (ext as Record<string, unknown>).chat_history;
-      if (Array.isArray(rawHist) && rawHist.length > 0) {
-        console.error(
-          `[openai-compat trace] raw chat_history (${rawHist.length} entries):`,
-        );
-        for (const [i, e] of rawHist.entries()) {
-          console.error(`  [${i}] ${JSON.stringify(e).slice(0, TRACE_ITEM_CLIP)}`);
+      const env = (ext as Record<string, unknown>).chat_completions_request;
+      if (env && typeof env === 'object') {
+        const rawMessages = (env as Record<string, unknown>).messages;
+        if (Array.isArray(rawMessages) && rawMessages.length > 0) {
+          console.error(
+            `[openai-compat trace] envelope.messages (${rawMessages.length} entries):`,
+          );
+          for (const [i, e] of rawMessages.entries()) {
+            console.error(`  [${i}] ${JSON.stringify(e).slice(0, TRACE_ITEM_CLIP)}`);
+          }
+        }
+      } else {
+        const rawHist = (ext as Record<string, unknown>).chat_history;
+        if (Array.isArray(rawHist) && rawHist.length > 0) {
+          console.error(
+            `[openai-compat trace] raw chat_history (${rawHist.length} entries):`,
+          );
+          for (const [i, e] of rawHist.entries()) {
+            console.error(`  [${i}] ${JSON.stringify(e).slice(0, TRACE_ITEM_CLIP)}`);
+          }
         }
       }
     }

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -410,7 +410,7 @@ test('parseChatCompletionUsage: missing primary counts yields null', () => {
   assert.equal(parseChatCompletionUsage({ prompt_tokens: 1 }, undefined), null);
 });
 
-test('buildResponseMetadata: chat_completion echo carries spec-required fields + normalized usage', () => {
+test('buildResponseMetadata: chat_completion envelope carries spec-required fields + normalized usage', () => {
   const response: ChatCompletionResponse = {
     id: 'chatcmpl-abc',
     object: 'chat.completion',
@@ -434,19 +434,19 @@ test('buildResponseMetadata: chat_completion echo carries spec-required fields +
   // Legacy top-level `usage` sibling for back-compat with v1-era codecs
   // that only read it; new codecs prefer `chat_completion.usage`.
   assert.ok(ext.usage);
-  const echo = ext.chat_completion as Record<string, unknown>;
-  assert.equal(echo.id, 'chatcmpl-abc');
-  assert.equal(echo.object, 'chat.completion');
-  assert.equal(echo.model, 'gpt-5.4');
-  assert.equal(echo.created, 1779177411);
+  const envelope = ext.chat_completion as Record<string, unknown>;
+  assert.equal(envelope.id, 'chatcmpl-abc');
+  assert.equal(envelope.object, 'chat.completion');
+  assert.equal(envelope.model, 'gpt-5.4');
+  assert.equal(envelope.created, 1779177411);
   // chat_completion.usage carries the normalized OpenAICompatUsage
   // (with the spec-mandated total === prompt + completion invariant)
   // — same value as the top-level sibling. Codec prefers this path.
-  assert.deepEqual(echo.usage, usage);
+  assert.deepEqual(envelope.usage, usage);
   // logprobs must be present on each choice per the spec (defaults to null
   // when the underlying runtime doesn't surface them — which vicoop-codex
   // never does today).
-  const choices = echo.choices as Array<Record<string, unknown>>;
+  const choices = envelope.choices as Array<Record<string, unknown>>;
   assert.equal(choices.length, 1);
   assert.equal(choices[0].logprobs, null);
   assert.equal(choices[0].finish_reason, 'stop');
@@ -469,12 +469,12 @@ test('buildResponseMetadata: synthesizes defensive defaults when upstream omits 
     string,
     Record<string, unknown>
   >;
-  const echo = (meta[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown>)
+  const envelope = (meta[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown>)
     .chat_completion as Record<string, unknown>;
-  assert.equal(echo.id, 'chatcmpl-vicoop-codex-task-fallback');
-  assert.equal(echo.object, 'chat.completion');
-  assert.equal(typeof echo.created, 'number');
-  assert.equal(echo.model, 'vicoop-codex');
+  assert.equal(envelope.id, 'chatcmpl-vicoop-codex-task-fallback');
+  assert.equal(envelope.object, 'chat.completion');
+  assert.equal(typeof envelope.created, 'number');
+  assert.equal(envelope.model, 'vicoop-codex');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -554,23 +554,23 @@ test('handle: success path — text response → artifact + complete with metada
   ];
   // Legacy top-level `usage` for v1-era back-compat.
   assert.ok(ext.usage);
-  const echo = ext.chat_completion as Record<string, unknown>;
-  assert.equal(echo.id, 'chatcmpl-1');
-  assert.equal(echo.model, 'gpt-5.4');
-  // Echo carries `usage` natively (preferred by the codec); same numeric
-  // totals as the legacy sibling above.
-  const echoUsage = echo.usage as Record<string, number>;
-  assert.equal(echoUsage.prompt_tokens, 3);
-  assert.equal(echoUsage.completion_tokens, 1);
-  assert.equal(echoUsage.total_tokens, 4);
+  const envelope = ext.chat_completion as Record<string, unknown>;
+  assert.equal(envelope.id, 'chatcmpl-1');
+  assert.equal(envelope.model, 'gpt-5.4');
+  // The envelope carries `usage` natively (preferred by the codec); same
+  // numeric totals as the legacy sibling above.
+  const envelopeUsage = envelope.usage as Record<string, number>;
+  assert.equal(envelopeUsage.prompt_tokens, 3);
+  assert.equal(envelopeUsage.completion_tokens, 1);
+  assert.equal(envelopeUsage.total_tokens, 4);
   // Spec requires logprobs on each choice (null when not surfaced).
-  const choices = echo.choices as Array<Record<string, unknown>>;
+  const choices = envelope.choices as Array<Record<string, unknown>>;
   assert.equal(choices.length, 1);
   assert.equal(choices[0].logprobs, null);
   assert.equal(choices[0].finish_reason, 'stop');
 });
 
-test('handle: tool_calls response → no data artifact; tool_calls only on terminal chat_completion echo (echo-only contract, oai2a2a#80)', async () => {
+test('handle: tool_calls response → no data artifact; tool_calls only on terminal chat_completion envelope (envelope contract, oai2a2a#80)', async () => {
   const task = makeTask({
     metadata: {
       [OPENAI_COMPAT_EXTENSION_URI]: {
@@ -606,7 +606,7 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
     child.emitStdout(JSON.stringify(response));
     child.finish(0);
   });
-  // Echo-only contract: no data-part `tool_calls` artifact. The legacy
+  // Envelope contract: no data-part `tool_calls` artifact. The legacy
   // `data` part shaped `{ "tool_calls": [...] }` is removed from this
   // extension — consumers ignore it, so emitting it would only confuse
   // non-OpenAI A2A inspectors.
@@ -618,7 +618,7 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
   assert.equal(
     dataArtifacts.length,
     0,
-    'no data-part tool_calls artifact under the echo-only contract',
+    'no data-part tool_calls artifact under the envelope contract',
   );
   // No text artifact either when there's no text content to surface
   // (content: null on a tool_calls turn).
@@ -637,13 +637,13 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
   // tool_calls envelope onto the message (A2A: "Messages SHOULD NOT be
   // used to deliver task outputs").
   assert.deepEqual(completeFrame.status.message!.parts, []);
-  // The chat_completion echo is the sole recovery wire for tool_calls.
+  // The chat_completion envelope is the sole recovery wire for tool_calls.
   const ext = (completeFrame.status.message!.metadata as Record<
     string,
     Record<string, unknown>
   >)[OPENAI_COMPAT_EXTENSION_URI];
-  const echo = ext.chat_completion as Record<string, unknown>;
-  const choices = echo.choices as Array<{
+  const envelope = ext.chat_completion as Record<string, unknown>;
+  const choices = envelope.choices as Array<{
     message: { role: string; content: unknown; tool_calls?: Array<Record<string, unknown>> };
     finish_reason: string;
     logprobs: unknown;

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -410,7 +410,7 @@ test('parseChatCompletionUsage: missing primary counts yields null', () => {
   assert.equal(parseChatCompletionUsage({ prompt_tokens: 1 }, undefined), null);
 });
 
-test('buildResponseMetadata: includes both usage and chat_completion echo', () => {
+test('buildResponseMetadata: chat_completion echo carries spec-required fields + normalized usage', () => {
   const response: ChatCompletionResponse = {
     id: 'chatcmpl-abc',
     object: 'chat.completion',
@@ -426,18 +426,55 @@ test('buildResponseMetadata: includes both usage and chat_completion echo', () =
     usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
   };
   const usage = parseChatCompletionUsage(response.usage, response.model);
-  const meta = buildResponseMetadata(response, usage) as Record<
+  const meta = buildResponseMetadata(response, usage, 'task-xyz') as Record<
     string,
     Record<string, unknown>
   >;
   const ext = meta[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown>;
+  // Legacy top-level `usage` sibling for back-compat with v1-era codecs
+  // that only read it; new codecs prefer `chat_completion.usage`.
   assert.ok(ext.usage);
   const echo = ext.chat_completion as Record<string, unknown>;
   assert.equal(echo.id, 'chatcmpl-abc');
+  assert.equal(echo.object, 'chat.completion');
   assert.equal(echo.model, 'gpt-5.4');
   assert.equal(echo.created, 1779177411);
-  assert.deepEqual(echo.usage, response.usage);
-  assert.ok(Array.isArray(echo.choices));
+  // chat_completion.usage carries the normalized OpenAICompatUsage
+  // (with the spec-mandated total === prompt + completion invariant)
+  // — same value as the top-level sibling. Codec prefers this path.
+  assert.deepEqual(echo.usage, usage);
+  // logprobs must be present on each choice per the spec (defaults to null
+  // when the underlying runtime doesn't surface them — which vicoop-codex
+  // never does today).
+  const choices = echo.choices as Array<Record<string, unknown>>;
+  assert.equal(choices.length, 1);
+  assert.equal(choices[0].logprobs, null);
+  assert.equal(choices[0].finish_reason, 'stop');
+});
+
+test('buildResponseMetadata: synthesizes defensive defaults when upstream omits id/object/created/model', () => {
+  // Advertising agents SHOULD always emit a complete envelope, but a wrapper
+  // bug shouldn't break OpenAI clients downstream — the codec relies on
+  // these fields being present.
+  const response: ChatCompletionResponse = {
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'ok' },
+        finish_reason: 'stop',
+      },
+    ],
+  };
+  const meta = buildResponseMetadata(response, null, 'task-fallback') as Record<
+    string,
+    Record<string, unknown>
+  >;
+  const echo = (meta[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown>)
+    .chat_completion as Record<string, unknown>;
+  assert.equal(echo.id, 'chatcmpl-vicoop-codex-task-fallback');
+  assert.equal(echo.object, 'chat.completion');
+  assert.equal(typeof echo.created, 'number');
+  assert.equal(echo.model, 'vicoop-codex');
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -515,13 +552,25 @@ test('handle: success path — text response → artifact + complete with metada
   const ext = (msg.metadata as Record<string, Record<string, unknown>>)[
     OPENAI_COMPAT_EXTENSION_URI
   ];
+  // Legacy top-level `usage` for v1-era back-compat.
   assert.ok(ext.usage);
   const echo = ext.chat_completion as Record<string, unknown>;
   assert.equal(echo.id, 'chatcmpl-1');
   assert.equal(echo.model, 'gpt-5.4');
+  // Echo carries `usage` natively (preferred by the codec); same numeric
+  // totals as the legacy sibling above.
+  const echoUsage = echo.usage as Record<string, number>;
+  assert.equal(echoUsage.prompt_tokens, 3);
+  assert.equal(echoUsage.completion_tokens, 1);
+  assert.equal(echoUsage.total_tokens, 4);
+  // Spec requires logprobs on each choice (null when not surfaced).
+  const choices = echo.choices as Array<Record<string, unknown>>;
+  assert.equal(choices.length, 1);
+  assert.equal(choices[0].logprobs, null);
+  assert.equal(choices[0].finish_reason, 'stop');
 });
 
-test('handle: tool_calls response → data artifact + no text in status message', async () => {
+test('handle: tool_calls response → no data artifact; tool_calls only on terminal chat_completion echo (echo-only contract, oai2a2a#80)', async () => {
   const task = makeTask({
     metadata: {
       [OPENAI_COMPAT_EXTENSION_URI]: {
@@ -557,22 +606,62 @@ test('handle: tool_calls response → data artifact + no text in status message'
     child.emitStdout(JSON.stringify(response));
     child.finish(0);
   });
-  const artifacts = frames.filter((f) => f.type === 'task.artifact');
-  assert.equal(artifacts.length, 1);
-  const artifact = artifacts[0];
-  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].kind, 'data');
-  if (artifact.artifact.parts[0].kind !== 'data') throw new Error('unreachable');
-  const data = artifact.artifact.parts[0].data as { tool_calls: unknown[] };
-  assert.equal(data.tool_calls.length, 1);
-  assert.ok(artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
+  // Echo-only contract: no data-part `tool_calls` artifact. The legacy
+  // `data` part shaped `{ "tool_calls": [...] }` is removed from this
+  // extension — consumers ignore it, so emitting it would only confuse
+  // non-OpenAI A2A inspectors.
+  const dataArtifacts = frames.filter(
+    (f) =>
+      f.type === 'task.artifact' &&
+      (f.artifact.parts[0] as { kind?: string })?.kind === 'data',
+  );
+  assert.equal(
+    dataArtifacts.length,
+    0,
+    'no data-part tool_calls artifact under the echo-only contract',
+  );
+  // No text artifact either when there's no text content to surface
+  // (content: null on a tool_calls turn).
+  const textArtifacts = frames.filter(
+    (f) =>
+      f.type === 'task.artifact' &&
+      (f.artifact.parts[0] as { kind?: string })?.kind === 'text',
+  );
+  assert.equal(textArtifacts.length, 0);
+
   const completes = frames.filter((f) => f.type === 'task.complete');
   assert.equal(completes.length, 1);
   const completeFrame = completes[0];
   if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
   // status.message exists but parts must be empty so we don't re-stamp the
-  // tool_calls envelope onto the message.
+  // tool_calls envelope onto the message (A2A: "Messages SHOULD NOT be
+  // used to deliver task outputs").
   assert.deepEqual(completeFrame.status.message!.parts, []);
+  // The chat_completion echo is the sole recovery wire for tool_calls.
+  const ext = (completeFrame.status.message!.metadata as Record<
+    string,
+    Record<string, unknown>
+  >)[OPENAI_COMPAT_EXTENSION_URI];
+  const echo = ext.chat_completion as Record<string, unknown>;
+  const choices = echo.choices as Array<{
+    message: { role: string; content: unknown; tool_calls?: Array<Record<string, unknown>> };
+    finish_reason: string;
+    logprobs: unknown;
+  }>;
+  assert.equal(choices.length, 1);
+  assert.equal(choices[0].finish_reason, 'tool_calls');
+  assert.equal(choices[0].logprobs, null);
+  assert.equal(choices[0].message.role, 'assistant');
+  assert.equal(choices[0].message.content, null);
+  const calls = choices[0].message.tool_calls!;
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].id, 'call_xyz');
+  assert.equal(calls[0].type, 'function');
+  const fn = calls[0].function as { name: string; arguments: string };
+  assert.equal(fn.name, 'list_files');
+  // OpenAI spec: arguments is a JSON-encoded string (vicoop-codex CLI
+  // already emits it that way).
+  assert.equal(fn.arguments, '{"path":"."}');
 });
 
 test('handle: stdin body carries only system/tools/tool_choice/history-derived messages', async () => {

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -351,9 +351,9 @@ export function parseChatCompletionUsage(
   });
 }
 
-// Assemble the OpenAI ChatCompletion envelope echoed under
+// Assemble the OpenAI ChatCompletion envelope placed under
 // `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completion` on the terminal
-// A2A message, per the openai-compat/v1 echo-only contract (oai2a2a#80).
+// A2A message, per the openai-compat/v1 envelope contract (oai2a2a#80).
 // The codec on the gateway unwraps this verbatim, so we own every required
 // field — id / object / created / model / choices[*]{message, finish_reason,
 // logprobs} / usage.
@@ -374,7 +374,7 @@ export function parseChatCompletionUsage(
 //     `usage` field.
 //
 // Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
-export function buildChatCompletionEcho(
+export function buildChatCompletionEnvelope(
   response: ChatCompletionResponse,
   usage: OpenAICompatUsage | null,
   taskId: string,
@@ -410,24 +410,24 @@ export function buildChatCompletionEcho(
 }
 
 // Build the metadata payload spread onto the final A2A message under
-// `OPENAI_COMPAT_EXTENSION_URI`. Includes the chat_completion echo per
-// the echo-only contract (oai2a2a#80) plus a transitional top-level
+// `OPENAI_COMPAT_EXTENSION_URI`. Includes the chat_completion envelope per
+// the envelope contract (oai2a2a#80) plus a transitional top-level
 // `usage` sibling for back-compat with codecs that read it as a fallback
-// when the echo lacks `usage`. New codecs prefer `chat_completion.usage`;
-// the sibling exists so v1-era consumers that only read the top-level
-// field keep working during the transition.
+// when the envelope lacks `usage`. New codecs prefer
+// `chat_completion.usage`; the sibling exists so v1-era consumers that
+// only read the top-level field keep working during the transition.
 export function buildResponseMetadata(
   response: ChatCompletionResponse,
   usage: OpenAICompatUsage | null,
   taskId: string,
 ): Record<string, unknown> {
-  const echo = buildChatCompletionEcho(response, usage, taskId);
+  const envelope = buildChatCompletionEnvelope(response, usage, taskId);
   // `buildOpenAICompatResponseMetadata` returns `undefined` when both
-  // `echo` and `usage` are absent — for vicoop-codex we always have at
+  // `envelope` and `usage` are absent — for vicoop-codex we always have at
   // least the synthesized envelope, so the non-undefined branch is
   // guaranteed. Coerce here to keep the call-site type narrow.
-  return buildOpenAICompatResponseMetadata(echo, usage) ?? {
-    [OPENAI_COMPAT_EXTENSION_URI]: { chat_completion: echo },
+  return buildOpenAICompatResponseMetadata(envelope, usage) ?? {
+    [OPENAI_COMPAT_EXTENSION_URI]: { chat_completion: envelope },
   };
 }
 
@@ -762,8 +762,8 @@ export function createVicoopCodexBackend(
         : [];
       const finishReason = typeof choice?.finish_reason === 'string' ? choice.finish_reason : '';
 
-      // Echo-only contract (oai2a2a#80): tool_calls flow exclusively through
-      // the terminal `chat_completion` echo metadata — NOT as a data-part
+      // Envelope contract (oai2a2a#80): tool_calls flow exclusively through
+      // the terminal `chat_completion` envelope metadata — NOT as a data-part
       // artifact. The legacy `data` part shaped `{ "tool_calls": [...] }`
       // is removed from this extension; consumers ignore it. Text content
       // still rides as a text artifact so non-OpenAI A2A consumers
@@ -790,9 +790,9 @@ export function createVicoopCodexBackend(
       //     path so we don't double-stamp the tool_calls envelope onto the
       //     status message).
       //   - `metadata[OPENAI_COMPAT_EXTENSION_URI]`: usage + the full
-      //     chat_completion echo. Always emitted so the caller has access
-      //     to id / model / created / choices / finish_reason without
-      //     parsing the artifact.
+      //     chat_completion envelope. Always emitted so the caller has
+      //     access to id / model / created / choices / finish_reason
+      //     without parsing the artifact.
       //   - `extensions`: the OPENAI_COMPAT_EXTENSION_URI marker.
       const parts: Part[] =
         toolCalls.length === 0 && contentText ? [{ kind: 'text', text: contentText }] : [];
@@ -812,7 +812,7 @@ export function createVicoopCodexBackend(
         },
       });
       // finish_reason is informational; surfaced only via the metadata
-      // echo above. The A2A `task.complete` state is always `completed`
+      // envelope above. The A2A `task.complete` state is always `completed`
       // (incl. `finish_reason: "tool_calls"`) because the tool-call round
       // is a successful turn from the bridge's perspective — the next A2A
       // turn brings back the tool result via `chat_history`.

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -14,6 +14,7 @@ import {
   type OpenAICompatMetadata,
 } from './openai-compat.js';
 import {
+  buildOpenAICompatResponseMetadata,
   buildOpenAICompatUsage,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
@@ -350,32 +351,84 @@ export function parseChatCompletionUsage(
   });
 }
 
+// Assemble the OpenAI ChatCompletion envelope echoed under
+// `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completion` on the terminal
+// A2A message, per the openai-compat/v1 echo-only contract (oai2a2a#80).
+// The codec on the gateway unwraps this verbatim, so we own every required
+// field — id / object / created / model / choices[*]{message, finish_reason,
+// logprobs} / usage.
+//
+// `vicoop-codex call` already prints a near-complete OpenAI ChatCompletion
+// envelope on stdout (see vicoop-codex-cli/src/translate/chat-completions.ts
+// `buildChatCompletion`), so we mostly forward it verbatim. We:
+//   - Synthesize defensive defaults for id / object / created / model when
+//     upstream omits them (the spec REQUIREs them; advertising agents
+//     SHOULD always provide them but a wrapper bug shouldn't break clients).
+//   - Inject `logprobs: null` on each choice when upstream didn't surface
+//     them — the spec marks logprobs as required on each choice (defaults
+//     to null) and the upstream binary does not emit them.
+//   - Put the normalized `OpenAICompatUsage` (with the spec-mandated
+//     `total === prompt + completion` invariant) in `chat_completion.usage`
+//     rather than the raw upstream usage — so consumers reading
+//     `chat_completion.usage` get the same totals as the legacy top-level
+//     `usage` field.
+//
+// Spec: extensions/openai-compat/v1/README.md#response-metadata-payload-agent--gateway
+export function buildChatCompletionEcho(
+  response: ChatCompletionResponse,
+  usage: OpenAICompatUsage | null,
+  taskId: string,
+): Record<string, unknown> {
+  const envelope: Record<string, unknown> = {
+    id: typeof response.id === 'string' && response.id.length > 0
+      ? response.id
+      : `chatcmpl-vicoop-codex-${taskId}`,
+    object: typeof response.object === 'string' && response.object.length > 0
+      ? response.object
+      : 'chat.completion',
+    created: typeof response.created === 'number'
+      ? response.created
+      : Math.floor(Date.now() / 1000),
+    model: typeof response.model === 'string' && response.model.length > 0
+      ? response.model
+      : 'vicoop-codex',
+    choices: Array.isArray(response.choices) && response.choices.length > 0
+      ? response.choices.map((c) => {
+          // Spread upstream verbatim and only add `logprobs: null` when the
+          // upstream binary didn't emit it (which is the common case today).
+          // Preserves any future fields codex may add (`message.refusal`,
+          // etc.) without a spec or codec change.
+          if (c && typeof c === 'object' && !('logprobs' in c)) {
+            return { ...c, logprobs: null };
+          }
+          return c;
+        })
+      : [],
+  };
+  if (usage) envelope.usage = usage;
+  return envelope;
+}
+
 // Build the metadata payload spread onto the final A2A message under
-// `OPENAI_COMPAT_EXTENSION_URI`. Includes the spec's `usage` field plus a
-// `chat_completion` echo of the binary's response envelope (id / model /
-// created / choices / finish_reason) so callers that need the full OpenAI
-// response shape (e.g. an oai2a2a gateway) can recover it from a single
-// metadata block instead of reconstructing from the text artifact.
+// `OPENAI_COMPAT_EXTENSION_URI`. Includes the chat_completion echo per
+// the echo-only contract (oai2a2a#80) plus a transitional top-level
+// `usage` sibling for back-compat with codecs that read it as a fallback
+// when the echo lacks `usage`. New codecs prefer `chat_completion.usage`;
+// the sibling exists so v1-era consumers that only read the top-level
+// field keep working during the transition.
 export function buildResponseMetadata(
   response: ChatCompletionResponse,
   usage: OpenAICompatUsage | null,
+  taskId: string,
 ): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-  if (usage) payload.usage = usage;
-  // Echo the upstream response envelope so callers downstream get the
-  // complete OpenAI Chat Completions shape (id / object / created / model /
-  // choices) without having to round-trip through the text artifact. Empty
-  // `choices` arrays still ride along — a malformed-but-non-fatal upstream
-  // payload is more useful to surface than to silently drop.
-  const echo: Record<string, unknown> = {};
-  if (response.id) echo.id = response.id;
-  if (response.object) echo.object = response.object;
-  if (typeof response.created === 'number') echo.created = response.created;
-  if (response.model) echo.model = response.model;
-  if (Array.isArray(response.choices)) echo.choices = response.choices;
-  if (response.usage) echo.usage = response.usage;
-  if (Object.keys(echo).length > 0) payload.chat_completion = echo;
-  return { [OPENAI_COMPAT_EXTENSION_URI]: payload };
+  const echo = buildChatCompletionEcho(response, usage, taskId);
+  // `buildOpenAICompatResponseMetadata` returns `undefined` when both
+  // `echo` and `usage` are absent — for vicoop-codex we always have at
+  // least the synthesized envelope, so the non-undefined branch is
+  // guaranteed. Coerce here to keep the call-site type narrow.
+  return buildOpenAICompatResponseMetadata(echo, usage) ?? {
+    [OPENAI_COMPAT_EXTENSION_URI]: { chat_completion: echo },
+  };
 }
 
 function defaultSpawn(
@@ -709,24 +762,14 @@ export function createVicoopCodexBackend(
         : [];
       const finishReason = typeof choice?.finish_reason === 'string' ? choice.finish_reason : '';
 
-      // When the model emitted a `tool_calls` envelope we mirror codex.ts's
-      // native dispatch artifact shape: a `data` part carrying the
-      // `tool_calls` array under the OPENAI_COMPAT_EXTENSION_URI. Callers
-      // downstream (oai2a2a) special-case this artifact to recover the
-      // OpenAI Chat Completions wire shape on the way out.
-      if (toolCalls.length > 0) {
-        emit({
-          type: 'task.artifact',
-          taskId: task.taskId,
-          artifact: {
-            artifactId: randomUUID(),
-            name: 'vicoop-codex-message',
-            parts: [{ kind: 'data', data: { tool_calls: toolCalls } }],
-            extensions: [OPENAI_COMPAT_EXTENSION_URI],
-          },
-          lastChunk: true,
-        });
-      } else if (contentText) {
+      // Echo-only contract (oai2a2a#80): tool_calls flow exclusively through
+      // the terminal `chat_completion` echo metadata — NOT as a data-part
+      // artifact. The legacy `data` part shaped `{ "tool_calls": [...] }`
+      // is removed from this extension; consumers ignore it. Text content
+      // still rides as a text artifact so non-OpenAI A2A consumers
+      // (debugging UIs, traceability tooling) see the task's response
+      // natively, per the spec's "Relationship to A2A artifacts" note.
+      if (toolCalls.length === 0 && contentText) {
         emit({
           type: 'task.artifact',
           taskId: task.taskId,
@@ -740,7 +783,7 @@ export function createVicoopCodexBackend(
       }
 
       const usage = parseChatCompletionUsage(response.usage, response.model);
-      const responseMetadata = buildResponseMetadata(response, usage);
+      const responseMetadata = buildResponseMetadata(response, usage, task.taskId);
 
       // The final `task.complete` message mirrors codex.ts's pattern:
       //   - `parts`: the assistant's text content (omitted on the tool-call

--- a/packages/server/src/cards/claude.json
+++ b/packages/server/src/cards/claude.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/server/src/cards/codex.json
+++ b/packages/server/src/cards/codex.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/server/src/cards/vicoop-codex.json
+++ b/packages/server/src/cards/vicoop-codex.json
@@ -8,7 +8,7 @@
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / tool_call_history) to assemble the call body; emits OpenAI Chat Completions tool_calls back as an A2A data part and the full response envelope on the final message metadata.",
+        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / chat_history) to assemble the call body; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]

--- a/packages/server/src/cards/vicoop-codex.json
+++ b/packages/server/src/cards/vicoop-codex.json
@@ -1,6 +1,6 @@
 {
   "name": "vicoop-codex",
-  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion echo on the final message metadata.",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": {

--- a/packages/server/src/cards/vicoop-codex.json
+++ b/packages/server/src/cards/vicoop-codex.json
@@ -8,7 +8,7 @@
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Reads the standard 4-field openai-compat metadata (system / tools / tool_choice / chat_history) to assemble the call body; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
+        "description": "Reads the full OpenAI Chat Completions request envelope (chat_completions_request) from the openai-compat A2A metadata and forwards it to the vicoop-codex CLI; surfaces the model's response (text, tool_calls, usage) as a complete OpenAI ChatCompletion envelope echoed on the final A2A message's metadata under the extension URI (chat_completion key).",
         "required": false
       }
     ]


### PR DESCRIPTION
Companion to planetarium/oai2a2a#80 / planetarium/oai2a2a#81.

## Summary

Aligns vicoop-bridge with the **symmetric envelope** contract for openai-compat/v1 — both request and response sides carry complete OpenAI Chat Completions bodies on `metadata[URI]`. Covers the supported backend set (vicoop-codex / codex / claude) end-to-end per @longfin's review on oai2a2a#81.

### Response side (agent → gateway)

- **codex**, **vicoop-codex**, and **claude** backends emit a spec-complete \`chat_completion\` envelope on the terminal A2A status message metadata: \`id\` / \`object\` / \`created\` / \`model\` / \`choices[].{message, finish_reason, logprobs}\` / \`usage\`.
- Tool calls surface **exclusively** via \`chat_completion.choices[0].message.tool_calls\`. The legacy data-part \`tool_calls\` artifact is no longer emitted from any of the three supported backends.
- Shared helper \`packages/client/src/backends/openai-compat-usage.ts\` (\`buildOpenAICompatResponseMetadata\`) is the single source of truth for the metadata payload so the three backends cannot drift on envelope shape.
- Each backend synthesizes a stable \`id\` keyed off the A2A task id (\`chatcmpl-codex-…\`, \`chatcmpl-vicoop-codex-…\`, \`chatcmpl-claude-…\`).
- Transitional sibling top-level \`usage\` kept for back-compat with v1-era codecs.

### Request side (gateway → agent)

- \`packages/client/src/backends/openai-compat.ts\` rewritten: \`parseOpenAICompatMetadata\` now reads \`metadata[URI].chat_completions_request\` (the new envelope) and decomposes it into the existing 4-field \`OpenAICompatMetadata\` view that backends already consume.
- **Four backends unchanged on the request side**: claude / codex / vicoop-codex / openclaw keep their existing parameter-reading code. The parser is the seam.
- Legacy decomposed shape (\`{system, tools, tool_choice, chat_history}\`) still accepted by the parser as a transitional compat shim during migration.

### Terminology

In the discussion thread / PR titles we use "echo-only" as shorthand. The **code uses "envelope"** to avoid collision with the existing \`echoBackend\` (\`packages/client/src/backends/echo.ts\`).

## Supported backend coverage (per @longfin's review)

| Backend | Request side (envelope read) | Response side (envelope emit) | Status |
|---|---|---|---|
| vicoop-codex (CLI) | ✅ via parser seam | ✅ \`6abe148\` | Supported |
| codex (app-server) | ✅ via parser seam | ✅ \`6abe148\` | Supported |
| claude | ✅ via parser seam | ✅ \`b9b9f1d\` | Supported |
| openclaw | ✅ via parser seam | ⚠️ still emits data-part tool_calls | Not supported (per review, openclaw stays unsupported) |

## Breaking changes

- Consumers reading tool_calls from data-part artifacts will see nothing for the three supported backends. They must consume \`metadata[URI].chat_completion.choices[0].message.tool_calls\`.
- Once oai2a2a#81 lands, the legacy decomposed-shape parser branch can eventually be removed.

## Out of scope

- \`openclaw.ts\` response envelope migration — explicitly out of scope per @longfin (openclaw can stay unsupported).

## Commits

1. \`feat(client)!: emit complete ChatCompletion echo for openai-compat\` — codex + vicoop-codex response envelope.
2. \`refactor(client): rename echo terminology to envelope\` — identifiers renamed.
3. \`feat(client)!: read chat_completions_request envelope from openai-compat metadata\` — request side parser update.
4. \`feat(client): extend ChatCompletion envelope emit to claude backend\` — claude response envelope, completing the supported-backend set (review condition 2).

## Test plan

- [x] \`pnpm -r test\` — client 604/604 (was 599 — added envelope-path tests across codex/vicoop-codex/claude), server 184/184
- [x] \`pnpm -r typecheck\` — clean
- [ ] CI green
- [ ] Manual roundtrip against oai2a2a#81 branch with tool-call requests through each supported backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)