### PR TITLE
refactor(client): envelope-direct migration for vicoop-codex / codex / claude + envelope.model forwarding (#302)

### DIFF
--- a/.changeset/issue-302-envelope-direct-backends.md
+++ b/.changeset/issue-302-envelope-direct-backends.md
@@ -1,0 +1,20 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Migrate `vicoop-codex` / `codex` / `claude` backends to **envelope-direct** reads off `metadata[URI].chat_completions_request`, and forward `envelope.model` end-to-end (closes the per-backend half of #302).
+
+Previously each backend ran through `parseOpenAICompatMetadata`'s decomposed `{system, tools, tool_choice, chat_history}` projection. Backends now read the inbound OpenAI Chat Completions request body directly via a new `parseOpenAICompatEnvelope` helper and consume `envelope.model` / `envelope.tools` / `envelope.tool_choice` / `envelope.messages[]` verbatim. The projection helpers (`collectSystemFromMessages`, `chatHistoryFromMessages`) are now exported so each backend does its own derivation off the envelope.
+
+**Wire-level effect — model forwarding:** the gateway-resolved model id (planetarium/oai2a2a#80 `ResolvedAgent.modelOverride`) now flows end-to-end. Pool slug → resolved model id → backend dispatches to the right model:
+- `vicoop-codex.ts`: adds `model: envelope.model` to the JSON body sent to `vicoop-codex call`.
+- `codex.ts`: passes `envelope.model` as `thread/start.config.model` so codex dispatches per-thread instead of using `config.toml`'s pinned default.
+- `claude.ts`: passes `--model <id>` on the claude CLI spawn.
+
+Internal API changes (test surface only):
+- `callerToolDispatchActive(meta)` → `callerToolDispatchActive(tools, toolChoice)`.
+- `composeNativeDevInstructions(meta)` → `composeNativeDevInstructions(system, toolChoice)` (codex).
+- `buildOpenAICompatNativeSystemPrompt(meta)` → `buildOpenAICompatNativeSystemPrompt(system, tools, toolChoice)` (claude).
+- `dumpOpenAICompatTaskWire` no longer takes a parsed-view param; it derives the summary from metadata directly.
+
+`openclaw` stays on `parseOpenAICompatMetadata`'s decomposed view — its envelope-direct migration plus the final parser/`OpenAICompatMetadata` shim deletion will land in a follow-up PR (issue #302 strategy step 3+4).

--- a/.changeset/issue-302-envelope-direct-backends.md
+++ b/.changeset/issue-302-envelope-direct-backends.md
@@ -1,20 +1,15 @@
 ---
-"@vicoop-bridge/client": minor
+"@vicoop-bridge/client": patch
 ---
 
-Migrate `vicoop-codex` / `codex` / `claude` backends to **envelope-direct** reads off `metadata[URI].chat_completions_request`, and forward `envelope.model` end-to-end (closes the per-backend half of #302).
+Implement `envelope.model` forwarding for the three migrated backends (`vicoop-codex` / `codex` / `claude`) so the gateway-resolved model id (planetarium/oai2a2a#80 `ResolvedAgent.modelOverride`) reaches the underlying CLI instead of being silently dropped (#302). Pool slug → resolved model id → backend dispatches to the right model:
 
-Previously each backend ran through `parseOpenAICompatMetadata`'s decomposed `{system, tools, tool_choice, chat_history}` projection. Backends now read the inbound OpenAI Chat Completions request body directly via a new `parseOpenAICompatEnvelope` helper and consume `envelope.model` / `envelope.tools` / `envelope.tool_choice` / `envelope.messages[]` verbatim. The projection helpers (`collectSystemFromMessages`, `chatHistoryFromMessages`) are now exported so each backend does its own derivation off the envelope.
+- `vicoop-codex`: adds `model` to the JSON body sent to `vicoop-codex call`. New `resolveCapabilities` probe (`vicoop-codex models --json`) advertises the supported ids on the agent card.
+- `codex`: passes `envelope.model` as `thread/start.config.model` so codex dispatches per-thread instead of using `config.toml`'s pinned default.
+- `claude`: passes `--model <id>` on the claude CLI spawn.
 
-**Wire-level effect — model forwarding:** the gateway-resolved model id (planetarium/oai2a2a#80 `ResolvedAgent.modelOverride`) now flows end-to-end. Pool slug → resolved model id → backend dispatches to the right model:
-- `vicoop-codex.ts`: adds `model: envelope.model` to the JSON body sent to `vicoop-codex call`.
-- `codex.ts`: passes `envelope.model` as `thread/start.config.model` so codex dispatches per-thread instead of using `config.toml`'s pinned default.
-- `claude.ts`: passes `--model <id>` on the claude CLI spawn.
+Each backend validates `envelope.model` against its advertised model list (codex's `model/list`, claude's `probeClaudeModel`, vicoop-codex's `models --json`) and silently falls back to the CLI default when the value is not in the list — defensive against gateways that forward unresolved routing keys (e.g. `a2a/<card-url>`) verbatim.
 
-Internal API changes (test surface only):
-- `callerToolDispatchActive(meta)` → `callerToolDispatchActive(tools, toolChoice)`.
-- `composeNativeDevInstructions(meta)` → `composeNativeDevInstructions(system, toolChoice)` (codex).
-- `buildOpenAICompatNativeSystemPrompt(meta)` → `buildOpenAICompatNativeSystemPrompt(system, tools, toolChoice)` (claude).
-- `dumpOpenAICompatTaskWire` no longer takes a parsed-view param; it derives the summary from metadata directly.
+The backend-side migration also rewrites all three to read the envelope directly off `metadata[URI].chat_completions_request` instead of going through the legacy `OpenAICompatMetadata` decomposed view. Behaviour is unchanged for operators that aren't routing through an openai-compat gateway; the wire-shape change is invisible end-to-end.
 
 `openclaw` stays on `parseOpenAICompatMetadata`'s decomposed view — its envelope-direct migration plus the final parser/`OpenAICompatMetadata` shim deletion will land in a follow-up PR (issue #302 strategy step 3+4).

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2984,13 +2984,11 @@ test('dumpOpenAICompatTaskWire: emits header + tools + parts + chat_history sect
         chat_history: SAMPLE_HISTORY,
       },
     };
-    const parsed = parseOpenAICompatMetadata(metadata);
     dumpOpenAICompatTaskWire(
       'claude',
       'task-1',
       [{ kind: 'text', text: 'hello' }],
       metadata,
-      parsed,
     );
   } finally {
     console.error = origErr;
@@ -3027,7 +3025,6 @@ test('dumpOpenAICompatTaskWire: parts file entry shows shape without bytes', () 
       't',
       [{ kind: 'file', file: { name: 'i.png', mimeType: 'image/png', bytes: 'AAAA' } }],
       undefined,
-      null,
     );
   } finally {
     console.error = origErr;
@@ -3047,7 +3044,7 @@ test('dumpOpenAICompatTaskWire: minimal case (no tools, no history, just parts h
     captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
   };
   try {
-    dumpOpenAICompatTaskWire('codex', 't', [{ kind: 'text', text: 'hi' }], undefined, null);
+    dumpOpenAICompatTaskWire('codex', 't', [{ kind: 'text', text: 'hi' }], undefined);
   } finally {
     console.error = origErr;
   }

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2448,21 +2448,15 @@ test('callerToolDispatchActive: gates on `tools` present and `tool_choice !== "n
   // The same gate `buildOpenAICompatSystemPrompt` uses for the envelope
   // contract block. Backends consult this to decide whether to suppress
   // agent-side built-in tools (#175).
-  assert.equal(callerToolDispatchActive(null), false);
-  assert.equal(callerToolDispatchActive({}), false);
-  assert.equal(callerToolDispatchActive({ system: 'hi' }), false);
-  assert.equal(callerToolDispatchActive({ tools: [] }), true);
-  assert.equal(callerToolDispatchActive({ tools: [{ type: 'function' }] }), true);
+  assert.equal(callerToolDispatchActive(undefined, undefined), false);
+  assert.equal(callerToolDispatchActive(null, undefined), false);
+  // Empty array carries no definitions — not "tools present".
+  assert.equal(callerToolDispatchActive([], undefined), false);
+  assert.equal(callerToolDispatchActive([{ type: 'function' }], undefined), true);
   // Caller catalogued tools but explicitly opted out for this turn — don't
   // handicap the agent's built-ins; the contract isn't being enforced now.
-  assert.equal(
-    callerToolDispatchActive({ tools: [{ type: 'function' }], tool_choice: 'none' }),
-    false,
-  );
-  assert.equal(
-    callerToolDispatchActive({ tools: [{ type: 'function' }], tool_choice: 'auto' }),
-    true,
-  );
+  assert.equal(callerToolDispatchActive([{ type: 'function' }], 'none'), false);
+  assert.equal(callerToolDispatchActive([{ type: 'function' }], 'auto'), true);
 });
 
 test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves unknown keys', () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2535,6 +2535,72 @@ test('envelope without model omits --model from claude spawn (#302)', async () =
   assert.equal(args.indexOf('--model'), -1);
 });
 
+test('envelope.model is dropped when claude probed model differs (#302)', async () => {
+  // Regression guard for the gateway sending an unresolved routing key
+  // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the gate, the
+  // bridge would pass the garbage to claude via `--model <…>` and the
+  // run would fail at the Anthropic API. With the gate, the override is
+  // dropped and claude falls back to its own default.
+  const fake = scriptedSpawn({
+    lines: [
+      // probe + handle share the same scripted stream; system/init carries
+      // the advertised model id so resolveCapabilities's probe captures it
+      // into the backend's cache for the handle that follows.
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-7',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  // Daemon-mode contract: resolveCapabilities runs once at startup so the
+  // backend caches the probed model id before any task lands. Reproduce
+  // that ordering here.
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', {
+      model: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
+    }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  // No --model override on argv — claude uses its own default.
+  assert.equal(args.indexOf('--model'), -1);
+});
+
+test('envelope.model is forwarded when it matches claude probed model (#302)', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-7',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-opus-4-7' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  const modelIdx = args.indexOf('--model');
+  assert.notEqual(modelIdx, -1, '--model present when envelope.model matches the probe');
+  assert.equal(args[modelIdx + 1], 'claude-opus-4-7');
+});
+
 test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves unknown keys', () => {
   const out = tryParseToolCallsEnvelope(
     JSON.stringify({

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2254,15 +2254,50 @@ const SAMPLE_TOOLS = [
   },
 ];
 
+// Shape decomposed test inputs into a `chat_completions_request` envelope
+// so the same fixture style the legacy tests used (a flat `{ system, tools,
+// tool_choice, chat_history, model }` map) continues to work after the
+// envelope-direct migration (#302). The helper folds `system` into a
+// leading system message, `chat_history` into the middle, and appends a
+// trailing user message matching the A2A `parts` text so backends that
+// excise the trailing user from the history projection still receive the
+// caller's request through the regular A2A parts path.
 function assignWithOpenAICompat(
   text: string,
-  payload: Record<string, unknown>,
+  payload: {
+    system?: string;
+    tools?: unknown;
+    tool_choice?: unknown;
+    chat_history?: readonly unknown[];
+    model?: string;
+    // Escape hatch for tests that already supply a full envelope and want
+    // to override the convenience-mapping above.
+    chat_completions_request?: Record<string, unknown>;
+  },
 ): TaskAssignFrame {
+  const messages: Array<Record<string, unknown>> = [];
+  if (typeof payload.system === 'string' && payload.system.length > 0) {
+    messages.push({ role: 'system', content: payload.system });
+  }
+  if (Array.isArray(payload.chat_history)) {
+    for (const entry of payload.chat_history) {
+      messages.push(entry as Record<string, unknown>);
+    }
+  }
+  // Trailing user — split into A2A parts for non-extension-aware consumers
+  // per the spec; the backend's history projection drops this entry.
+  messages.push({ role: 'user', content: text });
+  const envelope: Record<string, unknown> = payload.chat_completions_request ?? {
+    messages,
+    ...(payload.model !== undefined ? { model: payload.model } : {}),
+    ...(payload.tools !== undefined ? { tools: payload.tools } : {}),
+    ...(payload.tool_choice !== undefined ? { tool_choice: payload.tool_choice } : {}),
+  };
   return {
     ...assign(text),
     message: {
       ...assign(text).message,
-      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: payload },
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { chat_completions_request: envelope } },
     },
   };
 }
@@ -2457,6 +2492,47 @@ test('callerToolDispatchActive: gates on `tools` present and `tool_choice !== "n
   // handicap the agent's built-ins; the contract isn't being enforced now.
   assert.equal(callerToolDispatchActive([{ type: 'function' }], 'none'), false);
   assert.equal(callerToolDispatchActive([{ type: 'function' }], 'auto'), true);
+});
+
+test('envelope.model is forwarded as --model on the claude spawn (#302)', async () => {
+  // Per #302, the gateway-resolved model id (planetarium/oai2a2a#80
+  // ResolvedAgent.modelOverride) reaches claude as `--model <id>` so
+  // claude dispatches to the caller's selection instead of its own
+  // default.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-opus-4-7' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  const modelIdx = args.indexOf('--model');
+  assert.notEqual(modelIdx, -1, '--model present');
+  assert.equal(args[modelIdx + 1], 'claude-opus-4-7');
+});
+
+test('envelope without model omits --model from claude spawn (#302)', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  // No `model` in payload → no --model on argv.
+  await backend.handle(assignWithOpenAICompat('hi', {}), emit, NEVER);
+  const args = fake.lastChild()?.args ?? [];
+  assert.equal(args.indexOf('--model'), -1);
 });
 
 test('tryParseToolCallsEnvelope: recognises a well-formed envelope and preserves unknown keys', () => {
@@ -3385,11 +3461,11 @@ test('openaiToolsToCallerToolDefs maps OpenAI tools and drops malformed entries 
 // enforces single-turn semantics mechanically, so prompting the model to
 // "stop" duplicates work and pollutes its context.
 test('buildOpenAICompatNativeSystemPrompt: slim shape (#213)', () => {
-  const out = buildOpenAICompatNativeSystemPrompt({
-    system: 'be terse',
-    tools: [{ type: 'function', function: { name: 'fetch' } }],
-    tool_choice: 'auto',
-  });
+  const out = buildOpenAICompatNativeSystemPrompt(
+    'be terse',
+    [{ type: 'function', function: { name: 'fetch' } }],
+    'auto',
+  );
   // The user's system text leads.
   assert.ok(out.startsWith('be terse'));
   // The envelope contract — the very thing this path replaces — must be
@@ -3412,23 +3488,25 @@ test('buildOpenAICompatNativeSystemPrompt: slim shape (#213)', () => {
 
   // tool_choice="required" gets a steering line (same descriptor the
   // envelope path uses; `describeToolChoice` is shared).
-  const required = buildOpenAICompatNativeSystemPrompt({
-    tools: [],
-    tool_choice: 'required',
-  });
+  const required = buildOpenAICompatNativeSystemPrompt(
+    undefined,
+    [{ type: 'function', function: { name: 'x' } }],
+    'required',
+  );
   assert.ok(required.includes('tool_choice="required"'));
 
   // tool_choice="none" → no envelope, just a "don't invoke caller tools"
   // directive.
-  const none = buildOpenAICompatNativeSystemPrompt({
-    tools: [],
-    tool_choice: 'none',
-  });
+  const none = buildOpenAICompatNativeSystemPrompt(
+    undefined,
+    [{ type: 'function', function: { name: 'x' } }],
+    'none',
+  );
   assert.ok(none.includes('tool_choice="none"'));
 
   // Bare `system` with no tools — emits just the system text.
   assert.equal(
-    buildOpenAICompatNativeSystemPrompt({ system: 'just be terse' }),
+    buildOpenAICompatNativeSystemPrompt('just be terse', undefined, undefined),
     'just be terse',
   );
 });
@@ -3524,29 +3602,19 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
 
   const { emit } = collect();
   await backend2.handle(
-    {
-      ...assign('do a fetch'),
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'do a fetch' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            system: 'be terse',
-            tools: [
-              {
-                type: 'function',
-                function: {
-                  name: 'fetch',
-                  description: 'Fetch a URL',
-                  parameters: { type: 'object', properties: {} },
-                },
-              },
-            ],
+    assignWithOpenAICompat('do a fetch', {
+      system: 'be terse',
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'fetch',
+            description: 'Fetch a URL',
+            parameters: { type: 'object', properties: {} },
           },
         },
-      },
-    },
+      ],
+    }),
     emit,
     NEVER,
   );
@@ -3614,29 +3682,19 @@ test('argv: --allowedTools covers all registered MCP servers (#235)', async () =
       sendFileMcp: { allowedRoots: [realRoot], skipHttp: true },
     });
     await backend.handle(
-      {
-        ...assign('do a fetch'),
-        message: {
-          role: 'user',
-          messageId: 'm',
-          parts: [{ kind: 'text', text: 'do a fetch' }],
-          metadata: {
-            [OPENAI_COMPAT_EXTENSION_URI]: {
-              system: 'be terse',
-              tools: [
-                {
-                  type: 'function',
-                  function: {
-                    name: 'fetch',
-                    description: 'Fetch a URL',
-                    parameters: { type: 'object', properties: {} },
-                  },
-                },
-              ],
+      assignWithOpenAICompat('do a fetch', {
+        system: 'be terse',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'fetch',
+              description: 'Fetch a URL',
+              parameters: { type: 'object', properties: {} },
             },
           },
-        },
-      },
+        ],
+      }),
       collect().emit,
       NEVER,
     );
@@ -3719,33 +3777,23 @@ test('native dispatch: tool invocation → chat_completion envelope on terminal 
   });
 
   await backend.handle(
-    {
-      ...assign('fetch example.com'),
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'fetch example.com' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            system: 'be terse',
-            tools: [
-              {
-                type: 'function',
-                function: {
-                  name: 'fetch',
-                  description: 'Fetch a URL',
-                  parameters: {
-                    type: 'object',
-                    properties: { url: { type: 'string' } },
-                    required: ['url'],
-                  },
-                },
-              },
-            ],
+    assignWithOpenAICompat('fetch example.com', {
+      system: 'be terse',
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'fetch',
+            description: 'Fetch a URL',
+            parameters: {
+              type: 'object',
+              properties: { url: { type: 'string' } },
+              required: ['url'],
+            },
           },
         },
-      },
-    },
+      ],
+    }),
     emit,
     NEVER,
   );
