### PR TITLE
perf(client): trim claude openai-compat cold-start cost + 1h prompt cache

### DIFF
--- a/.changeset/claude-oai-compat-coldstart-cache.md
+++ b/.changeset/claude-oai-compat-coldstart-cache.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Cut claude-backend openai-compat per-request token/cost. These turns are stateless (a fresh claude session each request), so any fixed prefix is re-paid every time. We now: replace claude's default coding-agent prompt with a slim per-request `--system-prompt` (also more correct for a chat/completions proxy), drop the skills catalogue (`--disable-slash-commands`), spawn in an isolated empty cwd so no operator `CLAUDE.md` / project settings / hooks load, and opt these spawns into Anthropic's 1-hour prompt cache so the byte-stable system+tools prefix survives multi-minute gaps between turns. Scoped to openai-compat tasks; plain A2A tasks are unchanged.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -7,6 +7,7 @@ import { EventEmitter } from 'node:events';
 import {
   buildClaudeChatCompletionEnvelope,
   buildOpenAICompatNativeSystemPrompt,
+  DEFAULT_OPENAI_COMPAT_SYSTEM_PROMPT,
   createClaudeBackend,
   normalizeClaudeModelId,
   openaiToolsToCallerToolDefs,
@@ -35,6 +36,7 @@ interface FakeChild extends ClaudeChildHandle {
   readonly command: string;
   readonly args: readonly string[];
   readonly cwd?: string;
+  readonly env?: Record<string, string>;
   killed: boolean;
   killSignal: NodeJS.Signals | null;
   stdinPayload: string;
@@ -90,6 +92,7 @@ function makeFakeSpawn(configure: (child: FakeChild) => void): FakeSpawn {
         command,
         args,
         cwd: options.cwd,
+        env: options.env,
         stdin,
         stdout: mkReadable(stdoutEmitter),
         stderr: mkReadable(stderrEmitter),
@@ -2339,6 +2342,129 @@ test('envelope without model omits --model from claude spawn (#302)', async () =
   assert.equal(args.indexOf('--model'), -1);
 });
 
+test('openai-compat spawn trims cold-start context (--disable-slash-commands)', async () => {
+  // Every openai-compat task spawns a fresh session, so the skills catalogue is
+  // re-paid on each request for no benefit (the caller drives tool use). The
+  // flag is auth-neutral (unlike `--bare`) and applies whenever the envelope is
+  // present — tools or not. `--exclude-dynamic-system-prompt-sections` is NOT
+  // passed: replacing the default prompt via `--system-prompt` makes it a no-op.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assignWithOpenAICompat('hi', {}), emit, NEVER);
+  const args = fake.lastChild()?.args ?? [];
+  assert.ok(
+    args.includes('--disable-slash-commands'),
+    'expected --disable-slash-commands on the openai-compat spawn',
+  );
+  assert.equal(
+    args.includes('--exclude-dynamic-system-prompt-sections'),
+    false,
+    'no --exclude-dynamic-system-prompt-sections (redundant once --system-prompt replaces the default)',
+  );
+});
+
+test('non-openai-compat spawn keeps skills intact (no lean-context flags)', async () => {
+  // The trims are scoped to the stateless openai-compat path; a plain A2A
+  // task keeps claude's full context (skills, memory, env) intact.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+  const args = fake.lastChild()?.args ?? [];
+  assert.equal(args.includes('--disable-slash-commands'), false);
+});
+
+test('openai-compat task spawns in the isolation cwd, not the operator cwd', async () => {
+  // The operator cwd carries CLAUDE.md / project settings / hooks that are
+  // off-target for a stateless chat/completions proxy turn; openai-compat
+  // spawns are redirected to an empty isolation dir instead.
+  const isolation = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-oai-cwd-'));
+  try {
+    const fake = scriptedSpawn({
+      lines: [
+        JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+        JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+      ],
+      exitCode: 0,
+    });
+    const backend = createClaudeBackend({
+      spawn: fake.spawn,
+      cwd: '/operator/project',
+      openaiCompatCwd: isolation,
+    });
+    const { emit } = collect();
+    await backend.handle(assignWithOpenAICompat('hi', {}), emit, NEVER);
+    assert.equal(fake.lastChild()?.cwd, isolation);
+  } finally {
+    await fs.rm(isolation, { recursive: true, force: true });
+  }
+});
+
+test('non-openai-compat task keeps the operator cwd', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    cwd: '/operator/project',
+    openaiCompatCwd: '/should/not/be/used',
+  });
+  const { emit } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+  assert.equal(fake.lastChild()?.cwd, '/operator/project');
+});
+
+test('openai-compat spawn opts into the 1-hour prompt cache (ENABLE_PROMPT_CACHING_1H)', async () => {
+  // Stateless openai-compat turns can pause minutes between turns; the 1h cache
+  // keeps the byte-stable system+tools prefix warm past the 5-min default.
+  // Claude Code reads this only from the env, so we set it on the child.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assignWithOpenAICompat('hi', {}), emit, NEVER);
+  assert.equal(fake.lastChild()?.env?.ENABLE_PROMPT_CACHING_1H, '1');
+});
+
+test('non-openai-compat spawn does not set the 1-hour cache env', async () => {
+  // The 1h opt-in is scoped to openai-compat; plain A2A tasks keep the default
+  // (a 1h cache write costs 2x, only worth it for the stateless proxy pattern).
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  await backend.handle(assign('hi'), emit, NEVER);
+  // No env override at all on the plain path (child inherits parent env only).
+  assert.equal(fake.lastChild()?.env, undefined);
+});
+
 test('envelope.model is dropped when claude probed model differs (#302)', async () => {
   // Regression guard for the gateway sending an unresolved routing key
   // (e.g. `a2a/<card-url>`) as `envelope.model`. Without the gate, the
@@ -2405,7 +2531,7 @@ test('envelope.model is forwarded when it matches claude probed model (#302)', a
   assert.equal(args[modelIdx + 1], 'claude-opus-4-7');
 });
 
-test('spawn argv carries --append-system-prompt with the native directive when metadata is present', async () => {
+test('spawn argv carries --system-prompt with the native directive when metadata is present', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
@@ -2431,17 +2557,17 @@ test('spawn argv carries --append-system-prompt with the native directive when m
   );
 
   const args = fake.lastChild()?.args ?? [];
-  // The flag occurs at least once (operator can pass additional ones via
-  // extraArgs; identity-injecting variant may also fire). The openai-compat
+  // The openai-compat path REPLACES claude's default prompt via --system-prompt
+  // (no identity configured here, so this is the only --system-prompt). The
   // value carries the user's `system` text plus the native-dispatch directive
   // — NOT the old envelope JSON contract, which #213 removed.
   const idx = args.findIndex(
     (a, i) =>
-      args[i - 1] === '--append-system-prompt' &&
+      args[i - 1] === '--system-prompt' &&
       typeof a === 'string' &&
       a.includes('You are concise.'),
   );
-  assert.ok(idx >= 0, 'expected --append-system-prompt carrying the openai-compat system text');
+  assert.ok(idx >= 0, 'expected --system-prompt carrying the openai-compat system text');
   // The slim native prompt teaches the model to use the native tool surface
   // and how to read the history block — nothing more.
   assert.match(args[idx] as string, /native tool list/);
@@ -2460,7 +2586,7 @@ test('spawn argv carries --append-system-prompt with the native directive when m
   );
 });
 
-test('absent metadata → no openai-compat --append-system-prompt is injected', async () => {
+test('absent metadata → no openai-compat system prompt is injected', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
@@ -3030,6 +3156,14 @@ test('buildOpenAICompatNativeSystemPrompt: slim shape (#213)', () => {
     buildOpenAICompatNativeSystemPrompt('just be terse', undefined, undefined),
     'just be terse',
   );
+
+  // No system, no tools, tool_choice undefined → the builder still yields a
+  // non-empty neutral base. This is the invariant that makes the output safe
+  // to pass to `--system-prompt` (which would replace claude's default with ""
+  // otherwise). The append path used to receive "" here harmlessly.
+  const bare = buildOpenAICompatNativeSystemPrompt(undefined, undefined, undefined);
+  assert.equal(bare, DEFAULT_OPENAI_COMPAT_SYSTEM_PROMPT);
+  assert.ok(bare.trim().length > 0, 'bare invocation must never return an empty prompt');
 });
 
 // caller-tools MCP module: the onInvoke wiring. We drive the tool through
@@ -3155,11 +3289,11 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   assert.ok(cfg.mcpServers?.['_vb-caller-tools'], '_vb-caller-tools MCP server registered');
   assert.equal(cfg.mcpServers?.['_vb-caller-tools']?.type, 'http');
 
-  // (b) --append-system-prompt carries the native variant — the envelope
-  // contract block (the literal `{"tool_calls"` substring the legacy
-  // prompt teaches) must be absent.
-  const apsIdx = args.indexOf('--append-system-prompt');
-  assert.notEqual(apsIdx, -1, '--append-system-prompt present');
+  // (b) --system-prompt carries the native variant (replacing claude's
+  // default) — the envelope contract block (the literal `{"tool_calls"`
+  // substring the legacy prompt teaches) must be absent.
+  const apsIdx = args.indexOf('--system-prompt');
+  assert.notEqual(apsIdx, -1, '--system-prompt present');
   const prompt = args[apsIdx + 1] as string;
   assert.equal(prompt.includes('{"tool_calls"'), false);
   assert.ok(prompt.startsWith('be terse'));

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1,5 +1,8 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
+import { mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   OPENAI_COMPAT_EXTENSION_URI,
   TRACEABILITY_EXTENSION_URI,
@@ -56,6 +59,11 @@ export interface ClaudeChildHandle {
 
 export interface ClaudeSpawnOptions {
   cwd?: string;
+  // Extra environment variables for the spawned process, merged OVER the parent
+  // env (so the child still inherits the daemon's environment). Used for the
+  // per-spawn knobs Claude Code only reads from the environment — it exposes no
+  // CLI flag for them — e.g. `ENABLE_PROMPT_CACHING_1H`.
+  env?: Record<string, string>;
 }
 
 export type ClaudeSpawnFn = (
@@ -67,6 +75,17 @@ export type ClaudeSpawnFn = (
 export interface ClaudeBackendOptions {
   command?: string;
   cwd?: string;
+  // Working directory for stateless openai-compat spawns, overriding `cwd` for
+  // those tasks only. They have no legitimate use for the operator's `cwd`:
+  // native dispatch disables claude's built-ins (`--tools ""`) and the path
+  // replaces claude's default prompt via `--system-prompt` (so cwd never even
+  // reaches the model), while the operator-cwd's CLAUDE.md, project settings,
+  // and hooks are all off-target for a generic chat/completions proxy turn —
+  // and re-paid on every fresh session. Pointing these spawns at an empty dir
+  // with no CLAUDE.md / project-settings ancestors drops that overhead.
+  // Defaults to a stable dir under the OS temp root (created on first use);
+  // overridable for tests. Plain A2A tasks keep `cwd` untouched.
+  openaiCompatCwd?: string;
   extraArgs?: readonly string[];
   spawn?: ClaudeSpawnFn;
   stderrCaptureBytes?: number;
@@ -402,6 +421,9 @@ function defaultSpawn(
   return nodeSpawn(command, Array.from(args), {
     stdio: ['pipe', 'pipe', 'pipe'],
     ...(options.cwd ? { cwd: options.cwd } : {}),
+    // Merge over (not replace) the inherited env so the child keeps the
+    // daemon's environment and only the per-spawn overrides change.
+    ...(options.env ? { env: { ...process.env, ...options.env } } : {}),
   }) as ChildProcess;
 }
 
@@ -775,8 +797,24 @@ export function buildOpenAICompatNativeSystemPrompt(
     );
   }
 
+  // Never return an empty prompt. A bare chat-completion (no caller `system`,
+  // no tools, and tool_choice !== "none") would otherwise leave `sections`
+  // empty. Appending "" to claude's default prompt is harmless, but feeding
+  // "" to `--system-prompt` would *replace* the default with nothing — so the
+  // builder owns a neutral fallback here, keeping its output safe to use via
+  // either `--append-system-prompt` or `--system-prompt`.
+  if (sections.length === 0) {
+    return DEFAULT_OPENAI_COMPAT_SYSTEM_PROMPT;
+  }
   return sections.join('\n\n');
 }
+
+// Neutral base prompt for a bare openai-compat chat-completion turn that
+// carries no caller `system` and no tools. Kept minimal and transport-flavoured
+// (not a coding-agent persona) because the openai-compat path serves a generic
+// chat/completions proxy, not Claude Code's interactive CLI.
+export const DEFAULT_OPENAI_COMPAT_SYSTEM_PROMPT =
+  'You are a helpful assistant accessed through an OpenAI-compatible gateway. Respond to the user directly in natural language.';
 
 
 // Pull `tool_use` blocks out of an `assistant`-role message's content
@@ -1006,6 +1044,14 @@ export function createClaudeBackend(
 ): Backend & { getSendFileMcpServer(): SendFileMcpServer | null } {
   const command = opts.command ?? 'claude';
   const cwd = opts.cwd;
+  // Isolation cwd for openai-compat spawns (see ClaudeBackendOptions). Resolved
+  // lazily on first use and memoized — including the fallback to the operator
+  // `cwd` if the dir can't be created — so a hostile temp root degrades to the
+  // pre-isolation behaviour rather than failing the task.
+  const openaiCompatCwd = opts.openaiCompatCwd ?? join(tmpdir(), 'vicoop-bridge-claude-oai');
+  // `null` = not yet resolved; afterwards holds the dir to spawn in (or the
+  // operator cwd / undefined on a creation failure).
+  let openaiCompatCwdResolved: string | undefined | null = null;
   const extraArgs = opts.extraArgs ?? [];
   const spawnFn = opts.spawn ?? defaultSpawn;
   const stderrCap = opts.stderrCaptureBytes ?? 8192;
@@ -1016,6 +1062,22 @@ export function createClaudeBackend(
   const setIntervalImpl = opts.setIntervalFn ?? ((fn, ms) => setInterval(fn, ms));
   const clearIntervalImpl = opts.clearIntervalFn ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
   const timingLogger = createLogger();
+  // Resolve (and create-on-first-use) the openai-compat isolation cwd. Memoized
+  // so the mkdir runs at most once per backend; on failure we fall back to the
+  // operator `cwd` and remember that so we don't retry-and-warn every task.
+  const resolveOpenAICompatCwd = (): string | undefined => {
+    if (openaiCompatCwdResolved !== null) return openaiCompatCwdResolved;
+    try {
+      mkdirSync(openaiCompatCwd, { recursive: true });
+      openaiCompatCwdResolved = openaiCompatCwd;
+    } catch (err) {
+      timingLogger.warn?.(
+        `[claude] openai-compat isolation cwd ${openaiCompatCwd} could not be created; falling back to operator cwd: ${errorMessage(err)}`,
+      );
+      openaiCompatCwdResolved = cwd;
+    }
+    return openaiCompatCwdResolved;
+  };
   const sendFileMcpOpts =
     opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
       ? opts.sendFileMcp
@@ -1530,21 +1592,51 @@ export function createClaudeBackend(
       // read in terms of the model's view ("native tool surface is live").
       const nativeReady = nativeDispatchActive && callerToolsMcp !== null;
 
-      // Per-task `--append-system-prompt` carrying the openai-compat
-      // extension's system / tools / tool_choice. Placed AFTER identityArgs
-      // (so the self-identity directive is the model's first read) but
-      // BEFORE extraArgs (so an operator-supplied append still wins by
-      // appending last — claude concatenates each --append-system-prompt
-      // occurrence in argv order).
+      // Per-task `--system-prompt` carrying the openai-compat extension's
+      // system / tools / tool_choice. We *replace* claude's default agent
+      // prompt (rather than `--append-system-prompt`-ing onto it) for two
+      // reasons:
+      //   - Cost: every openai-compat task spawns a fresh session (no reuse),
+      //     so claude's multi-thousand-token coding-agent base prompt is
+      //     re-paid on each request. Replacing it with this slim, caller-
+      //     scoped prompt removes that fixed per-request overhead.
+      //   - Correctness: the openai-compat path is a generic chat/completions
+      //     proxy, not Claude Code's interactive CLI — the default persona
+      //     (TodoWrite, file-edit conventions, CLI verbosity) is off-target.
+      // Tool use is native to the model, not taught by the default prompt, so
+      // native MCP dispatch is unaffected. `buildOpenAICompatNativeSystemPrompt`
+      // never returns "" (it owns a neutral fallback), so the replacement is
+      // always a non-empty base. Identity (`identityArgs`) and operator
+      // `extraArgs` still ride `--append-system-prompt`, which claude appends
+      // onto this base; note the base is therefore the model's first read,
+      // ahead of any appended identity directive (a change from the prior
+      // append-only ordering, immaterial on the stateless proxy turn).
       const openaiCompatArgs: readonly string[] = envelope
         ? [
-            '--append-system-prompt',
+            '--system-prompt',
             buildOpenAICompatNativeSystemPrompt(
               envelopeSystem,
               envelopeTools,
               envelopeToolChoice,
             ),
           ]
+        : [];
+      // Trim the cold-start overhead for openai-compat tasks. Every such task
+      // spawns a fresh claude session (no reuse — see the gate above), so any
+      // fixed per-request context is re-paid each time. `--disable-slash-commands`
+      // drops the skills catalogue: the served backend never invokes skills
+      // under openai-compat (the caller drives tool use), so the listing is dead
+      // weight here. Auth-neutral, unlike `--bare`, so the operator's OAuth login
+      // still works.
+      //
+      // Note we do NOT pass `--exclude-dynamic-system-prompt-sections`: it only
+      // applies to claude's default system prompt and is ignored once we replace
+      // that prompt via `--system-prompt` (see openaiCompatArgs above), which
+      // already carries no per-machine dynamic sections. CLAUDE.md auto-discovery
+      // can only be disabled via `--bare` (API-key auth only — out of reach under
+      // OAuth), so it stays loaded.
+      const leanContextArgs: readonly string[] = envelope
+        ? ['--disable-slash-commands']
         : [];
       // Forward `envelope.model` to claude via `--model <id>` so the gateway-
       // resolved model id wins over claude's own default (#302). Sticky for
@@ -1642,6 +1734,7 @@ export function createClaudeBackend(
         ...identityArgs,
         ...modelArgs,
         ...openaiCompatArgs,
+        ...leanContextArgs,
         ...disableBuiltinToolArgs,
         ...nativeTurnCapArgs,
         '--include-partial-messages',
@@ -1655,18 +1748,36 @@ export function createClaudeBackend(
         status: { state: 'working', timestamp: new Date().toISOString() },
       });
 
+      // openai-compat tasks spawn in the isolation cwd (no operator CLAUDE.md /
+      // project settings / hooks); plain A2A tasks keep the operator cwd.
+      const effectiveCwd = envelope ? resolveOpenAICompatCwd() : cwd;
+
+      // Opt openai-compat spawns into Anthropic's 1-hour extended prompt cache.
+      // These turns are stateless (fresh session each time) and a conversation
+      // often pauses for minutes between user turns, so the default 5-min cache
+      // can lapse between turns even though our system+tools prefix is byte-
+      // stable. The 1h cache keeps that prefix warm across longer gaps. Claude
+      // Code reads this only from the environment (no CLI flag), so we set it on
+      // the child process — scoped to openai-compat; plain A2A tasks keep the
+      // 5-min default. Trade-off: a 1h cache *write* costs 2x base (vs 1.25x for
+      // 5m), paid once per prefix; reads stay 0.1x, so it wins whenever the
+      // prefix is reused at all within the hour.
+      const effectiveEnv = envelope
+        ? { ENABLE_PROMPT_CACHING_1H: '1' }
+        : undefined;
+
       let child: ClaudeChildHandle;
       try {
         timingLogger.debug(
-          `claude.spawn.start taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)}`,
+          `claude.spawn.start taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${effectiveCwd ? safeToken(effectiveCwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)}`,
         );
-        child = spawnFn(command, args, { cwd });
+        child = spawnFn(command, args, { cwd: effectiveCwd, env: effectiveEnv });
         recorder.mark('spawn');
       } catch (err) {
         rollbackFreshSession();
         await closeCallerToolsMcp();
         timingLogger.debug(
-          `claude.spawn.error taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${cwd ? safeToken(cwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)} error=${safeToken(errorMessage(err), 1000)}`,
+          `claude.spawn.error taskId=${safeToken(task.taskId)} command=${safeToken(command)} cwd=${effectiveCwd ? safeToken(effectiveCwd) : '<default>'} argv=${safeToken(JSON.stringify(args), 8000)} error=${safeToken(errorMessage(err), 1000)}`,
         );
         emit({
           type: 'task.fail',


### PR DESCRIPTION
## Why

When the `claude` backend serves **openai-compat** requests, every turn spawns a **fresh claude session** (stateless by design — see the session-reuse gate). That means any fixed per-request prefix (claude's default agent prompt + the spawn-cwd's `CLAUDE.md` + skills catalogue + tool schemas) is **re-paid on every request**, and the default 5‑min prompt cache lapses between user turns.

Investigation of real session logs showed the dominant cost was repeated `cache_creation` of this prefix on each cold session, plus a large static base (repo `CLAUDE.md`, skills) that doesn't belong in a generic chat/completions proxy turn.

## What

All changes are **scoped to openai-compat tasks** (`envelope !== null`); plain A2A tasks are unchanged. No new operator-facing CLI surface, no auth change (works under OAuth — `--bare` was rejected for that reason).

- **`--system-prompt` replaces** claude's default coding-agent prompt with our slim, caller-scoped prompt (previously `--append-system-prompt` on top of the default). Tool use is native to the model, not taught by the default prompt, so native MCP dispatch is unaffected. Also more correct: the proxy turn shouldn't carry the Claude Code CLI persona (TodoWrite, file-edit conventions, etc.).
- **`buildOpenAICompatNativeSystemPrompt` never returns `""`** — a bare chat completion (no caller `system`, no tools) now yields a neutral fallback, making the output safe to use as a full `--system-prompt` replacement.
- **`--disable-slash-commands`** drops the skills catalogue (the served backend never invokes skills under openai-compat).
- **Isolated cwd** — these spawns run in an empty dir (default `os.tmpdir()/vicoop-bridge-claude-oai`, overridable via `ClaudeBackendOptions.openaiCompatCwd`) so the operator's `CLAUDE.md`, project settings, and hooks don't load. Falls back to the operator cwd if the dir can't be created.
- **`ENABLE_PROMPT_CACHING_1H=1`** set on the child env (Claude Code exposes no CLI flag for it) so the byte-stable system+tools prefix survives multi-minute gaps between turns. Trade-off: a 1h cache write costs 2× vs 1.25× for 5m; reads stay 0.1×, so it wins whenever the prefix is reused within the hour.

## Empirical validation (live daemon, real traffic)

- Sessions now land in the isolation cwd's project dir → repo `CLAUDE.md` confirmed **not** loaded.
- The `system+tools` prefix (~56k tokens) is served as `cache_read` across fresh sessions — including image-generation turns — instead of being re-created.
- A turn **~8m42s after** the prior one still hit the cached prefix (`cache_read 168,882`), confirming the 1‑hour cache works under OAuth (the 5‑min default would have expired and re-created the prefix).

## Not addressed here

The full prior conversation is still re-sent as a `<chat_history>` block each turn (O(n²) on the history portion). That residual now rides cheap `cache_read` for the repeated prefix, but the real fix (session reuse / delta injection) is a separate, larger change.

## Tests

`pnpm --filter @vicoop-bridge/client test` → **641 pass / 0 fail** (typecheck clean). New coverage for the system-prompt replacement, the builder fallback, `--disable-slash-commands`, the isolation cwd, and the 1h cache env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)