### PR TITLE
fix(client): restore command-path prefix in --help usage lines

### DIFF
--- a/.changeset/wild-help-usage.md
+++ b/.changeset/wild-help-usage.md
@@ -1,0 +1,14 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Fix `--help` usage lines dropping the command-path prefix. `vicoop-client
+auth login --help` (and every other subcommand under an umbrella, e.g.
+`agent register`, `container init`, plus top-level `start` / `upgrade`)
+rendered its synopsis as `Usage: vicoop-client login …`, omitting the
+`auth`/`agent`/`container` prefix — so the new command's help pointed at
+the deprecated flat form. The umbrellas are marked `hidden: 'usage'` to
+keep them out of the top-level synopsis, but @optique 1.0.2's
+`formatUsage` also stripped those hidden command terms from each
+subcommand's own help. Patched via `patchedDependencies` so leading
+command-path terms survive; the top-level synopsis stays unchanged.

--- a/package.json
+++ b/package.json
@@ -16,13 +16,18 @@
     "changeset": "changeset"
   },
   "devDependencies": {
-    "typescript": "^5.6.3",
-    "tsx": "^4.19.2",
+    "@changesets/cli": "^2.27.10",
     "@types/node": "^22.9.0",
-    "@changesets/cli": "^2.27.10"
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
   },
   "packageManager": "pnpm@9.12.0",
   "engines": {
     "node": ">=20"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@optique/core@1.0.2": "patches/@optique__core@1.0.2.patch"
+    }
   }
 }

--- a/packages/client/src/help-usage-patch.test.ts
+++ b/packages/client/src/help-usage-patch.test.ts
@@ -1,0 +1,64 @@
+// Canary for the @optique/core patch in `patches/@optique__core@1.0.2.patch`.
+//
+// The `auth` / `agent` / `container` umbrellas (and top-level `start` etc.)
+// carry `hidden: 'usage'` so they stay OUT of the top-level `--help`
+// synopsis — the grouped sections list them instead. Upstream optique's
+// `formatUsage` strips every hidden command term unconditionally, which also
+// dropped the umbrella prefix from each subcommand's OWN help, so
+// `vicoop-client auth login --help` rendered `Usage: vicoop-client login …`
+// — pointing operators at the deprecated flat form. Our patch makes
+// `formatUsage` preserve leading command-path terms even when hidden.
+//
+// This lives in a pnpm `patchedDependencies` entry, NOT in our own source, so
+// nothing in normal code review fails if the patch is removed or stops
+// applying. If this test goes red, the patch is no longer in effect — check
+// `patches/@optique__core@1.0.2.patch` and the `pnpm.patchedDependencies`
+// block in package.json.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { command } from '@optique/core/primitives';
+import { group, longestMatch } from '@optique/core/constructs';
+import { message } from '@optique/core/message';
+import { getDocPageSync } from '@optique/core/parser';
+import { formatUsage } from '@optique/core/usage';
+import { authLoginCmd } from './login.js';
+
+// Mirror cli.ts: the real `authLogin` command sits under a `hidden: 'usage'`
+// umbrella, itself wrapped in a `group()` for the top-level help sections.
+function authUmbrellaCli() {
+  const authCmd = command('auth', longestMatch(authLoginCmd), {
+    brief: message`Manage owner-session and identity.`,
+    hidden: 'usage',
+  });
+  return longestMatch(group('Identity', authCmd));
+}
+
+function synopsis(args: string[]): string {
+  const cli = authUmbrellaCli();
+  const doc = getDocPageSync(cli, args);
+  assert.ok(doc?.usage, `getDocPageSync returned no usage for [${args.join(' ')}]`);
+  return formatUsage('vicoop-client', doc.usage, { expandCommands: true });
+}
+
+test("subcommand --help keeps the umbrella prefix in its synopsis (optique patch active)", () => {
+  const line = synopsis(['auth', 'login']);
+  // With the patch: `vicoop-client auth login …`.
+  // Without it (upstream bug): `vicoop-client login …`, omitting `auth`.
+  assert.match(
+    line,
+    /vicoop-client auth login\b/,
+    `expected the synopsis to include the full \`auth login\` invocation path, got: ${line}`,
+  );
+});
+
+test("the patch does not regress hidden: 'usage' suppression at the top level", () => {
+  // The umbrella must still be absent from the top-level synopsis — the patch
+  // only un-hides command-path terms on a command's OWN help page, not in the
+  // parent listing.
+  const line = synopsis([]);
+  assert.ok(
+    !/\bauth\b/.test(line),
+    `top-level synopsis should not list the hidden \`auth\` umbrella, got: ${line}`,
+  );
+});

