### PR TITLE
fix(client): force include_usage on streamed vicoop-codex calls (#317)

### DIFF
--- a/.changeset/vicoop-codex-stream-include-usage.md
+++ b/.changeset/vicoop-codex-stream-include-usage.md
@@ -1,0 +1,8 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+fix(client): force `stream_options.include_usage` on streamed vicoop-codex
+calls so the terminal usage chunk is always emitted. Without it the runtime
+could intermittently drop `usage` from the SSE stream, surfacing downstream
+as a silently $0-billed 0-token call (#317).

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -728,6 +728,11 @@ test('handle: request body carries stream:true + envelope-derived model/messages
   const body = JSON.parse(fetchRec.calls[0].body) as Record<string, unknown>;
   // Streaming flag is set on the wire.
   assert.equal(body.stream, true);
+  // `stream_options.include_usage` is forced on so `vicoop-codex serve` is
+  // contractually obliged to emit the terminal usage chunk — without it the
+  // runtime may drop usage on some turns, silently $0-billing downstream
+  // (#317).
+  assert.deepEqual(body.stream_options, { include_usage: true });
   // Messages: system → chat_history (assistant(tool_calls) → tool) →
   // trailing user.
   const messages = body.messages as Array<{ role: string }>;

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -1107,7 +1107,21 @@ export function createVicoopCodexBackend(
         // `stream:true` switches `vicoop-codex serve`'s `/v1/chat/completions`
         // into the `chat.completion.chunk` SSE mode we fold in
         // `streamChatCompletions`.
-        serialized = JSON.stringify({ ...body, stream: true });
+        //
+        // `stream_options.include_usage:true` makes the terminal usage chunk
+        // contractual. Per the OpenAI streaming contract `usage` is only
+        // guaranteed in the stream when this flag is set — without it
+        // `vicoop-codex serve` is free to omit usage on a given turn, which
+        // surfaces downstream as a silently $0-billed 0-token call (#317).
+        // We fold whichever chunk carries `usage` (piggybacked on the
+        // finish_reason frame or a trailing `choices:[]` frame) into
+        // `acc.usage`, so requesting it here is the robust fix regardless of
+        // which frame the runtime chooses.
+        serialized = JSON.stringify({
+          ...body,
+          stream: true,
+          stream_options: { include_usage: true },
+        });
       } catch (err) {
         emit({
           type: 'task.fail',
@@ -1246,6 +1260,21 @@ export function createVicoopCodexBackend(
       }
 
       const usage = parseChatCompletionUsage(response.usage, response.model);
+      // We force `stream_options.include_usage` on the request, so a missing
+      // usage block here means the runtime dropped it on this turn despite
+      // being asked for it — the #317 failure mode. Leave a breadcrumb in
+      // the logs rather than fabricating counts: a non-undefined `usage`
+      // omission is exactly what bills $0 downstream, so it should be
+      // diagnosable from fly logs by task id + finish_reason.
+      if (!usage) {
+        logger.warn?.(
+          `[vicoop-codex] task=${task.taskId} finish_reason=${JSON.stringify(
+            typeof response.choices?.[0]?.finish_reason === 'string'
+              ? response.choices[0].finish_reason
+              : null,
+          )}: streamed response carried no usage despite stream_options.include_usage; downstream will record 0 tokens`,
+        );
+      }
       const responseMetadata = buildResponseMetadata(response, usage, task.taskId);
 
       // The final `task.complete` message mirrors codex.ts's pattern:


### PR DESCRIPTION
## Summary

Fixes #317 — streamed vicoop-codex responses intermittently omit the openai-compat terminal usage chunk, surfacing downstream as 0-token / \$0 billing.

## Root cause

The `#315` serve-based streaming path posts the request body to `vicoop-codex serve` as `{ ...body, stream: true }` **without** `stream_options.include_usage` (`packages/client/src/backends/vicoop-codex.ts`). Per the OpenAI streaming contract, `usage` is only guaranteed in the SSE stream when `stream_options.include_usage: true` is set.

Reproducing against a local `vicoop-codex serve` (v0.1.0), the runtime *did* piggyback `usage` onto the `finish_reason` frame even without the flag for both `stop` and `tool_calls` turns — but that's a non-contractual convenience. Under production conditions (large 23k-token contexts, load, runtime version drift) that piggyback can drop, and then:

- the bridge folds no `usage` into its stream accumulator,
- emits a `chat_completion` envelope with no `usage`,
- the openai-compat consumer records `prompt_tokens=0 / completion_tokens=0` on an otherwise SUCCESS call → silent \$0 bill.

This matches the issue's intermittent evidence (mix of correct counts and 0/0 on the same agent/model/stream flag).

## Change

- **Force `stream_options: { include_usage: true }`** on the streamed body so the terminal usage chunk is contractual (issue ask #2). The existing fold (`applyChunk`) already captures `usage` from whichever frame carries it — the piggybacked finish frame or a trailing `choices:[]` frame — so no parser change is needed.
- **Warn-log when `usage` is still absent** despite the flag, with task id + finish_reason, so the residual case is diagnosable from fly logs (issue ask #1) rather than fabricating zero counts.
- Test asserts the streamed request body carries `stream_options: { include_usage: true }`.
- Client-only changeset (patch).

## Verification

- `pnpm --filter @vicoop-bridge/client typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` — 630/630 pass ✅
- Manually exercised `vicoop-codex serve` with/without `include_usage` (stop + tool_calls turns) to confirm the usage chunk shape the fold consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)