### PR TITLE
fix(client): qualify caller-tool names in claude native-dispatch chat_history

### DIFF
--- a/.changeset/spotty-bobcats-rule.md
+++ b/.changeset/spotty-bobcats-rule.md
@@ -1,0 +1,16 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+fix(client): qualify caller-tool names in replayed chat_history under claude
+native dispatch. Caller tools are exposed to claude as
+`mcp___vb-caller-tools__<name>`, but the wire `chat_history` records prior
+calls by their bare OpenAI name (e.g. `read`). Replaying the bare name
+conditioned the model to re-emit it; claude then rejected the call with "No
+such tool available: read", the call never reached the caller-tools MCP (so it
+was never captured), the model retried, and the run died at `--max-turns 1`
+with `terminal_reason:"max_turns"` surfaced as `claude_exit_nonzero`. The
+replayed history names are now rewritten to the live MCP ids so the model's
+historical view matches its tool list. As a diagnostic backstop, a "No such
+tool available" tool error now adds a tool-name-mismatch hint to the terminal
+failure message instead of a bare exit-1.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -3525,6 +3525,138 @@ test('native dispatch: exit-code-1 with NO tool capture still fails (#213)', asy
   }
 });
 
+// Tool-name qualification (fix #1): under native dispatch the caller's tools
+// are live as `mcp___vb-caller-tools__<name>`, but the wire chat_history
+// records prior calls by their bare OpenAI name (`read`). The bridge must
+// rewrite the replayed history names to the MCP ids so the model's historical
+// view matches its live tool list — otherwise it re-emits the bare name,
+// claude rejects it ("No such tool available"), and the run dies at the cap.
+test('native dispatch: chat_history caller-tool names are qualified to MCP ids on stdin', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 's' }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        terminal_reason: 'completed',
+        result: 'ok',
+      }),
+    ],
+    exitCode: 0,
+  });
+  const { emit } = collect();
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    onCallerToolsMcpReady: () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('continue', {
+      tools: [
+        { type: 'function', function: { name: 'read', parameters: { type: 'object' } } },
+      ],
+      chat_history: [
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'read', arguments: '{"filePath":"/a"}' },
+            },
+          ],
+        },
+        { role: 'tool', tool_call_id: 'call_1', name: 'read', content: 'file contents' },
+      ],
+    }),
+    emit,
+    NEVER,
+  );
+
+  const child = fake.lastChild()!;
+  const env = JSON.parse(child.stdinPayload.trim()) as {
+    message: { content: Array<{ type: string; text?: string }> };
+  };
+  const histBlock = env.message.content.find(
+    (c) => c.type === 'text' && (c.text ?? '').includes('<chat_history>'),
+  );
+  assert.ok(histBlock, 'chat_history block present on stdin');
+  const text = histBlock!.text!;
+  // Both the assistant tool_calls name AND the tool result name are qualified.
+  assert.match(text, /mcp___vb-caller-tools__read/);
+  // The bare OpenAI name no longer appears as a tool name (would re-condition
+  // the model to call the unqualified id). The arguments value `/a` and the
+  // qualified `..._read` both still contain "read" as a substring, so we pin
+  // the exact key/value form that the bare name would have produced.
+  assert.doesNotMatch(text, /"name": "read"/);
+});
+
+// Diagnostic (fix #3): a tool-name mismatch that slips through (model invents
+// an unregistered name) shows up as "No such tool available", the call is
+// never captured, and the `--max-turns 1` cap kills the run. The terminal
+// failure must spell out the proximate cause rather than a bare exit-1.
+test('native dispatch: "No such tool available" exit surfaces a tool-mismatch hint', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 's' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'tu1', name: 'read', input: { filePath: '/a' } }],
+        },
+      }),
+      JSON.stringify({
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tu1',
+              is_error: true,
+              content: '<tool_use_error>Error: No such tool available: read</tool_use_error>',
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'error_max_turns',
+        is_error: true,
+        terminal_reason: 'max_turns',
+        errors: ['Reached maximum number of turns (1)'],
+      }),
+    ],
+    exitCode: 1,
+  });
+  const { emit, frames } = collect();
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    onCallerToolsMcpReady: () => {},
+  });
+
+  await backend.handle(
+    assignWithOpenAICompat('read the file', {
+      tools: [
+        { type: 'function', function: { name: 'read', parameters: { type: 'object' } } },
+      ],
+    }),
+    emit,
+    NEVER,
+  );
+
+  const terminal = frames.at(-1);
+  assert.ok(terminal && terminal.type === 'task.fail');
+  if (terminal.type === 'task.fail') {
+    assert.equal(terminal.error.code, 'claude_exit_nonzero');
+    // The hint names the proximate cause and the expected id shape.
+    assert.match(terminal.error.message, /hint: model called a tool name claude does not expose/);
+    assert.match(terminal.error.message, /mcp___vb-caller-tools__/);
+  }
+});
+
 // Without an openai-compat `tools` field, no caller-tools MCP is stood
 // up and none of the native-dispatch argv (`--mcp-config caller-tools`,
 // `--max-turns 1`, native system prompt) attaches. Guards against the

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -40,6 +40,7 @@ import {
   dumpOpenAICompatTaskWire,
   formatChatHistory,
   parseOpenAICompatEnvelope,
+  requalifyHistoryToolNames,
 } from './openai-compat.js';
 
 // Slim subset of ChildProcess that the backend actually uses. Tests inject a
