### PR TITLE
feat(client): add --claude-model flag to pin the spawned claude's model

### DIFF
--- a/.changeset/claude-model-flag.md
+++ b/.changeset/claude-model-flag.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add a `--claude-model` flag (and matching `backends.claude.model` config
+key) to pin the model for the spawned `claude`, e.g.
+`vicoop-client start --backend claude --claude-model claude-opus-4-8`. The
+value is folded into Claude `--settings` as its `model` field, so the
+default sandbox guard and any operator-supplied settings are preserved. A
+per-request openai-compat `model` still overrides it. Pairing the flag with
+a non-claude backend exits non-zero.

--- a/.changeset/claude-model-flag.md
+++ b/.changeset/claude-model-flag.md
@@ -7,5 +7,9 @@ key) to pin the model for the spawned `claude`, e.g.
 `vicoop-client start --backend claude --claude-model claude-opus-4-8`. The
 value is folded into Claude `--settings` as its `model` field, so the
 default sandbox guard and any operator-supplied settings are preserved. A
-per-request openai-compat `model` still overrides it. Pairing the flag with
-a non-claude backend exits non-zero.
+per-request openai-compat `model` still overrides it (Claude is treated as a
+multi-model backend); a value the install doesn't advertise is dropped and
+falls back to the pin rather than erroring. When pinned, the agent advertises
+the pinned id (and skips the startup model probe) so the openai-compat
+model-match gate can't override the pin with claude's unpinned default.
+Pairing the flag with a non-claude backend exits non-zero.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -611,12 +611,13 @@ different repository than the one `vicoop-client` itself runs in:
 ```sh
 vicoop-client start \
   --backend claude \
-  --cwd "$HOME/vicoop-bridge"
+  --cwd "$HOME/vicoop-bridge" \
+  --claude-model claude-opus-4-8
 ```
 
-Both knobs can also live in the canonical `config.json` (resolved per Step
+These knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
-(`cwd`, `settings`) so the foreground command shrinks to just
+(`cwd`, `settings`, `model`) so the foreground command shrinks to just
 `vicoop-client start`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
@@ -624,6 +625,15 @@ the daemon-level precedence (Step 6 intro).
 |---|---|
 | `--cwd` | `cwd` |
 | `--claude-settings-file` | `settings` (JSON object) |
+| `--claude-model` | `model` |
+
+> **Picking a model.** `--claude-model <id>` (e.g. `claude-opus-4-8`) is
+> folded into Claude `--settings` as its `model` field, so it composes with
+> the sandbox default and any `--claude-settings-file` you supply rather than
+> replacing them. Leave it unset to let `claude` resolve its own model
+> (project / user `settings.json`, `ANTHROPIC_MODEL`, built-in default). A
+> per-request openai-compat `model` still overrides it. The flag is
+> claude-only — pairing it with another `--backend` exits non-zero.
 
 > **Sandbox-on by default.** When neither `--claude-settings-file` nor
 > `backends.claude.settings` is set, the backend forwards

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2576,6 +2576,88 @@ test('envelope.model is forwarded when it matches claude probed model (#302)', a
   assert.equal(args[modelIdx + 1], 'claude-opus-4-7');
 });
 
