### PR TITLE
fix(client): give each caller-tool call a conversation-unique id

### DIFF
--- a/.changeset/caller-tool-id-uniqueness.md
+++ b/.changeset/caller-tool-id-uniqueness.md
@@ -1,0 +1,12 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+claude backend: mint a conversation-unique `call_<uuid>` for each
+caller-tool invocation instead of reusing the MCP JSON-RPC request id.
+The request id only counts within a single MCP session, and the bridge
+stands up a fresh MCP server per A2A turn, so it reset every turn —
+every single-call turn emitted `tool_call_id` "2". Once the OpenAI loop
+replayed the accumulated history those duplicate ids collided, breaking
+the call↔result pairing and making the model restate its whole plan
+before each tool call.

--- a/packages/client/src/backends/caller-tools-mcp.ts
+++ b/packages/client/src/backends/caller-tools-mcp.ts
@@ -197,17 +197,22 @@ export async function startCallerToolsMcpServer(
     })),
   }));
 
-  server.setRequestHandler(CallToolRequestSchema, async (req, extra) => {
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
     const name = req.params.name;
     const argsRaw = req.params.arguments;
-    // MCP's wire-level call id (request id from the JSON-RPC envelope) is
-    // the most stable handle for round-tripping back to the caller. Fall
-    // back to a fresh UUID only if `requestId` is missing — which would
-    // be unusual for a real client but keeps the path total.
-    const callId =
-      typeof extra?.requestId === 'string' || typeof extra?.requestId === 'number'
-        ? String(extra.requestId)
-        : `call_${randomUUID()}`;
+    // Always mint a fresh UUID for the tool_call id. We must NOT reuse the
+    // MCP JSON-RPC request id (`extra.requestId`): it is only monotonic
+    // within a single MCP session, and the bridge stands up a brand-new
+    // caller-tools MCP server (and claude process) per A2A turn. So the
+    // request id resets every turn — `2` for the first tools/call of each
+    // turn, `3,4,5…` for further calls in the same turn. The OpenAI loop
+    // then replays the accumulated history, and those non-unique ids
+    // collide across turns: every single-call turn carries `tool_call_id`
+    // "2", breaking the call↔result pairing the model relies on (and the
+    // "don't repeat a call whose tool_call_id already appears" guard). The
+    // id only needs to be unique and echoed back verbatim on the next
+    // turn's chat_history — a UUID satisfies both.
+    const callId = `call_${randomUUID()}`;
     const ack = await performInvoke({
       callId,
       toolName: name,


### PR DESCRIPTION
## Problem

The claude backend derived the OpenAI `tool_call_id` from the MCP JSON-RPC request id (`extra.requestId`) in `caller-tools-mcp.ts`. That id is only monotonic **within a single MCP session**, but the bridge stands up a brand-new caller-tools MCP server (and claude process) **per A2A turn**, so the counter reset every turn:

- first `tools/call` of each turn → `2`
- further calls in the same turn → `3,4,5…`

When the openai-compat loop replayed the accumulated `<chat_history>`, those non-unique ids collided across turns. In one real session, `tool_call_id` "2" appeared **15 times** across 25 calls (only 5 distinct ids: 2,3,4,5,6).

## Symptom

With colliding ids, the call↔result pairing breaks (and the system-prompt guard *"don't repeat a call whose tool_call_id already appears"* is defeated). The model loses track of what it called vs. what came back, so it restates its entire plan before every tool call — the repeated *"I'll wire the visual novel… update the docs"* preambles visible in the backend prompt view around each tool call.

## Fix

Always mint a fresh `call_<uuid>`. The id only needs to be unique and echoed back verbatim on the next turn's `chat_history`; a UUID satisfies both. The now-unused `extra` handler arg is dropped.

## Verification

- `pnpm -r build`, `pnpm --filter @vicoop-bridge/client typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` → **647 pass / 0 fail** ✅ (existing tests inject `callId` via `invokeForTest`, so they're unaffected)
- **Live**: ran the daemon against a real request after the patch. An 8-call session now shows **8 distinct ids, zero collisions, every call paired 1:1 with its result** — vs. the old "2 × 15" collisions.

| | before (bug) | after |
|---|---|---|
| distinct ids | 5 (2,3,4,5,6) | all unique |
| `id="2"` reuse | 15× | — |
| call↔result 1:1 | broken | ✅ |

## Notes

- claude backend only, as scoped. Other backends (`codex.ts` etc.) were not inspected for the same pattern in this PR.
- No regression test added: exercising the real `CallToolRequestSchema` id-minting path needs an MCP-transport-level integration test (current tests bypass it via `invokeForTest`). Happy to add one if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)