### PR TITLE
test(client): de-flake fetch-uri-file timeout test (#312)

### DIFF
--- a/packages/client/src/backends/fetch-uri-file.test.ts
+++ b/packages/client/src/backends/fetch-uri-file.test.ts
@@ -72,20 +72,26 @@ test('fetchUriToBytes: blocks direct IPv6 loopback hosts', async () => {
   );
 });
 
-test('fetchUriToBytes: timeout bounds hostname resolution', async () => {
-  await assert.rejects(
-    fetchUriToBytes(
-      'https://example.com/x.png',
-      'image/png',
-      {
-        timeoutMs: 5,
-        fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
-        resolveHost: async () => new Promise<string[]>(() => undefined),
-      },
-      NEVER,
-    ),
-    { name: 'FetchUriError', code: 'fetch_failed' },
+test('fetchUriToBytes: timeout bounds hostname resolution', async (t) => {
+  // Drive the deadline with mock timers instead of a real sub-10ms timer.
+  // A real short timer racing a never-resolving resolveHost is flaky under
+  // CI load: the timeout timer is unref'd, so if it becomes the only live
+  // handle the runner can begin to exit and cancel in-flight siblings
+  // (`cancelledByParent`). Ticking deterministically keeps it instant and
+  // off the wall clock. See issue #312.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const pending = fetchUriToBytes(
+    'https://example.com/x.png',
+    'image/png',
+    {
+      timeoutMs: 5,
+      fetchImplForTest: async () => new Response(Buffer.from('unused'), { headers: { 'content-type': 'image/png' } }),
+      resolveHost: async () => new Promise<string[]>(() => undefined),
+    },
+    NEVER,
   );
+  t.mock.timers.tick(5);
+  await assert.rejects(pending, { name: 'FetchUriError', code: 'fetch_failed' });
 });
 
 test('fetchUriToBytes: revalidates redirect targets', async () => {


### PR DESCRIPTION
## Summary

Fixes the flaky `Client CI` failure where the run shows `# fail 0` but `# cancelled 6` (exit 1), with all cancelled subtests in `packages/client/src/backends/fetch-uri-file.test.ts`.

## Root cause

`fetchUriToBytes: timeout bounds hostname resolution` raced a **real 5ms timer** against a **never-resolving `resolveHost` mock**. The timeout timer is `unref()`'d in `fetch-uri-file.ts:215`, so under CI scheduling it could become the event loop's last live handle — letting the runner begin to exit and cancel the file's in-flight sibling tests as `cancelledByParent`. That produces a non-zero `cancelled` count (hence exit 1) with **no assertion failure**, exactly matching the symptom.

## Fix

Drive the deadline with node:test **mock timers**: enable `setTimeout`, start the call, then `t.mock.timers.tick(5)` to fire the timeout deterministically and instantly. No real wall-clock timer is left in the loop, so there's nothing to race the runner's exit. Production code (`fetch-uri-file.ts`) is unchanged — behavior was correct; only the test was non-deterministic.

## Verification

- Target test: deterministic pass (~0.6ms, no 5ms race).
- Full client suite: `tests 625 / pass 625 / fail 0 / cancelled 0`.
- `pnpm --filter @vicoop-bridge/client typecheck` passes.

Meets both acceptance criteria: `# cancelled 0` deterministically, and no reliance on sub-10ms real wall-clock deadlines.

No changeset: test-only change with no operator-facing behavior impact.

Fixes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)