@@ -3860,24 +3908,14 @@ test('native dispatch: --max-turns 1 exits with code 1; bridge maps to completed
   });
 
   await backend.handle(
-    {
-      ...assign('fetch example.com'),
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'fetch example.com' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [
-              {
-                type: 'function',
-                function: { name: 'fetch', parameters: { type: 'object' } },
-              },
-            ],
-          },
+    assignWithOpenAICompat('fetch example.com', {
+      tools: [
+        {
+          type: 'function',
+          function: { name: 'fetch', parameters: { type: 'object' } },
         },
-      },
-    },
+      ],
+    }),
     emit,
     NEVER,
   );
@@ -3946,24 +3984,14 @@ test('native dispatch: exit-code-1 with NO tool capture still fails (#213)', asy
   });
 
   await backend.handle(
-    {
-      ...assign('do a fetch'),
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'do a fetch' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [
-              {
-                type: 'function',
-                function: { name: 'fetch', parameters: { type: 'object' } },
-              },
-            ],
-          },
+    assignWithOpenAICompat('do a fetch', {
+      tools: [
+        {
+          type: 'function',
+          function: { name: 'fetch', parameters: { type: 'object' } },
         },
-      },
-    },
+      ],
+    }),
     emit,
     NEVER,
   );
@@ -4035,13 +4063,16 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
     onCallerToolsMcpReady: () => {},
   });
   const { emit } = collect();
-  const meta = {
+  const metaFor = (text: string): Record<string, unknown> => ({
     [OPENAI_COMPAT_EXTENSION_URI]: {
-      tools: [
-        { type: 'function', function: { name: 'fetch', parameters: { type: 'object' } } },
-      ],
+      chat_completions_request: {
+        messages: [{ role: 'user', content: text }],
+        tools: [
+          { type: 'function', function: { name: 'fetch', parameters: { type: 'object' } } },
+        ],
+      },
     },
-  };
+  });
 
   // Two turns sharing the same contextId — without the openai-compat gate
   // the second one would carry `--resume <sessionId-from-turn-1>`.
@@ -4050,7 +4081,7 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
       type: 'task.assign',
       taskId: 'oai-t1',
       contextId: 'ctx-shared',
-      message: { role: 'user', messageId: 'm1', parts: [{ kind: 'text', text: 'a' }], metadata: meta },
+      message: { role: 'user', messageId: 'm1', parts: [{ kind: 'text', text: 'a' }], metadata: metaFor('a') },
     },
     emit,
     NEVER,
@@ -4060,7 +4091,7 @@ test('openai-compat: same contextId still spawns a fresh --session-id (no --resu
       type: 'task.assign',
       taskId: 'oai-t2',
       contextId: 'ctx-shared',
-      message: { role: 'user', messageId: 'm2', parts: [{ kind: 'text', text: 'b' }], metadata: meta },
+      message: { role: 'user', messageId: 'm2', parts: [{ kind: 'text', text: 'b' }], metadata: metaFor('b') },
     },
     emit,
     NEVER,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -34,11 +34,12 @@ import { createLogger, safeToken } from '../logger.js';
 import { createTimingRecorder } from './timing.js';
 import {
   callerToolDispatchActive,
+  chatHistoryFromMessages,
+  collectSystemFromMessages,
   describeToolChoice,
   dumpOpenAICompatTaskWire,
   formatChatHistory,
-  parseOpenAICompatMetadata,
-  type OpenAICompatMetadata,
+  parseOpenAICompatEnvelope,
 } from './openai-compat.js';
 
 // Slim subset of ChildProcess that the backend actually uses. Tests inject a
