### PR TITLE
feat(client): align list/remove aliases across agent and container groups

### DIFF
--- a/.changeset/list-rm-aliases.md
+++ b/.changeset/list-rm-aliases.md
@@ -1,5 +1,5 @@
 ---
-'@vicoop-bridge/client': minor
+'@vicoop-bridge/client': patch
 ---
 
 Accept docker-style short aliases on the agent and container CLI groups: `agent list` / `agent callers list` / `container list` also accept `ls`, and `agent remove` / `agent callers remove` / `container remove` also accept `rm`. `agent remove` is now the canonical form of the previous `agent delete` (which keeps working as a third alias). Help output stays a single row per subcommand — the canonical name shows in the listing with the alias noted in the brief.

--- a/.changeset/list-rm-aliases.md
+++ b/.changeset/list-rm-aliases.md
@@ -1,0 +1,5 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Accept docker-style short aliases on the agent and container CLI groups: `agent list` / `agent callers list` / `container list` also accept `ls`, and `agent remove` / `agent callers remove` / `container remove` also accept `rm`. `agent remove` is now the canonical form of the previous `agent delete` (which keeps working as a third alias). Help output stays a single row per subcommand — the canonical name shows in the listing with the alias noted in the brief.

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -590,14 +590,14 @@ test('legacy list-clients warns and points at agent list', async (t) => {
   assert.match(stderr.read(), /list-clients.*deprecated.*agent list/s);
 });
 
