### PR TITLE
fix(client): inject codex backend's A2A self-identity (recurrence of #128)

### DIFF
--- a/.changeset/codex-self-identity.md
+++ b/.changeset/codex-self-identity.md
@@ -1,0 +1,16 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+codex backend: inject self-identity into `developerInstructions` on
+plain `thread/start` so the spawned codex agent recognises its own A2A
+mention (`@<agentId>@<host>` / `acct:<agentId>@<host>`) as a
+self-reference and answers directly instead of trying to a2a-call its
+own address via the a2a-wallet skill. Mirrors what PR #129 added for the
+claude backend; the codex backend (introduced after #129 merged) was
+missing the equivalent injection, so the failure mode from #128 had
+regressed for codex-backed agents. Skipped on openai-compat tasks
+because codex is acting as a model endpoint there, not an A2A agent —
+the gateway owns conversation context so the directive doesn't apply.
+`buildSelfIdentitySystemPrompt` is now shared from `identity.ts` so both
+backends use the exact same wording.

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -6,7 +6,7 @@ import {
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
-import { formatAcct, formatMention, type AgentIdentity } from '../identity.js';
+import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.js';
 import {
   buildOpenAICompatUsage,
   makeOpenAICompatUsageMetadata,
@@ -144,19 +144,6 @@ export interface ClaudeBackendOptions {
   // `chat_history` to stderr on every task. Operator diagnostic exposed
   // via `--openai-compat-trace`. Leave off in production.
   openaiCompatTrace?: boolean;
-}
-
-// Kept short and behaviour-focused. The risk we're guarding against is
-// concrete: a Claude-as-caller skill (a2a-wallet) interpreting the agent's
-// own mention as an external destination. Anything beyond self-reference
-// detection belongs in the operator-controlled prompt, not here.
-export function buildSelfIdentitySystemPrompt(id: AgentIdentity): string {
-  const mention = formatMention(id);
-  const acct = formatAcct(id);
-  return [
-    `You are an A2A agent reachable as the mention \`${mention}\` (${acct}).`,
-    `If a user message references this mention or acct, treat it as a self-reference and respond directly — do not invoke any outbound A2A tool or skill (e.g. a2a-wallet) to contact this address as if it were a separate agent.`,
-  ].join(' ');
 }
 
 interface SessionEntry {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1578,6 +1578,101 @@ test('composeNativeDevInstructions includes system text, omits JSON envelope con
   assert.equal(withTools.includes('{"tool_calls"'), false);
 });
 
+// Mirrors PR #129 for the codex backend: when `identity` is configured, every
+// `thread/start` must carry a `developerInstructions` field naming the agent's
+// own mention + acct, so codex doesn't try to a2a-call its own address via the
+// a2a-wallet skill on receiving a message that contains its own mention.
+test('developerInstructions carries self-identity directive when `identity` is configured', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    identity: {
+      agentId: '6eec0b6e-codex',
+      host: 'vicoop-bridge-server.fly.dev',
+      httpOrigin: 'https://vicoop-bridge-server.fly.dev',
+    },
+  });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { developerInstructions?: string } }).params;
+  assert.ok(
+    typeof params?.developerInstructions === 'string',
+    'developerInstructions field is present on thread/start',
+  );
+  assert.match(
+    params.developerInstructions ?? '',
+    /@6eec0b6e-codex@vicoop-bridge-server\.fly\.dev/,
+  );
+  assert.match(
+    params.developerInstructions ?? '',
+    /acct:6eec0b6e-codex@vicoop-bridge-server\.fly\.dev/,
+  );
+});
+
+// In openai-compat mode the bridge is acting as a model endpoint, not an
+// A2A agent — the gateway owns conversation context and never delivers
+// the agent's own mention to codex as a user-typed reference. Identity
+// directive must therefore be SUPPRESSED on these tasks so the caller's
+// system text isn't competing with bridge-injected wording the model
+// doesn't need.
+test('developerInstructions omits self-identity directive on openai-compat tasks (model-endpoint mode)', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    identity: {
+      agentId: 'me',
+      host: 'h.example',
+      httpOrigin: 'https://h.example',
+    },
+  });
+  const { emit } = collect();
+  await backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 'task-id-compat',
+      contextId: 'ctx-id-compat',
+      message: {
+        role: 'user',
+        messageId: 'm1',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: { system: 'be terse' },
+        },
+      },
+    },
+    emit,
+    NEVER,
+  );
+
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const di = (tsFrame as { params?: { developerInstructions?: string } }).params
+    ?.developerInstructions;
+  assert.equal(di, 'be terse');
+  assert.equal((di ?? '').includes('@me@h.example'), false);
+  assert.equal((di ?? '').includes('acct:me@h.example'), false);
+});
+
+// Default (no `identity` set): developerInstructions stays whatever it was
+// before — i.e. omitted entirely on a plain task, or the caller's system text
+// alone on an openai-compat task. Locks in the "no-op when not configured"
+// contract.
+test('developerInstructions omitted entirely on plain task when no identity is configured', async () => {
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as { params?: { developerInstructions?: string } }).params;
+  assert.equal(
+    params?.developerInstructions,
+    undefined,
+    'no identity + no openai-compat → no developerInstructions key',
+  );
+});
+
 // openai-compat tasks always do `thread/start` (never thread/resume — see
 // the session-reuse guard for #233), but the second A2A turn still needs a
 // working caller-tools handler. This guards against a regression where the

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -8,6 +8,7 @@ import {
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.js';
 import { createLogger, type Logger } from '../logger.js';
 import {
   callerToolDispatchActive,
@@ -91,6 +92,16 @@ export interface CodexBackendOptions {
   // `chat_history` to stderr on every task. Operator diagnostic exposed
   // via `--openai-compat-trace`. Leave off in production.
   openaiCompatTrace?: boolean;
+  // Agent's own A2A identity. When present, a self-identity directive is
+  // sent as `developerInstructions` on every plain-task `thread/start` so
+  // codex recognises its own mention (`@<agentId>@<host>`) / acct in user
+  // messages and answers directly instead of attempting an outbound A2A
+  // call to its own address via a2a-wallet. Mirrors what the claude backend
+  // does via `--append-system-prompt`; see PR #129 / issue #128 for the
+  // failure mode. Skipped entirely on openai-compat tasks (codex is a model
+  // endpoint, not an A2A agent, there). Carries through `thread/resume`
+  // because codex persists `developerInstructions` server-side per thread.
+  identity?: AgentIdentity;
 }
 
 interface SessionEntry {
@@ -616,6 +627,12 @@ export function createCodexBackend(
   const logger = opts.logger ?? createLogger();
   const initializeTimeoutMs = opts.initializeTimeoutMs ?? 10_000;
   const turnTimeoutMs = opts.turnTimeoutMs ?? 0;
+  // Precomputed once at construction (identity is per-daemon, not per-task).
+  // Prepended to `developerInstructions` on every `thread/start` so the model
+  // recognises its own mention / acct in user messages. See PR #129.
+  const identityDevInstructions: string = opts.identity
+    ? buildSelfIdentitySystemPrompt(opts.identity)
+    : '';
 
   // contextId → (threadId, lastUsedAt). writeId-protected rollback so a
   // concurrent task on the same contextId doesn't get its session entry
@@ -961,9 +978,17 @@ export function createCodexBackend(
           openaiCompat && callerToolDispatchActive(openaiCompat) && openaiCompat.tools
             ? openaiToolsToDynamicToolSpecs(openaiCompat.tools)
             : null;
+        // In openai-compat mode codex is acting as a *model endpoint*, not
+        // as an A2A agent — the gateway in front of it owns conversation
+        // context and never delivers the bridge's own mention to the model
+        // as a user-typed reference, so the self-identity directive doesn't
+        // apply and would just be wording the caller's system text has to
+        // compete with. Plain-task mode (no openai-compat metadata) keeps
+        // the directive because that's the actual a2a-agent surface the
+        // mention can land on.
         const systemPrompt = openaiCompat
           ? composeNativeDevInstructions(openaiCompat)
-          : '';
+          : identityDevInstructions;
 
         const mappedRaw = await mapPartsToCodexInput(task.message.parts, {
           mkdtemp,

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -376,6 +376,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         sandboxMode,
         approvalDecision: backends.codex?.approval_decision as ApprovalDecision | undefined,
         openaiCompatTrace: args.openaiCompatTrace,
+        identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         ...(spawn ? { spawn: spawn as AppServerSpawnFn } : {}),
       });
       return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };

--- a/packages/client/src/identity.ts
+++ b/packages/client/src/identity.ts
@@ -34,6 +34,24 @@ export function formatAcct(id: AgentIdentity): string {
   return `acct:${id.agentId}@${id.host}`;
 }
 
+// Self-identity directive injected into the spawned backend's system / developer
+// prompt so the model recognises its OWN A2A mention / acct in a user message
+// and answers directly instead of treating it as an external destination. The
+// concrete failure mode this prevents: a Claude-as-caller or codex-as-caller
+// skill (a2a-wallet) interpreting the agent's own mention as another agent and
+// emitting an outbound A2A call that the bridge then rejects (the agent's own
+// wallet isn't in its own `allowed_callers`). See PR #129 / issue #128. Lives
+// in identity.ts (not a backend file) so the claude and codex backends both
+// inject the exact same wording without one cross-importing the other.
+export function buildSelfIdentitySystemPrompt(id: AgentIdentity): string {
+  const mention = formatMention(id);
+  const acct = formatAcct(id);
+  return [
+    `You are an A2A agent reachable as the mention \`${mention}\` (${acct}).`,
+    `If a user message references this mention or acct, treat it as a self-reference and respond directly — do not invoke any outbound A2A tool or skill (e.g. a2a-wallet) to contact this address as if it were a separate agent.`,
+  ].join(' ');
+}
+
 // WebFinger lookup URL, useful for sanity-checking that the bridge actually
 // resolves this agent's acct from outside.
 export function webfingerUrl(id: AgentIdentity): string {


### PR DESCRIPTION
## Summary

PR #129 wired self-identity into the **claude** backend's spawn so the model recognises its own `@<agentId>@<host>` mention and doesn't try to a2a-call its own address via a2a-wallet. The **codex** backend was introduced after #129 merged (#143, #225) and was missing the equivalent injection — so the failure mode catalogued in #128 had regressed for codex-backed agents.

- Move `buildSelfIdentitySystemPrompt` from `claude.ts` to `identity.ts` so both backends share one source of wording.
- Add `identity?: AgentIdentity` to `CodexBackendOptions`. On plain `thread/start`, send the directive via `developerInstructions` — codex persists this server-side per thread, so `thread/resume` paths are covered without extra handling.
- **Skip the directive entirely on openai-compat tasks**: codex is acting as a model endpoint there, not an A2A agent. The gateway in front of it owns conversation context and never delivers the bridge's own mention to the model as a user-typed reference, so the directive would just be wording the caller's system text has to compete with.
- Wire `identity: deriveIdentity(args.agentId, args.server)` in the codex branch of `pickBackend` — same pattern as the claude branch.

Claude side intentionally untouched: PR #129's injection there is intact and behaviour matches.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r typecheck` clean
- [x] `pnpm --filter @vicoop-bridge/client test` — 601/601 pass, including 3 new codex cases:
  - `developerInstructions carries self-identity directive when \`identity\` is configured`
  - `developerInstructions omits self-identity directive on openai-compat tasks (model-endpoint mode)`
  - `developerInstructions omitted entirely on plain task when no identity is configured`
- [ ] Manual: connect a codex-backed agent, send `@<self-mention> 안녕` from a different Claude Code session, confirm codex now answers directly instead of attempting `a2a-wallet a2a stream` against its own address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)