### PR TITLE
[codex] Preserve task.fail error metadata

### DIFF
--- a/.changeset/backend-failure-codes.md
+++ b/.changeset/backend-failure-codes.md
@@ -2,4 +2,4 @@
 "@vicoop-bridge/client": patch
 ---
 
-Normalize backend runtime failure codes for router availability classification.
+Align backend terminal failure codes with the openai-compat/v1 terminal error contract.

--- a/.changeset/backend-failure-codes.md
+++ b/.changeset/backend-failure-codes.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Normalize backend runtime failure codes for router availability classification.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -344,7 +344,7 @@ test('maps non-zero exit to task.fail with stderr tail', async () => {
 
   const fail = frames.find((f): f is Extract<UpFrame, { type: 'task.fail' }> => f.type === 'task.fail');
   assert.ok(fail, 'expected task.fail');
-  assert.equal(fail.error.code, 'claude_exit_nonzero');
+  assert.equal(fail.error.code, 'auth_required');
   assert.match(fail.error.message, /code 2/);
   assert.match(fail.error.message, /auth required/);
 });
@@ -1149,7 +1149,7 @@ test('rolls back the session binding when claude exits non-zero on a fresh sessi
   t1.contextId = ctx;
   const c1 = collect();
   await backend.handle(t1, c1.emit, NEVER);
-  assert.equal(c1.frames.find((f) => f.type === 'task.fail')?.error.code, 'claude_exit_nonzero');
+  assert.equal(c1.frames.find((f) => f.type === 'task.fail')?.error.code, 'auth_required');
 
   const t2 = assign('second');
   t2.contextId = ctx;
@@ -1239,7 +1239,7 @@ test('non-zero claude exit with completed error result still fails', async () =>
   const terminal = frames.at(-1);
   assert.ok(terminal && terminal.type === 'task.fail');
   if (terminal.type === 'task.fail') {
-    assert.equal(terminal.error.code, 'claude_exit_nonzero');
+    assert.equal(terminal.error.code, 'login_required');
     assert.match(terminal.error.message, /Not logged in/);
   }
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -9,6 +9,7 @@ import {
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { normalizeTaskFailError } from '../failure-code.js';
 import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.js';
 import {
   buildOpenAICompatResponseMetadata,
@@ -1573,10 +1574,10 @@ export function createClaudeBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: 'caller_tools_mcp_start_failed',
               message: `caller-tools MCP server failed to start: ${errorMessage(err)}`,
-            },
+            }),
           });
           return;
         }
@@ -1782,7 +1783,7 @@ export function createClaudeBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code: 'spawn_failed', message: errorMessage(err) },
+          error: normalizeTaskFailError({ code: 'spawn_failed', message: errorMessage(err) }),
         });
         return;
       }
@@ -1807,10 +1808,10 @@ export function createClaudeBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: {
+          error: normalizeTaskFailError({
             code: 'spawn_no_stdin',
             message: 'spawned claude has no stdin pipe; cannot deliver user message',
-          },
+          }),
         });
         return;
       }
@@ -2323,7 +2324,7 @@ export function createClaudeBackend(
           // exit.error is typed Error from the child `error` event but a
           // custom spawn / fake child could emit a non-Error here. Route
           // through errorMessage so .message access can't crash the frame.
-          error: { code: 'spawn_failed', message: errorMessage(exit.error) },
+          error: normalizeTaskFailError({ code: 'spawn_failed', message: errorMessage(exit.error) }),
         });
         return;
       }
@@ -2378,10 +2379,10 @@ export function createClaudeBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: {
+          error: normalizeTaskFailError({
             code: 'claude_exit_nonzero',
             message: `claude exited with code ${exit.code}${sigPart}${detailPart}${stdoutPart}${stdinPart}${toolMismatchPart}`,
-          },
+          }),
         });
         return;
       }

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -741,7 +741,7 @@ test('approval server-request gets auto-decline by default', async () => {
   assert.equal(frames.at(-1)?.type, 'task.complete');
 });
 