-test('legacy revoke-client warns and points at agent delete', async (t) => {
+test('legacy revoke-client warns and points at agent remove', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   captureStdout(t);
   const stderr = captureStderr(t);
   installFetch(t, { body: { client_id: 'c', client_name: 'n', deleted: true, closed_connections: 0 } });
 
   assert.equal(await runRevokeClient(revokeClientArgs('n')), 0);
-  assert.match(stderr.read(), /revoke-client.*deprecated.*agent delete/s);
+  assert.match(stderr.read(), /revoke-client.*deprecated.*agent remove/s);
 });
 
 test('legacy {add,remove,list}-caller all emit the agent-callers deprecation hint', async (t) => {

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -36,48 +36,80 @@ const sharedFlags = {
 // `list-clients` / `revoke-client` / `{add,remove,list}-caller` commands below
 // remain as deprecated aliases; each handler calls `warnDeprecated` before
 // dispatching to the new shape.
+//
+// `list` / `remove` accept the docker-style short aliases (`ls` / `rm`) for
+// parity with the `container` group; `agent delete` is kept as a third alias
+// on the remove command because it was the canonical form briefly after the
+// `revoke-client` rename. Each alias is registered with `hidden: 'help'` so
+// only the canonical name shows in usage/docs — the aliases still parse and
+// still surface in "did you mean?" suggestions.
 
-const agentListSubCmd = command(
-  'list',
-  object({
-    action: constant('agent-list' as const),
-    ...sharedFlags,
-    connected: withDefault(flag('--connected', {
-      description: message`Only show agents whose daemon is currently connected.`,
-    }), false),
-  }),
-  {
-    brief: message`List agent registrations under this owner.`,
-    description: message`Calls GET /admin-api/clients (backed by the unified \`agents\` table) and prints one block per agent, including disconnected ones. Use --connected to filter to live daemons.`,
-  },
+function agentListCommand(name: 'list' | 'ls', alias: boolean) {
+  return command(
+    name,
+    object({
+      action: constant('agent-list' as const),
+      ...sharedFlags,
+      connected: withDefault(flag('--connected', {
+        description: message`Only show agents whose daemon is currently connected.`,
+      }), false),
+    }),
+    {
+      brief: message`List agent registrations under this owner. (alias: \`ls\`)`,
+      description: message`Calls GET /admin-api/clients (backed by the unified \`agents\` table) and prints one block per agent, including disconnected ones. Use --connected to filter to live daemons.`,
+      ...(alias ? { hidden: 'help' as const } : {}),
+    },
+  );
+}
+
+const agentListSubCmd = longestMatch(
+  agentListCommand('list', false),
+  agentListCommand('ls', true),
 );
 
-const agentDeleteSubCmd = command(
-  'delete',
-  object({
-    action: constant('agent-delete' as const),
-    ...sharedFlags,
-    target: argument(string({ metavar: 'AGENT_ID' })),
-    yes: withDefault(flag('--yes', {
-      description: message`Skip the confirmation prompt.`,
-    }), false),
-  }),
-  {
-    brief: message`Delete an agent by id (or registration name).`,
-    description: message`Calls DELETE /admin-api/clients/<AGENT_ID>. Hard-deletes the agents and clients rows, and if a daemon is live closes its WebSocket with code 4014 ("client deleted") so it exits without reconnecting. There is no undo. The legacy client_id and the registration name are still accepted for backward compatibility. Prompts for Y/N confirmation unless --yes / -y is set.`,
-  },
+function agentRemoveCommand(name: 'remove' | 'rm' | 'delete', alias: boolean) {
+  return command(
+    name,
+    object({
+      action: constant('agent-delete' as const),
+      ...sharedFlags,
+      target: argument(string({ metavar: 'AGENT_ID' })),
+      yes: withDefault(flag('--yes', {
+        description: message`Skip the confirmation prompt.`,
+      }), false),
+    }),
+    {
+      brief: message`Remove an agent by id (or registration name). (aliases: \`rm\`, \`delete\`)`,
+      description: message`Calls DELETE /admin-api/clients/<AGENT_ID>. Hard-deletes the agents and clients rows, and if a daemon is live closes its WebSocket with code 4014 ("client deleted") so it exits without reconnecting. There is no undo. The legacy client_id and the registration name are still accepted for backward compatibility. Prompts for Y/N confirmation unless --yes / -y is set.`,
+      ...(alias ? { hidden: 'help' as const } : {}),
+    },
+  );
+}
+
+const agentRemoveSubCmd = longestMatch(
+  agentRemoveCommand('remove', false),
+  agentRemoveCommand('rm', true),
+  agentRemoveCommand('delete', true),
 );
 
-const agentCallersListSubCmd = command(
-  'list',
-  object({
-    action: constant('agent-callers-list' as const),
-    ...sharedFlags,
-    agentId: argument(string({ metavar: 'AGENT_ID' })),
-  }),
-  {
-    brief: message`Show the agent's allowed-callers list.`,
-  },
+function agentCallersListCommand(name: 'list' | 'ls', alias: boolean) {
+  return command(
+    name,
+    object({
+      action: constant('agent-callers-list' as const),
+      ...sharedFlags,
+      agentId: argument(string({ metavar: 'AGENT_ID' })),
+    }),
+    {
+      brief: message`Show the agent's allowed-callers list. (alias: \`ls\`)`,
+      ...(alias ? { hidden: 'help' as const } : {}),
+    },
+  );
+}
+
+const agentCallersListSubCmd = longestMatch(
+  agentCallersListCommand('list', false),
+  agentCallersListCommand('ls', true),
 );
 
 const agentCallersAddSubCmd = command(
@@ -94,18 +126,26 @@ const agentCallersAddSubCmd = command(
   },
 );
 
-const agentCallersRemoveSubCmd = command(
-  'remove',
-  object({
-    action: constant('agent-callers-remove' as const),
-    ...sharedFlags,
-    agentId: argument(string({ metavar: 'AGENT_ID' })),
-    principal: argument(string({ metavar: 'PRINCIPAL' })),
-  }),
-  {
-    brief: message`Remove a principal from the agent's allowed-callers list.`,
-    description: message`Calls DELETE /admin-api/agents/<AGENT_ID>/callers?principal=<PRINCIPAL>. Hot-reloaded.`,
-  },
+function agentCallersRemoveCommand(name: 'remove' | 'rm', alias: boolean) {
+  return command(
+    name,
+    object({
+      action: constant('agent-callers-remove' as const),
+      ...sharedFlags,
+      agentId: argument(string({ metavar: 'AGENT_ID' })),
+      principal: argument(string({ metavar: 'PRINCIPAL' })),
+    }),
+    {
+      brief: message`Remove a principal from the agent's allowed-callers list. (alias: \`rm\`)`,
+      description: message`Calls DELETE /admin-api/agents/<AGENT_ID>/callers?principal=<PRINCIPAL>. Hot-reloaded.`,
+      ...(alias ? { hidden: 'help' as const } : {}),
+    },
+  );
+}
+
+const agentCallersRemoveSubCmd = longestMatch(
+  agentCallersRemoveCommand('remove', false),
+  agentCallersRemoveCommand('rm', true),
 );
 
 const agentCallersSubCmd = command(
@@ -118,10 +158,10 @@ const agentCallersSubCmd = command(
 
 export const agentCmd = command(
   'agent',
-  longestMatch(agentRegisterCmd, agentListSubCmd, agentDeleteSubCmd, agentCallersSubCmd),
+  longestMatch(agentRegisterCmd, agentListSubCmd, agentRemoveSubCmd, agentCallersSubCmd),
   {
     brief: message`Manage agent registrations and their allowed callers.`,
-    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`delete\`, \`callers {list,add,remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`remove\`, \`callers {list, add, remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
     hidden: 'usage',
   },
 );
@@ -219,8 +259,8 @@ export const revokeClientCmd = command(
     target: argument(string({ metavar: 'CLIENT_ID_OR_NAME' })),
   }),
   {
-    brief: message`[deprecated] Use \`agent delete\`.`,
-    description: message`Deprecated alias for \`vicoop-client agent delete\`. Hard-deletes the agent (renamed from revoke). Will be removed in a future release.`,
+    brief: message`[deprecated] Use \`agent remove\`.`,
+    description: message`Deprecated alias for \`vicoop-client agent remove\` (also accepts \`rm\` / \`delete\`). Hard-deletes the agent (renamed from revoke). Will be removed in a future release.`,
     hidden: 'help',
   },
 );
@@ -645,7 +685,7 @@ export async function runListClients(args: ListClientsArgs): Promise<number> {
 }
 
 export async function runRevokeClient(args: RevokeClientArgs): Promise<number> {
-  warnDeprecated('revoke-client', 'agent delete');
+  warnDeprecated('revoke-client', 'agent remove');
   const session = resolveSession(args);
   if ('error' in session) {
     process.stderr.write(`${session.error}\n`);

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -926,7 +926,11 @@ const containerInitSubCmd = command(
   },
 );
 
-function containerListCommand(name: 'ls' | 'list') {
+// `ls` / `rm` are registered as hidden aliases of `list` / `remove` so help
+// only shows the canonical long form. They still parse and still surface in
+// "did you mean?" suggestions.
+
+function containerListCommand(name: 'list' | 'ls', alias: boolean) {
   return command(
     name,
     object({
@@ -936,18 +940,19 @@ function containerListCommand(name: 'ls' | 'list') {
       }), false),
     }),
     {
-      brief: message`List runtime containers and volumes.`,
+      brief: message`List runtime containers and volumes. (alias: \`ls\`)`,
       description: message`Prints one row per managed runtime container, showing its kind, name, running state, image, and volume presence.`,
+      ...(alias ? { hidden: 'help' as const } : {}),
     },
   );
 }
 
 const containerListSubCmd = longestMatch(
-  containerListCommand('ls'),
-  containerListCommand('list'),
+  containerListCommand('list', false),
+  containerListCommand('ls', true),
 );
 
-function containerRemoveCommand(name: 'rm' | 'remove') {
+function containerRemoveCommand(name: 'remove' | 'rm', alias: boolean) {
   return command(
     name,
     object({
@@ -963,15 +968,16 @@ function containerRemoveCommand(name: 'rm' | 'remove') {
       }), false),
     }),
     {
-      brief: message`Remove a runtime container.`,
+      brief: message`Remove a runtime container. (alias: \`rm\`)`,
       description: message`Removes a runtime container and its agents, creds, and sessions volumes by name. Pass --preserve-volumes to keep the volumes.`,
+      ...(alias ? { hidden: 'help' as const } : {}),
     },
   );
 }
 
 const containerRemoveSubCmd = longestMatch(
-  containerRemoveCommand('rm'),
-  containerRemoveCommand('remove'),
+  containerRemoveCommand('remove', false),
+  containerRemoveCommand('rm', true),
 );
 
 export const containerCmd = command(
@@ -979,7 +985,7 @@ export const containerCmd = command(
   longestMatch(containerInitSubCmd, containerListSubCmd, containerRemoveSubCmd),
   {
     brief: message`Manage per-backend runtime containers.`,
-    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`ls\` / \`list\` (show managed runtime container and volume state), \`rm\` / \`remove\` (remove a runtime container and volumes by name). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
+    description: message`Subcommands: \`init\` (boot \`vicoop-runtime-<name>\`, install the agent CLI, optionally copy host creds), \`list\` (show managed runtime container and volume state), \`remove\` (remove a runtime container and volumes by name). Pairs with the daemon flag \`--runtime container\` (active backend selected via \`--backend\`).`,
     hidden: 'usage',
   },
 );


### PR DESCRIPTION
## Summary

CLI 의 list/delete 계열 별칭이 서브커맨드 그룹마다 들쭉날쭉하던 걸 정리합니다. `container ls`/`rm` 은 작동하는데 `agent ls`/`rm` 은 안 되던 비대칭을 없애고, 동시에 `agent delete` 와 `agent callers remove` / `container remove` 가 같은 종류의 동작인데도 동사가 달랐던 문제를 정리합니다.

## Changes

- `agent list` / `agent callers list` / `container list` 이 `ls` 별칭도 수용
- `agent remove` 가 canonical 이고 `rm`, `delete` 가 별칭. `agent callers remove` / `container remove` 는 `rm` 별칭 수용
- `agent delete` 는 가장 최근에 `revoke-client` 에서 막 옮겨온 형태라 backward compat 으로 보존
- `revoke-client` deprecation 힌트는 `agent remove` 를 가리키도록 갱신
- Help 출력은 한 서브커맨드당 한 줄 유지. 별칭은 brief 끝에 `(alias: \`ls\`)` 같이 표기 (Optique 의 `hidden: 'help'` 로 alias variant 를 usage/docs 에서 숨김)

## Help output (after)

```
Usage: vicoop-client register …
       vicoop-client list [--server URL] [--token TOKEN] [--json] [--connected]
       vicoop-client remove [--server URL] [--token TOKEN] [--json] [--yes] AGENT_ID
       vicoop-client callers list … AGENT_ID
       vicoop-client callers add … AGENT_ID PRINCIPAL
       vicoop-client callers remove … AGENT_ID PRINCIPAL

  register                    Register an agent and persist daemon credentials.
  list                        List agent registrations under this owner. (alias: `ls`)
  remove                      Remove an agent by id (or registration name). (aliases: `rm`, `delete`)
  callers                     Manage the agent's allowed-callers list.
```

## Test plan

- [x] `pnpm -r build` 통과
- [x] `pnpm --filter @vicoop-bridge/client test` — 601 / 601 통과
- [x] `vicoop-client agent ls`, `agent rm`, `agent delete`, `agent callers ls`, `agent callers rm`, `container ls`, `container rm` 가 모두 파싱됨 (수동 확인)
- [x] `agent ls --help`, `agent rm --help`, `agent delete --help` scoped help 정상 출력
- [x] "did you mean?" 후보에 별칭 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)