### PR TITLE
[codex] timestamp client logs

### DIFF
--- a/.changeset/timestamp-client-logs.md
+++ b/.changeset/timestamp-client-logs.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Prefix client daemon logs with ISO timestamps.

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -58,6 +58,7 @@ import {
   mergeClientArgs,
   type DaemonArgs as Args,
 } from './cli-args.js';
+import { createLogger, type Logger } from './logger.js';
 
 const KNOWN_CODEX_SANDBOX_MODES = new Set([
   'read-only',
@@ -470,16 +471,17 @@ export function disableClaudeSandboxGuard(
 // exit. Resolves either way; the caller decides whether to surface
 // the timeout in logs.
 const SHUTDOWN_TIMEOUT_MS = 15_000;
-async function runWithShutdownTimeout(shutdown: () => Promise<void>): Promise<void> {
+async function runWithShutdownTimeout(
+  shutdown: () => Promise<void>,
+  logger: Logger,
+): Promise<void> {
   let timer: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
       shutdown(),
       new Promise<void>((resolve) => {
         timer = setTimeout(() => {
-          console.warn(
-            `[client] runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; exiting anyway`,
-          );
+          logger.warn(`runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; exiting anyway`);
           resolve();
         }, SHUTDOWN_TIMEOUT_MS);
       }),
@@ -499,6 +501,7 @@ async function runWithShutdownTimeout(shutdown: () => Promise<void>): Promise<vo
 //      the local bundle when present makes the advertise reachable.
 async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
   const args = resolveDaemonArgs(parsed);
+  const logger = createLogger();
   const raw = args.card
     ? JSON.parse(readFileSync(args.card, 'utf8'))
     : resolveBundledCard(args.backend);
@@ -509,7 +512,7 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
   // 'echo'). Without this the only signal is downstream behavior —
   // operators reading boot logs to diagnose "wrong backend ran" can't
   // tell whether parsing landed where they expected.
-  console.log(`[client] backend: ${args.backend}`);
+  logger.info(`backend: ${args.backend}`);
 
   // pickBackend is async because container-mode backends boot a
   // long-lived runtime container before construction (#249).
@@ -522,6 +525,7 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     agentCard,
     backendKind: args.backend,
     backend,
+    logLevel: logger.level,
     // Daemon entrypoint: a fatal terminal close (currently 4014 "client
     // deleted") should drop the process with a non-zero exit so
     // systemd / a parent supervisor sees the deletion as a hard
@@ -541,18 +545,18 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
   let shuttingDown = false;
   const onSignal = (signal: NodeJS.Signals) => {
     if (shuttingDown) {
-      console.log(`[client] received second ${signal}; forcing exit`);
+      logger.info(`received second ${signal}; forcing exit`);
       process.exit(130);
     }
     shuttingDown = true;
     void (async () => {
-      console.log(`\n[client] shutting down (${signal})`);
+      logger.info(`shutting down (${signal})`);
       client.stop();
       if (backendShutdown) {
         try {
-          await runWithShutdownTimeout(backendShutdown);
+          await runWithShutdownTimeout(backendShutdown, logger);
         } catch (err) {
-          console.error('[client] shutdown error:', (err as Error).message);
+          logger.error('shutdown error:', (err as Error).message);
         }
       }
       process.exit(0);

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -204,10 +204,10 @@ test('Client logs identity block (mention/acct/a2a/card/webfinger) once on conne
       (l) =>
         l.includes('mention:') ||
         l.includes('acct:') ||
-        l.startsWith('[client] a2a:') ||
+        l.includes('[client] a2a:') ||
         l.includes('a2a card:') ||
         l.includes('webfinger:') ||
-        l.startsWith('[client] agentId:'),
+        l.includes('[client] agentId:'),
     );
     assert.equal(identityLines.length, 6, `expected 6 identity lines, got ${identityLines.length}: ${JSON.stringify(identityLines)}`);
     // Spot-check that the URLs were derived from the test server URL.

--- a/packages/client/src/logger.test.ts
+++ b/packages/client/src/logger.test.ts
@@ -17,6 +17,8 @@ interface Captured {
   sink: ConsoleSink;
 }
 
+const TIMESTAMPED_CLIENT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z \[client\] /;
+
 // Capturing sink. Tests inject this instead of monkey-patching the global
 // console so a parallel test file in the same process (or a future change
 // to test-runner isolation) cannot interleave global mutations.
@@ -189,11 +191,12 @@ test('resolveLogLevel: warn passes PREFIX as a separate sink argument', () => {
     resolveLogLevel(undefined, sink);
   });
   assert.equal(calls.length, 1);
-  // First arg is the prefix, second is the structured message — same shape
+  // First arg is the timestamp, second is the prefix, third is the structured message — same shape
   // the logger's own .warn() uses, so structured-logging sinks can treat
   // them consistently.
-  assert.equal(calls[0][0], '[client]');
-  assert.match(String(calls[0][1]), /ignoring invalid VICOOP_CLIENT_LOG_LEVEL="bogus"/);
+  assert.match(String(calls[0][0]), /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  assert.equal(calls[0][1], '[client]');
+  assert.match(String(calls[0][2]), /ignoring invalid VICOOP_CLIENT_LOG_LEVEL="bogus"/);
 });
 
 test('createLogger at info: error/warn/info pass, debug filtered', () => {
@@ -203,9 +206,12 @@ test('createLogger at info: error/warn/info pass, debug filtered', () => {
   logger.warn('careful');
   logger.info('hello');
   logger.debug('quiet');
-  assert.deepEqual(c.error, ['[client] boom']);
-  assert.deepEqual(c.warn, ['[client] careful']);
-  assert.deepEqual(c.log, ['[client] hello']);
+  assert.equal(c.error.length, 1);
+  assert.match(c.error[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}boom$`));
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}careful$`));
+  assert.equal(c.log.length, 1);
+  assert.match(c.log[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}hello$`));
 });
 
 test('createLogger at debug: every level passes through', () => {
@@ -215,9 +221,13 @@ test('createLogger at debug: every level passes through', () => {
   logger.warn('w');
   logger.info('i');
   logger.debug('d');
-  assert.deepEqual(c.error, ['[client] e']);
-  assert.deepEqual(c.warn, ['[client] w']);
-  assert.deepEqual(c.log, ['[client] i', '[client] d']);
+  assert.equal(c.error.length, 1);
+  assert.match(c.error[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}e$`));
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}w$`));
+  assert.equal(c.log.length, 2);
+  assert.match(c.log[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}i$`));
+  assert.match(c.log[1], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}d$`));
 });
 
 test('createLogger at warn: info and debug filtered', () => {
@@ -227,7 +237,8 @@ test('createLogger at warn: info and debug filtered', () => {
   logger.debug('d');
   logger.warn('w');
   assert.deepEqual(c.log, []);
-  assert.deepEqual(c.warn, ['[client] w']);
+  assert.equal(c.warn.length, 1);
+  assert.match(c.warn[0], new RegExp(`${TIMESTAMPED_CLIENT_RE.source}w$`));
 });
 
 test('createLogger at silent: every level filtered', () => {

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -9,6 +9,7 @@ const LEVEL_RANK: Record<LogLevel, number> = {
 };
 
 const PREFIX = '[client]';
+const timestamp = (): string => new Date().toISOString();
 export const LOG_LEVEL_ENV = 'VICOOP_CLIENT_LOG_LEVEL';
 
 export interface Logger {
@@ -49,7 +50,7 @@ export function _resetLogLevelWarningsForTests(): void {
 function warnOnce(sink: ConsoleSink, key: string, message: string): void {
   if (warnedKeys.has(key)) return;
   warnedKeys.add(key);
-  sink.warn(PREFIX, message);
+  sink.warn(timestamp(), PREFIX, message);
 }
 
 // JSON.stringify covers \n / \r / control chars and the standard JSON
@@ -155,16 +156,16 @@ export function createLogger(
   return {
     level: resolved,
     error: (...args) => {
-      if (enabled('error')) sink.error(PREFIX, ...args);
+      if (enabled('error')) sink.error(timestamp(), PREFIX, ...args);
     },
     warn: (...args) => {
-      if (enabled('warn')) sink.warn(PREFIX, ...args);
+      if (enabled('warn')) sink.warn(timestamp(), PREFIX, ...args);
     },
     info: (...args) => {
-      if (enabled('info')) sink.log(PREFIX, ...args);
+      if (enabled('info')) sink.log(timestamp(), PREFIX, ...args);
     },
     debug: (...args) => {
-      if (enabled('debug')) sink.log(PREFIX, ...args);
+      if (enabled('debug')) sink.log(timestamp(), PREFIX, ...args);
     },
   };
 }


### PR DESCRIPTION
## What changed

- Prefix client daemon log lines emitted by the shared logger with ISO timestamps.
- Route daemon startup and shutdown lifecycle messages through the shared logger so they use the same timestamped format.
- Update log-format tests and add a client patch changeset.

## Why

Operators reading foreground daemon logs need the event time at the start of each line for easier debugging and correlation.

## Impact

Client daemon logs now render like:

```text
2026-06-04T06:26:28.166Z [client] connected, sending hello
```

This is a log formatting change only; no protocol behavior changes.

## Validation

- `pnpm --filter @vicoop-bridge/client exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @vicoop-bridge/client test`