### PR TITLE
feat(client): stream vicoop-codex backend responses in openai-compat mode

### DIFF
--- a/.changeset/vicoop-codex-streaming.md
+++ b/.changeset/vicoop-codex-streaming.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+The `vicoop-codex` backend now streams responses token-by-token in openai-compat mode. Instead of a single buffered `vicoop-codex call` invocation that emitted the whole response as one artifact, the backend now drives a shared `vicoop-codex serve` instance and streams its `POST /v1/chat/completions` (`stream:true`) SSE, emitting each `delta.content` fragment as an incremental `append:true` A2A artifact. The oai2a2a gateway maps these to OpenAI SSE `delta.content` chunks, so callers see sub-second time-to-first-token and progressive rendering (matching the `claude` / `codex` backends fixed in #294). The terminal `chat_completion` envelope (tool_calls assembled from streamed `delta.tool_calls`, usage, finish_reason) is unchanged. The bundled `vicoop-codex` agent card now advertises `capabilities.streaming: true` so the gateway takes the `message/stream` path. Requires a `vicoop-codex` build that exposes the `serve` subcommand; an older binary fails the task with `serve_unavailable`.

--- a/packages/client/cards/vicoop-codex.json
+++ b/packages/client/cards/vicoop-codex.json
@@ -1,10 +1,10 @@
 {
   "name": "vicoop-codex",
-  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex` CLI. Each A2A task streams an OpenAI Chat Completions request (assembled from the openai-compat A2A extension) through a shared local `vicoop-codex serve` instance, emitting the model's response token-by-token as incremental A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": {
-    "streaming": false,
+    "streaming": true,
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -14,9 +14,11 @@ import {
   flattenA2AUserContent,
   historyToChatCompletionMessages,
   parseChatCompletionUsage,
+  parseServeListeningUrl,
   probeVicoopCodexModels,
   type ChatCompletionResponse,
   type VicoopCodexChildHandle,
+  type VicoopCodexFetchFn,
   type VicoopCodexSpawnFn,
   type VicoopCodexSpawnOptions,
 } from './vicoop-codex.js';
@@ -483,31 +485,110 @@ test('buildResponseMetadata: synthesizes defensive defaults when upstream omits 
 // End-to-end Backend.handle() tests via the fake spawn surface
 // ─────────────────────────────────────────────────────────────────────────────
 
-function runBackend(
+// ── Streaming HTTP fake ──────────────────────────────────────────────────
+// The backend now drives each task through `vicoop-codex serve`'s
+// `/v1/chat/completions` over `fetch`, parsing a `chat.completion.chunk` SSE
+// stream. These fakes script the serve child's `listening` line (via the
+// spawn fake) and the SSE body (via an injected `fetch`).
+
+interface RecordingFetch {
+  fetch: VicoopCodexFetchFn;
+  calls: Array<{ url: string; body: string }>;
+}
+
+// A fetch that records each request and returns a fixed SSE body. `status`
+// < 200 || >= 300 marks the response not-ok (drives the upstream_error path);
+// `bodyText` is what `.text()` returns on that error path.
+function makeSseFetch(
+  sse: string,
+  opts: { status?: number; bodyText?: string } = {},
+): RecordingFetch {
+  const calls: Array<{ url: string; body: string }> = [];
+  const status = opts.status ?? 200;
+  const fetch: VicoopCodexFetchFn = async (url, init) => {
+    calls.push({ url, body: init.body });
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      async text() {
+        return opts.bodyText ?? '';
+      },
+      async *chunks() {
+        yield sse;
+      },
+    };
+  };
+  return { fetch, calls };
+}
+
+// Serialise a list of chunk objects into an SSE body terminated by `[DONE]`.
+function sseStream(chunks: Array<Record<string, unknown>>): string {
+  return (
+    chunks.map((c) => `data: ${JSON.stringify(c)}\n\n`).join('') + 'data: [DONE]\n\n'
+  );
+}
+
+// Emit the `listening` line a freshly-spawned serve child prints. The real
+// `vicoop-codex serve` writes this (and all startup text) to STDERR, so the
+// fake drives it there to match production wiring.
+function driveServeListening(child: FakeChild, port = 8787): void {
+  child.emitStderr(
+    JSON.stringify({
+      event: 'listening',
+      host: '127.0.0.1',
+      port,
+      url: `http://127.0.0.1:${port}`,
+    }) + '\n',
+  );
+}
+
+// Run handle() end-to-end with a serve + fetch fake. `handle()` spawns the
+// serve child synchronously inside `ensureServe`, so we drive its listening
+// line on the next microtask, then await completion.
+async function runStreaming(
   task: TaskAssignFrame,
-  driveChild: (child: FakeChild) => void,
+  fetchRec: RecordingFetch,
 ): Promise<UpFrame[]> {
   const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const backend = createVicoopCodexBackend({
+    spawn: fake.spawn,
+    fetch: fetchRec.fetch,
+  });
   const frames: UpFrame[] = [];
   const ctrl = new AbortController();
   const done = backend.handle(task, (f) => frames.push(f), ctrl.signal);
-  // Wait one microtask so the backend has spawned its child before we drive
-  // it. The fake spawn is synchronous, so a single queueMicrotask suffices.
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     queueMicrotask(() => {
       try {
-        driveChild(fake.lastChild());
+        driveServeListening(fake.lastChild());
       } catch (err) {
-        reject(err);
+        reject(err as Error);
         return;
       }
-      done.then(() => resolve(frames), reject);
+      done.then(() => resolve(), reject);
     });
   });
+  return frames;
 }
 
-test('handle: success path — text response → artifact + complete with metadata', async () => {
+test('parseServeListeningUrl: reads the listening line, ignores other lines', () => {
+  assert.equal(
+    parseServeListeningUrl(
+      '{"event":"listening","host":"127.0.0.1","port":8787,"url":"http://127.0.0.1:8787"}',
+    ),
+    'http://127.0.0.1:8787',
+  );
+  // Falls back to host+port when `url` is absent; strips a trailing slash.
+  assert.equal(
+    parseServeListeningUrl('{"event":"listening","host":"127.0.0.1","port":9000}'),
+    'http://127.0.0.1:9000',
+  );
+  assert.equal(parseServeListeningUrl('vicoop-codex serve listening on:'), null);
+  assert.equal(parseServeListeningUrl('{"event":"other"}'), null);
+  assert.equal(parseServeListeningUrl('not json'), null);
+});
+
+test('handle: streamed text → one append artifact per delta + complete with metadata', async () => {
   const task = makeTask({
     metadata: {
       [OPENAI_COMPAT_EXTENSION_URI]: {
@@ -515,65 +596,160 @@ test('handle: success path — text response → artifact + complete with metada
       },
     },
   });
-  const frames = await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
+  // `chat.completion.chunk` SSE: role preamble → two content deltas → final
+  // chunk carrying finish_reason + usage.
+  const sse = sseStream([
+    {
       id: 'chatcmpl-1',
-      object: 'chat.completion',
+      object: 'chat.completion.chunk',
       created: 1700000000,
       model: 'gpt-5.4',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content: 'ok' },
-          finish_reason: 'stop',
-        },
-      ],
+      choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-1',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { content: 'o' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-1',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { content: 'k' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-1',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
       usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
-    };
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
-  });
+    },
+  ]);
+  const frames = await runStreaming(task, makeSseFetch(sse));
 
   const statuses = frames.filter((f) => f.type === 'task.status');
   const artifacts = frames.filter((f) => f.type === 'task.artifact');
   const completes = frames.filter((f) => f.type === 'task.complete');
   assert.equal(statuses.length, 1);
   assert.equal(statuses[0].status.state, 'working');