-test('app-server spawn failure surfaces app_server_unavailable', async () => {
+test('app-server spawn failure surfaces disconnected', async () => {
   const failingSpawn: AppServerSpawnFn = () => {
     throw new Error('ENOENT');
   };
@@ -753,7 +753,7 @@ test('app-server spawn failure surfaces app_server_unavailable', async () => {
   assert.equal(last?.type, 'task.fail');
   assert.equal(
     last?.type === 'task.fail' && last.error.code,
-    'app_server_unavailable',
+    'disconnected',
   );
 });
 
@@ -783,7 +783,7 @@ test('transport closing mid-turn emits task.fail', async () => {
 
   const last = frames.at(-1);
   assert.equal(last?.type, 'task.fail');
-  assert.equal(last?.type === 'task.fail' && last.error.code, 'turn_failed');
+  assert.equal(last?.type === 'task.fail' && last.error.code, 'disconnected');
 });
 
 test('traceability extension surfaces commandExecution item as a trace artifact', async () => {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -8,6 +8,7 @@ import {
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { normalizeTaskFailError } from '../failure-code.js';
 import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.js';
 import { createLogger, type Logger } from '../logger.js';
 import {
@@ -1166,10 +1167,10 @@ export function createCodexBackend(
             emit({
               type: 'task.fail',
               taskId: task.taskId,
-              error: {
+              error: normalizeTaskFailError({
                 code: 'app_server_unavailable',
                 message: `codex app-server failed to start: ${errorMessage(err)}`,
-              },
+              }),
             });
             return;
           }
@@ -1403,20 +1404,20 @@ export function createCodexBackend(
               emit({
                 type: 'task.fail',
                 taskId: task.taskId,
-                error: {
+                error: normalizeTaskFailError({
                   code: 'app_server_crashed',
                   message: `codex app-server transport closed during ${isResume ? 'thread/resume' : 'thread/start'}: ${err.message}`,
-                },
+                }),
               });
               return;
             }
             emit({
               type: 'task.fail',
               taskId: task.taskId,
-              error: {
+              error: normalizeTaskFailError({
                 code: isResume ? 'thread_resume_failed' : 'thread_start_failed',
                 message: errorMessage(err),
-              },
+              }),
             });
             return;
           }
@@ -1766,10 +1767,10 @@ export function createCodexBackend(
             emit({
               type: 'task.fail',
               taskId: task.taskId,
-              error: {
+              error: normalizeTaskFailError({
                 code: 'turn_failed',
                 message: outcome.error?.message ?? 'turn failed',
-              },
+              }),
             });
             return;
           }

--- a/packages/client/src/backends/openclaw.test.ts
+++ b/packages/client/src/backends/openclaw.test.ts
@@ -488,7 +488,7 @@ test('fast terminal event: final arrives on same socket read as ack and is still
   }
 });
 
-test('task timeout: no terminal event triggers task_timeout failure', async () => {
+test('task timeout: no terminal event triggers timeout failure', async () => {
   const fake = await createFakeGateway({
     onRequest: (sock, req) => {
       if (req.method === 'chat.send') {
@@ -510,7 +510,7 @@ test('task timeout: no terminal event triggers task_timeout failure', async () =
     await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f), NEVER);
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail, 'task must fail on timeout');
-    assert.equal(fail!.error.code, 'task_timeout');
+    assert.equal(fail!.error.code, 'timeout');
   } finally {
     await fake.close();
   }
@@ -767,7 +767,7 @@ test('cancel: chat.abort failure surfaces as gateway_abort_failed instead of han
   }
 });
 
-test('gateway close before ack emits gateway_closed (not gateway_send_failed)', async () => {
+test('gateway close before ack emits disconnected', async () => {
   const fake = await createFakeGateway({
     onRequest: (sock, req) => {
       if (req.method === 'chat.send') {
@@ -783,7 +783,7 @@ test('gateway close before ack emits gateway_closed (not gateway_send_failed)', 
     await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f), NEVER);
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail, 'task must fail');
-    assert.equal(fail!.error.code, 'gateway_closed');
+    assert.equal(fail!.error.code, 'disconnected');
   } finally {
     await fake.close();
   }
@@ -871,8 +871,8 @@ test('invalid URL: WebSocket constructor throwing does not wedge ensureConnected
   await backend.handle(makeTask('tB', 'b'), (f) => framesB.push(f), NEVER);
   const failA = framesA.find((f) => f.type === 'task.fail');
   const failB = framesB.find((f) => f.type === 'task.fail');
-  assert.ok(failA && failA.error.code === 'gateway_closed');
-  assert.ok(failB && failB.error.code === 'gateway_closed');
+  assert.ok(failA && failA.error.code === 'disconnected');
+  assert.ok(failB && failB.error.code === 'disconnected');
 });
 
 test('handshake timeout: gateway accepts TCP but never completes handshake', async () => {
@@ -887,7 +887,7 @@ test('handshake timeout: gateway accepts TCP but never completes handshake', asy
     await backend.handle(makeTask('t1', 'hi'), (f) => frames.push(f), NEVER);
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail, 'task must fail when handshake never completes');
-    assert.equal(fail!.error.code, 'gateway_closed');
+    assert.equal(fail!.error.code, 'disconnected');
     assert.match(fail!.error.message, /handshake timed out/);
   } finally {
     await fake.close();
@@ -972,7 +972,7 @@ test('gateway close mid-run fails in-flight task deterministically', async () =>
     await pending;
     const fail = frames.find((f) => f.type === 'task.fail');
     assert.ok(fail, 'task must fail after gateway close');
-    assert.equal(fail!.error.code, 'gateway_closed');
+    assert.equal(fail!.error.code, 'disconnected');
   } finally {
     await fake.close();
   }
@@ -1745,7 +1745,7 @@ test('discovery fallback: when primary URL is dead and no candidates match, orig
   await backend.handle(makeTask('t-disc', 'hi'), (f) => frames.push(f), NEVER);
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail, 'task must fail when no gateway is reachable');
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
 });
 
 test('discovery fallback: primary URL dead, discovered candidate completes handshake, task succeeds', async () => {
@@ -1828,7 +1828,7 @@ test('discovery: when all candidates fail, the original primary connect error is
   await backend.handle(makeTask('t-allfail', 'hi'), (f) => frames.push(f), NEVER);
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail);
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
   // Primary URL was 127.0.0.1:1. The error message from connect ECONNREFUSED
   // mentions the port that failed. The surfaced error must reference port 1
   // (the configured primary), not 3 (the last candidate).
@@ -1850,7 +1850,7 @@ test('discovery errors are swallowed so the primary connect failure still propag
   await backend.handle(makeTask('t-boom', 'hi'), (f) => frames.push(f), NEVER);
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail, 'task must fail even when discovery itself throws');
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
   // The message should be the original connect error, not "boom: discovery
   // exploded" — discovery failures are best-effort and must not mask it.
   assert.ok(
@@ -1877,7 +1877,7 @@ test('discovery error logging is defensive against non-Error rejections', async 
   await backend.handle(makeTask('t-null', 'hi'), (f) => frames.push(f), NEVER);
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail, 'task must fail, not hang, on a null discovery rejection');
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
 });
 
 test('discovery runs when configured URL uses a wildcard bind address (0.0.0.0 / ::)', async () => {
@@ -1897,7 +1897,7 @@ test('discovery runs when configured URL uses a wildcard bind address (0.0.0.0 /
   assert.equal(discoverCalls, 1, 'discover must run for wildcard bind URLs');
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail);
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
 });
 
 test('discovery skipped when configured URL is remote (non-loopback)', async () => {
@@ -1917,7 +1917,7 @@ test('discovery skipped when configured URL is remote (non-loopback)', async () 
   await backend.handle(makeTask('t-remote', 'hi'), (f) => frames.push(f), NEVER);
   const fail = frames.find((f) => f.type === 'task.fail');
   assert.ok(fail, 'task must fail when remote gateway is unreachable');
-  assert.equal(fail!.error.code, 'gateway_closed');
+  assert.equal(fail!.error.code, 'disconnected');
   assert.equal(discoverCalls, 0, 'discover must not be invoked for non-loopback URLs');
 });
 

--- a/packages/client/src/backends/openclaw.ts
+++ b/packages/client/src/backends/openclaw.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 import WebSocket from 'ws';
 import { OPENAI_COMPAT_EXTENSION_URI, type Part } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { normalizeTaskFailError } from '../failure-code.js';
 import {
   buildOpenAICompatSystemPrompt,
   chatHistoryFromMessages,
@@ -1456,7 +1457,7 @@ export function createOpenclawBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code: 'gateway_closed', message: errorMessage(err) },
+          error: normalizeTaskFailError({ code: 'gateway_closed', message: errorMessage(err) }),
         });
         return;
       }
@@ -1756,10 +1757,10 @@ export function createOpenclawBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: closed ? 'gateway_closed' : 'gateway_send_failed',
               message: errorMessage(err),
-            },
+            }),
           });
           return;
         }
@@ -1795,10 +1796,10 @@ export function createOpenclawBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: 'task_timeout',
               message: result.errorMessage ?? 'task timed out',
-            },
+            }),
           });
           return;
         }
