### PR TITLE
docs: replace deprecated flat CLI commands with auth/agent subcommands

### DIFF
--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -639,7 +639,7 @@ identifier external callers will see for this agent — the WebFinger acct, the
 `@<agentId>@<host>` mention, the JSON-RPC endpoint, and the agent-card URL.
 
 ```sh
-vicoop-client whoami
+vicoop-client auth whoami
 # agentId:    my-agent
 # host:       bridge.example.com
 # mention:    @my-agent@bridge.example.com
@@ -665,10 +665,10 @@ Typical follow-ups from this output:
    response doesn't match what you expect, that's the cue to override.
 
    ```sh
-   CARD_URL=$(vicoop-client whoami --json | jq -r .a2aCardUrl)
+   CARD_URL=$(vicoop-client auth whoami --json | jq -r .a2aCardUrl)
    curl -sf "$CARD_URL" | jq .
    ```
-3. **Verify WebFinger actually resolves the acct.** `whoami --verify`
+3. **Verify WebFinger actually resolves the acct.** `auth whoami --verify`
    additionally fetches the WebFinger URL and reports whether the bridge
    resolves this agent's acct under the derived host. This catches the
    client server URL host vs bridge `PUBLIC_URL` mismatch flagged in the

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -95,7 +95,7 @@ cd packages/client
 The WS registration auto-creates an `agent_policies` row with
 `allowed_callers = '{}'` (public). Two ways to populate it:
 
-- **`vicoop-client add-caller`** (Paths B/C below) — hot-reloads via
+- **`vicoop-client agent callers add`** (Paths B/C below) — hot-reloads via
   `registry.updateAllowedCallers`, no restart needed. Requires an
   owner-session bearer (issued via SIWE exchange or Google device flow).
 - **Raw SQL `UPDATE agent_policies SET allowed_callers = …`** (Path A
@@ -184,11 +184,11 @@ psql vicoop_bridge_dev -c \
 #     (`CLI` is just shorthand for the local-source invocation — see the
 #     callout below if you're working from a published bundle.)
 CLI="pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts"
-$CLI login --bridge http://localhost:8787
+$CLI auth login --bridge http://localhost:8787
 
 # 5b. Add the caller principal — hot-reloads via registry.updateAllowedCallers,
 #     no client restart needed.
-$CLI add-caller echo-agent "google:sub:<YOUR_SUB>"
+$CLI agent callers add echo-agent "google:sub:<YOUR_SUB>"
 
 # 6. Call the agent with the issued Bearer
 TOKEN="vbc_caller_..."   # from step 3
@@ -285,7 +285,7 @@ echo "$OWNER_TOKEN"   # vbc_owner_...
 
 CLI="pnpm --filter @vicoop-bridge/client exec tsx src/cli.ts"
 VICOOP_BRIDGE=http://localhost:8787 VICOOP_OWNER_TOKEN="$OWNER_TOKEN" \
-  $CLI add-caller echo-agent \
+  $CLI agent callers add echo-agent \
   'eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 
 # Call the agent with the caller-audience opaque token from step 3.
@@ -322,8 +322,8 @@ DATABASE_URL="postgres://$USER@localhost:5432/vicoop_bridge_dev" \
 - **`allowed_callers` edits via raw SQL don't hot-reload** — `registry.ts`
   caches the list in memory at WS registration. After a `psql` `UPDATE`
   (Path A), kill and re-run the echo client so it re-registers and the
-  registry re-reads the row. The `vicoop-client add-caller` /
-  `remove-caller` subcommands and the admin agent's `add_caller` tool
+  registry re-reads the row. The `vicoop-client agent callers add` /
+  `remove` subcommands and the admin agent's `add_caller` tool
   call `registry.updateAllowedCallers` and don't need a restart.
 - **Client `--server` URL must not include `/connect`** — client.ts appends it.
   `--server ws://localhost:8787/connect` results in `/connect/connect` and

--- a/docs/remote-testing.md
+++ b/docs/remote-testing.md
@@ -201,8 +201,8 @@ subject, so mutations on agents you own are authorized. Admin scope
 WALLET_PRINCIPAL=eth:0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266   # lowercase
 
 # Deterministic CLI path:
-vicoop-client login --bridge "$BRIDGE_URL"   # one-time
-vicoop-client add-caller "$AGENT_ID" "$WALLET_PRINCIPAL"
+vicoop-client auth login --bridge "$BRIDGE_URL"   # one-time
+vicoop-client agent callers add "$AGENT_ID" "$WALLET_PRINCIPAL"
 
 # Or the natural-language admin agent (uses $OWNER_TOKEN, a vbc_owner_*
 # bearer obtained via /auth/siwe/exchange or device flow with


### PR DESCRIPTION
## What

The operator-facing docs still referenced the **deprecated flat CLI commands**, which are hidden from `--help` and print a runtime deprecation warning ("will be removed in a future release"). Replace them with the canonical `auth` / `agent` subcommands.

## Replacements

| Deprecated (docs) | Canonical |
| --- | --- |
| `vicoop-client login` | `vicoop-client auth login` |
| `vicoop-client whoami` | `vicoop-client auth whoami` |
| `vicoop-client add-caller <id> <principal>` | `vicoop-client agent callers add <id> <principal>` |

(Positional args are identical between `add-caller` and `agent callers add` — verified against `packages/client/src/admin-cli.ts`.)

## Files

- `docs/install-client.md` — `whoami` → `auth whoami` (2 code blocks + 1 prose `--verify` mention)
- `docs/local-testing.md` — `add-caller`/`login` (`$CLI` shorthand + bullets) → `agent callers add` / `auth login`
- `docs/remote-testing.md` — CLI path snippet → `auth login` / `agent callers add`

## Left untouched (intentional)

- `packages/client/CHANGELOG.md` — historical release notes
- The **"Legacy flat aliases"** callout in `docs/install-client.md` that documents the deprecation itself
- The admin-agent `add_caller` **tool** name (a server-side tool, not a CLI command)

Docs-only — no changeset (no effect on the published client artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)