@@ -671,6 +672,19 @@ function traceabilityRequested(task: {
 // declared without `parameters`. Returns `null` when no usable entries
 // remain so callers can branch off "no tools to register" without checking
 // `length`.
+// MCP server name the bridge registers the per-task caller-tools server
+// under (`--mcp-config`). claude exposes that server's tools to the model as
+// `mcp__${CALLER_TOOLS_MCP_SERVER}__<tool>` — e.g. `mcp___vb-caller-tools__read`
+// (the leading `_` of the server name abuts the `mcp__` prefix, hence the
+// triple underscore). Single source of truth so the registration and the
+// chat_history name-qualification below cannot drift.
+const CALLER_TOOLS_MCP_SERVER = '_vb-caller-tools';
+
+// The id the model must use to call a caller tool under native MCP dispatch.
+function callerToolMcpId(toolName: string): string {
+  return `mcp__${CALLER_TOOLS_MCP_SERVER}__${toolName}`;
+}
+
 export function openaiToolsToCallerToolDefs(
   tools: readonly unknown[],
 ): CallerToolDefinition[] | null {
@@ -1252,6 +1266,12 @@ export function createClaudeBackend(
           ? openaiToolsToCallerToolDefs(envelopeTools)
           : null;
       const nativeDispatchActive = callerToolDefs !== null;
+      // Registered caller-tool names, used to qualify matching references in
+      // the replayed chat_history to their live MCP ids (see the history
+      // projection below). Empty on the non-native path.
+      const callerToolNameSet = new Set(
+        (callerToolDefs ?? []).map((d) => d.name),
+      );
 
       const mappedRaw = await mapPartsToContentBlocks(task.message.parts, opts.fetchUriPolicy, signal);
       recorder.mark('map');
@@ -1301,7 +1321,24 @@ export function createClaudeBackend(
         // turn over a multi-turn conversation. Folding everything into
         // a single user message via this block is the only way to give
         // the model the conversation in one shot on this backend.
-        const block = formatChatHistory(envelopeChatHistory);
+        //
+        // Under native MCP dispatch (#213) the caller's tools are live as
+        // `mcp___vb-caller-tools__<name>`, but the wire history records each
+        // prior call by its bare OpenAI name (e.g. `read`). Replaying the bare
+        // name conditions the model to re-emit it, and claude then rejects the
+        // call ("No such tool available: read") — it never reaches the
+        // caller-tools MCP (so it isn't captured), the model retries, and the
+        // run dies at `--max-turns 1`. Qualify the history names to the live
+        // MCP ids so the model's historical view matches its tool list. Only
+        // names that are actually registered caller tools are rewritten;
+        // everything else (and the non-native path, where callerToolDefs is
+        // null) passes through untouched.
+        const projectedHistory = callerToolDefs
+          ? requalifyHistoryToolNames(envelopeChatHistory, (name) =>
+              callerToolNameSet.has(name) ? callerToolMcpId(name) : name,
+            )
+          : envelopeChatHistory;
+        const block = formatChatHistory(projectedHistory);
         if (block) {
           mapped.blocks.unshift({ type: 'text', text: block });
         }
@@ -1568,7 +1605,7 @@ export function createClaudeBackend(
         mcpServers['_vb-send-file'] = { type: 'http', url: mcpServerForTask.url };
       }
       if (callerToolsMcp) {
-        mcpServers['_vb-caller-tools'] = { type: 'http', url: callerToolsMcp.url };
+        mcpServers[CALLER_TOOLS_MCP_SERVER] = { type: 'http', url: callerToolsMcp.url };
       }
       const mcpServerNames = Object.keys(mcpServers);
       const mcpConfigArgs: readonly string[] =
@@ -1705,6 +1742,16 @@ export function createClaudeBackend(
       let streamedResponseText = '';
       let sawCompletedResult = false;
       let sawErrorResult = false;
+      // Set when a tool_result comes back as claude's "No such tool available:
+      // <name>" error. Under native dispatch this is the signature of a
+      // tool-name mismatch — the model called a tool by a name claude doesn't
+      // expose (usually the bare OpenAI name when it should use the
+      // `mcp___vb-caller-tools__<name>` id). The call never reaches the
+      // caller-tools MCP, so it isn't captured, and the model burns the
+      // `--max-turns 1` budget retrying. fix #1 (history name qualification)
+      // should prevent it; this flag lets the terminal failure say WHY rather
+      // than surfacing a bare `claude_exit_nonzero`.
+      let sawUnknownToolError = false;
       let stdoutTail = '';
       let stderrTail = '';
       let aborted = false;
@@ -1955,6 +2002,28 @@ export function createClaudeBackend(
           return;
         }
         if (evt.type === 'user') {
+          // Tool-name-mismatch detection (native dispatch): a tool_result of
+          // "No such tool available: <name>" means the model called a tool id
+          // claude doesn't expose. Flag it so the terminal failure can explain
+          // the cause instead of a bare exit-nonzero. Cheap substring scan over
+          // the tool_result text; only meaningful on the native path but
+          // harmless elsewhere.
+          if (!sawUnknownToolError && nativeDispatchActive) {
+            const content = evt.message?.content;
+            if (Array.isArray(content)) {
+              for (const block of content) {
+                if (!block || typeof block !== 'object') continue;
+                const b = block as { type?: unknown; content?: unknown };
+                if (b.type !== 'tool_result') continue;
+                const text =
+                  typeof b.content === 'string' ? b.content : JSON.stringify(b.content);
+                if (text.includes('No such tool available')) {
+                  sawUnknownToolError = true;
+                  break;
+                }
+              }
+            }
+          }
           // Pair subagent completions back to the start events emitted
           // above. The registry is only populated when trace is on (see
           // the assistant handler above), so this loop is a no-op when
@@ -2187,12 +2256,20 @@ export function createClaudeBackend(
         // If stdin write blew up and the process exited non-zero, surface
         // both: the stdin error is usually the proximate cause.
         const stdinPart = stdinError ? ` [stdin: ${errorMessage(stdinError)}]` : '';
+        // Tool-name-mismatch diagnostic: a max_turns exit preceded by "No such
+        // tool available" almost always means the model called a caller tool
+        // by an id claude doesn't expose. Spell out the proximate cause so the
+        // failure isn't an inscrutable exit-1 (fix #1 should keep this from
+        // happening, but a model can still invent an unregistered name).
+        const toolMismatchPart = sawUnknownToolError
+          ? ' [hint: model called a tool name claude does not expose ("No such tool available"); caller tools are registered as mcp___vb-caller-tools__<name> — the call was never captured and the turn cap was exhausted retrying]'
+          : '';
         emit({
           type: 'task.fail',
           taskId: task.taskId,
           error: {
             code: 'claude_exit_nonzero',
-            message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdoutPart}${stdinPart}`,
+            message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdoutPart}${stdinPart}${toolMismatchPart}`,
           },
         });
         return;

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -9,6 +9,7 @@ import {
   dumpOpenAICompatTaskWire,
   formatChatHistory,
   parseOpenAICompatEnvelope,
+  requalifyHistoryToolNames,
   tryParseToolCallsEnvelope,
 } from './openai-compat.js';
 
@@ -439,6 +440,79 @@ test('formatChatHistory: wraps the full history as a JSON array verbatim', () =>
 
 test('formatChatHistory: returns empty when the history is empty', () => {
   assert.equal(formatChatHistory([]), '');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// requalifyHistoryToolNames — rename caller-tool references in replayed
+// history to a backend's live tool ids (claude native MCP dispatch, #213).
+// ───────────────────────────────────────────────────────────────────────────
+
+test('requalifyHistoryToolNames: renames assistant.tool_calls and tool result names', () => {
+  const history = [
+    { role: 'user' as const, content: 'go' },
+    {
+      role: 'assistant' as const,
+      content: null,
+      tool_calls: [
+        { id: 'call_1', type: 'function', function: { name: 'read', arguments: '{"p":1}' } },
+        { id: 'call_2', type: 'function', function: { name: 'write', arguments: '{}' } },
+      ],
+    },
+    { role: 'tool' as const, tool_call_id: 'call_1', name: 'read', content: 'data' },
+  ];
+  const out = requalifyHistoryToolNames(history, (n) => `mcp___vb-caller-tools__${n}`);
+
+  const calls = (out[1] as { tool_calls: Array<{ function: { name: string; arguments: string } }> })
+    .tool_calls;
+  assert.equal(calls[0]?.function.name, 'mcp___vb-caller-tools__read');
+  // arguments + id (and everything else) ride through untouched.
+  assert.equal(calls[0]?.function.arguments, '{"p":1}');
+  assert.equal(calls[1]?.function.name, 'mcp___vb-caller-tools__write');
+  assert.equal((out[2] as { name: string }).name, 'mcp___vb-caller-tools__read');
+  // Non-tool entries pass through unchanged.
+  assert.deepEqual(out[0], { role: 'user', content: 'go' });
+});
+
+test('requalifyHistoryToolNames: leaves names the renamer returns unchanged + does not mutate input', () => {
+  const history = [
+    {
+      role: 'assistant' as const,
+      content: null,
+      tool_calls: [{ id: 'c', type: 'function', function: { name: 'read', arguments: '{}' } }],
+    },
+  ];
+  // Renamer only qualifies registered names; 'read' is not registered here.
+  const registered = new Set(['write']);
+  const out = requalifyHistoryToolNames(history, (n) =>
+    registered.has(n) ? `mcp___vb-caller-tools__${n}` : n,
+  );
+  assert.equal(
+    (out[0] as { tool_calls: Array<{ function: { name: string } }> }).tool_calls[0]?.function.name,
+    'read',
+  );
+  // Original array/object untouched (pure projection).
+  assert.equal(
+    (history[0] as { tool_calls: Array<{ function: { name: string } }> }).tool_calls[0]?.function
+      .name,
+    'read',
+  );
+  assert.notEqual(out[0], history[0]);
+});
+
+test('requalifyHistoryToolNames: tolerates malformed tool_calls items', () => {
+  const history = [
+    {
+      role: 'assistant' as const,
+      content: null,
+      // null item, item without function, function without string name.
+      tool_calls: [null, { id: 'x' }, { function: {} }, { function: { name: 42 } }],
+    },
+    // tool entry without a name is left alone.
+    { role: 'tool' as const, tool_call_id: 'x', content: 'r' },
+  ];
+  const out = requalifyHistoryToolNames(history, (n) => `Q_${n}`);
+  // Nothing renamable → structurally equal to the input.
+  assert.deepEqual(out, history);
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -470,6 +470,50 @@ export function formatChatHistory(history: OpenAICompatHistoryEntry[]): string {
   ].join('\n');
 }
 
+// Return a copy of `history` with every caller-tool reference renamed via
+// `rename`. Touches the `function.name` on each `assistant.tool_calls[]`
+// entry and the `name` on each `tool` result entry; everything else passes
+// through unchanged (and unknown `tool_calls[]` item shapes are left intact).
+//
+// Why this exists: the wire history records each prior tool call by the
+// caller's bare OpenAI function name (e.g. `read`), but a backend whose live
+// tool surface exposes caller tools under a transport-specific id (claude's
+// native MCP dispatch registers them as `mcp___vb-caller-tools__<name>`) needs
+// the replayed history to use that id too. Replaying the bare names conditions
+// the model to re-emit them; the backend then has no such tool and rejects the
+// call ("No such tool available: read"), the call never reaches the capture
+// path, the model retries, and the run dies at its turn cap. `rename` receives
+// the wire name and returns the backend id — return the input unchanged to
+// leave a name alone (e.g. names that aren't registered caller tools).
+export function requalifyHistoryToolNames(
+  history: OpenAICompatHistoryEntry[],
+  rename: (name: string) => string,
+): OpenAICompatHistoryEntry[] {
+  return history.map((entry) => {
+    if (
+      entry.role === 'assistant' &&
+      'tool_calls' in entry &&
+      Array.isArray(entry.tool_calls)
+    ) {
+      return {
+        ...entry,
+        tool_calls: entry.tool_calls.map((call) => {
+          if (!call || typeof call !== 'object') return call;
+          const fn = (call as { function?: unknown }).function;
+          if (!fn || typeof fn !== 'object') return call;
+          const name = (fn as { name?: unknown }).name;
+          if (typeof name !== 'string') return call;
+          return { ...call, function: { ...(fn as object), name: rename(name) } };
+        }),
+      };
+    }
+    if (entry.role === 'tool' && typeof entry.name === 'string') {
+      return { ...entry, name: rename(entry.name) };
+    }
+    return entry;
+  });
+}
+
 // Wire-level diagnostic dump for a single incoming A2A task. Gated by
 // the `--openai-compat-trace` operator flag (see cli-args.ts). Emits to
 // stderr to keep the trace separate from the bridge's structured stdout


### PR DESCRIPTION
## Summary

Fixes openai-compat tasks on the **claude backend** failing with
`claude_exit_nonzero` / `terminal_reason: "max_turns"` when the caller has
supplied tools.

Under claude's native dispatch (#213), caller-supplied OpenAI tools are exposed
to the model as MCP tools `mcp___vb-caller-tools__<name>`, but the replayed
`chat_history` records prior calls by their **bare OpenAI name** (e.g. `read`).
The bare-name history conditions the model to re-emit `read`, which claude
can't resolve (`No such tool available: read`) — so the call never reaches the
caller-tools MCP `onInvoke` (`capturedToolCall` stays `false`), the model
retries, and the run dies at `--max-turns 1`. `permission_denials` is empty
because it's a tool-not-found, not a permission denial.

### Root cause (confirmed from an on-disk session transcript)

The failing run's claude transcript shows the model emitting `tool_use name=read`
**five times in a row**, each answered with
`<tool_use_error>Error: No such tool available: read</tool_use_error>`, until
the turn cap fired. The wire `chat_history` for that request recorded 7 prior
`assistant.tool_calls` all named `read` — i.e. the model was mimicking the
bare-name history. Two-model usage (`haiku-4-5` + `opus-4-8[1m]`) and the empty
`permission_denials` match the reported error signature exactly.

## Changes

- **Fix #1 (root cause):** rewrite caller-tool references in the replayed
  history to the live MCP ids so the model's historical view matches its tool
  list. New generic helper `requalifyHistoryToolNames` in `openai-compat.ts`;
  `claude.ts` applies it gated on native dispatch and only for registered
  caller-tool names. The MCP server name / id is now derived from a single
  `CALLER_TOOLS_MCP_SERVER` constant (registration + qualification can't drift).
- **Fix #3 (diagnostic backstop):** detect claude's "No such tool available"
  tool error under native dispatch and append a tool-name-mismatch hint to the
  terminal failure message instead of a bare exit-1.

## Not affected

`codex` registers `dynamicTools` and injects history under the **same bare
OpenAI name** (no MCP prefix layer), and `vicoop-codex` forwards `tools` +
`messages` verbatim to a remote OpenAI-compatible endpoint — both are naturally
consistent, so no analogous fix is needed there. Verified by inspecting
`openaiToolsToDynamicToolSpecs` / `historyToInjectItems`.

## Testing

- 3 unit tests for `requalifyHistoryToolNames` (rename tool_calls + tool result
  names; leave unregistered names alone + no input mutation; tolerate malformed
  items).
- 2 claude integration tests: chat_history names are qualified to MCP ids on
  stdin; a "No such tool available" exit surfaces the mismatch hint.
- Full client suite: **635 pass**. Client + server typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)