@@ -1806,10 +1807,10 @@ export function createOpenclawBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: 'gateway_closed',
               message: result.errorMessage ?? 'gateway closed',
-            },
+            }),
           });
           return;
         }
@@ -1817,10 +1818,10 @@ export function createOpenclawBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: 'gateway_abort_failed',
               message: result.errorMessage ?? 'chat.abort request failed',
-            },
+            }),
           });
           return;
         }
@@ -1828,10 +1829,10 @@ export function createOpenclawBackend(
           emit({
             type: 'task.fail',
             taskId: task.taskId,
-            error: {
+            error: normalizeTaskFailError({
               code: 'gateway_chat_error',
               message: result.errorMessage ?? 'unknown gateway error',
-            },
+            }),
           });
           return;
         }

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -893,7 +893,7 @@ test('handle: empty prompt → task.fail with empty_prompt code', async () => {
   assert.equal(failFrame.error.code, 'empty_prompt');
 });
 
-test('handle: serve exits before listening → task.fail serve_unavailable', async () => {
+test('handle: serve exits before listening -> task.fail disconnected', async () => {
   // Simulates an old binary that has no `serve` subcommand (exits non-zero
   // with usage on stderr) — startup never reports listening.
   const fake = makeFakeSpawn();
@@ -916,7 +916,7 @@ test('handle: serve exits before listening → task.fail serve_unavailable', asy
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-  assert.equal(failFrame.error.code, 'serve_unavailable');
+  assert.equal(failFrame.error.code, 'disconnected');
   assert.ok(failFrame.error.message.includes('serve'));
 });
 

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -5,6 +5,7 @@ import {
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
+import { normalizeTaskFailError } from '../failure-code.js';
 import { createLogger, type Logger } from '../logger.js';
 import {
   chatHistoryFromMessages,
@@ -1158,10 +1159,10 @@ export function createVicoopCodexBackend(
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: {
+          error: normalizeTaskFailError({
             code: 'serve_unavailable',
             message: `failed to start vicoop-codex serve: ${errorMessage(err)}`,
-          },
+          }),
         });
         return;
       }
@@ -1209,10 +1210,11 @@ export function createVicoopCodexBackend(
           return;
         }
         const code = err instanceof ServeRequestError ? err.a2aCode : 'vicoop_codex_failed';
+        const message = errorMessage(err);
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: { code, message: errorMessage(err) },
+          error: normalizeTaskFailError({ code, message }),
         });
         return;
       }

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -15,6 +15,16 @@ test('normalizeTaskFailError preserves caller/input validation failures', () => 
   );
   assert.deepEqual(
     normalizeTaskFailError({
+      code: 'invalid_input',
+      message: 'bad request shape',
+    }),
+    {
+      code: 'invalid_input',
+      message: 'bad request shape',
+    },
+  );
+  assert.deepEqual(
+    normalizeTaskFailError({
       code: 'file_too_large',
       message: 'FilePart exceeds INPUT_FILE_MAX_BYTES (10485761 > 10485760)',
     }),
@@ -76,10 +86,41 @@ test('normalizeTaskFailError maps local transport failures and timeouts', () => 
   );
   assert.equal(
     normalizeTaskFailError({
+      code: 'network_error',
+      message: 'vicoop-codex serve request failed',
+    }).code,
+    'network_error',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'turn_failed',
+      message: 'transport failure prevented completion after dispatch',
+    }).code,
+    'network_error',
+  );
+  assert.equal(
+    normalizeTaskFailError({
       code: 'task_timeout',
       message: 'task timed out',
     }).code,
     'timeout',
+  );
+});
+
+test('normalizeTaskFailError maps agent and model availability failures', () => {
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'turn_failed',
+      message: 'agent temporarily unavailable',
+    }).code,
+    'agent_unavailable',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'turn_failed',
+      message: 'model unavailable',
+    }).code,
+    'model_unavailable',
   );
 });
 

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -1,0 +1,108 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeTaskFailError } from './failure-code.js';
+
+test('normalizeTaskFailError preserves caller/input validation failures', () => {
+  assert.deepEqual(
+    normalizeTaskFailError({
+      code: 'empty_prompt',
+      message: 'no content in message',
+    }),
+    {
+      code: 'empty_prompt',
+      message: 'no content in message',
+    },
+  );
+  assert.deepEqual(
+    normalizeTaskFailError({
+      code: 'file_too_large',
+      message: 'FilePart exceeds INPUT_FILE_MAX_BYTES (10485761 > 10485760)',
+    }),
+    {
+      code: 'file_too_large',
+      message: 'FilePart exceeds INPUT_FILE_MAX_BYTES (10485761 > 10485760)',
+    },
+  );
+});
+
+test('normalizeTaskFailError maps quota and rate limit messages before generic upstream codes', () => {
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'turn_failed',
+      message: 'insufficient_quota: exceeded your current quota',
+    }).code,
+    'quota_exceeded',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: 'vicoop-codex serve returned HTTP 429: too many requests',
+    }).code,
+    'rate_limited',
+  );
+});
+
+test('normalizeTaskFailError maps login and auth failures separately', () => {
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'claude_exit_nonzero',
+      message: 'Claude Code session expired; please login',
+    }).code,
+    'login_required',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: 'provider returned HTTP 401 unauthorized: invalid token',
+    }).code,
+    'auth_required',
+  );
+});
+
+test('normalizeTaskFailError maps local transport failures and timeouts', () => {
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'gateway_closed',
+      message: 'gateway closed',
+    }).code,
+    'disconnected',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'app_server_crashed',
+      message: 'codex app-server transport closed during thread/start',
+    }).code,
+    'disconnected',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'task_timeout',
+      message: 'task timed out',
+    }).code,
+    'timeout',
+  );
+});
+
+test('normalizeTaskFailError maps clear upstream failures and preserves generic diagnostics', () => {
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'turn_failed',
+      message: 'provider returned HTTP 500 internal server error',
+    }).code,
+    'upstream_error',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'vicoop_codex_failed',
+      message: 'unknown provider failure',
+    }).code,
+    'upstream_error',
+  );
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'gateway_chat_error',
+      message: 'unknown gateway error',
+    }).code,
+    'gateway_chat_error',
+  );
+});

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -43,28 +43,26 @@ const SEMANTIC_CODES = new Set([
 ]);
 
 export function normalizeTaskFailError(error: TaskFailError): TaskFailError {
-  const code = normalizeTaskFailCode(error.code, error.message);
-  if (code === error.code) return error;
-  return { ...error, code };
-}
-
-export function normalizeTaskFailCode(code: string, message: string): string {
-  if (SEMANTIC_CODES.has(code)) return code;
-  if (PRESERVED_INPUT_CODES.has(code)) return code;
+  const { code, message } = error;
+  if (SEMANTIC_CODES.has(code)) return error;
+  if (PRESERVED_INPUT_CODES.has(code)) return error;
 
   const text = `${code} ${message}`.toLowerCase();
-  if (isQuotaExceeded(text)) return 'quota_exceeded';
-  if (isRateLimited(text)) return 'rate_limited';
-  if (isLoginRequired(text)) return 'login_required';
-  if (isAuthRequired(text)) return 'auth_required';
-  if (isAgentUnavailable(text)) return 'agent_unavailable';
-  if (isModelUnavailable(text)) return 'model_unavailable';
-  if (DISCONNECTED_CODES.has(code)) return 'disconnected';
-  if (isNetworkError(text)) return 'network_error';
-  if (isDisconnected(text)) return 'disconnected';
-  if (code === 'task_timeout' || isTimeout(text)) return 'timeout';
-  if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) return 'upstream_error';
-  return code;
+  let normalizedCode = code;
+  if (isQuotaExceeded(text)) normalizedCode = 'quota_exceeded';
+  else if (isRateLimited(text)) normalizedCode = 'rate_limited';
+  else if (isLoginRequired(text)) normalizedCode = 'login_required';
+  else if (isAuthRequired(text)) normalizedCode = 'auth_required';
+  else if (isAgentUnavailable(text)) normalizedCode = 'agent_unavailable';
+  else if (isModelUnavailable(text)) normalizedCode = 'model_unavailable';
+  else if (DISCONNECTED_CODES.has(code)) normalizedCode = 'disconnected';
+  else if (isNetworkError(text)) normalizedCode = 'network_error';
+  else if (isDisconnected(text)) normalizedCode = 'disconnected';
+  else if (code === 'task_timeout' || isTimeout(text)) normalizedCode = 'timeout';
+  else if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) normalizedCode = 'upstream_error';
+
+  if (normalizedCode === error.code) return error;
+  return { ...error, code: normalizedCode };
 }
 
 function isQuotaExceeded(text: string): boolean {

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -1,0 +1,143 @@
+export interface TaskFailError {
+  code: string;
+  message: string;
+}
+
+const PRESERVED_INPUT_CODES = new Set([
+  'empty_prompt',
+  'invalid_file_part',
+  'unsupported_file_uri',
+  'unsupported_file_mime',
+  'file_too_large',
+  'input_file_write_failed',
+  'fetch_blocked_host',
+  'fetch_too_large',
+  'fetch_mime_mismatch',
+  'fetch_failed',
+  'serialize_failed',
+  'parse_failed',
+]);
+
+const DISCONNECTED_CODES = new Set([
+  'network_error',
+  'serve_unavailable',
+  'app_server_unavailable',
+  'app_server_crashed',
+  'gateway_closed',
+  'gateway_send_failed',
+]);
+
+const UPSTREAM_CODES = new Set(['upstream_error']);
+
+const SEMANTIC_CODES = new Set([
+  'quota_exceeded',
+  'rate_limited',
+  'login_required',
+  'auth_required',
+  'client_not_connected',
+  'disconnected',
+  'timeout',
+]);
+
+export function normalizeTaskFailError(error: TaskFailError): TaskFailError {
+  const code = normalizeTaskFailCode(error.code, error.message);
+  if (code === error.code) return error;
+  return { ...error, code };
+}
+
+export function normalizeTaskFailCode(code: string, message: string): string {
+  if (SEMANTIC_CODES.has(code)) return code;
+  if (PRESERVED_INPUT_CODES.has(code)) return code;
+
+  const text = `${code} ${message}`.toLowerCase();
+  if (isQuotaExceeded(text)) return 'quota_exceeded';
+  if (isRateLimited(text)) return 'rate_limited';
+  if (isLoginRequired(text)) return 'login_required';
+  if (isAuthRequired(text)) return 'auth_required';
+  if (isDisconnected(text) || DISCONNECTED_CODES.has(code)) return 'disconnected';
+  if (code === 'task_timeout' || isTimeout(text)) return 'timeout';
+  if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) return 'upstream_error';
+  return code;
+}
+
+function isQuotaExceeded(text: string): boolean {
+  return (
+    /\bquota\b/.test(text) ||
+    text.includes('insufficient_quota') ||
+    text.includes('exceeded your current quota') ||
+    text.includes('usage limit')
+  );
+}
+
+function isRateLimited(text: string): boolean {
+  return (
+    text.includes('rate limit') ||
+    text.includes('rate_limit') ||
+    text.includes('rate-limited') ||
+    text.includes('rate limited') ||
+    text.includes('too many requests') ||
+    /\b429\b/.test(text)
+  );
+}
+
+function isLoginRequired(text: string): boolean {
+  return (
+    text.includes('login required') ||
+    text.includes('login_required') ||
+    text.includes('not logged in') ||
+    text.includes('please log in') ||
+    text.includes('please login') ||
+    text.includes('session expired') ||
+    text.includes('reauth') ||
+    text.includes('re-auth')
+  );
+}
+
+function isAuthRequired(text: string): boolean {
+  return (
+    text.includes('auth required') ||
+    text.includes('auth_required') ||
+    text.includes('authentication required') ||
+    text.includes('authentication failed') ||
+    text.includes('unauthorized') ||
+    text.includes('forbidden') ||
+    text.includes('invalid api key') ||
+    text.includes('invalid token') ||
+    text.includes('bad token') ||
+    text.includes('missing token') ||
+    text.includes('token expired') ||
+    text.includes('expired token') ||
+    /\b401\b/.test(text) ||
+    /\b403\b/.test(text)
+  );
+}
+
+function isDisconnected(text: string): boolean {
+  return (
+    text.includes('disconnected') ||
+    text.includes('connection refused') ||
+    text.includes('connection reset') ||
+    text.includes('connection closed') ||
+    text.includes('transport closed') ||
+    text.includes('socket closed') ||
+    text.includes('econnrefused') ||
+    text.includes('econnreset') ||
+    text.includes('enotfound') ||
+    text.includes('network error')
+  );
+}
+
+function isTimeout(text: string): boolean {
+  return text.includes('timeout') || text.includes('timed out');
+}
+
+function isUpstreamError(text: string): boolean {
+  return (
+    text.includes('upstream') ||
+    text.includes('provider error') ||
+    text.includes('provider failure') ||
+    text.includes('server error') ||
+    text.includes('internal server error') ||
+    /\b5\d\d\b/.test(text)
+  );
+}

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -5,6 +5,7 @@ export interface TaskFailError {
 
 const PRESERVED_INPUT_CODES = new Set([
   'empty_prompt',
+  'invalid_input',
   'invalid_file_part',
   'unsupported_file_uri',
   'unsupported_file_mime',
@@ -19,7 +20,6 @@ const PRESERVED_INPUT_CODES = new Set([
 ]);
 
 const DISCONNECTED_CODES = new Set([
-  'network_error',
   'serve_unavailable',
   'app_server_unavailable',
   'app_server_crashed',
@@ -36,6 +36,9 @@ const SEMANTIC_CODES = new Set([
   'auth_required',
   'client_not_connected',
   'disconnected',
+  'network_error',
+  'agent_unavailable',
+  'model_unavailable',
   'timeout',
 ]);
 
@@ -54,7 +57,11 @@ export function normalizeTaskFailCode(code: string, message: string): string {
   if (isRateLimited(text)) return 'rate_limited';
   if (isLoginRequired(text)) return 'login_required';
   if (isAuthRequired(text)) return 'auth_required';
-  if (isDisconnected(text) || DISCONNECTED_CODES.has(code)) return 'disconnected';
+  if (isAgentUnavailable(text)) return 'agent_unavailable';
+  if (isModelUnavailable(text)) return 'model_unavailable';
+  if (DISCONNECTED_CODES.has(code)) return 'disconnected';
+  if (isNetworkError(text)) return 'network_error';
+  if (isDisconnected(text)) return 'disconnected';
   if (code === 'task_timeout' || isTimeout(text)) return 'timeout';
   if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) return 'upstream_error';
   return code;
@@ -122,13 +129,39 @@ function isDisconnected(text: string): boolean {
     text.includes('socket closed') ||
     text.includes('econnrefused') ||
     text.includes('econnreset') ||
-    text.includes('enotfound') ||
-    text.includes('network error')
+    text.includes('enotfound')
   );
 }
 
 function isTimeout(text: string): boolean {
   return text.includes('timeout') || text.includes('timed out');
+}
+
+function isNetworkError(text: string): boolean {
+  return (
+    text.includes('network_error') ||
+    text.includes('network error') ||
+    text.includes('transport failure') ||
+    text.includes('transport failed')
+  );
+}
+
+function isAgentUnavailable(text: string): boolean {
+  return (
+    text.includes('agent_unavailable') ||
+    text.includes('agent unavailable') ||
+    text.includes('agent is unavailable') ||
+    text.includes('agent temporarily unavailable')
+  );
+}
+
+function isModelUnavailable(text: string): boolean {
+  return (
+    text.includes('model_unavailable') ||
+    text.includes('model unavailable') ||
+    text.includes('model is unavailable') ||
+    text.includes('model temporarily unavailable')
+  );
 }
 
 function isUpstreamError(text: string): boolean {

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -9,7 +9,11 @@ import {
   type TaskStatusUpdateEvent,
   type TaskStore,
 } from '@a2x/sdk';
-import { parseDownFrame, type AgentCard } from '@vicoop-bridge/protocol';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  parseDownFrame,
+  type AgentCard,
+} from '@vicoop-bridge/protocol';
 import { Registry, type ClientConnection } from './registry.js';
 import {
   WSForwardingExecutor,
@@ -443,9 +447,16 @@ test('executor persists history when agent is unreachable', async () => {
     ['m-5', 't-5-unreach'],
   );
   assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      terminal_error: {
+        code: 'client_not_connected',
+        message: 'client not connected',
+      },
+    },
     error: {
       code: 'client_not_connected',
       message: 'client not connected',
     },
   });
+  assert.deepEqual(statuses[0]?.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
 });

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -1,7 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
-import { TaskState, type Artifact, type Message, type Task, type TaskStore } from '@a2x/sdk';
+import {
+  TaskState,
+  type Artifact,
+  type Message,
+  type Task,
+  type TaskStatusUpdateEvent,
+  type TaskStore,
+} from '@a2x/sdk';
 import { parseDownFrame, type AgentCard } from '@vicoop-bridge/protocol';
 import { Registry, type ClientConnection } from './registry.js';
 import {
@@ -425,11 +432,20 @@ test('executor persists history when agent is unreachable', async () => {
     messageId: 'm-5',
   } as unknown as Message;
 
-  for await (const _event of executor.executeStream(task, message)) void _event;
+  const statuses: TaskStatusUpdateEvent[] = [];
+  for await (const event of executor.executeStream(task, message)) {
+    if ('status' in event) statuses.push(event);
+  }
 
   const update = taskStore.updates.at(-1) as { history?: Message[] };
   assert.deepEqual(
     update.history?.map((m) => m.messageId),
     ['m-5', 't-5-unreach'],
   );
+  assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    error: {
+      code: 'client_not_connected',
+      message: 'client not connected',
+    },
+  });
 });

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -434,6 +434,7 @@ test('executor persists history when agent is unreachable', async () => {
     role: 'user',
     parts: [{ kind: 'text', text: 'hi' }],
     messageId: 'm-5',
+    extensions: [OPENAI_COMPAT_EXTENSION_URI],
   } as unknown as Message;
 
   const statuses: TaskStatusUpdateEvent[] = [];
@@ -459,4 +460,28 @@ test('executor persists history when agent is unreachable', async () => {
     },
   });
   assert.deepEqual(statuses[0]?.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+});