--- a/patches/@optique__core@1.0.2.patch
+++ b/patches/@optique__core@1.0.2.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/usage.cjs b/dist/usage.cjs
+index 1ccca6be76ddebf844e6e02da15a8b39593f8206..a28c16ad86841e7ef59679a703a142cf411ad947 100644
+--- a/dist/usage.cjs
++++ b/dist/usage.cjs
+@@ -181,7 +181,20 @@ function extractArgumentMetavars(usage) {
+ */
+ function formatUsage(programName, usage, options = {}) {
+ 	require_validate.validateProgramName(programName);
+-	usage = normalizeUsage(filterUsageForDisplay(usage));
++	// PATCH(vicoop-bridge): preserve leading command-path terms even when they
++	// are `hidden: 'usage'`. Those terms identify the command whose help page
++	// this is (e.g. `auth login` for `vicoop-client auth login --help`), so
++	// they must stay in the synopsis. Upstream `filterUsageForDisplay` strips
++	// every hidden command unconditionally, which dropped the umbrella prefix
++	// from each subcommand's own `--help`. The top-level synopsis is unaffected
++	// because it renders via the `expandCommands` path below (which hides these
++	// commands at its own branch check), never this flat fallback.
++	let leadingCommandCount = 0;
++	while (leadingCommandCount < usage.length && usage[leadingCommandCount].type === "command") leadingCommandCount++;
++	usage = [
++		...usage.slice(0, leadingCommandCount),
++		...normalizeUsage(filterUsageForDisplay(usage.slice(leadingCommandCount)))
++	];
+ 	if (options.expandCommands) {
+ 		const lastTerm = usage.at(-1);
+ 		if (usage.length > 0 && usage.slice(0, -1).every((t) => t.type === "command") && lastTerm.type === "exclusive" && lastTerm.terms.every((t) => t.length > 0 && (t[0].type === "command" || t[0].type === "option" || t[0].type === "argument" || t[0].type === "optional" && t[0].terms.length === 1 && (t[0].terms[0].type === "command" || t[0].terms[0].type === "option" || t[0].terms[0].type === "argument")))) {
+diff --git a/dist/usage.js b/dist/usage.js
+index e55cf01234e239290dd7c036dfda091d0b375cea..830938ac06e6f5d2692ca6546b1d615d1fbcfb53 100644
+--- a/dist/usage.js
++++ b/dist/usage.js
+@@ -181,7 +181,20 @@ function extractArgumentMetavars(usage) {
+ */
+ function formatUsage(programName, usage, options = {}) {
+ 	validateProgramName(programName);
+-	usage = normalizeUsage(filterUsageForDisplay(usage));
++	// PATCH(vicoop-bridge): preserve leading command-path terms even when they
++	// are `hidden: 'usage'`. Those terms identify the command whose help page
++	// this is (e.g. `auth login` for `vicoop-client auth login --help`), so
++	// they must stay in the synopsis. Upstream `filterUsageForDisplay` strips
++	// every hidden command unconditionally, which dropped the umbrella prefix
++	// from each subcommand's own `--help`. The top-level synopsis is unaffected
++	// because it renders via the `expandCommands` path below (which hides these
++	// commands at its own branch check), never this flat fallback.
++	let leadingCommandCount = 0;
++	while (leadingCommandCount < usage.length && usage[leadingCommandCount].type === "command") leadingCommandCount++;
++	usage = [
++		...usage.slice(0, leadingCommandCount),
++		...normalizeUsage(filterUsageForDisplay(usage.slice(leadingCommandCount)))
++	];
+ 	if (options.expandCommands) {
+ 		const lastTerm = usage.at(-1);
+ 		if (usage.length > 0 && usage.slice(0, -1).every((t) => t.type === "command") && lastTerm.type === "exclusive" && lastTerm.terms.every((t) => t.length > 0 && (t[0].type === "command" || t[0].type === "option" || t[0].type === "argument" || t[0].type === "optional" && t[0].terms.length === 1 && (t[0].terms[0].type === "command" || t[0].terms[0].type === "option" || t[0].terms[0].type === "argument")))) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@optique/core@1.0.2':
+    hash: t4am5cfpokwj77r6su5ckmswma
+    path: patches/@optique__core@1.0.2.patch
+
 importers:
 
   .:
@@ -86,7 +91,7 @@ importers:
         version: 1.29.0(zod@3.25.76)
       '@optique/core':
         specifier: 1.0.2
-        version: 1.0.2
+        version: 1.0.2(patch_hash=t4am5cfpokwj77r6su5ckmswma)
       '@optique/run':
         specifier: 1.0.2
         version: 1.0.2
@@ -5452,11 +5457,11 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@optique/core@1.0.2': {}
+  '@optique/core@1.0.2(patch_hash=t4am5cfpokwj77r6su5ckmswma)': {}
 
   '@optique/run@1.0.2':
     dependencies:
-      '@optique/core': 1.0.2
+      '@optique/core': 1.0.2(patch_hash=t4am5cfpokwj77r6su5ckmswma)
 
   '@paulmillr/qr@0.2.1': {}
 


### PR DESCRIPTION
## Problem

`vicoop-client auth login --help` rendered its synopsis as:

```
Usage: vicoop-client login [--server URL] [--json] [--poll-once]
```

The `auth` prefix was dropped — so the **new** command's help told users to invoke the **deprecated** flat form (`vicoop-client login`). This affected every command marked `hidden: 'usage'`:

| Command | Before | After |
|---|---|---|
| `auth login --help` | `vicoop-client login …` | `vicoop-client auth login …` |
| `auth logout/whoami --help` | `vicoop-client logout/whoami …` | `vicoop-client auth logout/whoami …` |
| `agent register --help` | `vicoop-client register …` | `vicoop-client agent register …` |
| `container init --help` | `vicoop-client init …` | `vicoop-client container init …` |
| `start --help` | `vicoop-client [--token …]` | `vicoop-client start …` |
| `upgrade --help` | `vicoop-client [--check …]` | `vicoop-client upgrade …` |

## Root cause

The `auth`/`agent`/`container` umbrellas and top-level commands are marked `hidden: 'usage'` so they don't bloat the top-level `vicoop-client --help` synopsis (the grouped sections list them instead). But @optique `1.0.2`'s `formatUsage` → `filterUsageForDisplay` (`usage.cjs:390`) strips **every** hidden command term unconditionally — including the leading command-path terms of the very help page being rendered. One flag does two jobs and @optique can't tell them apart.

- Top-level synopsis suppression → handled by the `expandCommands` branch (`usage.cjs:191`) ✅
- Subcommand's own help usage line → broken by the flat-path filter (`usage.cjs:184`) ❌

Stable @optique is still `1.0.2` (only `1.1.0-dev.*` prereleases exist), and the `usageLine` option can't restore the prefix, so this is fixed via `patchedDependencies`.

## Fix

Patch `formatUsage` to preserve leading command-path terms even when they're `hidden: 'usage'`. The top-level synopsis is unaffected because it renders through the `expandCommands` branch (which applies its own hidden-command check), never this flat fallback.

```js
let leadingCommandCount = 0;
while (leadingCommandCount < usage.length && usage[leadingCommandCount].type === "command") leadingCommandCount++;
usage = [
  ...usage.slice(0, leadingCommandCount),
  ...normalizeUsage(filterUsageForDisplay(usage.slice(leadingCommandCount)))
];
```

## Verification

- ✅ All subcommand `--help` synopses now include the full command path
- ✅ `auth --help` / `agent --help` list subcommands with full paths (e.g. `vicoop-client agent callers list …`)
- ✅ Top-level `vicoop-client --help` synopsis unchanged (still clean)
- ✅ `pnpm -r typecheck` clean
- ✅ 656 client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)