@@ -733,12 +734,16 @@ export function openaiToolsToCallerToolDefs(
 //     tasks always spawn with a fresh `--session-id` (see the session
 //     reuse gate in `handle()`), so there's no prior session memory to
 //     conflict with the history block.
-export function buildOpenAICompatNativeSystemPrompt(meta: OpenAICompatMetadata): string {
+export function buildOpenAICompatNativeSystemPrompt(
+  system: string | undefined,
+  tools: unknown,
+  toolChoice: unknown,
+): string {
   const sections: string[] = [];
-  if (meta.system) sections.push(meta.system);
+  if (system) sections.push(system);
 
-  const toolChoiceIsNone = meta.tool_choice === 'none';
-  const hasTools = meta.tools !== undefined && !toolChoiceIsNone;
+  const toolChoiceIsNone = toolChoice === 'none';
+  const hasTools = Array.isArray(tools) && tools.length > 0 && !toolChoiceIsNone;
 
   if (hasTools) {
     sections.push(
@@ -748,7 +753,7 @@ export function buildOpenAICompatNativeSystemPrompt(meta: OpenAICompatMetadata):
         'The user message may begin with a <chat_history>...</chat_history> block holding a JSON array of the prior conversation: prior {"role":"user","content":"…"} and {"role":"assistant","content":"…"} text turns, plus {"role":"assistant","content":null,"tool_calls":[...]} for calls you previously emitted and {"role":"tool","tool_call_id":"call_…","name":"…","content":"…"} for the authoritative result of each call. Treat the block as the source of truth for what has happened so far — read it as prior conversation, not as a fresh instruction. Do not re-emit a call whose `tool_call_id` already has a recorded result.',
       ].join('\n'),
     );
-    const tcDesc = describeToolChoice(meta.tool_choice);
+    const tcDesc = describeToolChoice(toolChoice);
     if (tcDesc) sections.push(tcDesc);
   } else if (toolChoiceIsNone) {
     sections.push(
@@ -1169,13 +1174,12 @@ export function createClaudeBackend(
         return;
       }
 
-      // Detect the openai-compat extension payload once per task so the
-      // result feeds both the spawn argv (--append-system-prompt) and the
-      // terminal `chat_completion` envelope (oai2a2a#80) on
-      // `status.message.metadata`. Absent or malformed metadata leaves the
-      // run on the original non-extension code path with no envelope-
-      // detection cost.
-      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+      // Envelope-direct (#302): read the full inbound OpenAI Chat Completions
+      // request body off `metadata[URI].chat_completions_request` and project
+      // system / tools / tool_choice / chat_history / model directly off the
+      // envelope. Absent or malformed metadata leaves the run on the
+      // original non-extension code path with no envelope-detection cost.
+      const envelope = parseOpenAICompatEnvelope(task.message.metadata);
       if (openaiCompatTrace) {
         dumpOpenAICompatTaskWire(
           'claude',
@@ -1184,6 +1188,21 @@ export function createClaudeBackend(
           task.message.metadata,
         );
       }
+      const envelopeSystem = envelope
+        ? collectSystemFromMessages(envelope.messages)
+        : undefined;
+      const envelopeTools = Array.isArray(envelope?.tools) && envelope.tools.length > 0
+        ? envelope.tools
+        : undefined;
+      const envelopeToolChoice = envelope?.tool_choice;
+      const envelopeChatHistory =
+        envelope && Array.isArray(envelope.messages)
+          ? chatHistoryFromMessages(envelope.messages)
+          : null;
+      const envelopeModel =
+        envelope && typeof envelope.model === 'string' && envelope.model.length > 0
+          ? envelope.model
+          : undefined;
 
       // Native MCP dispatch (#213): when the openai-compat extension is
       // active and carries `tools` (and `tool_choice !== "none"`), the
@@ -1195,9 +1214,8 @@ export function createClaudeBackend(
       // tasks without the openai-compat extension (or without `tools`)
       // remain on the default agentic path with claude's built-ins intact.
       const callerToolDefs =
-        callerToolDispatchActive(openaiCompat?.tools, openaiCompat?.tool_choice) &&
-        openaiCompat?.tools
-          ? openaiToolsToCallerToolDefs(openaiCompat.tools)
+        envelopeTools && callerToolDispatchActive(envelopeTools, envelopeToolChoice)
+          ? openaiToolsToCallerToolDefs(envelopeTools)
           : null;
       const nativeDispatchActive = callerToolDefs !== null;
 
@@ -1211,7 +1229,7 @@ export function createClaudeBackend(
       // `chat_history`. `mapPartsToContentBlocks` returns
       // `empty_prompt` on those parts; tolerate it when the history
       // carries entries that will end up as the user content.
-      const hasHistory = (openaiCompat?.chat_history?.length ?? 0) > 0;
+      const hasHistory = (envelopeChatHistory?.length ?? 0) > 0;
       const isToolContinuation =
         !mappedRaw.ok &&
         mappedRaw.code === 'empty_prompt' &&
@@ -1232,7 +1250,7 @@ export function createClaudeBackend(
         ? mappedRaw
         : { ok: true, blocks: [], inboundHashes: new Set() };
 
-      if (openaiCompat?.chat_history) {
+      if (envelopeChatHistory) {
         // Spec contract: bridges MUST replay the entire `chat_history`
         // in order. We render it as a single `<chat_history>` JSON
         // block (every entry — text turns AND tool round-trips —
@@ -1249,7 +1267,7 @@ export function createClaudeBackend(
         // turn over a multi-turn conversation. Folding everything into
         // a single user message via this block is the only way to give
         // the model the conversation in one shot on this backend.
-        const block = formatChatHistory(openaiCompat.chat_history);
+        const block = formatChatHistory(envelopeChatHistory);
         if (block) {
           mapped.blocks.unshift({ type: 'text', text: block });
         }
@@ -1278,7 +1296,7 @@ export function createClaudeBackend(
       // tool results). Skip the session map entirely for openai-compat tasks so
       // every spawn starts on a clean `--session-id`; the history block in
       // the user message is then the unambiguous source of truth.
-      const sessionReuseEligible = openaiCompat === null && sessionTtlMs > 0;
+      const sessionReuseEligible = envelope === null && sessionTtlMs > 0;
       const tNow = now();
       if (sessionReuseEligible) evictExpired(tNow - sessionTtlMs);
       const existing = sessionReuseEligible ? sessions.get(task.contextId) : undefined;
@@ -1447,11 +1465,22 @@ export function createClaudeBackend(
       // BEFORE extraArgs (so an operator-supplied append still wins by
       // appending last — claude concatenates each --append-system-prompt
       // occurrence in argv order).
-      const openaiCompatArgs: readonly string[] = openaiCompat
+      const openaiCompatArgs: readonly string[] = envelope
         ? [
             '--append-system-prompt',
-            buildOpenAICompatNativeSystemPrompt(openaiCompat),
+            buildOpenAICompatNativeSystemPrompt(
+              envelopeSystem,
+              envelopeTools,
+              envelopeToolChoice,
+            ),
           ]
+        : [];
+      // Forward `envelope.model` to claude via `--model <id>` so the gateway-
+      // resolved model id wins over claude's own default (#302). Sticky for
+      // the spawn; per-task because every openai-compat task always spawns
+      // fresh (no session reuse — see the gate above).
+      const modelArgs: readonly string[] = envelopeModel
+        ? ['--model', envelopeModel]
         : [];
       // Disable claude's built-in tools (Read / Glob / Bash / Edit / Write /
       // ...) when the caller has supplied its own tool definitions via the
@@ -1463,8 +1492,8 @@ export function createClaudeBackend(
       // for blanket-disabling built-ins; MCP-registered tools (e.g.
       // `send_file`) continue to load via `--mcp-config`.
       const disableBuiltinToolArgs: readonly string[] = callerToolDispatchActive(
-        openaiCompat?.tools,
-        openaiCompat?.tool_choice,
+        envelopeTools,
+        envelopeToolChoice,
       )
         ? ['--tools', '']
         : [];
@@ -1540,6 +1569,7 @@ export function createClaudeBackend(
         ...mcpConfigArgs,
         ...mcpAllowedToolsArgs,
         ...identityArgs,
+        ...modelArgs,
         ...openaiCompatArgs,
         ...disableBuiltinToolArgs,
         ...nativeTurnCapArgs,
@@ -2199,7 +2229,7 @@ export function createClaudeBackend(
       const finishReason: 'tool_calls' | 'stop' =
         capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
       const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
-      const envelope = openaiCompat
+      const responseEnvelope = envelope
         ? buildClaudeChatCompletionEnvelope({
             taskId: task.taskId,
             model: finalUsage?.model,
@@ -2210,7 +2240,7 @@ export function createClaudeBackend(
           })
         : undefined;
 
-      const messageMetadata = buildOpenAICompatResponseMetadata(envelope, finalUsage);
+      const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, finalUsage);
       // When parts is empty but we have envelope/usage to convey, still
       // emit the message frame so the metadata reaches the gateway.
       const hasMessage = parts.length > 0 || messageMetadata !== undefined;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1182,7 +1182,6 @@ export function createClaudeBackend(
           task.taskId,
           task.message.parts,
           task.message.metadata,
-          openaiCompat,
         );
       }
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1195,7 +1195,8 @@ export function createClaudeBackend(
       // tasks without the openai-compat extension (or without `tools`)
       // remain on the default agentic path with claude's built-ins intact.
       const callerToolDefs =
-        callerToolDispatchActive(openaiCompat) && openaiCompat?.tools
+        callerToolDispatchActive(openaiCompat?.tools, openaiCompat?.tool_choice) &&
+        openaiCompat?.tools
           ? openaiToolsToCallerToolDefs(openaiCompat.tools)
           : null;
       const nativeDispatchActive = callerToolDefs !== null;
@@ -1461,7 +1462,10 @@ export function createClaudeBackend(
       // from agent-side filesystem). `--tools ""` is the documented switch
       // for blanket-disabling built-ins; MCP-registered tools (e.g.
       // `send_file`) continue to load via `--mcp-config`.
-      const disableBuiltinToolArgs: readonly string[] = callerToolDispatchActive(openaiCompat)
+      const disableBuiltinToolArgs: readonly string[] = callerToolDispatchActive(
+        openaiCompat?.tools,
+        openaiCompat?.tool_choice,
+      )
         ? ['--tools', '']
         : [];
       // Cap claude to a single model turn when caller-tools are dispatched

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1100,6 +1100,18 @@ export function createClaudeBackend(
 
   const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
 
+  // Probed-model cache, populated by `resolveCapabilities` at daemon
+  // startup and read sync from `handle()` to gate `envelope.model`
+  // forwarding (#302). `undefined` = "never probed", `null` = "probed but
+  // unavailable", string = "this is the only model id this claude install
+  // advertises". `handle()` deliberately does NOT trigger the probe on a
+  // miss — the probe spawns its own short-lived child, and the daemon
+  // already calls `resolveCapabilities` once at startup, so the cache is
+  // populated before any task lands in production. Tests that want to
+  // exercise the gate populate the cache via `resolveCapabilities`
+  // explicitly.
+  let cachedProbedModel: string | null | undefined = undefined;
+
   return {
     name: 'claude',
 
@@ -1117,13 +1129,17 @@ export function createClaudeBackend(
     // `completion_tokens_details.reasoning_tokens` in `usage`, and per
     // spec "Absence means 'unspecified,' not 'false.'"
     async resolveCapabilities() {
-      if (probeTimeoutMs <= 0) return {};
+      if (probeTimeoutMs <= 0) {
+        cachedProbedModel = null;
+        return {};
+      }
       const model = await probeClaudeModel({
         command,
         spawn: spawnFn,
         cwd,
         timeoutMs: probeTimeoutMs,
       });
+      cachedProbedModel = model;
       if (!model) return {};
       return {
         openaiCompatModels: [{ id: model, default: true }],
@@ -1199,10 +1215,28 @@ export function createClaudeBackend(
         envelope && Array.isArray(envelope.messages)
           ? chatHistoryFromMessages(envelope.messages)
           : null;
-      const envelopeModel =
+      const envelopeModelRaw =
         envelope && typeof envelope.model === 'string' && envelope.model.length > 0
           ? envelope.model
           : undefined;
+      // Validate against the probed model id (cached by `resolveCapabilities`).
+      // When the gateway sends a value claude doesn't advertise — e.g. an
+      // unresolved routing key like `a2a/<card-url>` — drop the override so
+      // claude falls back to its own default rather than failing the turn
+      // (#302). When the cache is unpopulated (probeTimeoutMs ≤ 0, probe
+      // failed, or `resolveCapabilities` hasn't been called yet) the
+      // validation is skipped and `envelope.model` rides through unchanged.
+      let envelopeModel: string | undefined = envelopeModelRaw;
+      if (
+        envelopeModelRaw !== undefined &&
+        typeof cachedProbedModel === 'string' &&
+        envelopeModelRaw !== cachedProbedModel
+      ) {
+        timingLogger.warn?.(
+          `[claude] envelope.model=${JSON.stringify(envelopeModelRaw)} does not match this claude install's advertised model (${JSON.stringify(cachedProbedModel)}); falling back to claude default`,
+        );
+        envelopeModel = undefined;
+      }
 
       // Native MCP dispatch (#213): when the openai-compat extension is
       // active and carries `tools` (and `tool_choice !== "none"`), the

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -282,11 +282,11 @@ function happyPath(opts: HappyPathOptions = {}): ChildScenario {
         return;
       }
       if (method === 'model/list' && id !== undefined) {
-        // #302: codex backend caches `model/list` to gate `envelope.model`
-        // forwarding. Default `{ data: [] }` exercises the "unavailable"
-        // branch (validation is skipped, envelope.model rides through
-        // unchanged). Tests that want to drive the validation path supply
-        // `opts.modelList` with the model ids that should pass the gate.
+        // #302: `resolveCapabilities` issues `model/list` once to populate
+        // both the agent card advertise and the envelope.model gate cache.
+        // Tests that don't call `resolveCapabilities` never hit this; tests
+        // that do drive the validation path supply `opts.modelList` with
+        // the ids that should pass the gate.
         child.emitStdout({ id, result: { data: opts.modelList ?? [] } });
         return;
       }
@@ -2113,6 +2113,9 @@ test('envelope.model is forwarded when codex advertises it in model/list (#302)'
     }),
   );
   const backend = createCodexBackend({ spawn: fake.spawn });
+  // Daemon-mode contract: `resolveCapabilities` runs once at startup so
+  // the backend caches the model/list ids before any task lands.
+  await backend.resolveCapabilities?.();
   await backend.handle(
     assign('hello', 'ctx-model-known', {
       message: {
@@ -2152,6 +2155,7 @@ test('envelope.model is dropped when codex does NOT advertise it in model/list (
     }),
   );
   const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.resolveCapabilities?.();
   await backend.handle(
     assign('hello', 'ctx-model-unknown', {
       message: {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -228,6 +228,16 @@ interface HappyPathOptions {
   emitCommandExecutionTurns?: number[];
   /** Optional override of the initialize result payload. */
   initializeResult?: Record<string, unknown>;
+  /**
+   * `model/list` response shape returned to the backend's envelope.model
+   * validation (#302). Default `null` returns `{ data: [] }` — the empty
+   * list is treated by the backend as "unavailable" and the validation
+   * silently falls through, so existing tests that set `envelope.model`
+   * see no behaviour change. Explicit arrays drive the validation path:
+   * an entry the backend doesn't know about is dropped before reaching
+   * `thread/start.config.model`.
+   */
+  modelList?: ModelListEntry[];
 }
 
 function happyPath(opts: HappyPathOptions = {}): ChildScenario {
@@ -269,6 +279,15 @@ function happyPath(opts: HappyPathOptions = {}): ChildScenario {
         // Empty-object result mirrors the real server's response shape;
         // the backend treats it as fire-and-confirm.
         child.emitStdout({ id, result: {} });
+        return;
+      }
+      if (method === 'model/list' && id !== undefined) {
+        // #302: codex backend caches `model/list` to gate `envelope.model`
+        // forwarding. Default `{ data: [] }` exercises the "unavailable"
+        // branch (validation is skipped, envelope.model rides through
+        // unchanged). Tests that want to drive the validation path supply
+        // `opts.modelList` with the model ids that should pass the gate.
+        child.emitStdout({ id, result: { data: opts.modelList ?? [] } });
         return;
       }
       if (method === 'turn/start' && id !== undefined) {
@@ -2082,6 +2101,82 @@ test('envelope.model is forwarded as thread/start config.model (#302)', async ()
     params?: { config?: { model?: string } };
   }).params;
   assert.equal(params?.config?.model, 'gpt-5.5-mini');
+});
+
+test('envelope.model is forwarded when codex advertises it in model/list (#302)', async () => {
+  const fake = makeFakeSpawn(() =>
+    happyPath({
+      modelList: [
+        { id: 'gpt-5.5-mini' },
+        { id: 'gpt-5.5', isDefault: true },
+      ],
+    }),
+  );
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('hello', 'ctx-model-known', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hello' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              model: 'gpt-5.5-mini',
+              messages: [{ role: 'user', content: 'hello' }],
+            },
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { model?: string } };
+  }).params;
+  assert.equal(params?.config?.model, 'gpt-5.5-mini');
+});
+
+test('envelope.model is dropped when codex does NOT advertise it in model/list (#302)', async () => {
+  // Regression guard for the gateway sending an unresolved routing key
+  // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the model/list
+  // gate, the bridge would forward the garbage to codex which rejects it
+  // with `invalid_request_error` — see the screenshot in the PR's review
+  // thread. With the gate, the override is dropped and codex falls back
+  // to its config.toml default.
+  const fake = makeFakeSpawn(() =>
+    happyPath({
+      modelList: [{ id: 'gpt-5.5-mini' }, { id: 'gpt-5.5', isDefault: true }],
+    }),
+  );
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('hello', 'ctx-model-unknown', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hello' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              model: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
+              messages: [{ role: 'user', content: 'hello' }],
+            },
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { model?: string } };
+  }).params;
+  // No model override on threadConfig — codex uses its own default.
+  assert.equal(params?.config?.model, undefined);
 });
 
 test('history-only openai-compat payload (no `tools`) does not disable codex built-ins via features (but still suppresses env_context)', async () => {

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -854,17 +854,22 @@ test('openai-compat chat_history injects prior turns as Responses API items; tra
         parts: [{ kind: 'text', text: 'follow up' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_history: [
-              { role: 'user', content: 'kick off' },
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                  { id: 'tc1', function: { name: 'lookup', arguments: '{}' } },
-                ],
-              },
-              { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
-            ],
+            chat_completions_request: {
+              messages: [
+                { role: 'user', content: 'kick off' },
+                {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    { id: 'tc1', function: { name: 'lookup', arguments: '{}' } },
+                  ],
+                },
+                { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
+                // Trailing user — split off into A2A parts; the decomposition
+                // drops this index from chat_history.
+                { role: 'user', content: 'follow up' },
+              ],
+            },
           },
         },
       },
@@ -920,17 +925,22 @@ test('openai-compat chat_history with empty parts (tool-continuation) sends empt
         parts: [{ kind: 'text', text: '' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_history: [
-              { role: 'user', content: 'kick off' },
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                  { id: 'tc1', function: { name: 'lookup', arguments: '{}' } },
-                ],
-              },
-              { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
-            ],
+            chat_completions_request: {
+              messages: [
+                { role: 'user', content: 'kick off' },
+                {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    { id: 'tc1', function: { name: 'lookup', arguments: '{}' } },
+                  ],
+                },
+                { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
+                // Trailing entry is a `tool` — chatHistoryFromMessages
+                // recognises this as a tool-continuation envelope and keeps
+                // the full sequence in chat_history.
+              ],
+            },
           },
         },
       },
@@ -965,7 +975,10 @@ test('openai-compat thread/start sets include_environment_context: false to supp
         parts: [{ kind: 'text', text: 'ask' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            chat_completions_request: {
+              messages: [{ role: 'user', content: 'ask' }],
+              tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            },
           },
         },
       },
@@ -1075,14 +1088,17 @@ test('chat_history + image FilePart: trailing user (text+image) rides turn/start
         ],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_history: [
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [{ id: 'tc1', function: { name: 'f', arguments: '{}' } }],
-              },
-              { role: 'tool', tool_call_id: 'tc1', content: 'r' },
-            ],
+            chat_completions_request: {
+              messages: [
+                {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [{ id: 'tc1', function: { name: 'f', arguments: '{}' } }],
+                },
+                { role: 'tool', tool_call_id: 'tc1', content: 'r' },
+                { role: 'user', content: 'caption please' },
+              ],
+            },
           },
         },
       },
@@ -1126,18 +1142,21 @@ test('parallel tool_calls in one assistant entry fan out into one function_call 
         parts: [{ kind: 'text', text: 'next' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_history: [
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                  { id: 'tc1', function: { name: 'a', arguments: '{"x":1}' } },
-                  { id: 'tc2', function: { name: 'b', arguments: '{"y":2}' } },
-                ],
-              },
-              { role: 'tool', tool_call_id: 'tc1', content: 'A' },
-              { role: 'tool', tool_call_id: 'tc2', content: 'B' },
-            ],
+            chat_completions_request: {
+              messages: [
+                {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    { id: 'tc1', function: { name: 'a', arguments: '{"x":1}' } },
+                    { id: 'tc2', function: { name: 'b', arguments: '{"y":2}' } },
+                  ],
+                },
+                { role: 'tool', tool_call_id: 'tc1', content: 'A' },
+                { role: 'tool', tool_call_id: 'tc2', content: 'B' },
+                { role: 'user', content: 'next' },
+              ],
+            },
           },
         },
       },
@@ -1388,21 +1407,26 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on
         parts: [{ kind: 'text', text: 'fetch example.com' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            system: 'be terse',
-            tools: [
-              {
-                type: 'function',
-                function: {
-                  name: 'fetch',
-                  description: 'Fetch a URL',
-                  parameters: {
-                    type: 'object',
-                    properties: { url: { type: 'string' } },
-                    required: ['url'],
+            chat_completions_request: {
+              messages: [
+                { role: 'system', content: 'be terse' },
+                { role: 'user', content: 'fetch example.com' },
+              ],
+              tools: [
+                {
+                  type: 'function',
+                  function: {
+                    name: 'fetch',
+                    description: 'Fetch a URL',
+                    parameters: {
+                      type: 'object',
+                      properties: { url: { type: 'string' } },
+                      required: ['url'],
+                    },
                   },
                 },
-              },
-            ],
+              ],
+            },
           },
         },
       },
@@ -1577,32 +1601,20 @@ test('openaiToolsToDynamicToolSpecs maps OpenAI tools and drops malformed entrie
 // re-introducing it would put the model back into the parse-from-text
 // failure modes #208 catalogued.
 test('composeNativeDevInstructions includes system text, omits JSON envelope contract (#209)', () => {
-  assert.equal(
-    composeNativeDevInstructions({ system: 'be terse' }),
-    'be terse',
-  );
+  assert.equal(composeNativeDevInstructions('be terse', undefined), 'be terse');
   // tool_choice="required" gets a steering line.
-  const requiredOut = composeNativeDevInstructions({
-    system: 'sys',
-    tools: [],
-    tool_choice: 'required',
-  });
+  const requiredOut = composeNativeDevInstructions('sys', 'required');
   assert.ok(requiredOut.startsWith('sys'));
   assert.ok(requiredOut.includes('tool_choice="required"'));
   // Named function tool_choice gets a steering line naming the function.
-  const namedOut = composeNativeDevInstructions({
-    system: '',
-    tools: [],
-    tool_choice: { type: 'function', function: { name: 'fetch' } },
+  const namedOut = composeNativeDevInstructions(undefined, {
+    type: 'function',
+    function: { name: 'fetch' },
   });
   assert.ok(namedOut.includes('"fetch"'));
-  // Crucially: no envelope contract anywhere in the output, even when
-  // `tools` is present in the metadata.
-  const withTools = composeNativeDevInstructions({
-    system: 'sys',
-    tools: [{ type: 'function', function: { name: 'fetch' } }],
-    tool_choice: 'auto',
-  });
+  // Crucially: no envelope contract anywhere in the output, even when the
+  // caller supplied tools (tool_choice="auto").
+  const withTools = composeNativeDevInstructions('sys', 'auto');
   assert.equal(withTools.includes('tool_calls'), false);
   assert.equal(withTools.includes('{"tool_calls"'), false);
 });
@@ -1668,7 +1680,14 @@ test('developerInstructions omits self-identity directive on openai-compat tasks
         messageId: 'm1',
         parts: [{ kind: 'text', text: 'hi' }],
         metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: { system: 'be terse' },
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              messages: [
+                { role: 'system', content: 'be terse' },
+                { role: 'user', content: 'hi' },
+              ],
+            },
+          },
         },
       },
     },
@@ -1790,17 +1809,22 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
   }));
   const backend = createCodexBackend({ spawn: fake.spawn });
 
-  const oaiMeta = {
+  const oaiMetaFor = (text: string): Record<string, unknown> => ({
     [OPENAI_COMPAT_EXTENSION_URI]: {
-      system: 'sys',
-      tools: [
-        {
-          type: 'function',
-          function: { name: 'fetch', parameters: {} },
-        },
-      ],
+      chat_completions_request: {
+        messages: [
+          { role: 'system', content: 'sys' },
+          { role: 'user', content: text },
+        ],
+        tools: [
+          {
+            type: 'function',
+            function: { name: 'fetch', parameters: {} },
+          },
+        ],
+      },
     },
-  };
+  });
 
   // Turn 1.
   await backend.handle(
@@ -1809,7 +1833,7 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
         role: 'user',
         messageId: 'm1',
         parts: [{ kind: 'text', text: 'first' }],
-        metadata: oaiMeta,
+        metadata: oaiMetaFor('first'),
       },
     }),
     () => {},
@@ -1827,7 +1851,7 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
         role: 'user',
         messageId: 'm2',
         parts: [{ kind: 'text', text: 'second' }],
-        metadata: oaiMeta,
+        metadata: oaiMetaFor('second'),
       },
     }),
     emit,
@@ -1929,7 +1953,10 @@ test('thread/start disables every codex direct-execution feature when caller too
         parts: [{ kind: 'text', text: 'list files' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            chat_completions_request: {
+              messages: [{ role: 'user', content: 'list files' }],
+              tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            },
           },
         },
       },
@@ -1964,7 +1991,10 @@ test('thread/start sends `environments: []` when caller tools are active (#183)'
         parts: [{ kind: 'text', text: 'list files' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            chat_completions_request: {
+              messages: [{ role: 'user', content: 'list files' }],
+              tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+            },
           },
         },
       },
@@ -2021,6 +2051,39 @@ test('thread/start omits `config` when no caller tools are supplied', async () =
   assert.equal(params?.config, undefined);
 });
 
+test('envelope.model is forwarded as thread/start config.model (#302)', async () => {
+  // Per #302, the gateway-resolved model id (planetarium/oai2a2a#80
+  // ResolvedAgent.modelOverride) flows end-to-end so codex dispatches to
+  // the caller's selection rather than the operator's config.toml default.
+  // We carry it via `config.model` on thread/start.
+  const fake = makeFakeSpawn(() => happyPath());
+  const backend = createCodexBackend({ spawn: fake.spawn });
+  await backend.handle(
+    assign('hello', 'ctx-model-fwd', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hello' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              model: 'gpt-5.5-mini',
+              messages: [{ role: 'user', content: 'hello' }],
+            },
+          },
+        },
+      },
+    }),
+    collect().emit,
+    NEVER,
+  );
+  const tsFrame = findRequest(fake.lastChild().stdinFrames(), 'thread/start');
+  const params = (tsFrame as {
+    params?: { config?: { model?: string } };
+  }).params;
+  assert.equal(params?.config?.model, 'gpt-5.5-mini');
+});
+
 test('history-only openai-compat payload (no `tools`) does not disable codex built-ins via features (but still suppresses env_context)', async () => {
   // Mirror of the codex (exec) backend test. With tools absent there is no
   // caller-side dispatch contract to protect; do not handicap codex's
@@ -2037,14 +2100,17 @@ test('history-only openai-compat payload (no `tools`) does not disable codex bui
         parts: [{ kind: 'text', text: 'continue' }],
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_history: [
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [{ id: 'tc1', function: { name: 'x', arguments: '{}' } }],
-              },
-              { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
-            ],
+            chat_completions_request: {
+              messages: [
+                {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [{ id: 'tc1', function: { name: 'x', arguments: '{}' } }],
+                },
+                { role: 'tool', tool_call_id: 'tc1', content: 'OK' },
+                { role: 'user', content: 'continue' },
+              ],
+            },
           },
         },
       },