+
+test('executor omits terminal error metadata when openai-compat extension was not requested', async () => {
+  const registry = new Registry();
+  const taskStore = captureTaskStore();
+  const executor = new WSForwardingExecutor('missing', registry, taskStore);
+  const task = {
+    id: 't-plain',
+    contextId: 'ctx-plain',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-plain',
+  } as unknown as Message;
+
+  const statuses: TaskStatusUpdateEvent[] = [];
+  for await (const event of executor.executeStream(task, message)) {
+    if ('status' in event) statuses.push(event);
+  }
+
+  assert.equal(statuses[0]?.status.message?.metadata, undefined);
+  assert.equal(statuses[0]?.status.message?.extensions, undefined);
 });

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -16,7 +16,7 @@ import {
 import type { Registry, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
-import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
+import { terminalErrorMessageFields } from './terminal-error.js';
 
 // AgentExecutor's constructor requires a Runner+BaseAgent because Layer 2
 // (the in-process LLM model) is the default. Our WS-forwarding path
@@ -155,6 +155,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     const principalId =
       typeof rawMetadata?._principalId === 'string' ? rawMetadata._principalId : undefined;
     const forwardMetadata = stripInternalMetadata(rawMetadata);
+    const requestedExtensions = message.extensions;
 
     this.registry.bindTask({
       agentId: this.agentId,
@@ -162,6 +163,7 @@ export class WSForwardingExecutor extends AgentExecutor {
       contextId,
       sink,
       ...(principalId !== undefined ? { principalId } : {}),
+      ...(requestedExtensions !== undefined ? { requestedExtensions } : {}),
     });
 
     let history = appendHistoryMessage(task.history ?? [], message);
@@ -202,11 +204,13 @@ export class WSForwardingExecutor extends AgentExecutor {
             messageId: `${taskId}-unreach`,
             role: 'agent',
             parts: [{ text: 'client not connected' }],
-            metadata: terminalErrorMetadata({
-              code: 'client_not_connected',
-              message: 'client not connected',
-            }),
-            extensions: terminalErrorExtensions(),
+            ...terminalErrorMessageFields(
+              {
+                code: 'client_not_connected',
+                message: 'client not connected',
+              },
+              requestedExtensions,
+            ),
             taskId,
             contextId,
           },

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -201,6 +201,12 @@ export class WSForwardingExecutor extends AgentExecutor {
             messageId: `${taskId}-unreach`,
             role: 'agent',
             parts: [{ text: 'client not connected' }],
+            metadata: {
+              error: {
+                code: 'client_not_connected',
+                message: 'client not connected',
+              },
+            },
             taskId,
             contextId,
           },

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -16,6 +16,7 @@ import {
 import type { Registry, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
+import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
 
 // AgentExecutor's constructor requires a Runner+BaseAgent because Layer 2
 // (the in-process LLM model) is the default. Our WS-forwarding path
@@ -201,12 +202,11 @@ export class WSForwardingExecutor extends AgentExecutor {
             messageId: `${taskId}-unreach`,
             role: 'agent',
             parts: [{ text: 'client not connected' }],
-            metadata: {
-              error: {
-                code: 'client_not_connected',
-                message: 'client not connected',
-              },
-            },
+            metadata: terminalErrorMetadata({
+              code: 'client_not_connected',
+              message: 'client not connected',
+            }),
+            extensions: terminalErrorExtensions(),
             taskId,
             contextId,
           },

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
-import type { AgentCard } from '@vicoop-bridge/protocol';
+import { OPENAI_COMPAT_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
 import { Registry } from './registry.js';
 
 // Minimal WebSocket stub — Registry only uses `.close()` on replacement and
@@ -139,7 +139,7 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
     connectedAt: 0,
   });
 
-  const statuses: Array<{ status: { message?: { metadata?: unknown } } }> = [];
+  const statuses: Array<{ status: { message?: { metadata?: unknown; extensions?: string[] } } }> = [];
   let finished = false;
   registry.bindTask({
     agentId: 'a1',
@@ -159,11 +159,18 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
   assert.equal(finished, true);
   assert.equal(registry.getBinding('t-disc'), undefined);
   assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      terminal_error: {
+        code: 'disconnected',
+        message: 'client disconnected mid-task',
+      },
+    },
     error: {
       code: 'disconnected',
       message: 'client disconnected mid-task',
     },
   });
+  assert.deepEqual(statuses[0]?.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
 });
 
 test('onAgentChange does NOT fire on unregister if the ws does not match the current connection', () => {

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -126,6 +126,46 @@ test('onAgentChange fires on disconnect (unregister) so stale transports do not 
   assert.deepEqual(seen, ['a1']);
 });
 
+test('unregisterAgent reports mid-task disconnect with structured error metadata', () => {
+  const registry = new Registry();
+  const ws = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+
+  const statuses: Array<{ status: { message?: { metadata?: unknown } } }> = [];
+  let finished = false;
+  registry.bindTask({
+    agentId: 'a1',
+    taskId: 't-disc',
+    contextId: 'ctx-disc',
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        finished = true;
+      },
+    },
+  });
+
+  registry.unregisterAgent('a1', ws);
+
+  assert.equal(finished, true);
+  assert.equal(registry.getBinding('t-disc'), undefined);
+  assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    error: {
+      code: 'disconnected',
+      message: 'client disconnected mid-task',
+    },
+  });
+});
+
 test('onAgentChange does NOT fire on unregister if the ws does not match the current connection', () => {
   // Defensive: a late-arriving close event from a superseded socket must not
   // trigger invalidation of the new connection's cached transport.

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -145,6 +145,7 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
     agentId: 'a1',
     taskId: 't-disc',
     contextId: 'ctx-disc',
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
     sink: {
       pushStatus: (event) => statuses.push(event),
       pushArtifact: () => undefined,
@@ -171,6 +172,37 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
     },
   });
   assert.deepEqual(statuses[0]?.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+});