+test('a --claude-model pin makes resolveCapabilities advertise the pin without probing', async () => {
+  // The pin IS the advertised model, so resolveCapabilities must not spawn
+  // the probe (it can't see our --settings) — it just reports the pin.
+  let spawned = 0;
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        // Probe would report claude's own default if it ran — assert it does
+        // not by watching the spawn count and the advertised id.
+        model: 'claude-sonnet-4-6',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const countingSpawn: typeof fake.spawn = (cmd, a, o) => {
+    spawned += 1;
+    return fake.spawn(cmd, a, o);
+  };
+  const backend = createClaudeBackend({ spawn: countingSpawn, model: 'claude-opus-4-8' });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'claude-opus-4-8', default: true }],
+  });
+  assert.equal(spawned, 0, 'pinned model must not trigger a probe spawn');
+});
+
+test('envelope.model matching the --claude-model pin rides through as --model', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, model: 'claude-opus-4-8' });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-opus-4-8' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  const modelIdx = args.indexOf('--model');
+  assert.notEqual(modelIdx, -1, '--model present');
+  assert.equal(args[modelIdx + 1], 'claude-opus-4-8');
+});
+
+test('envelope.model differing from the --claude-model pin falls back to the pin, not the envelope', async () => {
+  // Regression guard for the pin-defeat bug: the probe runs WITHOUT our
+  // --settings, so before seeding the cache with the pin an envelope echoing
+  // the unpinned default would have overridden the pin via --model. With the
+  // seed, a non-matching envelope.model is dropped and the spawn falls back
+  // to settings.model (= the pin), so claude never runs a different model
+  // than the operator pinned.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, model: 'claude-opus-4-8' });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-sonnet-4-6' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  // No --model override (sonnet dropped); the pin survives via --settings.
+  assert.equal(args.indexOf('--model'), -1, 'mismatched envelope.model must be dropped');
+  const settingsIdx = args.indexOf('--settings');
+  assert.notEqual(settingsIdx, -1);
+  assert.equal(JSON.parse(String(args[settingsIdx + 1])).model, 'claude-opus-4-8');
+});
+
 test('spawn argv carries --system-prompt with the native directive when metadata is present', async () => {
   const fake = scriptedSpawn({
     lines: [

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -804,6 +804,51 @@ test('injects default sandbox-on --settings when settings option is not provided
   });
 });
 
+test('model option folds into --settings as `model`, keeping the default sandbox', async () => {
+  // `--claude-model` with no explicit settings must NOT wipe the
+  // sandbox-on-by-default guard: the model is merged onto DEFAULT_SETTINGS,
+  // not substituted for it.
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, model: 'claude-opus-4-8' });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const idx = child.args.indexOf('--settings');
+  assert.ok(idx !== -1, 'expected --settings flag');
+  assert.deepEqual(JSON.parse(String(child.args[idx + 1])), {
+    sandbox: { enabled: true, failIfUnavailable: true },
+    model: 'claude-opus-4-8',
+  });
+});
+
+test('model option wins over a `model` already present in operator settings', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    settings: { sandbox: { enabled: false }, model: 'claude-sonnet-4-6' },
+    model: 'claude-opus-4-8',
+  });
+  await backend.handle(assign('hi'), collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  const idx = child.args.indexOf('--settings');
+  assert.ok(idx !== -1, 'expected --settings flag');
+  assert.deepEqual(JSON.parse(String(child.args[idx + 1])), {
+    sandbox: { enabled: false },
+    model: 'claude-opus-4-8',
+  });
+});
+
 test('createClaudeBackend throws a named error if settings is not JSON-serializable', () => {
   // Circular reference — JSON.stringify throws TypeError. The wrapped Error
   // must name the option so an operator can find the misconfiguration

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1203,7 +1203,17 @@ export function createClaudeBackend(
   // populated before any task lands in production. Tests that want to
   // exercise the gate populate the cache via `resolveCapabilities`
   // explicitly.
-  let cachedProbedModel: string | null | undefined = undefined;
+  //
+  // A `--claude-model` pin seeds the cache directly: the pin IS the
+  // advertised model (every spawn loads it via settings.model), so it must
+  // be what the `envelope.model` gate compares against. Without this seed
+  // the probe — which deliberately runs WITHOUT our `--settings` (see
+  // `CLAUDE_PROBE_ARGS`) — would report claude's *unpinned* default, the
+  // gateway would route by that default, and the matching `--model <default>`
+  // argv would then override the pin on the spawn (CLI `--model` beats
+  // settings.model). Seeding here holds the pin even if `resolveCapabilities`
+  // never runs.
+  let cachedProbedModel: string | null | undefined = opts.model ?? undefined;
 
   return {
     name: 'claude',
@@ -1222,6 +1232,13 @@ export function createClaudeBackend(
     // `completion_tokens_details.reasoning_tokens` in `usage`, and per
     // spec "Absence means 'unspecified,' not 'false.'"
     async resolveCapabilities() {
+      // A pinned model is authoritative — there's nothing to discover, so
+      // skip the probe spawn entirely (it can't see our `--settings` anyway)
+      // and advertise the pin, which the construction-time seed already put
+      // in `cachedProbedModel`.
+      if (opts.model) {
+        return { openaiCompatModels: [{ id: opts.model, default: true }] };
+      }
       if (probeTimeoutMs <= 0) {
         cachedProbedModel = null;
         return {};

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -141,6 +141,15 @@ export interface ClaudeBackendOptions {
   // thrown Error from `createClaudeBackend(...)` so misconfiguration is
   // visible at startup rather than as a corrupted argv on the first task.
   settings?: Record<string, unknown>;
+  // Model id for the spawned `claude` (e.g. `claude-opus-4-8`), exposed via
+  // the `--claude-model` flag. Merged into the resolved `--settings` JSON as
+  // its `model` field so it survives alongside the default sandbox guard and
+  // any operator-supplied `settings`. A per-request openai-compat envelope
+  // `model` still wins: that path adds an explicit `--model <id>` argv, which
+  // claude prioritises over the settings.json `model` field. When unset, the
+  // model falls back to claude's own resolution (project/user settings.json,
+  // ANTHROPIC_MODEL, built-in default).
+  model?: string;
   /**
    * Test seam: invoked once per task with the caller-tools MCP server
    * handle immediately after the bridge stands one up (when the
@@ -1100,7 +1109,14 @@ export function createClaudeBackend(
   const DEFAULT_SETTINGS: Record<string, unknown> = {
     sandbox: { enabled: true, failIfUnavailable: true },
   };
-  const resolvedSettings = opts.settings ?? DEFAULT_SETTINGS;
+  // Fold `--claude-model` into the resolved settings as its `model` field.
+  // Merging here (rather than at the cli.ts layer) means an operator who
+  // passes only `--claude-model` still keeps the DEFAULT_SETTINGS sandbox
+  // guard above — a naive `{ model }` at the call site would have replaced
+  // it. The flag wins over a `model` already present in operator settings.
+  const resolvedSettings = opts.model
+    ? { ...(opts.settings ?? DEFAULT_SETTINGS), model: opts.model }
+    : (opts.settings ?? DEFAULT_SETTINGS);
   // Serialize once at backend construction so per-task spawn stays cheap and
   // a malformed settings object (circular reference, BigInt value, etc.)
   // fails loud at setup time rather than producing a corrupted argv on the

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -149,6 +149,52 @@ test('--runtime-name with a non-runtime-capable backend is a hard error', () => 
   );
 });
 
+test('--claude-model resolves from the flag for the claude backend', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', claudeModel: 'claude-opus-4-8' },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeModel, 'claude-opus-4-8');
+});
+
+test('--claude-model flag beats backends.claude.model from config', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', claudeModel: 'claude-opus-4-8' },
+    { backends: { claude: { model: 'claude-sonnet-4-6' } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeModel, 'claude-opus-4-8');
+});
+
+test('backends.claude.model fills in when the flag is absent', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude' },
+    { backends: { claude: { model: 'claude-sonnet-4-6' } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeModel, 'claude-sonnet-4-6');
+});
+
+test('--claude-model with a non-claude backend is a hard error', () => {
+  // Only the claude backend takes an operator-selectable model id; codex
+  // reads its model from config.toml and openclaw from the remote gateway,
+  // so pairing the flag with either is almost always an operator mistake.
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'codex', claudeModel: 'claude-opus-4-8' },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--claude-model') && e.includes('codex')),
+    `expected error mentioning --claude-model and codex, got: ${r.errors.join(' | ')}`,
+  );
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',
@@ -158,12 +204,14 @@ test('parseFlags picks up known flags', () => {
     '--card', '/c.json',
     '--config', '/etc/vicoop/config.json',
     '--runtime-name', 'work',
+    '--claude-model', 'claude-opus-4-8',
   ]);
   assert.equal(r.ok, true);
   if (!r.ok) return;
   assert.equal(r.flags.server, 'wss://x');
   assert.equal(r.flags.token, 't');
   assert.equal(r.flags.runtimeName, 'work');
+  assert.equal(r.flags.claudeModel, 'claude-opus-4-8');
   assert.equal(r.flags.agentId, 'a');
   assert.equal(r.flags.backend, 'claude');
   assert.equal(r.flags.card, '/c.json');

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -87,6 +87,9 @@ export const daemonFlagsFields = {
   claudeSettingsFile: optional(option('--claude-settings-file', string({ metavar: 'PATH' }), {
     description: message`Path to a JSON file used as Claude \`--settings\`.`,
   })),
+  claudeModel: optional(option('--claude-model', string({ metavar: 'MODEL' }), {
+    description: message`Model id for the spawned Claude, e.g. \`claude-opus-4-8\`. Sets the \`model\` field in Claude \`--settings\`; a per-request openai-compat \`model\` still overrides it. Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
+  })),
 
   // Backend-specific (Codex)
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
@@ -141,6 +144,7 @@ export interface DaemonArgs {
   runtime?: BackendRuntime;
   runtimeName?: string;
   claudeSettingsFile?: string;
+  claudeModel?: string;
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
   openclawGatewayToken?: string;
@@ -250,6 +254,7 @@ export function mergeClientArgs(
     runtime: flags.runtime ?? activeRuntime,
     runtimeName: pick(flags.runtimeName) || activeRuntimeName || undefined,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
+    claudeModel: pick(flags.claudeModel) || backends.claude?.model || undefined,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     openclawGateway:
@@ -272,6 +277,7 @@ export function mergeClientArgs(
   // can `if (resolved.cwd)` cleanly instead of having to filter "".
   if (resolved.cwd === '') resolved.cwd = undefined;
   if (resolved.claudeSettingsFile === '') resolved.claudeSettingsFile = undefined;
+  if (resolved.claudeModel === '') resolved.claudeModel = undefined;
   if (resolved.openclawGateway === '') resolved.openclawGateway = undefined;
   if (resolved.openclawGatewayToken === '') resolved.openclawGatewayToken = undefined;
   if (resolved.openclawAgent === '') resolved.openclawAgent = undefined;
@@ -304,6 +310,11 @@ export function mergeClientArgs(
   if (pick(flags.cwd) && !CWD_BACKENDS.has(backend)) {
     errors.push(
       `--cwd is not supported by --backend ${backend}; only claude / codex spawn a backend process with a working directory`,
+    );
+  }
+  if (pick(flags.claudeModel) && backend !== 'claude') {
+    errors.push(
+      `--claude-model is not supported by --backend ${backend}; only the claude backend takes a model id`,
     );
   }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -347,6 +347,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         cwd,
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         settings,
+        model: args.claudeModel,
         openaiCompatTrace: args.openaiCompatTrace,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -164,7 +164,11 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
     backend: 'claude',
     card: '/path/card.json',
     backends: {
-      claude: { cwd: '/srv/work', settings: { sandbox: { enabled: true } } },
+      claude: {
+        cwd: '/srv/work',
+        settings: { sandbox: { enabled: true } },
+        model: 'claude-opus-4-8',
+      },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
         gateway_url: 'ws://127.0.0.1:18789',
@@ -182,7 +186,11 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
     backend: 'claude',
     card: '/path/card.json',
     backends: {
-      claude: { cwd: '/srv/work', settings: { sandbox: { enabled: true } } },
+      claude: {
+        cwd: '/srv/work',
+        settings: { sandbox: { enabled: true } },
+        model: 'claude-opus-4-8',
+      },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
         gateway_url: 'ws://127.0.0.1:18789',

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -109,6 +109,13 @@ export type BackendRuntime = 'host' | 'container';
 export interface ClaudeBackendConfig {
   cwd?: string;
   settings?: Record<string, unknown>;
+  /**
+   * Model id for the spawned `claude`, e.g. `claude-opus-4-8`. Folded into
+   * the `--settings` JSON as its `model` field at launch (a per-request
+   * openai-compat `model` still overrides it). Mirrors the `--claude-model`
+   * flag.
+   */
+  model?: string;
   runtime?: BackendRuntime;
   runtime_name?: string;
 }
@@ -232,12 +239,14 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
     if (claudeRaw) {
       const cwd = asString(claudeRaw.cwd);
       const settings = asRecord(claudeRaw.settings);
+      const model = asString(claudeRaw.model);
       const runtime = pickBackendRuntime(claudeRaw.runtime);
       const runtimeName = asString(claudeRaw.runtime_name);
-      if (cwd || settings || runtime || runtimeName) {
+      if (cwd || settings || model || runtime || runtimeName) {
         out.claude = {};
         if (cwd) out.claude.cwd = cwd;
         if (settings) out.claude.settings = settings;
+        if (model) out.claude.model = model;
         if (runtime) out.claude.runtime = runtime;
         if (runtimeName) out.claude.runtime_name = runtimeName;
       }


### PR DESCRIPTION
## What

Adds a `--claude-model` flag (and matching `backends.claude.model` config key) so operators can pin the model for the **Claude backend** at launch:

```sh
vicoop-client start --backend claude --claude-model claude-opus-4-8
```

Previously the only ways to set the model were Claude Code's own `project/user settings.json`, `ANTHROPIC_MODEL`, or a hand-written `--claude-settings-file` JSON — there was no direct knob on `vicoop-client start`.

## Design

- **Claude-specific flag, not global.** Only the claude backend takes an operator-selectable model: codex reads its model from `config.toml`, openclaw from the remote gateway. A global `--model` would be a no-op for those, so the flag follows the existing `--<backend>-<option>` precedent (`--claude-settings-file`, `--codex-sandbox`) and **exits non-zero when paired with another `--backend`**, matching the `--cwd` / `--runtime` compat gates.
- **Folded into `--settings`, merged at the backend layer.** The value lands in Claude `--settings` as its `model` field. The merge happens in `createClaudeBackend` against `resolvedSettings` (not at the cli.ts call site) so that passing only `--claude-model` — with no explicit settings — **preserves the sandbox-on-by-default guard** rather than replacing it. The flag also wins over a `model` already present in operator settings.

## Multi-model semantics & the pin-defeat fix

Claude is treated as a **multi-model backend**: a per-request openai-compat envelope `model` may differ from the launch pin, and the existing #302 rule is *drop-and-fall-back, not error* — an id the install doesn't advertise (e.g. an unresolved routing key `a2a/<url>`) is dropped with a warning and the spawn falls back to its default. We keep that policy.

But naively adding the pin exposed a real bug: the `resolveCapabilities` startup probe deliberately spawns **without** our `--settings`, so it reported claude's *unpinned* default as the advertised model. The gateway routes by that advertised id, and the matching `--model <default>` argv then **overrode the pin** on the spawn (CLI `--model` beats `settings.model`) — silently defeating `--claude-model`.

Fix: seed the probed-model cache with the pin at construction, and when pinned have `resolveCapabilities` advertise the pin and skip the probe (nothing to discover; the probe can't see our settings anyway). The openai-compat gate then compares `envelope.model` against the pin — a match rides through, a mismatch is dropped and falls back to the pin via `settings.model`. The operator's pinned model is now guaranteed to be what actually runs.

**Precedence:** request `model` *that the install advertises* (= the pin) → the pin. Anything else → dropped → the pin. So under a pin, the agent is effectively single-model from the caller's perspective, which is the correct multi-model-registry behavior.

## Changes

| File | Change |
|---|---|
| `cli-args.ts` | `--claude-model` flag, `DaemonArgs.claudeModel`, merge (`flag > backends.claude.model`), non-claude backend hard error |
| `config.ts` | `ClaudeBackendConfig.model` + normalize parsing |
| `cli.ts` | thread `model: args.claudeModel` into `createClaudeBackend` |
| `backends/claude.ts` | `ClaudeBackendOptions.model`, merge into `resolvedSettings`, seed `cachedProbedModel` with the pin, advertise-pin-and-skip-probe in `resolveCapabilities` |
| `docs/install-client.md` | flag table row + "Picking a model" note |
| tests | cli-args (4), config round-trip, claude backend (5 — settings folding ×2, advertise-without-probe, envelope match/mismatch vs pin) |

## Testing

- `pnpm --filter @vicoop-bridge/client test` — 656 pass
- `pnpm --filter @vicoop-bridge/client typecheck` — clean
- `pnpm -r build` — clean

Changeset: `@vicoop-bridge/client` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)