### PR TITLE
feat(client): render `agent callers list` as a TYPE/PRINCIPAL table

### DIFF
--- a/.changeset/callers-list-table.md
+++ b/.changeset/callers-list-table.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+`vicoop-client agent callers list` now renders allowed callers as a plain `TYPE`/`PRINCIPAL` table (matching `agent list` and the other list commands), with a `(no callers — agent is public)` empty-state, instead of the old multi-line `agent:` / `owner_principal:` / `is_public:` header block. The `--json` output is unchanged (it still carries `agent_id`, `owner_principal`, `is_public`, and `allowed_callers`).

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -297,16 +297,17 @@ test('callers list renders allowed_callers as a TYPE/PRINCIPAL table', async (t)
 
   assert.equal(await runListCallers(listCallersArgs('foo')), 0);
   const out = stdout.read();
-  assert.match(out, /^agent:\s+foo$/m);
-  assert.match(out, /^is_public:\s+false$/m);
-  assert.match(out, /TYPE\s+PRINCIPAL/);
-  // The PRINCIPAL column keeps the full canonical form so it pastes straight
-  // into `agent callers remove`.
+  // Pure TYPE/PRINCIPAL table — no agent/owner/is_public header block (those
+  // stay in --json). The PRINCIPAL column keeps the full canonical form so it
+  // pastes straight into `agent callers remove`.
+  assert.match(out, /^TYPE\s+PRINCIPAL$/m);
   assert.match(out, /^eth\s+eth:0x1111111111111111111111111111111111111111$/m);
   assert.match(out, /^google:email\s+google:email:alice@example\.com$/m);
+  assert.doesNotMatch(out, /^agent:/m);
+  assert.doesNotMatch(out, /^is_public:/m);
 });
 
-test('callers list shows the public sentinel when there are no allowed_callers', async (t) => {
+test('callers list shows the public empty-state when there are no allowed_callers', async (t) => {
   withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
   const stdout = captureStdout(t);
   installFetch(t, {
@@ -315,7 +316,7 @@ test('callers list shows the public sentinel when there are no allowed_callers',
 
   assert.equal(await runListCallers(listCallersArgs('foo')), 0);
   const out = stdout.read();
-  assert.match(out, /allowed_callers: \(none — agent is public\)/);
+  assert.match(out, /\(no callers — agent is public\)/);
   assert.doesNotMatch(out, /TYPE\s+PRINCIPAL/);
 });
 

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -475,26 +475,19 @@ function principalType(principal: string): string {
 
 function renderCallerList(body: unknown): string {
   if (!body || typeof body !== 'object') return String(body);
-  const b = body as {
-    agent_id?: string;
-    owner_principal?: string;
-    allowed_callers?: string[];
-    is_public?: boolean;
-  };
+  const b = body as { allowed_callers?: string[] };
   const callers = b.allowed_callers ?? [];
-  const header = [
-    `agent:           ${b.agent_id}`,
-    `owner_principal: ${b.owner_principal}`,
-    `is_public:       ${b.is_public}`,
-  ].join('\n');
+  // Empty allowed_callers means the dispatcher treats the agent as public.
+  // Surface that as the table's empty-state, matching the other `list`
+  // commands (e.g. `agent list` → "(no connected agents)"). The agent_id /
+  // owner_principal / is_public fields remain available via --json.
   if (callers.length === 0) {
-    return `${header}\nallowed_callers: (none — agent is public)`;
+    return '(no callers — agent is public)';
   }
-  const table = renderTable(
+  return renderTable(
     ['TYPE', 'PRINCIPAL'],
     callers.map((p) => [principalType(p), p]),
   );
-  return `${header}\n\n${table}`;
 }
 
 // Agent-centric renderer for `agent list`. The /admin-api/clients response


### PR DESCRIPTION
Follow-up polish for the unified callers surface (#308 / #311): make `agent callers list` consistent with the other `list` commands.

## Before
```
agent:           swen-2026052702
owner_principal: google:117535647789389656258
is_public:       true
allowed_callers: (none — agent is public)
```

## After
Empty:
```
(no callers — agent is public)
```
Populated:
```
TYPE           PRINCIPAL
eth            eth:0x1111111111111111111111111111111111111111
google:email   google:email:alice@example.com
google:domain  google:domain:planetariumhq.com
apikey         apikey:k7Qm2_aB9xZ
```

- Drops the multi-line `agent:` / `owner_principal:` / `is_public:` header block in favor of a plain `TYPE`/`PRINCIPAL` table — same shape as `agent list` / `list-clients`.
- `PRINCIPAL` keeps the full canonical form so a row pastes straight into `agent callers remove <id> <principal>` (the `TYPE` column is display-only).
- Empty `allowed_callers` → `(no callers — agent is public)` empty-state.
- **`--json` is unchanged** — still carries `agent_id`, `owner_principal`, `is_public`, `allowed_callers` for scripts.

## Release

Client-only, `patch` changeset. Merging folds into the open "chore: version packages" PR (#310), so it ships with the same client release.

## Tests

Updated the two `renderCallerList` assertions (table form + empty-state). `admin-cli` 30/30; typecheck clean. Verified against a compiled `bun build --compile` binary (live empty-state + stubbed populated table + unchanged `--json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)