+
+test('unregisterAgent omits terminal error metadata when openai-compat extension was not requested', () => {
+  const registry = new Registry();
+  const ws = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+
+  const statuses: Array<{ status: { message?: { metadata?: unknown; extensions?: string[] } } }> = [];
+  registry.bindTask({
+    agentId: 'a1',
+    taskId: 't-disc-plain',
+    contextId: 'ctx-disc-plain',
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => undefined,
+    },
+  });
+
+  registry.unregisterAgent('a1', ws);
+
+  assert.equal(statuses[0]?.status.message?.metadata, undefined);
+  assert.equal(statuses[0]?.status.message?.extensions, undefined);
 });
 
 test('onAgentChange does NOT fire on unregister if the ws does not match the current connection', () => {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -3,6 +3,7 @@ import type { AgentCard, DownFrame } from '@vicoop-bridge/protocol';
 import { encodeFrame } from '@vicoop-bridge/protocol';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { logEvent, truncate } from './log.js';
+import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
 
 export interface ClientConnection {
   agentId: string;
@@ -149,12 +150,11 @@ export class Registry {
             messageId: `${binding.taskId}-disc`,
             role: 'agent',
             parts: [{ text: 'client disconnected mid-task' }],
-            metadata: {
-              error: {
-                code: 'disconnected',
-                message: 'client disconnected mid-task',
-              },
-            },
+            metadata: terminalErrorMetadata({
+              code: 'disconnected',
+              message: 'client disconnected mid-task',
+            }),
+            extensions: terminalErrorExtensions(),
             taskId: binding.taskId,
             contextId: binding.contextId,
           },

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -3,7 +3,7 @@ import type { AgentCard, DownFrame } from '@vicoop-bridge/protocol';
 import { encodeFrame } from '@vicoop-bridge/protocol';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { logEvent, truncate } from './log.js';
-import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
+import { terminalErrorMessageFields } from './terminal-error.js';
 
 export interface ClientConnection {
   agentId: string;
@@ -37,6 +37,7 @@ export interface TaskBinding {
   // route does not create TaskBindings — it has its own executor
   // (AdminA2XExecutor) that never calls registry.bindTask().
   principalId?: string;
+  requestedExtensions?: string[];
 }
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;
@@ -150,11 +151,13 @@ export class Registry {
             messageId: `${binding.taskId}-disc`,
             role: 'agent',
             parts: [{ text: 'client disconnected mid-task' }],
-            metadata: terminalErrorMetadata({
-              code: 'disconnected',
-              message: 'client disconnected mid-task',
-            }),
-            extensions: terminalErrorExtensions(),
+            ...terminalErrorMessageFields(
+              {
+                code: 'disconnected',
+                message: 'client disconnected mid-task',
+              },
+              binding.requestedExtensions,
+            ),
             taskId: binding.taskId,
             contextId: binding.contextId,
           },

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -149,6 +149,12 @@ export class Registry {
             messageId: `${binding.taskId}-disc`,
             role: 'agent',
             parts: [{ text: 'client disconnected mid-task' }],
+            metadata: {
+              error: {
+                code: 'disconnected',
+                message: 'client disconnected mid-task',
+              },
+            },
             taskId: binding.taskId,
             contextId: binding.contextId,
           },

--- a/packages/server/src/terminal-error.ts
+++ b/packages/server/src/terminal-error.ts
@@ -23,3 +23,18 @@ export function terminalErrorMetadata(error: TerminalError): Record<string, unkn
 export function terminalErrorExtensions(): string[] {
   return [OPENAI_COMPAT_EXTENSION_URI];
 }
+
+export function hasOpenAICompatExtension(extensions: readonly string[] | undefined): boolean {
+  return extensions?.includes(OPENAI_COMPAT_EXTENSION_URI) === true;
+}
+
+export function terminalErrorMessageFields(
+  error: TerminalError,
+  requestedExtensions: readonly string[] | undefined,
+): { metadata?: Record<string, unknown>; extensions?: string[] } {
+  if (!hasOpenAICompatExtension(requestedExtensions)) return {};
+  return {
+    metadata: terminalErrorMetadata(error),
+    extensions: terminalErrorExtensions(),
+  };
+}

--- a/packages/server/src/terminal-error.ts
+++ b/packages/server/src/terminal-error.ts
@@ -1,0 +1,25 @@
+import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+
+export interface TerminalError {
+  code: string;
+  message: string;
+}
+
+export function terminalErrorMetadata(error: TerminalError): Record<string, unknown> {
+  const terminalError = {
+    code: error.code,
+    message: error.message,
+  };
+  return {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      terminal_error: terminalError,
+    },
+    // Transitional fallback for gateways that have not migrated to the
+    // openai-compat/v1 namespaced terminal_error payload yet.
+    error: terminalError,
+  };
+}
+
+export function terminalErrorExtensions(): string[] {
+  return [OPENAI_COMPAT_EXTENSION_URI];
+}

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -96,6 +96,7 @@ test('task.fail preserves backend error code and message on status message metad
       taskId: 'task-1',
       contextId: 'ctx-1',
       sink,
+      requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
     });
 
     ws.send(encodeFrame({
@@ -130,6 +131,57 @@ test('task.fail preserves backend error code and message on status message metad
     });
     assert.deepEqual(event.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
     assert.equal(registry.getBinding('task-1'), undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('task.fail omits terminal error metadata when openai-compat extension was not requested', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: {
+        name: 'agent',
+        version: '0.0.0',
+        protocolVersion: '0.3.0',
+      },
+    }));
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-plain',
+      contextId: 'ctx-plain',
+      sink,
+    });
+
+    ws.send(encodeFrame({
+      type: 'task.fail',
+      taskId: 'task-plain',
+      error: {
+        code: 'rate_limited',
+        message: 'slow down',
+      },
+    }));
+
+    await sink.finished;
+
+    const event = sink.statuses[0]!;
+    assert.equal(event.status.state, 'failed');
+    assert.deepEqual(event.status.message?.parts, [{ text: 'rate_limited: slow down' }]);
+    assert.equal(event.status.message?.metadata, undefined);
+    assert.equal(event.status.message?.extensions, undefined);
   } finally {
     ws.close();
     await closeServer(server);

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1,0 +1,126 @@
+import { once } from 'node:events';
+import { createServer, type Server } from 'node:http';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import WebSocket from 'ws';
+import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
+import { encodeFrame, PROTOCOL_VERSION } from '@vicoop-bridge/protocol';
+import { Registry, type TaskSink } from './registry.js';
+import { attachWsServer } from './ws.js';
+import type { Sql } from './db.js';
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  return address.port;
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function mockSql(): Sql {
+  const fn = async () => [
+    {
+      id: 'agent-1',
+      client_id: 'client-1',
+      owner_principal: 'eth:0x0',
+      allowed_callers: [],
+    },
+  ];
+  return fn as unknown as Sql;
+}
+
+function makeSink(): TaskSink & {
+  statuses: TaskStatusUpdateEvent[];
+  artifacts: TaskArtifactUpdateEvent[];
+  finished: Promise<void>;
+} {
+  const statuses: TaskStatusUpdateEvent[] = [];
+  const artifacts: TaskArtifactUpdateEvent[] = [];
+  let resolveFinished!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    resolveFinished = resolve;
+  });
+  return {
+    statuses,
+    artifacts,
+    finished,
+    pushStatus: (event) => statuses.push(event),
+    pushArtifact: (event) => artifacts.push(event),
+    finish: () => resolveFinished(),
+  };
+}
+
+async function waitForAgent(registry: Registry, agentId: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!registry.getAgent(agentId)) {
+    assert.ok(Date.now() < deadline, `timed out waiting for ${agentId} registration`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+test('task.fail preserves backend error code and message on status message metadata', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: {
+        name: 'agent',
+        version: '0.0.0',
+        protocolVersion: '0.3.0',
+      },
+    }));
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      contextId: 'ctx-1',
+      sink,
+    });
+
+    ws.send(encodeFrame({
+      type: 'task.fail',
+      taskId: 'task-1',
+      error: {
+        code: 'rate_limited',
+        message: 'slow down',
+      },
+    }));
+
+    await sink.finished;
+
+    assert.equal(sink.statuses.length, 1);
+    const event = sink.statuses[0]!;
+    assert.equal(event.final, true);
+    assert.equal(event.taskId, 'task-1');
+    assert.equal(event.contextId, 'ctx-1');
+    assert.equal(event.status.state, 'failed');
+    assert.deepEqual(event.status.message?.parts, [{ text: 'rate_limited: slow down' }]);
+    assert.deepEqual(event.status.message?.metadata, {
+      error: {
+        code: 'rate_limited',
+        message: 'slow down',
+      },
+    });
+    assert.equal(registry.getBinding('task-1'), undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -4,7 +4,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import WebSocket from 'ws';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
-import { encodeFrame, PROTOCOL_VERSION } from '@vicoop-bridge/protocol';
+import {
+  encodeFrame,
+  OPENAI_COMPAT_EXTENSION_URI,
+  PROTOCOL_VERSION,
+} from '@vicoop-bridge/protocol';
 import { Registry, type TaskSink } from './registry.js';
 import { attachWsServer } from './ws.js';
 import type { Sql } from './db.js';
@@ -113,11 +117,18 @@ test('task.fail preserves backend error code and message on status message metad
     assert.equal(event.status.state, 'failed');
     assert.deepEqual(event.status.message?.parts, [{ text: 'rate_limited: slow down' }]);
     assert.deepEqual(event.status.message?.metadata, {
+      [OPENAI_COMPAT_EXTENSION_URI]: {
+        terminal_error: {
+          code: 'rate_limited',
+          message: 'slow down',
+        },
+      },
       error: {
         code: 'rate_limited',
         message: 'slow down',
       },
     });
+    assert.deepEqual(event.status.message?.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
     assert.equal(registry.getBinding('task-1'), undefined);
   } finally {
     ws.close();

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -281,6 +281,12 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
               messageId: `${frame.taskId}-err`,
               role: 'agent',
               parts: [{ text: `${frame.error.code}: ${frame.error.message}` }],
+              metadata: {
+                error: {
+                  code: frame.error.code,
+                  message: frame.error.message,
+                },
+              },
               taskId: frame.taskId,
               contextId: b.contextId,
             },

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -15,6 +15,7 @@ import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
 import { isReservedAgentId } from './reserved-agent-ids.js';
 import { resolveHelloAgentCard } from './card-resolver.js';
+import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
 
 interface ClientRow {
   id: string;
@@ -281,12 +282,8 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
               messageId: `${frame.taskId}-err`,
               role: 'agent',
               parts: [{ text: `${frame.error.code}: ${frame.error.message}` }],
-              metadata: {
-                error: {
-                  code: frame.error.code,
-                  message: frame.error.message,
-                },
-              },
+              metadata: terminalErrorMetadata(frame.error),
+              extensions: terminalErrorExtensions(),
               taskId: frame.taskId,
               contextId: b.contextId,
             },

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -15,7 +15,7 @@ import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
 import { isReservedAgentId } from './reserved-agent-ids.js';
 import { resolveHelloAgentCard } from './card-resolver.js';
-import { terminalErrorExtensions, terminalErrorMetadata } from './terminal-error.js';
+import { terminalErrorMessageFields } from './terminal-error.js';
 
 interface ClientRow {
   id: string;
@@ -282,8 +282,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
               messageId: `${frame.taskId}-err`,
               role: 'agent',
               parts: [{ text: `${frame.error.code}: ${frame.error.message}` }],
-              metadata: terminalErrorMetadata(frame.error),
-              extensions: terminalErrorExtensions(),
+              ...terminalErrorMessageFields(frame.error, b.requestedExtensions),
               taskId: frame.taskId,
               contextId: b.contextId,
             },


### PR DESCRIPTION
## What changed

- Preserve backend `task.fail.error.code/message` on emitted A2A failed status messages.
- Emit terminal errors under the canonical openai-compat/v1 namespace from planetarium/oai2a2a#92 only when the inbound A2A request enabled that extension:
  - `status.message.metadata[OPENAI_COMPAT_EXTENSION_URI].terminal_error`
  - `status.message.extensions: [OPENAI_COMPAT_EXTENSION_URI]`
- Keep transitional legacy `status.message.metadata.error` alongside the canonical payload for older gateways on those extension-enabled terminal errors.
- Leave non-extension failed statuses text-only; no terminal error metadata/extensions are added.
- Add structured metadata for bridge-generated server failures when the originating request enabled openai-compat/v1:
  - `client_not_connected` when a task is assigned while no client is connected.
  - `disconnected` when a client disconnects mid-task.
- Normalize client backend adapter failure codes for router availability classification:
  - quota context -> `quota_exceeded`
  - 429 / too many requests / rate limit -> `rate_limited`
  - login/session required -> `login_required`
  - auth/token problems -> `auth_required`
  - local client/app-server/gateway connectivity -> `disconnected`
  - transport failure after dispatch -> `network_error`
  - agent/model availability text -> `agent_unavailable` / `model_unavailable`
  - provider 5xx / provider failure -> `upstream_error`
- Preserve caller/input validation failures and generic diagnostic codes unless the message has a clear runtime classification signal.
- Keep the existing human-readable text parts unchanged for display-only clients.
- Add regression coverage for client-originated `task.fail`, server-generated failure paths, extension gating, and backend failure code normalization.
- Add a client patch changeset.

## Why

Issue #325 notes that downstream routers need machine-readable backend failure details without parsing `status.message.parts[0].text`. The server already receives structured failures from clients, but flattened them into text only. Server-generated connection failures also need structured codes so runtime availability logic can distinguish disconnected agents from generic task errors.

planetarium/oai2a2a#92 makes `metadata[OPENAI_COMPAT_EXTENSION_URI].terminal_error` the documented v1 terminal error contract. The follow-up router work can now prefer that canonical payload for openai-compat/v1 requests while older consumers can still read the legacy top-level `metadata.error` fallback on the same extension-enabled responses.

Closes #325.

## Validation

- `pnpm --filter @vicoop-bridge/client test`
- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/server test`
- `pnpm --filter @vicoop-bridge/server typecheck`