### PR TITLE
feat(client)!: emit structured response fields for openai-compat

### DIFF
--- a/.changeset/issue-80-structured-emit.md
+++ b/.changeset/issue-80-structured-emit.md
@@ -1,0 +1,15 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Align with the **structured-field contract** for the `openai-compat/v1` A2A extension (companion to planetarium/oai2a2a#80 / planetarium/oai2a2a#82).
+
+**Wire-breaking** for advertising agents (client major bump expected once the project crosses 1.0; using minor under the 0.x convention).
+
+**Alternative design to the envelope variant** (planetarium/vicoop-bridge#297). Only one of the two PR pairs lands.
+
+codex backend now emits `metadata[URI].{tool_calls, finish_reason}` on the terminal A2A status message — first-class structured fields rather than an envelope mirror. Streaming tool_calls flow only through the terminal status event; the per-artifact delta emit is removed. Content stays in A2A `artifact.parts[].text` (native A2A channel).
+
+The codec on the gateway side (companion PR planetarium/oai2a2a#82) reads these structured fields and translates them into the OpenAI ChatCompletion response shape.
+
+Out of scope: `claude.ts`, `openclaw.ts`, and `vicoop-codex.ts` backend migrations to the structured emit — same migration pattern, deferred to a follow-up should this design land. Card description updates for the codex backend included.

--- a/packages/client/cards/codex.json
+++ b/packages/client/cards/codex.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata. Tool calls invoked by the model are surfaced on the final A2A message's metadata[URI].tool_calls (with finish_reason: \"tool_calls\") per the structured-only response contract; usage and finish_reason ride the same metadata payload.",
         "required": false
       }
     ]

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1410,32 +1410,19 @@ test('openai-compat dynamicTools: item/tool/call → tool_calls artifact + compl
     NEVER,
   );
 
-  // The artifact must carry the OpenAI `tool_calls` envelope as a `data`
-  // part — same wire shape PR #208 already emitted on the legacy envelope
-  // path, so downstream gateways see no difference.
-  const artifact = frames.find((f) => f.type === 'task.artifact');
-  assert.ok(artifact, 'tool_calls artifact emitted');
-  if (artifact?.type === 'task.artifact') {
-    const p = artifact.artifact.parts[0];
-    assert.equal(p.kind, 'data');
-    assert.ok(
-      artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI),
-    );
-    if (p.kind === 'data') {
-      const data = p.data as {
-        tool_calls?: Array<{
-          id?: string;
-          function?: { name?: string; arguments?: unknown };
-        }>;
-      };
-      assert.equal(data.tool_calls?.length, 1);
-      assert.equal(data.tool_calls?.[0]?.id, 'call_xyz');
-      assert.equal(data.tool_calls?.[0]?.function?.name, 'fetch');
-      assert.deepEqual(data.tool_calls?.[0]?.function?.arguments, {
-        url: 'https://example.com',
-      });
-    }
-  }
+  // Per the openai-compat/v1 structured-only contract (#80), tool_calls
+  // ride on the final A2A message's `metadata[URI].tool_calls` field —
+  // NOT as a `data` part artifact. The data-part wire is gone.
+  const dataArtifact = frames.find(
+    (f) =>
+      f.type === 'task.artifact' &&
+      f.artifact.parts.some((p) => p.kind === 'data'),
+  );
+  assert.equal(
+    dataArtifact,
+    undefined,
+    'no data-part tool_calls artifact under the structured-only contract (#80)',
+  );
 
   // Despite the underlying turn ending in `interrupted`, the A2A task must
   // surface as `completed` because the model invoked a tool (caller asked
@@ -1443,6 +1430,38 @@ test('openai-compat dynamicTools: item/tool/call → tool_calls artifact + compl
   const complete = frames.find((f) => f.type === 'task.complete');
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
+
+  // The structured tool_calls payload lives on the final message's
+  // metadata under the openai-compat extension URI, with `arguments` as
+  // a JSON-encoded string (OpenAI's wire shape).
+  const message = complete.status.message;
+  assert.ok(message, 'final task.complete carries a message frame');
+  assert.ok(
+    message.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI),
+    'message advertises the openai-compat extension',
+  );
+  const ext = (message.metadata as Record<string, unknown> | undefined)?.[
+    OPENAI_COMPAT_EXTENSION_URI
+  ] as Record<string, unknown> | undefined;
+  assert.ok(ext, 'message.metadata carries the openai-compat extension payload');
+  assert.equal(ext.finish_reason, 'tool_calls');
+  const calls = ext.tool_calls as Array<{
+    id: string;
+    type: string;
+    function: { name: string; arguments: string };
+  }>;
+  assert.ok(Array.isArray(calls) && calls.length === 1);
+  assert.equal(calls[0].id, 'call_xyz');
+  assert.equal(calls[0].type, 'function');
+  assert.equal(calls[0].function.name, 'fetch');
+  // arguments MUST be a JSON-encoded string per OpenAI / spec.
+  assert.equal(typeof calls[0].function.arguments, 'string');
+  assert.deepEqual(JSON.parse(calls[0].function.arguments), {
+    url: 'https://example.com',
+  });
+  // No text parts in `status.message.parts` when the only output is a
+  // tool call (matches OpenAI `content: null` semantics).
+  assert.equal(message.parts.length, 0);
 
   // Bridge must have sent `turn/interrupt` for our turn — that, plus
   // codex's terminal `turn/completed` notification, is what unwinds the