-  assert.equal(artifacts.length, 1);
-  const artifact = artifacts[0];
-  if (artifact.type !== 'task.artifact') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].kind, 'text');
-  if (artifact.artifact.parts[0].kind !== 'text') throw new Error('unreachable');
-  assert.equal(artifact.artifact.parts[0].text, 'ok');
+  // One incremental append artifact per content delta.
+  assert.equal(artifacts.length, 2);
+  const texts: string[] = [];
+  const ids = new Set<string>();
+  for (const a of artifacts) {
+    if (a.type !== 'task.artifact') throw new Error('unreachable');
+    assert.equal(a.append, true, 'streamed deltas are append:true');
+    const part = a.artifact.parts[0];
+    if (part.kind !== 'text') throw new Error('unreachable');
+    texts.push(part.text);
+    ids.add(a.artifact.artifactId);
+  }
+  assert.deepEqual(texts, ['o', 'k']);
+  // All deltas share one artifactId so the server merges them into one
+  // artifact (and the gateway into one OpenAI message).
+  assert.equal(ids.size, 1);
+
   assert.equal(completes.length, 1);
   const completeFrame = completes[0];
   if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
   assert.equal(completeFrame.status.state, 'completed');
   const msg = completeFrame.status.message!;
+  // Terminal message carries the full assembled text for A2A history /
+  // non-streaming consumers.
+  assert.deepEqual(msg.parts, [{ kind: 'text', text: 'ok' }]);
   assert.ok(msg.extensions?.includes(OPENAI_COMPAT_EXTENSION_URI));
   const ext = (msg.metadata as Record<string, Record<string, unknown>>)[
     OPENAI_COMPAT_EXTENSION_URI
   ];
-  // Envelope contract: only `chat_completion` is stamped — the
-  // transitional top-level `usage` sibling for v1-era codecs has been
-  // retired.
   assert.equal(ext.usage, undefined);
   const envelope = ext.chat_completion as Record<string, unknown>;
   assert.equal(envelope.id, 'chatcmpl-1');
   assert.equal(envelope.model, 'gpt-5.4');
-  // The envelope carries `usage` natively (codec reads it here).
   const envelopeUsage = envelope.usage as Record<string, number>;
   assert.equal(envelopeUsage.prompt_tokens, 3);
   assert.equal(envelopeUsage.completion_tokens, 1);
   assert.equal(envelopeUsage.total_tokens, 4);
-  // Spec requires logprobs on each choice (null when not surfaced).
   const choices = envelope.choices as Array<Record<string, unknown>>;
   assert.equal(choices.length, 1);
   assert.equal(choices[0].logprobs, null);
   assert.equal(choices[0].finish_reason, 'stop');
+  const choiceMsg = choices[0].message as Record<string, unknown>;
+  assert.equal(choiceMsg.content, 'ok');
 });
 