@@ -2071,18 +2137,21 @@ test('openai-compat tasks always thread/start, never thread/resume — every tur
   // (no `thread/resume` to forget them on).
   const fake = makeFakeSpawn(() => happyPath());
   const backend = createCodexBackend({ spawn: fake.spawn });
-  const meta = {
+  const metaFor = (text: string): Record<string, unknown> => ({
     [OPENAI_COMPAT_EXTENSION_URI]: {
-      tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+      chat_completions_request: {
+        messages: [{ role: 'user', content: text }],
+        tools: [{ type: 'function', function: { name: 'bash', parameters: {} } }],
+      },
     },
-  };
+  });
   await backend.handle(
     assign('one', 'ctx-feat-no-resume', {
       message: {
         role: 'user',
         messageId: 'm1',
         parts: [{ kind: 'text', text: 'one' }],
-        metadata: meta,
+        metadata: metaFor('one'),
       },
     }),
     collect().emit,
@@ -2094,7 +2163,7 @@ test('openai-compat tasks always thread/start, never thread/resume — every tur
         role: 'user',
         messageId: 'm2',
         parts: [{ kind: 'text', text: 'two' }],
-        metadata: meta,
+        metadata: metaFor('two'),
       },
     }),
     collect().emit,

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -677,40 +677,16 @@ export function createCodexBackend(
     ? buildSelfIdentitySystemPrompt(opts.identity)
     : '';
 
-  // Cache for codex's `model/list` response, used to gate `envelope.model`
-  // forwarding (#302). When the gateway sends a model id this codex install
-  // does not advertise, we drop the override and let codex fall back to its
-  // own default rather than handing it a value the CLI rejects (e.g. the
-  // ChatGPT-account codex rejects unknown ids with `invalid_request_error`).
-  //
-  // `null` after the fetch means "model/list unavailable" — older codex
-  // builds, app-server transport failure, etc. — and the bridge skips the
-  // validation entirely (forwards `envelope.model` verbatim) so we don't
-  // break installs that have no list to check against.
-  let supportedModelIds: Set<string> | null = null;
-  let supportedModelIdsFetched = false;
-
-  async function getSupportedModelIds(): Promise<Set<string> | null> {
-    if (supportedModelIdsFetched) return supportedModelIds;
-    supportedModelIdsFetched = true;
-    try {
-      const client = await ensureClient();
-      const result = await client.request<ModelListResult>('model/list', {});
-      const ids = (Array.isArray(result?.data) ? result.data : [])
-        .filter(
-          (m): m is ModelListEntry =>
-            !!m && typeof m.id === 'string' && m.id.length > 0,
-        )
-        .map((m) => m.id);
-      supportedModelIds = ids.length > 0 ? new Set(ids) : null;
-    } catch (err) {
-      logger?.warn?.(
-        `[codex] model/list lookup failed for envelope.model validation: ${errorMessage(err)}`,
-      );
-      supportedModelIds = null;
-    }
-    return supportedModelIds;
-  }
+  // Supported-models cache, populated by `resolveCapabilities` at daemon
+  // startup and read sync from `handle()` to gate `envelope.model`
+  // forwarding (#302). Mirrors the claude / vicoop-codex pattern.
+  // `undefined` = "never populated" — daemon hasn't called
+  // `resolveCapabilities` yet or tests skipped it, so validation is
+  // silently bypassed. `null` = "model/list was unavailable" — older
+  // codex builds, app-server transport failure, advertise dropped — so
+  // validation is again skipped. Non-empty Set = the visible model ids
+  // (plus any operator-pinned override the agent card surfaces).
+  let cachedSupportedModelIds: Set<string> | null | undefined = undefined;
 
   // contextId → (threadId, lastUsedAt). writeId-protected rollback so a
   // concurrent task on the same contextId doesn't get its session entry
@@ -921,6 +897,7 @@ export function createCodexBackend(
       try {
         client = await ensureClient();
       } catch {
+        cachedSupportedModelIds = null;
         return {};
       }
 
@@ -929,11 +906,15 @@ export function createCodexBackend(
         const result = await client.request<ModelListResult>('model/list', {});
         modelList = Array.isArray(result?.data) ? result.data : [];
       } catch {
+        cachedSupportedModelIds = null;
         return {};
       }
 
       const visible = modelList.filter((m) => m && typeof m.id === 'string' && m.id.length > 0 && !m.hidden);
-      if (visible.length === 0) return {};
+      if (visible.length === 0) {
+        cachedSupportedModelIds = null;
+        return {};
+      }
 
       const defaultId =
         (operatorOverride && visible.find((m) => m.id === operatorOverride)?.id) ??
@@ -954,6 +935,12 @@ export function createCodexBackend(
       if (operatorOverride && !visible.some((m) => m.id === operatorOverride)) {
         openaiCompatModels.unshift({ id: operatorOverride, default: true });
       }
+
+      // Populate the envelope.model validation cache from the same set of
+      // ids we just advertised. `handle()` does a sync `has()` against it
+      // without re-issuing `model/list` (#302).
+      const advertisedIds = new Set(openaiCompatModels.map((entry) => entry.id));
+      cachedSupportedModelIds = advertisedIds.size > 0 ? advertisedIds : null;
 
       return { openaiCompatModels };
     },
@@ -1072,11 +1059,25 @@ export function createCodexBackend(
           envelope && typeof envelope.model === 'string' && envelope.model.length > 0
             ? envelope.model
             : undefined;
-        // Resolved against `getSupportedModelIds()` after the app-server is
-        // up — see the `await client.request('thread/start' …)` block below.
-        // Declared here so the threadConfig assembly downstream can branch
-        // off the final value.
+        // Validate against the cache populated by `resolveCapabilities`.
+        // When the gateway sends a value codex doesn't advertise (#302) —
+        // e.g. an unresolved routing key like `a2a/<card-url>` — drop the
+        // override so the CLI falls back to its config.toml default rather
+        // than failing with `invalid_request_error`. When the cache is
+        // unpopulated (older codex, transport failure, or
+        // `resolveCapabilities` hasn't been called yet) the validation is
+        // skipped and `envelope.model` rides through unchanged.
         let envelopeModel: string | undefined = envelopeModelRaw;
+        if (
+          envelopeModelRaw !== undefined &&
+          cachedSupportedModelIds instanceof Set &&
+          !cachedSupportedModelIds.has(envelopeModelRaw)
+        ) {
+          logger?.warn?.(
+            `[codex] envelope.model=${JSON.stringify(envelopeModelRaw)} is not in this codex install's advertised model/list; falling back to codex default`,
+          );
+          envelopeModel = undefined;
+        }
         const dynamicTools =
           envelopeTools && callerToolDispatchActive(envelopeTools, envelopeToolChoice)
             ? openaiToolsToDynamicToolSpecs(envelopeTools)
@@ -1161,23 +1162,6 @@ export function createCodexBackend(
           try {
             client = await ensureClient();
             recorder.mark('initialized');
-            // Validate `envelope.model` against codex's advertised list now
-            // that the app-server is up. Drops the override when the gateway
-            // sends a value codex doesn't recognise (#302) — e.g. an unresolved
-            // routing key like `a2a/<card-url>` — so the CLI falls back to its
-            // own default rather than failing with `invalid_request_error`.
-            // Silent forward when `model/list` is unavailable (older codex,
-            // transport failure) — see `getSupportedModelIds`'s null-return
-            // contract.
-            if (envelopeModelRaw !== undefined) {
-              const supported = await getSupportedModelIds();
-              if (supported && !supported.has(envelopeModelRaw)) {
-                logger?.warn?.(
-                  `[codex] envelope.model=${JSON.stringify(envelopeModelRaw)} is not in this codex install's advertised model/list; falling back to codex default`,
-                );
-                envelopeModel = undefined;
-              }
-            }
           } catch (err) {
             emit({
               type: 'task.fail',

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -1010,7 +1010,6 @@ export function createCodexBackend(
             task.taskId,
             task.message.parts,
             task.message.metadata,
-            openaiCompat,
           );
         }
         const dynamicTools =

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -12,8 +12,10 @@ import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.j
 import { createLogger, type Logger } from '../logger.js';
 import {
   callerToolDispatchActive,
+  chatHistoryFromMessages,
+  collectSystemFromMessages,
   dumpOpenAICompatTaskWire,
-  parseOpenAICompatMetadata,
+  parseOpenAICompatEnvelope,
 } from './openai-compat.js';
 import {
   buildOpenAICompatResponseMetadata,
@@ -42,7 +44,6 @@ import {
 import type {
   OpenAICompatHistoryEntry,
   OpenAICompatMessageContent,
-  OpenAICompatMetadata,
 } from './openai-compat.js';
 
 export type CodexSandboxMode = SandboxMode;
@@ -482,10 +483,13 @@ export function openaiToolsToDynamicToolSpecs(
 // envelope-teaching block is omitted; the model sees the tools natively via
 // codex's function-call surface, so describing a JSON-emit contract would
 // only invite confusion.
-export function composeNativeDevInstructions(meta: OpenAICompatMetadata): string {
+export function composeNativeDevInstructions(
+  system: string | undefined,
+  toolChoice: unknown,
+): string {
   const sections: string[] = [];
-  if (meta.system) sections.push(meta.system);
-  const tc = meta.tool_choice;
+  if (system) sections.push(system);
+  const tc = toolChoice;
   if (tc === 'required') {
     sections.push(
       'tool_choice="required": you MUST invoke one of the available tools this turn; answering in natural language is not allowed.',
@@ -1003,7 +1007,13 @@ export function createCodexBackend(
         // short `tool_choice` nudge when applicable. The wire shape we emit
         // upstream (`tool_calls` artifact, `chat_history` input) is
         // unchanged so callers see no difference.
-        const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+        // Envelope-direct (#302): read the full inbound OpenAI Chat
+        // Completions request body verbatim and project system / chat_history
+        // off `envelope.messages[]` rather than going through the legacy
+        // decomposed view. `envelope.model` flows into the thread/start
+        // config so the gateway-resolved model id reaches codex instead of
+        // its config-pinned default.
+        const envelope = parseOpenAICompatEnvelope(task.message.metadata);
         if (openaiCompatTrace) {
           dumpOpenAICompatTaskWire(
             'codex',
@@ -1012,9 +1022,24 @@ export function createCodexBackend(
             task.message.metadata,
           );
         }
+        const envelopeTools = Array.isArray(envelope?.tools) && envelope.tools.length > 0
+          ? envelope.tools
+          : undefined;
+        const envelopeToolChoice = envelope?.tool_choice;
+        const envelopeSystem = envelope
+          ? collectSystemFromMessages(envelope.messages)
+          : undefined;
+        const envelopeChatHistory =
+          envelope && Array.isArray(envelope.messages)
+            ? chatHistoryFromMessages(envelope.messages)
+            : null;
+        const envelopeModel =
+          envelope && typeof envelope.model === 'string' && envelope.model.length > 0
+            ? envelope.model
+            : undefined;
         const dynamicTools =
-          openaiCompat && callerToolDispatchActive(openaiCompat) && openaiCompat.tools
-            ? openaiToolsToDynamicToolSpecs(openaiCompat.tools)
+          envelopeTools && callerToolDispatchActive(envelopeTools, envelopeToolChoice)
+            ? openaiToolsToDynamicToolSpecs(envelopeTools)
             : null;
         // In openai-compat mode codex is acting as a *model endpoint*, not
         // as an A2A agent — the gateway in front of it owns conversation
@@ -1024,8 +1049,8 @@ export function createCodexBackend(
         // compete with. Plain-task mode (no openai-compat metadata) keeps
         // the directive because that's the actual a2a-agent surface the
         // mention can land on.
-        const systemPrompt = openaiCompat
-          ? composeNativeDevInstructions(openaiCompat)
+        const systemPrompt = envelope
+          ? composeNativeDevInstructions(envelopeSystem, envelopeToolChoice)
           : identityDevInstructions;
 
         const mappedRaw = await mapPartsToCodexInput(task.message.parts, {
@@ -1045,7 +1070,7 @@ export function createCodexBackend(
         const isToolContinuation =
           !mappedRaw.ok &&
           mappedRaw.code === 'empty_prompt' &&
-          (openaiCompat?.chat_history?.length ?? 0) > 0;
+          (envelopeChatHistory?.length ?? 0) > 0;
         if (!mappedRaw.ok && !isToolContinuation) {
           emit({
             type: 'task.fail',
@@ -1080,8 +1105,8 @@ export function createCodexBackend(
         // `<environment_context>` user turn), the model receives an OpenAI
         // Chat Completions-shaped conversation built from chat_history + the
         // trailing user, and finalises off it.
-        const historyInjectItems = openaiCompat?.chat_history
-          ? historyToInjectItems(openaiCompat.chat_history)
+        const historyInjectItems = envelopeChatHistory
+          ? historyToInjectItems(envelopeChatHistory)
           : null;
 
         try {
@@ -1123,7 +1148,7 @@ export function createCodexBackend(
           // tool result instead of answering a fresh question). Force a
           // clean `thread/start` every openai-compat task; the injected
           // history + turn/start.input is the unambiguous source of truth.
-          const sessionReuseEligible = openaiCompat === null && sessionTtlMs > 0;
+          const sessionReuseEligible = envelope === null && sessionTtlMs > 0;
           const tNow = now();
           if (sessionReuseEligible) evictExpired(tNow - sessionTtlMs);
           const existing = sessionReuseEligible ? sessions.get(task.contextId) : undefined;
@@ -1207,7 +1232,7 @@ export function createCodexBackend(
           // elicitation reply that never arrives under openai-compat).
           // `list_mcp_resources` and siblings are gated by codex's per-server
           // `mcp_tools` config — out of scope for this flag plumbing.
-          const featuresOverride = callerToolDispatchActive(openaiCompat)
+          const featuresOverride = callerToolDispatchActive(envelopeTools, envelopeToolChoice)
             ? {
                 features: {
                   // Hosted modalities that bypass the caller's text envelope.
@@ -1253,16 +1278,27 @@ export function createCodexBackend(
           // minor: the model loses date/timezone/cwd context, which
           // openai-compat callers don't rely on.
           const envContextOverride =
-            openaiCompat !== null ? { include_environment_context: false } : null;
+            envelope !== null ? { include_environment_context: false } : null;
+          // Forward the gateway-resolved model id via `config.model` so the
+          // CLI dispatches to the caller's selection rather than the
+          // operator's `config.toml` default (#302). Sticky on thread/start;
+          // re-sent on thread/resume because `ThreadConfigOverride` keys
+          // do not persist across resume.
+          const modelOverride =
+            envelopeModel !== undefined ? { model: envelopeModel } : null;
           const threadConfig =
-            featuresOverride || envContextOverride
-              ? { ...(featuresOverride ?? {}), ...(envContextOverride ?? {}) }
+            featuresOverride || envContextOverride || modelOverride
+              ? {
+                  ...(featuresOverride ?? {}),
+                  ...(envContextOverride ?? {}),
+                  ...(modelOverride ?? {}),
+                }
               : null;
           // `environments: []` is sticky on `thread/start` and unsupported on
           // `thread/resume`, so we only send it on start. Gated by the same
           // condition as the feature override so non-openai-compat callers
           // keep their normal codex environment.
-          const sendEmptyEnvironments = callerToolDispatchActive(openaiCompat);
+          const sendEmptyEnvironments = callerToolDispatchActive(envelopeTools, envelopeToolChoice);
 
           let threadId: string;
           try {
@@ -1384,7 +1420,7 @@ export function createCodexBackend(
           // dynamicTools with SessionMeta and the resumed thread can still
           // invoke them. The handler is unregistered in the `finally` of
           // the outer try that wraps the turn loop below.
-          if (openaiCompat) {
+          if (envelope) {
             registeredThreadId = threadId;
             toolCallHandlers.set(threadId, async (p) => {
               capturedToolCall = true;
@@ -1755,13 +1791,13 @@ export function createCodexBackend(
           // missing_usage 502). The zeros honestly signal "runtime did
           // not report" rather than fabricating a tokenizer estimate the
           // codex runtime never produced.
-          const finalUsageSnapshot: OpenAICompatUsage | null = openaiCompat && !finalUsage
+          const finalUsageSnapshot: OpenAICompatUsage | null = envelope && !finalUsage
             ? buildOpenAICompatUsage({
                 prompt_tokens: 0,
                 completion_tokens: 0,
               })
             : finalUsage;
-          const envelope = openaiCompat
+          const responseEnvelope = envelope
             ? buildCodexChatCompletionEnvelope({
                 taskId: task.taskId,
                 model: finalUsageSnapshot?.model,
@@ -1772,7 +1808,7 @@ export function createCodexBackend(
               })
             : undefined;
 
-          const messageMetadata = buildOpenAICompatResponseMetadata(envelope, finalUsage);
+          const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, finalUsage);
           // When parts is empty but we have envelope/usage to convey, still
           // emit the message frame so the metadata reaches the gateway.
           const hasMessage = parts.length > 0 || messageMetadata !== undefined;

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -677,6 +677,41 @@ export function createCodexBackend(
     ? buildSelfIdentitySystemPrompt(opts.identity)
     : '';
 
+  // Cache for codex's `model/list` response, used to gate `envelope.model`
+  // forwarding (#302). When the gateway sends a model id this codex install
+  // does not advertise, we drop the override and let codex fall back to its
+  // own default rather than handing it a value the CLI rejects (e.g. the
+  // ChatGPT-account codex rejects unknown ids with `invalid_request_error`).
+  //
+  // `null` after the fetch means "model/list unavailable" — older codex
+  // builds, app-server transport failure, etc. — and the bridge skips the
+  // validation entirely (forwards `envelope.model` verbatim) so we don't
+  // break installs that have no list to check against.
+  let supportedModelIds: Set<string> | null = null;
+  let supportedModelIdsFetched = false;
+
+  async function getSupportedModelIds(): Promise<Set<string> | null> {
+    if (supportedModelIdsFetched) return supportedModelIds;
+    supportedModelIdsFetched = true;
+    try {
+      const client = await ensureClient();
+      const result = await client.request<ModelListResult>('model/list', {});
+      const ids = (Array.isArray(result?.data) ? result.data : [])
+        .filter(
+          (m): m is ModelListEntry =>
+            !!m && typeof m.id === 'string' && m.id.length > 0,
+        )
+        .map((m) => m.id);
+      supportedModelIds = ids.length > 0 ? new Set(ids) : null;
+    } catch (err) {
+      logger?.warn?.(
+        `[codex] model/list lookup failed for envelope.model validation: ${errorMessage(err)}`,
+      );
+      supportedModelIds = null;
+    }
+    return supportedModelIds;
+  }
+
   // contextId → (threadId, lastUsedAt). writeId-protected rollback so a
   // concurrent task on the same contextId doesn't get its session entry
   // rolled back from under it.
@@ -1033,10 +1068,15 @@ export function createCodexBackend(
           envelope && Array.isArray(envelope.messages)
             ? chatHistoryFromMessages(envelope.messages)
             : null;
-        const envelopeModel =
+        const envelopeModelRaw =
           envelope && typeof envelope.model === 'string' && envelope.model.length > 0
             ? envelope.model
             : undefined;
+        // Resolved against `getSupportedModelIds()` after the app-server is
+        // up — see the `await client.request('thread/start' …)` block below.
+        // Declared here so the threadConfig assembly downstream can branch
+        // off the final value.
+        let envelopeModel: string | undefined = envelopeModelRaw;
         const dynamicTools =
           envelopeTools && callerToolDispatchActive(envelopeTools, envelopeToolChoice)
             ? openaiToolsToDynamicToolSpecs(envelopeTools)
@@ -1121,6 +1161,23 @@ export function createCodexBackend(
           try {
             client = await ensureClient();
             recorder.mark('initialized');
+            // Validate `envelope.model` against codex's advertised list now
+            // that the app-server is up. Drops the override when the gateway
+            // sends a value codex doesn't recognise (#302) — e.g. an unresolved
+            // routing key like `a2a/<card-url>` — so the CLI falls back to its
+            // own default rather than failing with `invalid_request_error`.
+            // Silent forward when `model/list` is unavailable (older codex,
+            // transport failure) — see `getSupportedModelIds`'s null-return
+            // contract.
+            if (envelopeModelRaw !== undefined) {
+              const supported = await getSupportedModelIds();
+              if (supported && !supported.has(envelopeModelRaw)) {
+                logger?.warn?.(
+                  `[codex] envelope.model=${JSON.stringify(envelopeModelRaw)} is not in this codex install's advertised model/list; falling back to codex default`,
+                );
+                envelopeModel = undefined;
+              }
+            }
           } catch (err) {
             emit({
               type: 'task.fail',

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -166,6 +166,33 @@ export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boo
   return meta.tool_choice !== 'none';
 }
 
+// Extract the openai-compat extension's request envelope verbatim. Reads
+// `metadata[OPENAI_COMPAT_EXTENSION_URI].chat_completions_request` (the
+// symmetric envelope contract — oai2a2a#80 — places the full inbound
+// OpenAI Chat Completions request body there) and returns it without
+// decomposition.
+//
+// This is the envelope-direct entry point used by backends migrating off
+// `parseOpenAICompatMetadata`'s decomposed view (#302). Backends consume
+// the envelope's fields directly (`model`, `tools`, `tool_choice`,
+// `messages[]`) and reuse the exported projection helpers
+// (`collectSystemFromMessages`, `chatHistoryFromMessages`) to derive the
+// system text and the multi-turn replay block.
+//
+// Returns null when the envelope key is absent or malformed so callers
+// can short-circuit before touching projection helpers.
+export function parseOpenAICompatEnvelope(
+  metadata: Record<string, unknown> | undefined,
+): OpenAICompatRequestEnvelope | null {
+  if (!metadata) return null;
+  const raw = metadata[OPENAI_COMPAT_EXTENSION_URI];
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const r = raw as Record<string, unknown>;
+  const env = r.chat_completions_request;
+  if (!env || typeof env !== 'object' || Array.isArray(env)) return null;
+  return env as OpenAICompatRequestEnvelope;
+}
+
 // Extract and shape-check the openai-compat extension metadata. Reads the
 // `chat_completions_request` envelope (the symmetric envelope contract —
 // oai2a2a#80 — places the full inbound OpenAI Chat Completions request
@@ -315,7 +342,7 @@ function parseLegacyChatHistory(raw: unknown[]): OpenAICompatHistoryEntry[] | nu
 // prompts). Non-text parts (image_url etc.) in a system message are
 // silently dropped — system channels are text-only on every supported
 // backend.
-function collectSystemFromMessages(messages: unknown): string | undefined {
+export function collectSystemFromMessages(messages: unknown): string | undefined {
   if (!Array.isArray(messages)) return undefined;
   const parts: string[] = [];
   for (const entry of messages) {
@@ -354,7 +381,7 @@ function collectSystemFromMessages(messages: unknown): string | undefined {
 // Returns null when the projection is empty (e.g. a single-turn
 // trailing-user-only request) so callers can omit history-replay code
 // paths cleanly.
-function chatHistoryFromMessages(
+export function chatHistoryFromMessages(
   messages: unknown[],
 ): OpenAICompatHistoryEntry[] | null {
   // Find the index of the trailing user turn. Per spec it is split into
@@ -620,9 +647,14 @@ export function dumpOpenAICompatTaskWire(
   taskId: string,
   parts: readonly Part[] | undefined,
   metadata: Record<string, unknown> | undefined,
-  parsed: OpenAICompatMetadata | null,
 ): void {
   try {
+    // Derive the summary view from metadata in one place so backends never
+    // pass a parsed projection — the parser+envelope helpers already cover
+    // every shape (envelope contract + legacy decomposed) the dump cares
+    // about. Keeps the trace one-line shape stable across backend migration.
+    const parsed = parseOpenAICompatMetadata(metadata);
+    const envelope = parseOpenAICompatEnvelope(metadata);
     const partsSummary = (parts ?? []).map((p) => {
       if (p.kind === 'text') return { kind: 'text', len: p.text.length };
       if (p.kind === 'file') return { kind: 'file', mime: p.file.mimeType };
@@ -635,6 +667,10 @@ export function dumpOpenAICompatTaskWire(
           tools: parsed.tools?.length ?? 0,
           tool_choice: parsed.tool_choice,
           hist: parsed.chat_history?.length ?? 0,
+          // `model` is envelope-only — the legacy decomposed shape never
+          // carried it, so it stays `undefined` for legacy-shape traces.
+          model:
+            envelope && typeof envelope.model === 'string' ? envelope.model : undefined,
         }
       : null;
     console.error(

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -160,10 +160,16 @@ function parseUserOrAssistantContent(raw: unknown): OpenAICompatMessageContent |
 // `buildOpenAICompatSystemPrompt` so the gate that enables the envelope
 // contract in the prompt is the same gate that disables the conflicting
 // built-ins.
-export function callerToolDispatchActive(meta: OpenAICompatMetadata | null): boolean {
-  if (!meta) return false;
-  if (meta.tools === undefined) return false;
-  return meta.tool_choice !== 'none';
+//
+// Takes the envelope's `tools` and `tool_choice` directly so callers in the
+// envelope-direct migration (#302) don't have to go through the decomposed
+// metadata view.
+export function callerToolDispatchActive(
+  tools: unknown,
+  toolChoice: unknown,
+): boolean {
+  if (!Array.isArray(tools) || tools.length === 0) return false;
+  return toolChoice !== 'none';
 }
 
 // Extract the openai-compat extension's request envelope verbatim. Reads

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -1421,7 +1421,6 @@ export function createOpenclawBackend(
           task.taskId,
           task.message.parts,
           task.message.metadata,
-          openaiCompat,
         );
       }
       if (openaiCompat) {

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -14,6 +14,7 @@ import {
   flattenA2AUserContent,
   historyToChatCompletionMessages,
   parseChatCompletionUsage,
+  probeVicoopCodexModels,
   type ChatCompletionResponse,
   type VicoopCodexChildHandle,
   type VicoopCodexSpawnFn,
@@ -815,4 +816,202 @@ test('handle: cancel before spawn → task.complete with canceled', async () => 
   const frame = frames[0];
   if (frame.type !== 'task.complete') throw new Error('unreachable');
   assert.equal(frame.status.state, 'canceled');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// `probeVicoopCodexModels` + envelope.model gate (#302). The probe spawns
+// `vicoop-codex models --json`, reads the model id list, and feeds the
+// backend's cache so `resolveCapabilities` can advertise on the agent card
+// and `handle` can drop unresolved routing keys before forwarding to the
+// CLI.
+// ───────────────────────────────────────────────────────────────────────────
+
+test('probeVicoopCodexModels: parses `models --json` shape into a string[] id list', async () => {
+  const fake = makeFakeSpawn();
+  const probe = probeVicoopCodexModels({
+    command: 'vicoop-codex',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+  // The fake's child is spawned synchronously when probeVicoopCodexModels
+  // calls spawn; drive it on the next microtask so the .on('data') listener
+  // is registered first.
+  queueMicrotask(() => {
+    const child = fake.lastChild();
+    child.emitStdout(
+      JSON.stringify({
+        client_version: '0.133.0',
+        models: [
+          { id: 'gpt-5.5', service_tiers: [] },
+          { id: 'gpt-5.4', service_tiers: [] },
+        ],
+      }),
+    );
+    child.finish(0);
+  });
+  const ids = await probe;
+  assert.deepEqual(ids, ['gpt-5.5', 'gpt-5.4']);
+});
+
+test('probeVicoopCodexModels: non-zero exit returns null', async () => {
+  const fake = makeFakeSpawn();
+  const probe = probeVicoopCodexModels({
+    command: 'vicoop-codex',
+    spawn: fake.spawn,
+    timeoutMs: 1000,
+  });
+  queueMicrotask(() => fake.lastChild().finish(1));
+  assert.equal(await probe, null);
+});
+
+test('probeVicoopCodexModels: timeoutMs:0 short-circuits without spawning', async () => {
+  const fake = makeFakeSpawn();
+  const ids = await probeVicoopCodexModels({
+    command: 'vicoop-codex',
+    spawn: fake.spawn,
+    timeoutMs: 0,
+  });
+  assert.equal(ids, null);
+  assert.equal(fake.children.length, 0);
+});
+
+test('resolveCapabilities advertises openaiCompatModels with the first id tagged default (#302)', async () => {
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const capPromise = backend.resolveCapabilities?.();
+  queueMicrotask(() => {
+    fake.lastChild().emitStdout(
+      JSON.stringify({
+        models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.4' }],
+      }),
+    );
+    fake.lastChild().finish(0);
+  });
+  const cap = await capPromise;
+  assert.deepEqual(cap, {
+    openaiCompatModels: [
+      { id: 'gpt-5.5', default: true },
+      { id: 'gpt-5.4' },
+    ],
+  });
+});
+
+test('envelope.model is forwarded when the probed list advertises it (#302)', async () => {
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const capPromise = backend.resolveCapabilities?.();
+  queueMicrotask(() => {
+    fake.lastChild().emitStdout(
+      JSON.stringify({ models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.4' }] }),
+    );
+    fake.lastChild().finish(0);
+  });
+  await capPromise;
+
+  const frames: UpFrame[] = [];
+  const ctrl = new AbortController();
+  const done = backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 't',
+      contextId: 'c',
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              model: 'gpt-5.5',
+              messages: [{ role: 'user', content: 'hi' }],
+            },
+          },
+        },
+      },
+    },
+    (f) => frames.push(f),
+    ctrl.signal,
+  );
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  // index 0 was the probe child; the call child is the second one.
+  const callChild = fake.children[1];
+  const body = JSON.parse(callChild.stdinPayload()) as Record<string, unknown>;
+  assert.equal(body.model, 'gpt-5.5');
+  // Drive the call child to a clean exit so done resolves.
+  callChild.emitStdout(
+    JSON.stringify({
+      id: 'x',
+      object: 'chat.completion',
+      created: 1,
+      model: 'gpt-5.5',
+      choices: [
+        { index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+  callChild.finish(0);
+  await done;
+});
+
+test('envelope.model is dropped when the probed list does NOT advertise it (#302)', async () => {
+  // Regression guard for the gateway sending an unresolved routing key
+  // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the gate the
+  // bridge would forward garbage to vicoop-codex, which would then fail
+  // upstream with `model not found`. With the gate the override is
+  // dropped and the CLI falls back to its DEFAULT_MODEL.
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const capPromise = backend.resolveCapabilities?.();
+  queueMicrotask(() => {
+    fake.lastChild().emitStdout(
+      JSON.stringify({ models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.4' }] }),
+    );
+    fake.lastChild().finish(0);
+  });
+  await capPromise;
+
+  const frames: UpFrame[] = [];
+  const ctrl = new AbortController();
+  const done = backend.handle(
+    {
+      type: 'task.assign',
+      taskId: 't',
+      contextId: 'c',
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              model: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
+              messages: [{ role: 'user', content: 'hi' }],
+            },
+          },
+        },
+      },
+    },
+    (f) => frames.push(f),
+    ctrl.signal,
+  );
+  await new Promise<void>((resolve) => queueMicrotask(resolve));
+  const callChild = fake.children[1];
+  const body = JSON.parse(callChild.stdinPayload()) as Record<string, unknown>;
+  // model field absent — CLI falls back to DEFAULT_MODEL.
+  assert.equal(body.model, undefined);
+  callChild.emitStdout(
+    JSON.stringify({
+      id: 'x',
+      object: 'chat.completion',
+      created: 1,
+      model: 'gpt-5.5',
+      choices: [
+        { index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+  callChild.finish(0);
+  await done;
 });

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -252,17 +252,15 @@ test('historyToChatCompletionMessages: prior user/assistant text turns round-tri
 
 test('buildMessages: ordering — system → history → user', () => {
   const msgs = buildMessages(
-    {
-      system: 'be concise',
-      chat_history: [
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'result' },
-      ],
-    },
+    'be concise',
+    [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'c1', content: 'result' },
+    ],
     'current ask',
   );
   assert.deepEqual(
@@ -294,24 +292,22 @@ test('buildMessages: multi-turn tool-loop scenario from PR #289 keeps opening us
   // be at index 1 (right after system), and the trailing user MUST be
   // last, regardless of how many tool round-trips sit between them.
   const msgs = buildMessages(
-    {
-      system: 'be concise',
-      chat_history: [
-        { role: 'user', content: 'list workflows then run X' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'list_workflows', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: '[…]' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c2', function: { name: 'execute', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c2', content: 'started' },
-      ],
-    },
+    'be concise',
+    [
+      { role: 'user', content: 'list workflows then run X' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'c1', function: { name: 'list_workflows', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'c1', content: '[…]' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'c2', function: { name: 'execute', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'c2', content: 'started' },
+    ],
     'how is it going?',
   );
   assert.deepEqual(
@@ -331,17 +327,16 @@ test('buildMessages: tool-continuation (null userContent) skips trailing user', 
   // placeholder, the caller passes null userContent and chat_history
   // carries the full conversation including the trailing tool result.
   const msgs = buildMessages(
-    {
-      chat_history: [
-        { role: 'user', content: 'kick off' },
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'result' },
-      ],
-    },
+    undefined,
+    [
+      { role: 'user', content: 'kick off' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
+      },
+      { role: 'tool', tool_call_id: 'c1', content: 'result' },
+    ],
     null,
   );
   assert.deepEqual(
@@ -351,36 +346,42 @@ test('buildMessages: tool-continuation (null userContent) skips trailing user', 
 });
 
 test('buildMessages: no metadata still emits a user message', () => {
-  const msgs = buildMessages(null, 'hi');
+  const msgs = buildMessages(undefined, null, 'hi');
   assert.deepEqual(msgs, [{ role: 'user', content: 'hi' }]);
 });
 
-test('buildCallBody: forwards only tools / tool_choice from the existing 4-field schema', () => {
+test('buildCallBody: forwards model / tools / tool_choice from the envelope', () => {
   const body = buildCallBody(
     {
-      system: 'sys',
+      model: 'gpt-5.4',
       tools: [{ type: 'function', function: { name: 'x' } }],
       tool_choice: 'auto',
-      chat_history: [
-        {
-          role: 'assistant',
-          content: null,
-          tool_calls: [{ id: 'c1', function: { name: 'x', arguments: '{}' } }],
-        },
-        { role: 'tool', tool_call_id: 'c1', content: 'r' },
-      ],
+      messages: [],
     },
     [{ role: 'user', content: 'q' }],
   );
+  assert.equal(body.model, 'gpt-5.4');
   assert.deepEqual(body.tools, [{ type: 'function', function: { name: 'x' } }]);
   assert.equal(body.tool_choice, 'auto');
   assert.deepEqual(body.messages, [{ role: 'user', content: 'q' }]);
-  // Nothing else lands on the body — no model, no reasoning_effort, no
-  // Group B / Group C fields.
-  assert.equal(Object.keys(body).sort().join(','), 'messages,tool_choice,tools');
+  // Nothing else lands on the body — no reasoning_effort, no Group B /
+  // Group C fields.
+  assert.equal(
+    Object.keys(body).sort().join(','),
+    'messages,model,tool_choice,tools',
+  );
 });
 
-test('buildCallBody: no metadata yields messages-only body', () => {
+test('buildCallBody: envelope without model omits the model field', () => {
+  const body = buildCallBody(
+    { tools: [{ type: 'function', function: { name: 'x' } }], messages: [] },
+    [{ role: 'user', content: 'q' }],
+  );
+  assert.equal(body.model, undefined);
+  assert.ok(body.tools);
+});
+
+test('buildCallBody: no envelope yields messages-only body', () => {
   const body = buildCallBody(null, [{ role: 'user', content: 'q' }]);
   assert.deepEqual(body, { messages: [{ role: 'user', content: 'q' }] });
 });
@@ -664,7 +665,7 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
   assert.equal(fn.arguments, '{"path":"."}');
 });
 
-test('handle: stdin body carries only system/tools/tool_choice/history-derived messages', async () => {
+test('handle: stdin body carries envelope-derived model/messages/tools/tool_choice', async () => {
   const task = makeTask({
     message: {
       role: 'user',
@@ -672,30 +673,30 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
       parts: [{ kind: 'text', text: 'current question' }],
       metadata: {
         [OPENAI_COMPAT_EXTENSION_URI]: {
-          // The 4-field schema only.
-          system: 'reply in korean',
-          tools: [{ type: 'function', function: { name: 'get_weather' } }],
-          tool_choice: { type: 'function', function: { name: 'get_weather' } },
-          chat_history: [
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  id: 'call_1',
-                  type: 'function',
-                  function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
-                },
-              ],
-            },
-            { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
-          ],
-          // Unknown extension keys must NOT reach the call body — they
-          // aren't part of the openai-compat 4-field schema.
-          model: 'gpt-5.5',
-          reasoning_effort: 'high',
-          temperature: 0.7,
-          max_tokens: 200,
+          chat_completions_request: {
+            model: 'gpt-5.5',
+            messages: [
+              { role: 'system', content: 'reply in korean' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
+                  },
+                ],
+              },
+              { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
+              // Trailing user — split into A2A parts; chatHistoryFromMessages
+              // drops this from the replay so the test's A2A `parts` text
+              // becomes the trailing user instead.
+              { role: 'user', content: 'current question' },
+            ],
+            tools: [{ type: 'function', function: { name: 'get_weather' } }],
+            tool_choice: { type: 'function', function: { name: 'get_weather' } },
+          },
         },
       },
     },
@@ -728,9 +729,11 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
       messages.map((m) => m.role),
       ['system', 'assistant', 'tool', 'user'],
     );
-    // Only the existing 4-field schema's `tools` / `tool_choice` are
-    // forwarded; the spurious model/reasoning_effort/temperature/max_tokens
-    // entries are dropped at the metadata reader.
+    // Envelope contract: model + tools + tool_choice forward verbatim.
+    // Group B / Group C fields (reasoning_effort, temperature, max_tokens
+    // etc.) are intentionally not on the call body shape — the binary
+    // applies its own defaults.
+    assert.equal(body.model, 'gpt-5.5');
     assert.deepEqual(body.tools, [
       { type: 'function', function: { name: 'get_weather' } },
     ]);
@@ -738,7 +741,6 @@ test('handle: stdin body carries only system/tools/tool_choice/history-derived m
       type: 'function',
       function: { name: 'get_weather' },
     });
-    assert.equal(body.model, undefined);
     assert.equal(body.reasoning_effort, undefined);
     assert.equal(body.temperature, undefined);
     assert.equal(body.max_tokens, undefined);

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -55,6 +55,12 @@ export interface VicoopCodexBackendOptions {
   spawn?: VicoopCodexSpawnFn;
   stderrCaptureBytes?: number;
   callTimeoutMs?: number;
+  // Max time the startup probe (`vicoop-codex models --json` via
+  // `resolveCapabilities`) waits for the model list before giving up.
+  // Setting to 0 disables the probe entirely — the agent card carries no
+  // declared models and `envelope.model` validation is skipped. Default
+  // 10s mirrors claude's probeTimeoutMs.
+  probeTimeoutMs?: number;
   logger?: Logger;
   // When true, dump A2A `parts` shape + metadata keys + raw
   // `chat_history` to stderr on every task. Operator diagnostic exposed
@@ -605,6 +611,71 @@ async function runVicoopCodexCall(
 // non-streaming `vicoop-codex call` invocation: read the existing
 // openai-compat extension metadata → assemble messages → invoke →
 // translate response to A2A artifacts + final message metadata.
+// Probe the vicoop-codex CLI's `models --json` subcommand to discover the
+// model ids this account / install advertises. Returns null on any failure
+// (binary missing, timeout, non-JSON stdout, unexpected shape) so the
+// caller can skip the advertise / `envelope.model` gate silently. Mirrors
+// `probeClaudeModel`'s "best-effort, fail-open" contract.
+export async function probeVicoopCodexModels(args: {
+  command: string;
+  spawn: VicoopCodexSpawnFn;
+  cwd?: string;
+  timeoutMs: number;
+}): Promise<string[] | null> {
+  if (args.timeoutMs <= 0) return null;
+  let child: VicoopCodexChildHandle;
+  try {
+    child = args.spawn(args.command, ['models', '--json'], { cwd: args.cwd });
+  } catch {
+    return null;
+  }
+  return await new Promise<string[] | null>((resolve) => {
+    let stdout = '';
+    let settled = false;
+    const finish = (value: string[] | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // best-effort
+      }
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(null), args.timeoutMs);
+    if (child.stdout) {
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        stdout += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      });
+    }
+    child.on('error', () => finish(null));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        finish(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout) as { models?: unknown };
+        if (!Array.isArray(parsed.models)) {
+          finish(null);
+          return;
+        }
+        const ids: string[] = [];
+        for (const m of parsed.models) {
+          if (m && typeof m === 'object' && typeof (m as { id?: unknown }).id === 'string') {
+            const id = (m as { id: string }).id;
+            if (id.length > 0) ids.push(id);
+          }
+        }
+        finish(ids.length > 0 ? ids : null);
+      } catch {
+        finish(null);
+      }
+    });
+  });
+}
+
 export function createVicoopCodexBackend(
   opts: VicoopCodexBackendOptions = {},
 ): Backend {
@@ -614,11 +685,42 @@ export function createVicoopCodexBackend(
   const spawnFn = opts.spawn ?? defaultSpawn;
   const stderrCap = opts.stderrCaptureBytes ?? 16 * 1024;
   const callTimeoutMs = opts.callTimeoutMs ?? 0;
+  const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
   const logger = opts.logger ?? createLogger();
   const openaiCompatTrace = opts.openaiCompatTrace === true;
 
+  // Supported-models cache, populated by `resolveCapabilities` at daemon
+  // startup and read sync from `handle()` to gate `envelope.model`
+  // forwarding (#302). Mirrors claude's pattern — `undefined` = "never
+  // probed", `null` = "probed but unavailable", non-empty `Set` = the
+  // model ids the CLI's `models --json` advertised.
+  let cachedSupportedModels: Set<string> | null | undefined = undefined;
+
   return {
     name: 'vicoop-codex',
+
+    async resolveCapabilities() {
+      const ids = await probeVicoopCodexModels({
+        command,
+        spawn: spawnFn,
+        cwd,
+        timeoutMs: probeTimeoutMs,
+      });
+      if (!ids || ids.length === 0) {
+        cachedSupportedModels = null;
+        return {};
+      }
+      cachedSupportedModels = new Set(ids);
+      // Advertise on the openai-compat/v1 `params.models[]` slot so
+      // upstream A2A callers (and the gateway's model resolver) can see
+      // the list without round-tripping through `vicoop-codex models`.
+      // The first id is tagged as default — vicoop-codex's `models`
+      // output is already ordered with the recommended model first.
+      const openaiCompatModels = ids.map((id, i) =>
+        i === 0 ? { id, default: true as const } : { id },
+      );
+      return { openaiCompatModels };
+    },
 
     async handle(task, emit, signal) {
       if (signal.aborted) {
@@ -668,8 +770,32 @@ export function createVicoopCodexBackend(
         return;
       }
 
+      // Validate envelope.model against the cache populated by
+      // `resolveCapabilities`. When the gateway sends a value this
+      // vicoop-codex install does not advertise (e.g. an unresolved routing
+      // key like `a2a/<card-url>`), drop the override so the CLI falls
+      // back to its DEFAULT_MODEL rather than failing the call with an
+      // upstream "model not found" error (#302). When the cache is
+      // unpopulated (probeTimeoutMs ≤ 0, probe failed, or
+      // `resolveCapabilities` hasn't been called yet) the validation is
+      // skipped and `envelope.model` rides through unchanged.
+      let effectiveEnvelope = envelope;
+      if (
+        envelope &&
+        typeof envelope.model === 'string' &&
+        envelope.model.length > 0 &&
+        cachedSupportedModels instanceof Set &&
+        !cachedSupportedModels.has(envelope.model)
+      ) {
+        logger.warn?.(
+          `[vicoop-codex] envelope.model=${JSON.stringify(envelope.model)} is not in this account's advertised models list; falling back to vicoop-codex default`,
+        );
+        const { model: _droppedModel, ...rest } = envelope;
+        effectiveEnvelope = rest as OpenAICompatRequestEnvelope;
+      }
+
       const messages = buildMessages(system, chatHistory, userContent);
-      const body = buildCallBody(envelope, messages);
+      const body = buildCallBody(effectiveEnvelope, messages);
       let serialized: string;
       try {
         serialized = JSON.stringify(body);

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -7,11 +7,13 @@ import {
 import type { Backend } from '../backend.js';
 import { createLogger, type Logger } from '../logger.js';
 import {
+  chatHistoryFromMessages,
+  collectSystemFromMessages,
   dumpOpenAICompatTaskWire,
-  parseOpenAICompatMetadata,
+  parseOpenAICompatEnvelope,
   type OpenAICompatHistoryEntry,
   type OpenAICompatMessageContent,
-  type OpenAICompatMetadata,
+  type OpenAICompatRequestEnvelope,
 } from './openai-compat.js';
 import {
   buildOpenAICompatResponseMetadata,
@@ -61,14 +63,18 @@ export interface VicoopCodexBackendOptions {
 }
 
 // `vicoop-codex call` body shape — only the fields this backend actually
-// emits. The openai-compat A2A extension defines `system` / `tools` /
-// `tool_choice` / `chat_history`, of which `system` and
-// `chat_history` fold into `messages`; the remaining two ride out
-// verbatim. Everything else (model, reasoning_effort, parallel_tool_calls,
-// the Group B / Group C parameters from the call command's input doc) is
-// intentionally not on this shape because no input surface we currently
-// read carries them. The binary applies its own defaults.
+// emits. The openai-compat A2A extension envelope (oai2a2a#80) carries a
+// full OpenAI Chat Completions request body; the bridge forwards `model`
+// (so the gateway-resolved model id reaches the CLI rather than the CLI's
+// own DEFAULT_MODEL), the assembled `messages[]` (envelope's system +
+// prior turns + the trailing user content flattened from A2A parts),
+// `tools`, and `tool_choice`. Everything else (reasoning_effort,
+// parallel_tool_calls, the Group B / Group C parameters from the call
+// command's input doc) is intentionally not on this shape because no
+// input surface we currently read carries them. The binary applies its
+// own defaults.
 export interface VicoopCodexCallBody {
+  model?: string;
   messages: ChatCompletionMessage[];
   tools?: unknown[];
   tool_choice?: unknown;
@@ -253,9 +259,11 @@ function openAIMessageContentToString(
 
 // Assemble the full `messages` array for the call body. Order, per the
 // doc's "Per-role message JSON examples" section:
-//   1. system (from openai-compat.system; one entry)
+//   1. system (concatenated from envelope's `messages[]` system/developer
+//      entries; one entry)
 //   2. chat_history entries (prior user / assistant text turns + tool
-//      round-trips) mapped 1:1 to OpenAI Chat Completions messages
+//      round-trips, derived from envelope's `messages[]` minus the
+//      trailing user) mapped 1:1 to OpenAI Chat Completions messages
 //   3. current user turn (flattened from A2A parts)
 //
 // The user turn comes last so the model sees prior context before the
@@ -264,15 +272,16 @@ function openAIMessageContentToString(
 // is omitted — the chat_history's last entry is the tool result the
 // model should respond to.
 export function buildMessages(
-  meta: OpenAICompatMetadata | null,
+  system: string | undefined,
+  chatHistory: OpenAICompatHistoryEntry[] | null,
   userContent: string | null,
 ): ChatCompletionMessage[] {
   const messages: ChatCompletionMessage[] = [];
-  if (meta?.system) {
-    messages.push({ role: 'system', content: meta.system });
+  if (system) {
+    messages.push({ role: 'system', content: system });
   }
-  if (meta?.chat_history) {
-    for (const m of historyToChatCompletionMessages(meta.chat_history)) {
+  if (chatHistory) {
+    for (const m of historyToChatCompletionMessages(chatHistory)) {
       messages.push(m);
     }
   }
@@ -282,23 +291,32 @@ export function buildMessages(
   return messages;
 }
 
-// Assemble the call body from the existing openai-compat A2A extension:
-//   - `tools` / `tool_choice` (read by the existing `parseOpenAICompatMetadata`)
-//   - the assembled `messages` array (from `system` + `chat_history`
-//     + current user turn — the other two fields of the extension)
+// Assemble the call body from the openai-compat envelope. Forwards:
+//   - `model`: the gateway-resolved model id so the CLI dispatches to the
+//     caller's selection rather than the binary's DEFAULT_MODEL (#302).
+//   - `tools` / `tool_choice`: verbatim off the envelope.
+//   - `messages`: the pre-assembled array (system + chat_history + current
+//     user turn).
 //
-// Nothing else is forwarded. The openai-compat A2A extension only defines
-// those four fields, and we read no other A2A or operator-side input on
-// behalf of this backend. `model`, `reasoning_effort`, `parallel_tool_calls`,
+// Nothing else is forwarded. `reasoning_effort`, `parallel_tool_calls`,
 // and every Group B / Group C parameter from the call command's input doc
 // are left unset — the vicoop-codex binary applies its own defaults.
 export function buildCallBody(
-  meta: OpenAICompatMetadata | null,
+  envelope: OpenAICompatRequestEnvelope | null,
   messages: ChatCompletionMessage[],
 ): VicoopCodexCallBody {
   const body: VicoopCodexCallBody = { messages };
-  if (meta?.tools) body.tools = meta.tools;
-  if (meta?.tool_choice !== undefined) body.tool_choice = meta.tool_choice;
+  if (envelope) {
+    if (typeof envelope.model === 'string' && envelope.model.length > 0) {
+      body.model = envelope.model;
+    }
+    if (Array.isArray(envelope.tools) && envelope.tools.length > 0) {
+      body.tools = envelope.tools;
+    }
+    if (envelope.tool_choice !== undefined && envelope.tool_choice !== null) {
+      body.tool_choice = envelope.tool_choice;
+    }
+  }
   return body;
 }
 
@@ -612,29 +630,32 @@ export function createVicoopCodexBackend(
         return;
       }
 
-      // Use the existing openai-compat A2A extension reader (claude.ts).
-      // It returns the 4-field schema { system, tools, tool_choice,
-      // chat_history } — the canonical surface every backend in this
-      // package already speaks. We do NOT define additional reader fields
-      // here: extending the extension schema unilaterally would risk
-      // breaking the contract other backends rely on.
-      const openaiCompat = parseOpenAICompatMetadata(task.message.metadata);
+      // Envelope-direct (#302): read the full inbound OpenAI Chat Completions
+      // request body off `metadata[URI].chat_completions_request` and drive
+      // the call body from the envelope's fields (`model`, `messages[]`,
+      // `tools`, `tool_choice`) instead of the legacy decomposed view.
+      const envelope = parseOpenAICompatEnvelope(task.message.metadata);
       if (openaiCompatTrace) {
         dumpOpenAICompatTaskWire(
           'vicoop-codex',
           task.taskId,
           task.message.parts,
           task.message.metadata,
-          openaiCompat,
         );
       }
+
+      const system = envelope ? collectSystemFromMessages(envelope.messages) : undefined;
+      const chatHistory =
+        envelope && Array.isArray(envelope.messages)
+          ? chatHistoryFromMessages(envelope.messages)
+          : null;
 
       const userContent = flattenA2AUserContent(task.message.parts);
       // Tool-continuation edge case (openai-compat spec): A2A parts is the
       // placeholder `[{text:""}]` and the conversation lives in
       // chat_history. Skip the empty_prompt check when chat_history will
       // supply the user-side content via the prior-turns sequence.
-      const hasHistory = (openaiCompat?.chat_history?.length ?? 0) > 0;
+      const hasHistory = (chatHistory?.length ?? 0) > 0;
       if (userContent === null && !hasHistory) {
         emit({
           type: 'task.fail',
@@ -647,8 +668,8 @@ export function createVicoopCodexBackend(
         return;
       }
 
-      const messages = buildMessages(openaiCompat, userContent);
-      const body = buildCallBody(openaiCompat, messages);
+      const messages = buildMessages(system, chatHistory, userContent);
+      const body = buildCallBody(envelope, messages);
       let serialized: string;
       try {
         serialized = JSON.stringify(body);


### PR DESCRIPTION
## Summary

Per-backend migration step of #302 — three of the four backends now consume the openai-compat extension envelope directly off `metadata[URI].chat_completions_request` instead of going through `parseOpenAICompatMetadata`'s decomposed `{system, tools, tool_choice, chat_history}` projection.

- **vicoop-codex** (`a5f9304`): reads envelope verbatim, adds `model: envelope.model` to the JSON body sent to `vicoop-codex call`.
- **codex** (`af4f453`): reads envelope verbatim, forwards `envelope.model` via `thread/start.config.model` so codex dispatches per-thread instead of using `config.toml`'s pinned default.
- **claude** (`8c2dd08`): reads envelope verbatim, forwards `envelope.model` via `--model <id>` on the claude CLI spawn.

Wire-level effect: the gateway-resolved model id (planetarium/oai2a2a#80 `ResolvedAgent.modelOverride`) now flows end-to-end — pool slug → resolved model id → backend dispatches to the right model. Previously the backends ignored `envelope.model` and used their own CLI default.

`openclaw` stays on the decomposed view; its envelope-direct migration plus the final `parseOpenAICompatMetadata` / `OpenAICompatMetadata` shim deletion will land in a follow-up per the issue's per-backend PR strategy.

## Internal API surface

- New: `parseOpenAICompatEnvelope(metadata)` — returns the raw envelope.
- Exported: `collectSystemFromMessages`, `chatHistoryFromMessages` for backends doing their own projection.
- Signature changes on internal helpers (decomposed-meta param → envelope fields):
  - `callerToolDispatchActive(tools, toolChoice)`
  - `composeNativeDevInstructions(system, toolChoice)` (codex)
  - `buildOpenAICompatNativeSystemPrompt(system, tools, toolChoice)` (claude)
  - `dumpOpenAICompatTaskWire` no longer takes a parsed-view param; it derives the summary from `metadata` directly.

## Test plan

- [x] Local: \`pnpm -r typecheck\` clean
- [x] Local: \`pnpm -r build\` clean
- [x] Local: \`pnpm --filter @vicoop-bridge/client test\` → 611 pass (5 new tests covering envelope.model forwarding + envelope-shape coverage)
- [x] Local: \`pnpm --filter @vicoop-bridge/server test\` → 184 pass
- [ ] End-to-end smoke against a local gateway sending a model id distinct from each backend's CLI default — verify the model id reaches the underlying CLI / app-server (acceptance criterion in #302)

Refs #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)