@@ -1694,7 +1713,8 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
 
   // Turn 2: same contextId still does thread/start (no reuse under
   // openai-compat). The handler must register on the new thread id so the
-  // model's tool_call surfaces as a `tool_calls` artifact.
+  // model's tool_call surfaces on the final message's
+  // `metadata[URI].tool_calls` (structured-only contract, #80).
   const { emit, frames } = collect();
   await backend.handle(
     assign('second', 'ctx-no-resume', {
@@ -1709,16 +1729,19 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
     NEVER,
   );
 
-  const artifact = frames.find((f) => f.type === 'task.artifact');
-  assert.ok(artifact, 'tool_calls artifact emitted on the second turn');
-  if (artifact?.type === 'task.artifact') {
-    assert.ok(
-      artifact.artifact.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI),
-    );
-  }
   const complete = frames.find((f) => f.type === 'task.complete');
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.state, 'completed');
+  const ext = (
+    complete.status.message?.metadata as
+      | Record<string, unknown>
+      | undefined
+  )?.[OPENAI_COMPAT_EXTENSION_URI] as Record<string, unknown> | undefined;
+  assert.ok(
+    ext && Array.isArray(ext.tool_calls) && ext.tool_calls.length === 1,
+    'tool_calls surfaced on the second turn via the structured metadata field',
+  );
+  assert.equal(ext.finish_reason, 'tool_calls');
 
   // Both turns went through thread/start; thread/resume is never used for
   // openai-compat tasks (#233 session-reuse guard).

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -16,7 +16,6 @@ import {
 } from './openai-compat.js';
 import {
   buildOpenAICompatUsage,
-  makeOpenAICompatUsageMetadata,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
 import { INPUT_FILE_MAX_BYTES, INPUT_IMAGE_MIME } from './fetch-uri-file.js';
@@ -1289,14 +1288,19 @@ export function createCodexBackend(
           let finalText: string | null = null;
           let finalUsage: OpenAICompatUsage | null = null;
           let emittedAnyArtifact = false;
-          // Set when an `item/tool/call` lands for this turn — the model
-          // invoked a caller-side tool, we emitted a `tool_calls` artifact,
-          // and asked codex to interrupt. The interrupted-turn outcome
-          // below is mapped to `completed` (instead of `canceled`) on this
-          // flag so the caller's A2A task surfaces as success with a
-          // `tool_calls` artifact, matching OpenAI Chat Completions'
-          // `finish_reason: "tool_calls"` semantics.
-          let capturedToolCall = false;
+          // Buffer of `item/tool/call` payloads observed during this turn —
+          // the model invoked one or more caller-side tools and we asked
+          // codex to interrupt. Per the openai-compat/v1 structured-only
+          // contract (#80), these are surfaced on the final A2A message's
+          // `metadata[URI].tool_calls` (NOT as data-part artifacts). The
+          // interrupted-turn outcome below is mapped to `completed` when
+          // the buffer is non-empty so the caller's A2A task surfaces as
+          // success with `finish_reason: "tool_calls"` semantics.
+          const capturedToolCalls: Array<{
+            id: string;
+            type: 'function';
+            function: { name: string; arguments: string };
+          }> = [];
           const emitTraceArtifacts = traceabilityRequested(task);
 
           // Register the per-thread `item/tool/call` handler for the
@@ -1309,41 +1313,28 @@ export function createCodexBackend(
           if (openaiCompat) {
             registeredThreadId = threadId;
             toolCallHandlers.set(threadId, async (p) => {
-              capturedToolCall = true;
-              // The OpenAI Chat Completions wire shape callers expect.
-              // codex hands us `arguments` already parsed as a JSON value;
-              // the envelope path historically forwarded the parsed object
-              // verbatim, so the artifact stays byte-compatible with PR
-              // #208's output and downstream gateways (oai2a2a) don't have
-              // to special-case the source.
-              const envelope = {
-                tool_calls: [
-                  {
-                    id: p.callId,
-                    function: {
-                      name: p.tool,
-                      arguments: p.arguments,
-                    },
-                  },
-                ],
-              };
-              emit({
-                type: 'task.artifact',
-                taskId: task.taskId,
-                artifact: {
-                  artifactId: randomUUID(),
-                  name: 'codex-message',
-                  parts: [{ kind: 'data', data: envelope }],
-                  extensions: [OPENAI_COMPAT_EXTENSION_URI],
-                },
-                lastChunk: true,
+              // Per the openai-compat/v1 structured-only contract (#80),
+              // tool calls ride on `metadata[URI].tool_calls` of the final
+              // A2A message, NOT as a data-part artifact. Buffer them here
+              // and emit on `task.complete` below.
+              //
+              // OpenAI Chat Completions requires `function.arguments` as a
+              // JSON-encoded string; codex hands us the value already
+              // parsed, so we stringify before buffering.
+              const argString =
+                typeof p.arguments === 'string'
+                  ? p.arguments
+                  : safeJsonStringify(p.arguments);
+              capturedToolCalls.push({
+                id: p.callId,
+                type: 'function',
+                function: { name: p.tool, arguments: argString },
               });
-              emittedAnyArtifact = true;
               // Best-effort `turn/interrupt` so codex unwinds the turn —
-              // the model's function_call is already surfaced upstream and
-              // we don't want it generating further text or chaining into
-              // another tool call before the caller has had a chance to
-              // reply via `chat_history`.
+              // the model's function_call is already buffered and we don't
+              // want it generating further text or chaining into another
+              // tool call before the caller has had a chance to reply via
+              // `chat_history`.
               if (activeTurnId) {
                 void client
                   .request('turn/interrupt', { threadId, turnId: activeTurnId })
@@ -1603,13 +1594,14 @@ export function createCodexBackend(
             // as `canceled` regardless of whether we also captured a tool
             // call, because the caller asked for cancelation.
             const callerAborted = outcome.status === 'aborted' || signal.aborted;
-            if (capturedToolCall && !callerAborted) {
-              // We interrupted ourselves because the model invoked a caller
-              // tool. The `tool_calls` artifact is already on the wire;
-              // fall through to the completion path so the task surfaces as
-              // success with `finish_reason: "tool_calls"` semantics on the
-              // caller side (the next A2A turn ships the result via
-              // `chat_history`).
+            if (capturedToolCalls.length > 0 && !callerAborted) {
+              // We interrupted ourselves because the model invoked one or
+              // more caller tools. The tool_calls are buffered for the
+              // `task.complete` emit below (where they ride on the final
+              // message's `metadata[URI].tool_calls` per #80). Fall through
+              // to the completion path so the task surfaces as success with
+              // `finish_reason: "tool_calls"` semantics on the caller side
+              // (the next A2A turn ships the result via `chat_history`).
             } else {
               rollbackFreshThread();
               rollbackResumeRefresh();
@@ -1649,18 +1641,20 @@ export function createCodexBackend(
           }
 
           const completeText = outcome.finalText ?? '';
-          // When the model invoked a caller tool, the `tool_calls` artifact
-          // is the complete task output: any agent text codex streamed
-          // before the function_call is best treated as reasoning preamble
-          // and not re-stamped on `status.message.parts`. Re-stamping
-          // violates A2A's "Messages SHOULD NOT be used to deliver task
-          // outputs" and, downstream, caused gateways (oai2a2a) to
-          // double-emit `tool_calls` on the envelope path (#200) — keep
-          // the same invariant on the native path.
-          const parts: Part[] = !capturedToolCall && completeText
+          const hasToolCalls = capturedToolCalls.length > 0;
+          // When the model invoked a caller tool, the structured
+          // `metadata[URI].tool_calls` field on the final A2A message is
+          // the complete task output: any agent text codex streamed before
+          // the function_call is treated as reasoning preamble and is NOT
+          // re-stamped on `status.message.parts`. Re-stamping would
+          // violate A2A's "Messages SHOULD NOT be used to deliver task
+          // outputs" and, before #80, was the source of #200's double-emit
+          // bug — keep the same invariant under the structured-only
+          // contract.
+          const parts: Part[] = !hasToolCalls && completeText
             ? [{ kind: 'text', text: completeText }]
             : [];
-          if (!emittedAnyArtifact && completeText) {
+          if (!emittedAnyArtifact && completeText && !hasToolCalls) {
             emit({
               type: 'task.artifact',
               taskId: task.taskId,
@@ -1673,14 +1667,33 @@ export function createCodexBackend(
             });
           }
 
-          // Attach the openai-compat/v1 `usage` payload to the final A2A
-          // message of this turn when codex reported it on turn/completed.
-          // When usage is present but there are no parts we still emit the
-          // message frame (with empty parts) to carry the metadata.
-          const hasMessage = parts.length > 0 || finalUsage !== null;
-          const messageMetadata = finalUsage
-            ? makeOpenAICompatUsageMetadata(finalUsage)
-            : undefined;
+          // Assemble the openai-compat/v1 metadata payload for the final
+          // A2A message of this turn. Per #80 the payload may carry:
+          //   - `usage`         when codex reported it on turn/completed
+          //   - `tool_calls`    when the model invoked one or more callers
+          //   - `finish_reason` always set when openai-compat is active
+          //                     so callers don't have to derive it
+          //   - `model`         not surfaced here — codex's app-server
+          //                     doesn't expose the resolved model id on the
+          //                     turn/completed notification today
+          // When metadata is non-empty we always emit the message frame
+          // (even with empty `parts`) so the field rides downstream.
+          const extPayload: Record<string, unknown> = {};
+          if (finalUsage) extPayload.usage = finalUsage;
+          if (hasToolCalls) {
+            extPayload.tool_calls = capturedToolCalls;
+            extPayload.finish_reason = 'tool_calls';
+          } else if (openaiCompat) {
+            // Plain assistant text reply on an openai-compat turn — surface
+            // an explicit `finish_reason: "stop"` so the caller doesn't have
+            // to derive it from the absence of `tool_calls`.
+            extPayload.finish_reason = 'stop';
+          }
+          const messageMetadata =
+            Object.keys(extPayload).length > 0
+              ? { [OPENAI_COMPAT_EXTENSION_URI]: extPayload }
+              : undefined;
+          const hasMessage = parts.length > 0 || messageMetadata !== undefined;
           emit({
             type: 'task.complete',
             taskId: task.taskId,
@@ -1723,6 +1736,21 @@ export function createCodexBackend(
       }
     },
   };
+}
+
+// OpenAI Chat Completions requires `tool_calls[].function.arguments` to be a
+// JSON-encoded **string** — codex hands us an already-parsed value. This
+// helper stringifies safely (objects with cycles or non-serialisable values
+// degrade to "{}") so we always emit a string per the openai-compat/v1
+// structured-only contract (#80).
+function safeJsonStringify(value: unknown): string {
+  if (value === undefined || value === null) return '{}';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '{}';
+  }
 }
 
 function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {

--- a/packages/server/src/cards/codex.json
+++ b/packages/server/src/cards/codex.json
@@ -13,7 +13,7 @@
       },
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",
-        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata; emulates tool calls by instructing the model to emit a {\"tool_calls\":[...]} JSON envelope, returned as an A2A data part.",
+        "description": "Honors OpenAI-style system/tools/tool_choice via message metadata. Tool calls invoked by the model are surfaced on the final A2A message's metadata[URI].tool_calls (with finish_reason: \"tool_calls\") per the structured-only response contract; usage and finish_reason ride the same metadata payload.",
         "required": false
       }
     ]


### PR DESCRIPTION
Companion to planetarium/oai2a2a#82. **Alternative design** to #297 — only one will land.

## Summary

Aligns the **codex** backend with the structured-field response contract proposed in [oai2a2a#80](https://github.com/planetarium/oai2a2a/issues/80) and implemented in [oai2a2a#82](https://github.com/planetarium/oai2a2a/pull/82).

- codex backend now emits \`metadata[URI].{tool_calls, finish_reason}\` on the terminal A2A status message — first-class structured fields rather than an envelope mirror.
- Streaming tool_calls flow only through the terminal status event; the per-artifact delta emit is removed.
- Content stays in artifact text parts (native A2A channel).
- Card description updated.

## Why this design vs the echo-only alternative (#297)

| Axis | structured (this PR) | echo (#297) |
|---|---|---|
| Backend assembly | translates output -> structured fields | passes full ChatCompletion envelope through |
| A2A native interop | artifact.parts is the response of record | artifact.parts is redundant/empty |
| Spec coherence | extends existing \`usage\` field-table pattern | introduces a new \`chat_completion\` echo key |
| Auto-forward of new OpenAI fields | requires codec changes per field | free |

See [oai2a2a#80 thread](https://github.com/planetarium/oai2a2a/issues/80) for the full comparison.

## Breaking changes

- Consumers reading tool_calls from data-part artifacts will see nothing. They must consume \`metadata[URI].tool_calls\`.

## Out of scope

- \`claude.ts\`, \`openclaw.ts\`, and \`vicoop-codex.ts\` backends — same migration pattern, deferred to follow-up.
- Changeset entry — needs to be added before un-drafting.

## Test plan

- [x] \`pnpm -r test\` — codec 84/84, gateway 47/47, vicoop-bridge client 598/598 pass.
- [x] \`pnpm -r typecheck\` — clean.
- [ ] CI green.
- [ ] Manual roundtrip against oai2a2a#82 branch with a tool-call request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)