### PR TITLE
feat(client): advertise host-only vicoop-codex backend in `info`

### DIFF
--- a/.changeset/info-advertises-vicoop-codex.md
+++ b/.changeset/info-advertises-vicoop-codex.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+`vicoop-client info` now advertises the host-only `vicoop-codex` backend (with its supported CLI range `>=0.3.0`) alongside the container-installable `claude` / `codex`. The container compat manifest is unchanged — `vicoop-codex` remains host-process only and is not installed or driven under `--runtime container`.

--- a/packages/client/src/backends-manifest.test.ts
+++ b/packages/client/src/backends-manifest.test.ts
@@ -1,19 +1,37 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { BACKENDS_MANIFEST } from './backends-manifest.js';
+import { BACKEND_COMPAT, BACKENDS_MANIFEST, HOST_ONLY_BACKENDS } from './backends-manifest.js';
 
-test('manifest lists only image-installable backends', () => {
+test('manifest lists only container-installable backends', () => {
   // Membership in the manifest is the contract — if a backend appears here,
-  // it must have an `install-backend.sh` recipe. echo / openclaw /
-  // vicoop-codex are valid daemon backends but the image doesn't ship a
-  // recipe for them today; they intentionally don't appear.
+  // it must have an `install-backend.sh` recipe (container/backends/<kind>.sh)
+  // and full container-runtime creds/auth wiring (it's keyed by
+  // InstallableBackendKind). echo / openclaw / vicoop-codex are valid daemon
+  // backends but don't run under `--runtime container`; they intentionally
+  // don't appear here.
   const expected = new Set(['claude', 'codex']);
   const actual = new Set(Object.keys(BACKENDS_MANIFEST));
   assert.deepEqual(actual, expected);
 });
 
-test('every entry has a non-empty supportedRange', () => {
-  for (const [kind, entry] of Object.entries(BACKENDS_MANIFEST)) {
+test('host-only backends are disjoint from the container manifest', () => {
+  // The two sets must not overlap — a backend is either container-installable
+  // (BACKENDS_MANIFEST) or host-only (HOST_ONLY_BACKENDS), never both.
+  for (const kind of Object.keys(HOST_ONLY_BACKENDS)) {
+    assert.ok(!(kind in BACKENDS_MANIFEST), `${kind} must not also be in BACKENDS_MANIFEST`);
+  }
+});
+
+test('info advertises the union of container + host-only backends', () => {
+  // `vicoop-client info` reports BACKEND_COMPAT, which must surface
+  // vicoop-codex alongside the container-installable claude / codex.
+  const expected = new Set(['claude', 'codex', 'vicoop-codex']);
+  const actual = new Set(Object.keys(BACKEND_COMPAT));
+  assert.deepEqual(actual, expected);
+});
+
+test('every compat entry has a non-empty supportedRange', () => {
+  for (const [kind, entry] of Object.entries(BACKEND_COMPAT)) {
     assert.equal(typeof entry.supportedRange, 'string', `${kind}: range must be string`);
     assert.notEqual(entry.supportedRange.trim(), '', `${kind}: range must be non-empty`);
   }

--- a/packages/client/src/backends-manifest.ts
+++ b/packages/client/src/backends-manifest.ts
@@ -4,12 +4,19 @@
 // start and tells the operator which `install-backend.sh` invocation will
 // realign things.
 //
-// Membership in this manifest is the authoritative answer to "does the image
-// know how to install this backend?". Backends absent from here (echo,
-// openclaw, vicoop-codex today) are still valid `VICOOP_BACKEND` choices —
-// they just need the operator to handle any out-of-process setup (e.g.
-// openclaw's gateway runs as a separate service). To add a new installable
-// backend: add an entry here AND create `container/backends/<kind>.sh`.
+// Membership in BACKENDS_MANIFEST is the authoritative answer to "does the
+// container runtime install AND drive this backend?" — it's the set keyed by
+// `InstallableBackendKind`, which the whole container-runtime creds/auth path
+// (expectedCredsPath, copyHostCreds, resolveRuntime, …) is typed against.
+// Backends absent from here (echo, openclaw, vicoop-codex today) are still
+// valid `VICOOP_BACKEND` choices — they just don't run under `--runtime
+// container`; the operator handles any setup on the host. To add a new
+// container-installable backend: add an entry here AND create
+// `container/backends/<kind>.sh`.
+//
+// `info` advertises a SUPERSET of these — see BACKEND_COMPAT below — so
+// operators can see the supported CLI version range for host-only backends
+// (vicoop-codex) too, without dragging them into the container machinery.
 //
 // `supportedRange` follows node-semver syntax. Ranges are intentionally
 // permissive in this initial cut: we tighten them once a real breakage
@@ -24,4 +31,25 @@ export interface BackendManifestEntry {
 export const BACKENDS_MANIFEST: Record<InstallableBackendKind, BackendManifestEntry> = {
   claude: { supportedRange: '>=2.0.0' },
   codex: { supportedRange: '>=0.100.0' },
+};
+
+// Backends the client knows how to drive but the container image does NOT
+// install or run under `--runtime container`. They're host-process only, so
+// they stay out of `InstallableBackendKind` (and its creds/auth machinery) —
+// but `info` still advertises their supported CLI range so operators running
+// them on the host can check compatibility.
+//
+// vicoop-codex: driven via `vicoop-codex serve` + `vicoop-codex models
+// --json`, both of which land in the 0.3.x line — hence the >=0.3.0 floor.
+export type HostOnlyBackendKind = 'vicoop-codex';
+
+export const HOST_ONLY_BACKENDS: Record<HostOnlyBackendKind, BackendManifestEntry> = {
+  'vicoop-codex': { supportedRange: '>=0.3.0' },
+};
+
+// What `vicoop-client info` reports under `backends`: every backend the client
+// can drive, container-installable or not, each with its supported CLI range.
+export const BACKEND_COMPAT: Record<string, BackendManifestEntry> = {
+  ...BACKENDS_MANIFEST,
+  ...HOST_ONLY_BACKENDS,
 };

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -32,7 +32,7 @@ import {
 import isInsideContainer from 'is-inside-container';
 import { clientVersion } from './version.js';
 import { runUpgrade } from './upgrade.js';
-import { BACKENDS_MANIFEST } from './backends-manifest.js';
+import { BACKEND_COMPAT } from './backends-manifest.js';
 import { authLoginCmd, loginCmd, runAuthLogin, runLogin } from './login.js';
 import { authLogoutCmd, logoutCmd, runAuthLogout, runLogout } from './logout.js';
 import { setupCmd, runAgentRegister, runSetup } from './setup.js';
@@ -642,7 +642,7 @@ async function main(): Promise<void> {
       const payload = {
         version: clientVersion,
         ...(imageVersion ? { imageVersion } : {}),
-        backends: BACKENDS_MANIFEST,
+        backends: BACKEND_COMPAT,
       };
       process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
       process.exit(0);


### PR DESCRIPTION
## What

`vicoop-client info` now advertises the `vicoop-codex` backend (supported CLI range `>=0.3.0`) alongside the container-installable `claude` / `codex`:

```json
"backends": {
  "claude":       { "supportedRange": ">=2.0.0" },
  "codex":        { "supportedRange": ">=0.100.0" },
  "vicoop-codex": { "supportedRange": ">=0.3.0" }
}
```

## Why

`vicoop-codex` is a distinct backend from `codex`, and it's already a valid `--backend` choice — but it never showed up in `info` because `info` dumped `BACKENDS_MANIFEST`, which only lists the two container-installable backends.

## How

`vicoop-codex` is **host-process only** — it doesn't run under `--runtime container`, so it deliberately stays out of `InstallableBackendKind` and the container-runtime creds/auth machinery (`expectedCredsPath`, `copyHostCreds`, `resolveRuntime`, …) typed against it. Folding it into `BACKENDS_MANIFEST` would have forced those switches to grow cases for a backend the container can't drive.

So the manifest is split instead:

- `BACKENDS_MANIFEST` — container-installable backends (`claude`, `codex`), unchanged; still what `container-init.ts` compat-checks against.
- `HOST_ONLY_BACKENDS` — host-only backends (`vicoop-codex`).
- `BACKEND_COMPAT` — the union, which is what `info` now reports.

`supportedRange` here is advisory metadata in `info`; the client doesn't yet hard-gate the host `vicoop-codex` CLI version. The `>=0.3.0` floor reflects that the backend drives `vicoop-codex serve` + `vicoop-codex models --json`, both in the 0.3.x line.

## Test

- `pnpm --filter @vicoop-bridge/client typecheck` ✅
- New `backends-manifest.test.ts` coverage (manifest membership, host-only disjointness, info union, non-empty ranges) ✅
- Verified `vicoop-client info` output includes `vicoop-codex` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)