### PR TITLE
fix(client): parse `agent callers list/remove <AGENT_ID>` correctly

### DIFF
--- a/.changeset/fix-agent-callers-subcommand-parse.md
+++ b/.changeset/fix-agent-callers-subcommand-parse.md
@@ -9,3 +9,7 @@ top-level `agent list`/`agent remove` commands, and optique's
 commands — dropping the `AGENT_ID` positional and erroring with
 "Unexpected option or subcommand: <id>". Reordered the `agent` command
 group so `callers` is matched first.
+
+Also render `agent callers list` as a `TYPE` / `PRINCIPAL` table; the
+`PRINCIPAL` column keeps the full canonical form so a row can be pasted
+straight into `agent callers remove`.

--- a/.changeset/fix-agent-callers-subcommand-parse.md
+++ b/.changeset/fix-agent-callers-subcommand-parse.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Fix `agent callers list/remove <AGENT_ID>` failing to parse. The
+sub-subcommands shared the literal names `list`/`remove` with the
+top-level `agent list`/`agent remove` commands, and optique's
+`longestMatch` resolved the tie in favour of the all-optional top-level
+commands — dropping the `AGENT_ID` positional and erroring with
+"Unexpected option or subcommand: <id>". Reordered the `agent` command
+group so `callers` is matched first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,8 @@ pnpm -r build                               # build all packages (run this befor
 pnpm -r typecheck                           # typecheck all packages
 pnpm --filter @vicoop-bridge/client test    # client tests (~490 today)
 pnpm --filter @vicoop-bridge/server test    # server tests
-pnpm dev:client                             # tsx watch on the client CLI
+pnpm dev:client                             # tsx watch on the client CLI (long-running daemon)
+pnpm -s cli:client <args>                   # run a one-shot client subcommand from source (no watch), e.g. `pnpm -s cli:client agent callers list <id>`
 pnpm dev:server                             # tsx watch on the server
 pnpm dev:admin-ui                           # vite dev server for the admin UI
 pnpm deploy:server                          # fly deploy the server

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "uninstall:client": "npm uninstall -g @vicoop-bridge/client",
     "dev:server": "pnpm --filter @vicoop-bridge/server dev",
     "dev:client": "pnpm --filter @vicoop-bridge/client dev",
+    "cli:client": "pnpm --filter @vicoop-bridge/client cli",
     "dev:admin-ui": "pnpm --filter @vicoop-bridge/admin-ui dev",
     "deploy:server": "fly deploy -c packages/server/fly.toml .",
     "changeset": "changeset"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "dev": "tsx watch src/cli.ts",