-test('handle: tool_calls response → no data artifact; tool_calls only on terminal chat_completion envelope (envelope contract, oai2a2a#80)', async () => {
+test('handle: request body carries stream:true + envelope-derived model/messages/tools', async () => {
+  const task = makeTask({
+    message: {
+      role: 'user',
+      messageId: 'msg',
+      parts: [{ kind: 'text', text: 'current question' }],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          chat_completions_request: {
+            model: 'gpt-5.5',
+            messages: [
+              { role: 'system', content: 'reply in korean' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
+                  },
+                ],
+              },
+              { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
+              { role: 'user', content: 'current question' },
+            ],
+            tools: [{ type: 'function', function: { name: 'get_weather' } }],
+            tool_choice: { type: 'function', function: { name: 'get_weather' } },
+          },
+        },
+      },
+    },
+  });
+  const sse = sseStream([
+    {
+      id: 'chatcmpl-3',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.5',
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ]);
+  const fetchRec = makeSseFetch(sse);
+  await runStreaming(task, fetchRec);
+
+  assert.equal(fetchRec.calls.length, 1);
+  assert.ok(fetchRec.calls[0].url.endsWith('/v1/chat/completions'));
+  const body = JSON.parse(fetchRec.calls[0].body) as Record<string, unknown>;
+  // Streaming flag is set on the wire.
+  assert.equal(body.stream, true);
+  // Messages: system → chat_history (assistant(tool_calls) → tool) →
+  // trailing user.
+  const messages = body.messages as Array<{ role: string }>;
+  assert.deepEqual(
+    messages.map((m) => m.role),
+    ['system', 'assistant', 'tool', 'user'],
+  );
+  assert.equal(body.model, 'gpt-5.5');
+  assert.deepEqual(body.tools, [
+    { type: 'function', function: { name: 'get_weather' } },
+  ]);
+  assert.deepEqual(body.tool_choice, {
+    type: 'function',
+    function: { name: 'get_weather' },
+  });
+  // Group B / Group C fields stay off the wire — the binary applies defaults.
+  assert.equal(body.reasoning_effort, undefined);
+  assert.equal(body.temperature, undefined);
+  assert.equal(body.max_tokens, undefined);
+});
+
+test('handle: streamed tool_calls → no artifact; tool_calls only on terminal chat_completion envelope (envelope contract, oai2a2a#80)', async () => {
   const task = makeTask({
     metadata: {
       [OPENAI_COMPAT_EXTENSION_URI]: {
@@ -581,34 +757,59 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
       },
     },
   });
-  const frames = await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
+  // Tool-call stream: role preamble (content null) → tool_calls delta (with
+  // arguments split across two fragments to exercise the accumulator) →
+  // terminal finish_reason + usage.
+  const sse = sseStream([
+    {
       id: 'chatcmpl-2',
-      object: 'chat.completion',
+      object: 'chat.completion.chunk',
       created: 1700000001,
+      model: 'gpt-5.3-codex',
+      choices: [{ index: 0, delta: { role: 'assistant', content: null }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-2',
+      object: 'chat.completion.chunk',
       model: 'gpt-5.3-codex',
       choices: [
         {
           index: 0,
-          message: {
-            role: 'assistant',
-            content: null,
+          delta: {
             tool_calls: [
               {
+                index: 0,
                 id: 'call_xyz',
                 type: 'function',
-                function: { name: 'list_files', arguments: '{"path":"."}' },
+                function: { name: 'list_files', arguments: '{"path"' },
               },
             ],
           },
-          finish_reason: 'tool_calls',
+          finish_reason: null,
         },
       ],
+    },
+    {
+      id: 'chatcmpl-2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.3-codex',
+      choices: [
+        {
+          index: 0,
+          delta: { tool_calls: [{ index: 0, function: { arguments: ':"."}' } }] },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: 'chatcmpl-2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.3-codex',
+      choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
       usage: { prompt_tokens: 4, completion_tokens: 6, total_tokens: 10 },
-    };
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
-  });
+    },
+  ]);
+  const frames = await runStreaming(task, makeSseFetch(sse));
   // Envelope contract: no data-part `tool_calls` artifact. The legacy
   // `data` part shaped `{ "tool_calls": [...] }` is removed from this
   // extension — consumers ignore it, so emitting it would only confuse
@@ -667,90 +868,6 @@ test('handle: tool_calls response → no data artifact; tool_calls only on termi
   assert.equal(fn.arguments, '{"path":"."}');
 });
 
-test('handle: stdin body carries envelope-derived model/messages/tools/tool_choice', async () => {
-  const task = makeTask({
-    message: {
-      role: 'user',
-      messageId: 'msg',
-      parts: [{ kind: 'text', text: 'current question' }],
-      metadata: {
-        [OPENAI_COMPAT_EXTENSION_URI]: {
-          chat_completions_request: {
-            model: 'gpt-5.5',
-            messages: [
-              { role: 'system', content: 'reply in korean' },
-              {
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                  {
-                    id: 'call_1',
-                    type: 'function',
-                    function: { name: 'get_weather', arguments: '{"city":"Seoul"}' },
-                  },
-                ],
-              },
-              { role: 'tool', tool_call_id: 'call_1', content: '{"temp":13}' },
-              // Trailing user — split into A2A parts; chatHistoryFromMessages
-              // drops this from the replay so the test's A2A `parts` text
-              // becomes the trailing user instead.
-              { role: 'user', content: 'current question' },
-            ],
-            tools: [{ type: 'function', function: { name: 'get_weather' } }],
-            tool_choice: { type: 'function', function: { name: 'get_weather' } },
-          },
-        },
-      },
-    },
-  });
-
-  await runBackend(task, (child) => {
-    const response: ChatCompletionResponse = {
-      id: 'chatcmpl-3',
-      object: 'chat.completion',
-      created: 1,
-      model: 'gpt-5.5',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content: 'ok' },
-          finish_reason: 'stop',
-        },
-      ],
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-    };
-    const payload = child.stdinPayload();
-    const body = JSON.parse(payload) as Record<string, unknown>;
-    // Messages: system → chat_history (assistant(tool_calls) → tool) →
-    // trailing user. Per the new openai-compat chat_history wire, the
-    // trailing user (the current A2A `parts` turn) sits AFTER the
-    // history slice, mirroring how OpenAI Chat Completions arranges
-    // `[..., assistant.tool_calls, tool, user]` for a follow-up.
-    const messages = body.messages as Array<{ role: string }>;
-    assert.deepEqual(
-      messages.map((m) => m.role),
-      ['system', 'assistant', 'tool', 'user'],
-    );
-    // Envelope contract: model + tools + tool_choice forward verbatim.
-    // Group B / Group C fields (reasoning_effort, temperature, max_tokens
-    // etc.) are intentionally not on the call body shape — the binary
-    // applies its own defaults.
-    assert.equal(body.model, 'gpt-5.5');
-    assert.deepEqual(body.tools, [
-      { type: 'function', function: { name: 'get_weather' } },
-    ]);
-    assert.deepEqual(body.tool_choice, {
-      type: 'function',
-      function: { name: 'get_weather' },
-    });
-    assert.equal(body.reasoning_effort, undefined);
-    assert.equal(body.temperature, undefined);
-    assert.equal(body.max_tokens, undefined);
-    child.emitStdout(JSON.stringify(response));
-    child.finish(0);
-  });
-});
-
 test('handle: empty prompt → task.fail with empty_prompt code', async () => {
   const task = makeTask({
     message: {
@@ -771,38 +888,85 @@ test('handle: empty prompt → task.fail with empty_prompt code', async () => {
   assert.equal(failFrame.error.code, 'empty_prompt');
 });
 
-test('handle: non-zero exit maps to documented exit-code error codes', async () => {
-  const exitCases: Array<{ code: number; expected: string }> = [
-    { code: 2, expected: 'invalid_input' },
-    { code: 3, expected: 'login_required' },
-    { code: 4, expected: 'upstream_error' },
-    { code: 5, expected: 'network_error' },
-    { code: 99, expected: 'vicoop_codex_failed' },
-  ];
-  for (const { code, expected } of exitCases) {
-    const frames = await runBackend(makeTask(), (child) => {
-      child.emitStderr('Error: simulated');
-      child.finish(code);
+test('handle: serve exits before listening → task.fail serve_unavailable', async () => {
+  // Simulates an old binary that has no `serve` subcommand (exits non-zero
+  // with usage on stderr) — startup never reports listening.
+  const fake = makeFakeSpawn();
+  const backend = createVicoopCodexBackend({
+    spawn: fake.spawn,
+    fetch: makeSseFetch('').fetch,
+  });
+  const frames: UpFrame[] = [];
+  const ctrl = new AbortController();
+  const done = backend.handle(makeTask(), (f) => frames.push(f), ctrl.signal);
+  await new Promise<void>((resolve, reject) => {
+    queueMicrotask(() => {
+      const child = fake.lastChild();
+      child.emitStderr("error: unknown command 'serve'");
+      child.finish(1);
+      done.then(() => resolve(), reject);
     });
-    const fails = frames.filter((f) => f.type === 'task.fail');
-    assert.equal(fails.length, 1, `exit code ${code}`);
-    const failFrame = fails[0];
-    if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-    assert.equal(failFrame.error.code, expected, `exit code ${code} → ${expected}`);
-    assert.ok(failFrame.error.message.includes('simulated'));
-  }
-});
-
-test('handle: malformed JSON stdout → parse_failed', async () => {
-  const frames = await runBackend(makeTask(), (child) => {
-    child.emitStdout('not json at all');
-    child.finish(0);
   });
   const fails = frames.filter((f) => f.type === 'task.fail');
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-  assert.equal(failFrame.error.code, 'parse_failed');
+  assert.equal(failFrame.error.code, 'serve_unavailable');
+  assert.ok(failFrame.error.message.includes('serve'));
+});
+
+test('handle: non-2xx from serve → task.fail upstream_error', async () => {
+  const frames = await runStreaming(
+    makeTask(),
+    makeSseFetch('', { status: 500, bodyText: 'model overloaded' }),
+  );
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.ok(failFrame.error.message.includes('500'));
+  assert.ok(failFrame.error.message.includes('overloaded'));
+});
+
+test('handle: serve is a shared singleton — two tasks reuse one server', async () => {
+  const fake = makeFakeSpawn();
+  const sse = sseStream([
+    {
+      id: 'c',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ]);
+  const fetchRec = makeSseFetch(sse);
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn, fetch: fetchRec.fetch });
+
+  const runOne = async (): Promise<UpFrame[]> => {
+    const frames: UpFrame[] = [];
+    const done = backend.handle(makeTask(), (f) => frames.push(f), new AbortController().signal);
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(() => {
+        // Drive the listening line only on the first spawn; a second task
+        // reuses the already-listening singleton (lastChild stays the same
+        // serve child, and re-driving is an inert no-op).
+        driveServeListening(fake.lastChild());
+        done.then(() => resolve(), reject);
+      });
+    });
+    return frames;
+  };
+
+  const first = await runOne();
+  const second = await runOne();
+
+  // Exactly one serve child spawned across both tasks.
+  assert.equal(fake.children.length, 1);
+  // Both tasks completed and both issued a fetch to the shared server.
+  assert.equal(first.filter((f) => f.type === 'task.complete').length, 1);
+  assert.equal(second.filter((f) => f.type === 'task.complete').length, 1);
+  assert.equal(fetchRec.calls.length, 2);
 });
 
 test('handle: cancel before spawn → task.complete with canceled', async () => {
@@ -897,9 +1061,24 @@ test('resolveCapabilities advertises openaiCompatModels with the first id tagged
   });
 });
 
-test('envelope.model is forwarded when the probed list advertises it (#302)', async () => {
+// Shared SSE body + driver for the #302 envelope.model gate tests: probe
+// child (children[0]) feeds the cache, then handle() spawns the serve child
+// (children[1]) and the request rides over `fetch` — so we assert on the
+// recorded fetch body, not subprocess stdin.
+const OK_STREAM = sseStream([
+  {
+    id: 'x',
+    object: 'chat.completion.chunk',
+    model: 'gpt-5.5',
+    choices: [{ index: 0, delta: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  },
+]);
+
+async function runModelGate(envelopeModel: string): Promise<Record<string, unknown>> {
   const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
+  const fetchRec = makeSseFetch(OK_STREAM);
+  const backend = createVicoopCodexBackend({ spawn: fake.spawn, fetch: fetchRec.fetch });
   const capPromise = backend.resolveCapabilities?.();
   queueMicrotask(() => {
     fake.lastChild().emitStdout(
@@ -910,7 +1089,6 @@ test('envelope.model is forwarded when the probed list advertises it (#302)', as
   await capPromise;
 
   const frames: UpFrame[] = [];
-  const ctrl = new AbortController();
   const done = backend.handle(
     {
       type: 'task.assign',
@@ -923,7 +1101,7 @@ test('envelope.model is forwarded when the probed list advertises it (#302)', as
         metadata: {
           [OPENAI_COMPAT_EXTENSION_URI]: {
             chat_completions_request: {
-              model: 'gpt-5.5',
+              model: envelopeModel,
               messages: [{ role: 'user', content: 'hi' }],
             },
           },
@@ -931,88 +1109,33 @@ test('envelope.model is forwarded when the probed list advertises it (#302)', as
       },
     },
     (f) => frames.push(f),
-    ctrl.signal,
+    new AbortController().signal,
   );
-  await new Promise<void>((resolve) => queueMicrotask(resolve));
-  // index 0 was the probe child; the call child is the second one.
-  const callChild = fake.children[1];
-  const body = JSON.parse(callChild.stdinPayload()) as Record<string, unknown>;
+  // handle() spawns the serve child synchronously inside ensureServe; drive
+  // its listening line, then await completion.
+  await new Promise<void>((resolve, reject) => {
+    queueMicrotask(() => {
+      driveServeListening(fake.lastChild());
+      done.then(() => resolve(), reject);
+    });
+  });
+  assert.equal(fetchRec.calls.length, 1);
+  return JSON.parse(fetchRec.calls[0].body) as Record<string, unknown>;
+}
+
+test('envelope.model is forwarded when the probed list advertises it (#302)', async () => {
+  const body = await runModelGate('gpt-5.5');
   assert.equal(body.model, 'gpt-5.5');
-  // Drive the call child to a clean exit so done resolves.
-  callChild.emitStdout(
-    JSON.stringify({
-      id: 'x',
-      object: 'chat.completion',
-      created: 1,
-      model: 'gpt-5.5',
-      choices: [
-        { index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' },
-      ],
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-    }),
-  );
-  callChild.finish(0);
-  await done;
 });
 
 test('envelope.model is dropped when the probed list does NOT advertise it (#302)', async () => {
   // Regression guard for the gateway sending an unresolved routing key
-  // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the gate the
-  // bridge would forward garbage to vicoop-codex, which would then fail
-  // upstream with `model not found`. With the gate the override is
-  // dropped and the CLI falls back to its DEFAULT_MODEL.
-  const fake = makeFakeSpawn();
-  const backend = createVicoopCodexBackend({ spawn: fake.spawn });
-  const capPromise = backend.resolveCapabilities?.();
-  queueMicrotask(() => {
-    fake.lastChild().emitStdout(
-      JSON.stringify({ models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.4' }] }),
-    );
-    fake.lastChild().finish(0);
-  });
-  await capPromise;
-
-  const frames: UpFrame[] = [];
-  const ctrl = new AbortController();
-  const done = backend.handle(
-    {
-      type: 'task.assign',
-      taskId: 't',
-      contextId: 'c',
-      message: {
-        role: 'user',
-        messageId: 'm',
-        parts: [{ kind: 'text', text: 'hi' }],
-        metadata: {
-          [OPENAI_COMPAT_EXTENSION_URI]: {
-            chat_completions_request: {
-              model: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
-              messages: [{ role: 'user', content: 'hi' }],
-            },
-          },
-        },
-      },
-    },
-    (f) => frames.push(f),
-    ctrl.signal,
+  // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the gate the bridge
+  // would forward garbage to vicoop-codex, which would then fail upstream
+  // with `model not found`. With the gate the override is dropped and the
+  // CLI falls back to its DEFAULT_MODEL.
+  const body = await runModelGate(
+    'a2a/https://example.com/agents/x/.well-known/agent-card.json',
   );
-  await new Promise<void>((resolve) => queueMicrotask(resolve));
-  const callChild = fake.children[1];
-  const body = JSON.parse(callChild.stdinPayload()) as Record<string, unknown>;
-  // model field absent — CLI falls back to DEFAULT_MODEL.
   assert.equal(body.model, undefined);
-  callChild.emitStdout(
-    JSON.stringify({
-      id: 'x',
-      object: 'chat.completion',
-      created: 1,
-      model: 'gpt-5.5',
-      choices: [
-        { index: 0, message: { role: 'assistant', content: 'OK' }, finish_reason: 'stop' },
-      ],
-      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
-    }),
-  );
-  callChild.finish(0);
-  await done;
 });

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -42,6 +42,25 @@ export type VicoopCodexSpawnFn = (
   options: VicoopCodexSpawnOptions,
 ) => VicoopCodexChildHandle;
 
+// Minimal subset of `fetch`'s Response the backend consumes from
+// `vicoop-codex serve`'s streaming `POST /v1/chat/completions`. Production
+// wraps the global `fetch` (see `defaultFetch`); tests inject a fake that
+// satisfies this without an HTTP round-trip.
+export interface VicoopCodexStreamResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  // Full body as text — read only on the non-2xx error path for diagnostics.
+  text(): Promise<string>;
+  // Decoded UTF-8 chunks of the SSE body, in arrival order. Chunk boundaries
+  // are arbitrary (not aligned to SSE events); the parser reassembles lines.
+  chunks(): AsyncIterable<string>;
+}
+
+export type VicoopCodexFetchFn = (
+  url: string,
+  init: { body: string; signal: AbortSignal },
+) => Promise<VicoopCodexStreamResponse>;
+
 export interface VicoopCodexBackendOptions {
   // Test seams only — the production CLI calls `createVicoopCodexBackend()`
   // with no arguments. We don't expose operator-facing knobs here because
@@ -54,7 +73,13 @@ export interface VicoopCodexBackendOptions {
   extraArgs?: readonly string[];
   spawn?: VicoopCodexSpawnFn;
   stderrCaptureBytes?: number;
-  callTimeoutMs?: number;
+  // Test seam for the streaming HTTP call to `vicoop-codex serve`'s
+  // `/v1/chat/completions`. Production defaults to the global `fetch`; tests
+  // inject a fake that returns a scripted SSE body without a real socket.
+  fetch?: VicoopCodexFetchFn;
+  // Max time `ensureServe` waits for the spawned `vicoop-codex serve` to
+  // print its `listening` line before giving up. Default 10s.
+  serveStartupTimeoutMs?: number;
   // Max time the startup probe (`vicoop-codex models --json` via
   // `resolveCapabilities`) waits for the model list before giving up.
   // Setting to 0 disables the probe entirely — the agent card carries no
@@ -97,10 +122,11 @@ export interface ChatCompletionMessage {
   name?: string;
 }
 
-// Parsed OpenAI Chat Completions non-streaming response (the shape
-// `vicoop-codex call` prints to stdout). All optional / nullable
-// per OpenAI — the binary always emits `id` / `object` / `model` / `choices`
-// but we tolerate missing fields rather than crash on a future schema bump.
+// OpenAI Chat Completions response shape. The backend no longer parses this
+// off `vicoop-codex call` stdout — it synthesises one (`synthesizeStreamedResponse`)
+// from the `chat.completion.chunk` SSE deltas streamed by `vicoop-codex serve`
+// so the existing envelope builders below can be reused unchanged. All fields
+// optional / nullable so a future schema bump degrades rather than crashes.
 export interface ChatCompletionResponse {
   id?: string;
   object?: string;
@@ -326,25 +352,6 @@ export function buildCallBody(
   return body;
 }
 
-// Map `vicoop-codex call` exit codes (doc's "Exit codes" section) to A2A
-// task.fail error codes. Anything outside the documented set surfaces as
-// `vicoop_codex_failed` so an operator can grep stderr without needing to
-// memorise the table.
-function exitCodeToA2ACode(code: number | null): string {
-  switch (code) {
-    case 2:
-      return 'invalid_input';
-    case 3:
-      return 'login_required';
-    case 4:
-      return 'upstream_error';
-    case 5:
-      return 'network_error';
-    default:
-      return 'vicoop_codex_failed';
-  }
-}
-
 // Convert the parsed `usage` block to a spec-compliant OpenAICompatUsage.
 // vicoop-codex prints the standard OpenAI shape so the mapping is direct;
 // total_tokens is recomputed by `buildOpenAICompatUsage` to enforce the
@@ -470,145 +477,294 @@ function defaultSpawn(
   }) as ChildProcess;
 }
 
-// Internal record of the binary's exit + collected streams. Returned by
-// `runVicoopCodexCall` so `handle()` can branch on exit code without
-// re-parsing the stderr / stdout itself.
-interface CallResult {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  stdout: string;
-  stderr: string;
-}
-
-// Spawn `vicoop-codex call`, write the JSON body on stdin, and collect
-// the result. Honours abort/cancel via `signal` — on abort we SIGTERM the
-// child so the daemon doesn't wait on a stale subprocess after the
-// caller's A2A `tasks/cancel` lands. Stderr is captured in full (no cap)
-// because vicoop-codex's user-facing error guidance lives there and the
-// task.fail message is operator-visible.
-async function runVicoopCodexCall(
-  body: string,
-  opts: {
-    command: string;
-    args: readonly string[];
-    cwd?: string;
-    spawn: VicoopCodexSpawnFn;
-    timeoutMs: number;
-    signal: AbortSignal;
-    stderrCap: number;
-    logger?: Logger;
-  },
-): Promise<CallResult> {
-  return await new Promise<CallResult>((resolve, reject) => {
-    let child: VicoopCodexChildHandle;
-    try {
-      child = opts.spawn(opts.command, opts.args, { cwd: opts.cwd });
-    } catch (err) {
-      reject(err);
-      return;
-    }
-
-    let stdout = '';
-    let stderr = '';
-    let timer: NodeJS.Timeout | null = null;
-    let aborted = false;
-    let settled = false;
-
-    const finish = (result: CallResult): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      opts.signal.removeEventListener('abort', onAbort);
-      resolve(result);
-    };
-
-    const fail = (err: Error): void => {
-      if (settled) return;
-      settled = true;
-      if (timer) clearTimeout(timer);
-      opts.signal.removeEventListener('abort', onAbort);
-      reject(err);
-    };
-
-    const onAbort = (): void => {
-      aborted = true;
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // best-effort
-      }
-    };
-    if (opts.signal.aborted) {
-      try {
-        child.kill('SIGTERM');
-      } catch {
-        // best-effort
-      }
-    } else {
-      opts.signal.addEventListener('abort', onAbort);
-    }
-
-    if (opts.timeoutMs > 0) {
-      timer = setTimeout(() => {
-        if (settled) return;
-        try {
-          child.kill('SIGTERM');
-        } catch {
-          // best-effort
-        }
-        fail(new Error(`vicoop-codex call timed out after ${opts.timeoutMs}ms`));
-      }, opts.timeoutMs);
-    }
-
-    if (child.stdout) {
-      child.stdout.on('data', (chunk: Buffer | string) => {
-        stdout += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-      });
-    }
-    if (child.stderr) {
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        const piece = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        if (stderr.length < opts.stderrCap) {
-          const remaining = opts.stderrCap - stderr.length;
-          stderr += piece.length > remaining ? piece.slice(0, remaining) : piece;
-        }
-      });
-    }
-
-    child.on('error', (err) => {
-      fail(err);
-    });
-    child.on('close', (code, signal) => {
-      finish({
-        code: aborted ? null : code,
-        signal,
-        stdout,
-        stderr,
-      });
-    });
-
-    if (child.stdin) {
-      child.stdin.on('error', (err: NodeJS.ErrnoException) => {
-        // EPIPE on early exit is expected (e.g. exit code 2 before reading
-        // the body) — surface it as a normal close, not a hard error.
-        if (err.code !== 'EPIPE') {
-          opts.logger?.warn?.(`[vicoop-codex] stdin error: ${errorMessage(err)}`);
-        }
-      });
-      try {
-        child.stdin.write(body);
-        child.stdin.end();
-      } catch (err) {
-        opts.logger?.warn?.(`[vicoop-codex] failed to write stdin: ${errorMessage(err)}`);
-      }
-    }
+// Default streaming transport: wrap the global `fetch` into the slim
+// `VicoopCodexStreamResponse` the backend consumes. The SSE body is exposed
+// as an async iterable of decoded UTF-8 string chunks read off the response's
+// `ReadableStream`.
+async function defaultFetch(
+  url: string,
+  init: { body: string; signal: AbortSignal },
+): Promise<VicoopCodexStreamResponse> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: init.body,
+    signal: init.signal,
   });
+  return {
+    ok: res.ok,
+    status: res.status,
+    text: () => res.text(),
+    async *chunks() {
+      const body = res.body;
+      if (!body) return;
+      const reader = body.getReader();
+      const decoder = new TextDecoder();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) yield decoder.decode(value, { stream: true });
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    },
+  };
 }
 
-// Construct the A2A Backend. The handler turns each task into a single
-// non-streaming `vicoop-codex call` invocation: read the existing
-// openai-compat extension metadata → assemble messages → invoke →
-// translate response to A2A artifacts + final message metadata.
+// A live `vicoop-codex serve` instance: the child process plus the base URL
+// (`http://127.0.0.1:<port>`) parsed from its `listening` line.
+interface ServeHandle {
+  child: VicoopCodexChildHandle;
+  baseUrl: string;
+}
+
+// `vicoop-codex serve` prints a single JSON line on stdout when the HTTP
+// server is up, e.g.
+//   {"event":"listening","host":"127.0.0.1","port":8787,"url":"http://127.0.0.1:8787"}
+// followed by human-readable text lines. Parse the JSON line to recover the
+// base URL; ignore everything else. Returns null for non-JSON / non-listening
+// lines so the caller keeps scanning.
+export function parseServeListeningUrl(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('{')) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+  if (o.event !== 'listening') return null;
+  if (typeof o.url === 'string' && o.url.length > 0) return o.url.replace(/\/$/, '');
+  if (typeof o.host === 'string' && typeof o.port === 'number') {
+    return `http://${o.host}:${o.port}`;
+  }
+  return null;
+}
+
+// A typed error carrying the A2A `task.fail` code the streaming layer wants
+// the handler to surface, so HTTP/transport failures map cleanly without the
+// handler re-inspecting error shapes.
+class ServeRequestError extends Error {
+  constructor(
+    readonly a2aCode: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ServeRequestError';
+  }
+}
+
+// One `chat.completion.chunk` SSE frame. Only the fields the accumulator
+// reads — everything optional / nullable per OpenAI's streaming schema.
+interface ChatCompletionChunk {
+  id?: string;
+  object?: string;
+  created?: number;
+  model?: string;
+  choices?: Array<{
+    index?: number;
+    delta?: {
+      role?: string;
+      content?: string | null;
+      tool_calls?: Array<{
+        index?: number;
+        id?: string;
+        type?: string;
+        function?: { name?: string; arguments?: string };
+      }>;
+    };
+    finish_reason?: string | null;
+  }>;
+  usage?: ChatCompletionResponse['usage'];
+}
+
+// Per-index tool-call assembly buffer. OpenAI streams a tool call's
+// `function.arguments` as a sequence of string fragments across chunks, so we
+// concatenate; `id` / `type` / `name` arrive on the first fragment for that
+// index but we tolerate them landing on any.
+interface ToolCallBuffer {
+  id?: string;
+  type?: string;
+  name?: string;
+  arguments: string;
+}
+
+// Running fold over the SSE stream — assembled into a `ChatCompletionResponse`
+// by `synthesizeStreamedResponse` once the stream ends.
+interface StreamAccumulator {
+  id?: string;
+  model?: string;
+  created?: number;
+  content: string;
+  toolCalls: Map<number, ToolCallBuffer>;
+  finishReason?: string;
+  usage?: ChatCompletionResponse['usage'];
+}
+
+function applyChunk(
+  acc: StreamAccumulator,
+  chunk: ChatCompletionChunk,
+  onContentDelta: (text: string) => void,
+): void {
+  if (typeof chunk.id === 'string' && chunk.id.length > 0) acc.id = chunk.id;
+  if (typeof chunk.model === 'string' && chunk.model.length > 0) acc.model = chunk.model;
+  if (typeof chunk.created === 'number') acc.created = chunk.created;
+  if (chunk.usage) acc.usage = chunk.usage;
+  const choice = chunk.choices?.[0];
+  if (!choice) return;
+  if (typeof choice.finish_reason === 'string') acc.finishReason = choice.finish_reason;
+  const delta = choice.delta;
+  if (!delta) return;
+  if (typeof delta.content === 'string' && delta.content.length > 0) {
+    acc.content += delta.content;
+    onContentDelta(delta.content);
+  }
+  if (Array.isArray(delta.tool_calls)) {
+    for (const tc of delta.tool_calls) {
+      const idx = typeof tc.index === 'number' ? tc.index : 0;
+      let cur = acc.toolCalls.get(idx);
+      if (!cur) {
+        cur = { arguments: '' };
+        acc.toolCalls.set(idx, cur);
+      }
+      if (typeof tc.id === 'string') cur.id = tc.id;
+      if (typeof tc.type === 'string') cur.type = tc.type;
+      if (tc.function) {
+        if (typeof tc.function.name === 'string') cur.name = tc.function.name;
+        if (typeof tc.function.arguments === 'string') cur.arguments += tc.function.arguments;
+      }
+    }
+  }
+}
+
+// Fold the accumulated SSE state into the non-streaming `ChatCompletionResponse`
+// shape the existing envelope builders consume. Mirrors the OpenAI contract:
+// a tool-call turn carries `content:null` + `tool_calls`, a text turn carries
+// the assembled content.
+function synthesizeStreamedResponse(acc: StreamAccumulator): ChatCompletionResponse {
+  const toolCalls = [...acc.toolCalls.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, t]) => ({
+      id: t.id,
+      type: t.type ?? 'function',
+      function: { name: t.name, arguments: t.arguments },
+    }));
+  const hasToolCalls = toolCalls.length > 0;
+  return {
+    id: acc.id,
+    object: 'chat.completion',
+    created: acc.created,
+    model: acc.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: hasToolCalls ? null : acc.content,
+          ...(hasToolCalls ? { tool_calls: toolCalls } : {}),
+        },
+        finish_reason: acc.finishReason ?? (hasToolCalls ? 'tool_calls' : 'stop'),
+      },
+    ],
+    usage: acc.usage,
+  };
+}
+
+// POST the Chat Completions request (with `stream:true`) to `vicoop-codex
+// serve` and fold the `chat.completion.chunk` SSE stream into a single
+// `ChatCompletionResponse`. `onContentDelta` fires for each incremental text
+// fragment so the caller can emit `append:true` artifacts. Throws
+// `ServeRequestError` (with an A2A code) on HTTP / transport failure; the
+// caller maps abort separately via `signal.aborted`.
+async function streamChatCompletions(
+  fetchFn: VicoopCodexFetchFn,
+  url: string,
+  body: string,
+  signal: AbortSignal,
+  onContentDelta: (text: string) => void,
+): Promise<ChatCompletionResponse> {
+  let res: VicoopCodexStreamResponse;
+  try {
+    res = await fetchFn(url, { body, signal });
+  } catch (err) {
+    throw new ServeRequestError(
+      'network_error',
+      `vicoop-codex serve request failed: ${errorMessage(err)}`,
+    );
+  }
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = (await res.text()).trim().slice(0, 512);
+    } catch {
+      // best-effort — diagnostics only
+    }
+    throw new ServeRequestError(
+      'upstream_error',
+      `vicoop-codex serve returned HTTP ${res.status}${detail ? `: ${detail}` : ''}`,
+    );
+  }
+
+  const acc: StreamAccumulator = { content: '', toolCalls: new Map() };
+  // Process one `data:` payload; returns true when the stream's `[DONE]`
+  // sentinel is seen so the reader can stop.
+  const consume = (data: string): boolean => {
+    if (data === '[DONE]') return true;
+    let chunk: ChatCompletionChunk;
+    try {
+      chunk = JSON.parse(data) as ChatCompletionChunk;
+    } catch {
+      // Defensive: OpenAI guarantees valid JSON per data line, but a stray
+      // keep-alive / comment shouldn't abort the turn — skip it.
+      return false;
+    }
+    applyChunk(acc, chunk, onContentDelta);
+    return false;
+  };
+
+  let buf = '';
+  try {
+    let done = false;
+    for await (const piece of res.chunks()) {
+      buf += piece;
+      let nl: number;
+      while ((nl = buf.indexOf('\n')) >= 0) {
+        const line = buf.slice(0, nl).replace(/\r$/, '');
+        buf = buf.slice(nl + 1);
+        if (!line.startsWith('data:')) continue; // blank lines, `event:`, comments
+        const data = line.slice(5).trim();
+        if (data.length === 0) continue;
+        if (consume(data)) {
+          done = true;
+          break;
+        }
+      }
+      if (done) break;
+    }
+    if (!done) {
+      // Flush a trailing `data:` payload that arrived without a final newline.
+      const tail = buf.replace(/\r$/, '');
+      if (tail.startsWith('data:')) {
+        const data = tail.slice(5).trim();
+        if (data.length > 0) consume(data);
+      }
+    }
+  } catch (err) {
+    // Surface as a transport error; the handler prioritises `signal.aborted`
+    // (→ canceled) over this mapping when the abort caused the interruption.
+    throw new ServeRequestError(
+      'network_error',
+      `vicoop-codex serve stream interrupted: ${errorMessage(err)}`,
+    );
+  }
+
+  return synthesizeStreamedResponse(acc);
+}
+
 // Probe the vicoop-codex CLI's `models --json` subcommand to discover the
 // model ids this account / install advertises. Returns null on any failure
 // (binary missing, timeout, non-JSON stdout, unexpected shape) so the
@@ -678,11 +834,22 @@ export function createVicoopCodexBackend(
   opts: VicoopCodexBackendOptions = {},
 ): Backend {
   const command = opts.command ?? 'vicoop-codex';
-  const baseArgs: readonly string[] = ['call', ...(opts.extraArgs ?? [])];
+  // `vicoop-codex serve -p 0` binds an ephemeral loopback port and prints its
+  // URL on stdout (`parseServeListeningUrl`). One server is spawned lazily and
+  // shared across every task (mirrors codex's `app-server` singleton).
+  const serveArgs: readonly string[] = [
+    'serve',
+    '-p',
+    '0',
+    '-H',
+    '127.0.0.1',
+    ...(opts.extraArgs ?? []),
+  ];
   const cwd = opts.cwd;
   const spawnFn = opts.spawn ?? defaultSpawn;
+  const fetchFn = opts.fetch ?? defaultFetch;
   const stderrCap = opts.stderrCaptureBytes ?? 16 * 1024;
-  const callTimeoutMs = opts.callTimeoutMs ?? 0;
+  const serveStartupTimeoutMs = opts.serveStartupTimeoutMs ?? 10_000;
   const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
   const logger = opts.logger ?? createLogger();
   const openaiCompatTrace = opts.openaiCompatTrace === true;
@@ -694,8 +861,149 @@ export function createVicoopCodexBackend(
   // model ids the CLI's `models --json` advertised.
   let cachedSupportedModels: Set<string> | null | undefined = undefined;
 
+  // Lazy `vicoop-codex serve` singleton + in-flight startup dedup. `serve`
+  // holds the live server; `servePending` coalesces concurrent first-task
+  // starts so we never spawn two servers. Both clear when the child dies so
+  // the next task respawns.
+  let serve: ServeHandle | null = null;
+  let servePending: Promise<ServeHandle> | null = null;
+
+  function startServe(): Promise<ServeHandle> {
+    return new Promise<ServeHandle>((resolve, reject) => {
+      let child: VicoopCodexChildHandle;
+      try {
+        child = spawnFn(command, serveArgs, { cwd });
+      } catch (err) {
+        reject(err instanceof Error ? err : new Error(errorMessage(err)));
+        return;
+      }
+
+      // `vicoop-codex serve` prints its `listening` JSON line — and all other
+      // human-readable startup text — to STDERR, not stdout. We scan both
+      // streams for the line (robust to a future change) and separately keep a
+      // capped stderr buffer for the exit-before-listening diagnostic.
+      let outBuf = '';
+      let errBuf = '';
+      let stderrDiag = '';
+      let settled = false;
+      let timer: NodeJS.Timeout | null = null;
+
+      const clearSingletonFor = (): void => {
+        if (serve?.child === child) serve = null;
+      };
+
+      const scanForListening = (buf: string): { url: string | null; rest: string } => {
+        let nl: number;
+        let rest = buf;
+        while ((nl = rest.indexOf('\n')) >= 0) {
+          const line = rest.slice(0, nl);
+          rest = rest.slice(nl + 1);
+          const url = parseServeListeningUrl(line);
+          if (url) return { url, rest };
+        }
+        return { url: null, rest };
+      };
+
+      const onLine = (url: string | null): void => {
+        if (settled || !url) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve({ child, baseUrl: url });
+      };
+
+      child.on('close', (code) => {
+        clearSingletonFor();
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        const head = stderrDiag.trim().slice(0, 512);
+        reject(
+          new Error(
+            `vicoop-codex serve exited (code ${code}) before reporting listening` +
+              (head ? `: ${head}` : ''),
+          ),
+        );
+      });
+      child.on('error', (err) => {
+        clearSingletonFor();
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      });
+
+      if (child.stdout) {
+        child.stdout.on('data', (chunk: Buffer | string) => {
+          if (settled) return;
+          outBuf += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          const { url, rest } = scanForListening(outBuf);
+          outBuf = rest;
+          onLine(url);
+        });
+      }
+      if (child.stderr) {
+        child.stderr.on('data', (chunk: Buffer | string) => {
+          const piece = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          if (stderrDiag.length < stderrCap) {
+            stderrDiag += piece.slice(0, stderrCap - stderrDiag.length);
+          }
+          if (settled) return;
+          errBuf += piece;
+          const { url, rest } = scanForListening(errBuf);
+          errBuf = rest;
+          onLine(url);
+        });
+      }
+
+      if (serveStartupTimeoutMs > 0) {
+        timer = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          try {
+            child.kill('SIGTERM');
+          } catch {
+            // best-effort
+          }
+          reject(
+            new Error(
+              `vicoop-codex serve did not report listening within ${serveStartupTimeoutMs}ms`,
+            ),
+          );
+        }, serveStartupTimeoutMs);
+      }
+    });
+  }
+
+  async function ensureServe(): Promise<ServeHandle> {
+    if (serve) return serve;
+    if (servePending) return servePending;
+    servePending = startServe().then(
+      (h) => {
+        serve = h;
+        servePending = null;
+        return h;
+      },
+      (err) => {
+        servePending = null;
+        throw err;
+      },
+    );
+    return servePending;
+  }
+
   return {
     name: 'vicoop-codex',
+
+    stop() {
+      if (serve) {
+        try {
+          serve.child.kill('SIGTERM');
+        } catch {
+          // best-effort
+        }
+        serve = null;
+      }
+    },
 
     async resolveCapabilities() {
       const ids = await probeVicoopCodexModels({
@@ -796,7 +1104,10 @@ export function createVicoopCodexBackend(
       const body = buildCallBody(effectiveEnvelope, messages);
       let serialized: string;
       try {
-        serialized = JSON.stringify(body);
+        // `stream:true` switches `vicoop-codex serve`'s `/v1/chat/completions`
+        // into the `chat.completion.chunk` SSE mode we fold in
+        // `streamChatCompletions`.
+        serialized = JSON.stringify({ ...body, stream: true });
       } catch (err) {
         emit({
           type: 'task.fail',
@@ -815,18 +1126,12 @@ export function createVicoopCodexBackend(
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
 
-      let result: CallResult;
+      // Ensure the shared `vicoop-codex serve` is up. A startup failure (binary
+      // missing, too old to expose `serve`, port never opened) is terminal for
+      // this task — surface `serve_unavailable` with the captured stderr.
+      let serveHandle: ServeHandle;
       try {
-        result = await runVicoopCodexCall(serialized, {
-          command,
-          args: baseArgs,
-          cwd,
-          spawn: spawnFn,
-          timeoutMs: callTimeoutMs,
-          signal,
-          stderrCap,
-          logger,
-        });
+        serveHandle = await ensureServe();
       } catch (err) {
         if (signal.aborted) {
           emit({
@@ -840,57 +1145,71 @@ export function createVicoopCodexBackend(
           type: 'task.fail',
           taskId: task.taskId,
           error: {
-            code: 'spawn_failed',
-            message: `failed to spawn vicoop-codex: ${errorMessage(err)}`,
+            code: 'serve_unavailable',
+            message: `failed to start vicoop-codex serve: ${errorMessage(err)}`,
           },
         });
         return;
       }
 
-      // Aborted mid-flight — caller already pulled the plug, surface as
-      // canceled regardless of what the subprocess did before SIGTERM
-      // delivered.
+      // Stream the response. Each `delta.content` fragment is emitted as an
+      // `append:true` text artifact (single reused artifactId) so the gateway
+      // codec maps it to an OpenAI SSE `delta.content` chunk (#293/#294).
+      let responseArtifactId: string | null = null;
+      let emittedAnyArtifact = false;
+      const emitDelta = (text: string): void => {
+        if (!text) return;
+        responseArtifactId ??= randomUUID();
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: responseArtifactId,
+            name: 'vicoop-codex-message',
+            parts: [{ kind: 'text', text }],
+          },
+          append: true,
+          lastChunk: false,
+        });
+        emittedAnyArtifact = true;
+      };
+
+      let response: ChatCompletionResponse;
+      try {
+        response = await streamChatCompletions(
+          fetchFn,
+          `${serveHandle.baseUrl}/v1/chat/completions`,
+          serialized,
+          signal,
+          emitDelta,
+        );
+      } catch (err) {
+        // Abort wins over any transport-error mapping — the caller pulled the
+        // plug, so surface canceled.
+        if (signal.aborted) {
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'canceled', timestamp: new Date().toISOString() },
+          });
+          return;
+        }
+        const code = err instanceof ServeRequestError ? err.a2aCode : 'vicoop_codex_failed';
+        emit({
+          type: 'task.fail',
+          taskId: task.taskId,
+          error: { code, message: errorMessage(err) },
+        });
+        return;
+      }
+
+      // Aborted mid-stream — surface as canceled regardless of what arrived
+      // before the abort delivered.
       if (signal.aborted) {
         emit({
           type: 'task.complete',
           taskId: task.taskId,
           status: { state: 'canceled', timestamp: new Date().toISOString() },
-        });
-        return;
-      }
-
-      if (result.code !== 0) {
-        const trimmedStderr = result.stderr.trim();
-        const message =
-          trimmedStderr.length > 0
-            ? trimmedStderr
-            : `vicoop-codex exited with code ${result.code}`;
-        emit({
-          type: 'task.fail',
-          taskId: task.taskId,
-          error: {
-            code: exitCodeToA2ACode(result.code),
-            message,
-          },
-        });
-        return;
-      }
-
-      // Parse the stdout payload. A malformed (non-JSON) stdout shouldn't
-      // crash the backend — surface as `parse_failed` with the head of
-      // the output so the operator can diagnose without `--verbose`.
-      let response: ChatCompletionResponse;
-      try {
-        response = JSON.parse(result.stdout) as ChatCompletionResponse;
-      } catch (err) {
-        const head = result.stdout.slice(0, 256);
-        emit({
-          type: 'task.fail',
-          taskId: task.taskId,
-          error: {
-            code: 'parse_failed',
-            message: `failed to parse vicoop-codex stdout as JSON: ${errorMessage(err)}; head: ${JSON.stringify(head)}`,
-          },
         });
         return;
       }
@@ -909,12 +1228,11 @@ export function createVicoopCodexBackend(
 
       // Envelope contract (oai2a2a#80): tool_calls flow exclusively through
       // the terminal `chat_completion` envelope metadata — NOT as a data-part
-      // artifact. The legacy `data` part shaped `{ "tool_calls": [...] }`
-      // is removed from this extension; consumers ignore it. Text content
-      // still rides as a text artifact so non-OpenAI A2A consumers
-      // (debugging UIs, traceability tooling) see the task's response
-      // natively, per the spec's "Relationship to A2A artifacts" note.
-      if (toolCalls.length === 0 && contentText) {
+      // artifact. Text content already streamed as `append:true` artifacts
+      // above. Fallback: if the server returned text WITHOUT chunking it (no
+      // deltas seen), emit it once here so non-OpenAI A2A consumers still see
+      // the response — mirrors codex's `!emittedAnyArtifact` guard.
+      if (!emittedAnyArtifact && toolCalls.length === 0 && contentText) {
         emit({
           type: 'task.artifact',
           taskId: task.taskId,

--- a/packages/server/src/cards/vicoop-codex.json
+++ b/packages/server/src/cards/vicoop-codex.json
@@ -1,10 +1,10 @@
 {
   "name": "vicoop-codex",
-  "description": "OpenAI Codex agent driven via the `vicoop-codex call` CLI. Each A2A task spawns a single non-streaming `vicoop-codex call` invocation with an OpenAI Chat Completions body assembled from the openai-compat A2A extension, and returns the response payload as A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
+  "description": "OpenAI Codex agent driven via the `vicoop-codex` CLI. Each A2A task streams an OpenAI Chat Completions request (assembled from the openai-compat A2A extension) through a shared local `vicoop-codex serve` instance, emitting the model's response token-by-token as incremental A2A artifacts plus an openai-compat usage / chat_completion envelope on the final message metadata.",
   "version": "0.0.1",
   "protocolVersion": "0.3.0",
   "capabilities": {
-    "streaming": false,
+    "streaming": true,
     "extensions": [
       {
         "uri": "https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1",


### PR DESCRIPTION
## What

Closes the streaming gap for the **`vicoop-codex`** backend in openai-compat mode. #294 added token-level streaming for `claude` / `codex`, but `vicoop-codex` was left making a single non-streaming `vicoop-codex call` invocation that emitted the whole response as one artifact — so callers saw no streaming.

It now drives a shared, lazily-spawned **`vicoop-codex serve`** instance and streams its `POST /v1/chat/completions` (`stream:true`) `chat.completion.chunk` SSE:

- each `delta.content` fragment → incremental `append:true` A2A artifact (single reused `artifactId`), which the oai2a2a gateway maps to an OpenAI SSE `delta.content` chunk
- `delta.tool_calls` accumulated by index and folded — with usage / finish_reason — into a synthesized `ChatCompletionResponse`, so the existing terminal `chat_completion` envelope builders are **reused unchanged**
- the bundled `vicoop-codex` agent card now advertises `capabilities.streaming: true` (was `false`, with a stale "non-streaming \`call\`" description) so the gateway takes the `message/stream` path

## How

- **serve lifecycle** mirrors codex's app-server singleton: spawned on first task, reused across tasks, respawned on crash, killed via `stop()`. Its `listening` line is read from **stderr** (where the binary prints it).
- `call` subprocess path (+ exit-code mapping) removed. Failures map to `serve_unavailable` / `upstream_error` / `network_error`.
- Message assembly (`buildMessages` / `buildCallBody` / model gate / empty-prompt / abort / trace) preserved; the body just gains `stream:true`.

**Compat:** requires a `vicoop-codex` build that exposes the `serve` subcommand; an older binary fails the task with `serve_unavailable` (serve-only, by design).

## Testing

- `pnpm -r build` / `pnpm -r typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` → **630/630** (vicoop-codex suite rewritten onto a serve + injected-`fetch` SSE harness; pure-function + #302 model-gate tests preserved)
- **E2E against the real binary**: "count 1→8" prompt streamed as 15 per-token `append:true` deltas, time-to-first-token ~1.2s (vs the old single buffered chunk), terminal `finish_reason=stop` + usage — matching #293's "Expected Result"
- **Live**: launched `swen-2026052702` with `--backend vicoop-codex`; agent card now serves `streaming: true` and the openai-compat model list

🤖 Generated with [Claude Code](https://claude.com/claude-code)