+    "cli": "tsx src/cli.ts",
     "start": "node dist/cli.js",
     "test": "tsx --test \"src/**/*.test.ts\""
   },

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -273,6 +273,45 @@ test('list-callers GETs the agent endpoint', async (t) => {
   assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/callers`);
 });
 
+test('callers list renders allowed_callers as a TYPE/PRINCIPAL table', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, {
+    body: {
+      agent_id: 'foo',
+      owner_principal: 'eth:0xabc',
+      is_public: false,
+      allowed_callers: [
+        'eth:0x1111111111111111111111111111111111111111',
+        'google:email:alice@example.com',
+      ],
+    },
+  });
+
+  assert.equal(await runListCallers(listCallersArgs('foo')), 0);
+  const out = stdout.read();
+  assert.match(out, /^agent:\s+foo$/m);
+  assert.match(out, /^is_public:\s+false$/m);
+  assert.match(out, /TYPE\s+PRINCIPAL/);
+  // The PRINCIPAL column keeps the full canonical form so it pastes straight
+  // into `agent callers remove`.
+  assert.match(out, /^eth\s+eth:0x1111111111111111111111111111111111111111$/m);
+  assert.match(out, /^google:email\s+google:email:alice@example\.com$/m);
+});
+
+test('callers list shows the public sentinel when there are no allowed_callers', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, {
+    body: { agent_id: 'foo', owner_principal: 'eth:0xabc', is_public: true, allowed_callers: [] },
+  });
+
+  assert.equal(await runListCallers(listCallersArgs('foo')), 0);
+  const out = stdout.read();
+  assert.match(out, /allowed_callers: \(none — agent is public\)/);
+  assert.doesNotMatch(out, /TYPE\s+PRINCIPAL/);
+});
+
 test('subcommand exits 1 with hint when no token is available', async (t) => {
   // Hermetic missing-auth: redirect HOME (and USERPROFILE on Windows) to an
   // empty temp dir so os.homedir() resolves into a location without an

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { parse } from '@optique/core/parser';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,6 +16,7 @@ import {
   runListClients,
   runRemoveCaller,
   runRevokeClient,
+  agentCmd,
   type AddCallerArgs,
   type AgentCallersAddArgs,
   type AgentCallersListArgs,
@@ -554,6 +556,45 @@ test('agent callers list/add/remove hit the existing /admin-api/agents/:id/calle
     calls[2].url,
     `${BRIDGE}/admin-api/agents/foo/callers?principal=${encodeURIComponent(principal)}`,
   );
+});
+
+// Regression: the sub-subcommands `agent callers list <ID>` and
+// `agent callers remove <ID> <PRINCIPAL>` share the literal names `list` /
+// `remove` with the top-level `agent list` / `agent remove` commands. Those
+// top-level commands have all-optional bodies, so `@optique` `longestMatch`
+// used to break the consumed-token tie in their favour — swallowing the
+// branch and dropping the `AGENT_ID` positional, which surfaced as
+// "Unexpected option or subcommand: <id>". `agentCallersSubCmd` is now ordered
+// before the colliding siblings so the correct branch wins. These assertions
+// go through the real optique parser (the `runXxx` tests above construct the
+// parsed shape directly and would not have caught the parse-level regression).
+test('agent callers {list,remove} parse through the real parser with their AGENT_ID', () => {
+  const expectOk = (argv: string[], expected: Record<string, unknown>) => {
+    const r = parse(agentCmd, argv);
+    assert.equal(r.success, true, `expected ${argv.join(' ')} to parse`);
+    if (r.success) assert.deepEqual(r.value, { ...SHARED, ...expected });
+  };
+  const principal = 'eth:0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+  expectOk(['agent', 'callers', 'list', 'foo'], { action: 'agent-callers-list', agentId: 'foo' });
+  expectOk(['agent', 'callers', 'ls', 'foo'], { action: 'agent-callers-list', agentId: 'foo' });
+  expectOk(['agent', 'callers', 'add', 'foo', principal], {
+    action: 'agent-callers-add',
+    agentId: 'foo',
+    principal,
+  });
+  expectOk(['agent', 'callers', 'remove', 'foo', principal], {
+    action: 'agent-callers-remove',
+    agentId: 'foo',
+    principal,
+  });
+  expectOk(['agent', 'callers', 'rm', 'foo', principal], {
+    action: 'agent-callers-remove',
+    agentId: 'foo',
+    principal,
+  });
+  // The top-level siblings must keep working after the reorder.
+  expectOk(['agent', 'list'], { action: 'agent-list', connected: false });
+  expectOk(['agent', 'remove', 'foo', '--yes'], { action: 'agent-delete', target: 'foo', yes: true });
 });
 
 // The new `agent` commands must not print a deprecation warning — that's

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -158,7 +158,13 @@ const agentCallersSubCmd = command(
 
 export const agentCmd = command(
   'agent',
-  longestMatch(agentRegisterCmd, agentListSubCmd, agentRemoveSubCmd, agentCallersSubCmd),
+  // `agentCallersSubCmd` MUST come before `agentListSubCmd` / `agentRemoveSubCmd`.
+  // `@optique` `longestMatch` breaks consumed-token ties by source order, and the
+  // top-level `list` / `remove` commands have all-optional bodies that tie with the
+  // nested `callers {list,remove} <AGENT_ID>` match — when they win the tie the
+  // AGENT_ID positional is dropped and parsing fails with "Unexpected ... <id>".
+  // Putting `callers` first makes the correct branch win. See admin-cli.test.ts.
+  longestMatch(agentRegisterCmd, agentCallersSubCmd, agentListSubCmd, agentRemoveSubCmd),
   {
     brief: message`Manage agent registrations and their allowed callers.`,
     description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`remove\`, \`callers {list, add, remove}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -400,6 +400,20 @@ function renderCallerMutation(body: unknown): string {
   return `agent: ${b.agent_id}\nallowed_callers: ${callers}${note}`;
 }
 
+// The `TYPE` column of the callers table is display-only; the `PRINCIPAL`
+// column keeps the full canonical form (`eth:0x…`, `google:email:…`) so an
+// operator can copy a row straight into `agent callers remove <id> <principal>`.
+// `eth` is a single-segment scheme; the google schemes carry a sub-kind, so the
+// type is the first two colon-separated segments.
+function principalType(principal: string): string {
+  if (principal.startsWith('google:')) {
+    const [, kind] = principal.split(':');
+    return kind ? `google:${kind}` : 'google';
+  }
+  const idx = principal.indexOf(':');
+  return idx === -1 ? '' : principal.slice(0, idx);
+}
+
 function renderCallerList(body: unknown): string {
   if (!body || typeof body !== 'object') return String(body);
   const b = body as {
@@ -408,14 +422,20 @@ function renderCallerList(body: unknown): string {
     allowed_callers?: string[];
     is_public?: boolean;
   };
-  const callers = (b.allowed_callers ?? []).join('\n  ') || '(none — agent is public)';
-  return [
+  const callers = b.allowed_callers ?? [];
+  const header = [
     `agent:           ${b.agent_id}`,
     `owner_principal: ${b.owner_principal}`,
     `is_public:       ${b.is_public}`,
-    'allowed_callers:',
-    `  ${callers}`,
   ].join('\n');
+  if (callers.length === 0) {
+    return `${header}\nallowed_callers: (none — agent is public)`;
+  }
+  const table = renderTable(
+    ['TYPE', 'PRINCIPAL'],
+    callers.map((p) => [principalType(p), p]),
+  );
+  return `${header}\n\n${table}`;
 }
 
 // Agent-centric renderer for `agent list`. The /admin-api/clients response


### PR DESCRIPTION
## Problem

`vicoop-client agent callers list <AGENT_ID>` (and `agent callers remove <AGENT_ID> <PRINCIPAL>`) failed at the parsing stage:

```
$ vicoop-client agent callers list <id>
Error: Unexpected option or subcommand: `<id>`.
```

`agent callers list --help` even rendered the **wrong** command's help — the top-level `agent list` brief, `--connected` flag, and "Calls GET /admin-api/clients" description.

## Root cause

The `callers` sub-subcommands (`list`, `remove`) share the literal names `list`/`remove` with the top-level `agent list`/`agent remove` commands. Those top-level commands have **all-optional bodies** (no positional). optique's `longestMatch` breaks consumed-token ties by **source order**, and the all-optional top-level branch won the tie — swallowing the match and dropping the `AGENT_ID` positional, which surfaced as `Unexpected option or subcommand: <id>`.

`agent callers add` worked because there is no top-level `agent add` to collide with — which pinned down the pattern.

Reproduced the trigger and verified the fix against a minimal `@optique` harness (`current` / flattened / reordered structures): only reordering so `callers` is matched first resolves it, while keeping `agent list`/`ls`/`remove`/`rm` working.

## Fix

```diff
- longestMatch(agentRegisterCmd, agentListSubCmd, agentRemoveSubCmd, agentCallersSubCmd)
+ longestMatch(agentRegisterCmd, agentCallersSubCmd, agentListSubCmd, agentRemoveSubCmd)
```

(`'callers'` is a unique literal, so ordering it first only changes tie-breaks for inputs that start with `callers` — exactly the intended behaviour.)

## Also: `agent callers list` is now a table

Brought the output in line with `agent list` / client list (`renderTable`). The `PRINCIPAL` column keeps the full canonical form so a row pastes straight into `agent callers remove`:

```
agent:           my-agent
owner_principal: eth:0xAbC…0001
is_public:       false

TYPE           PRINCIPAL
eth            eth:0x1111111111111111111111111111111111111111
google:email   google:email:alice@example.com
google:domain  google:domain:example.com
google:sub     google:sub:1234567890
```

Empty case still prints `allowed_callers: (none — agent is public)`.

## Tests

- Added a **parser-level** regression test in `admin-cli.test.ts`. The existing callers tests call the `runXxx` handlers with a directly-constructed parsed shape, so they bypassed the parser and never caught the parse bug. The new test goes through `parse(agentCmd, argv)` and was confirmed to **fail without** the reorder and **pass with** it.
- Added render tests for the populated table and the empty/public sentinel.
- Full client suite: **624 passing**; typecheck clean.

## Verified manually

```
agent callers list <id>            → GET /admin-api/agents/<id>/callers, table output
agent callers remove <id> <p>      → DELETE .../callers?principal=<p>
agent list / ls / remove / rm      → still parse correctly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)