### PR TITLE
fix(container): copy patches/ before pnpm install in bundled image

### DIFF
--- a/container/bundled/Dockerfile
+++ b/container/bundled/Dockerfile
@@ -51,6 +51,11 @@ COPY packages/protocol/package.json packages/protocol/
 COPY packages/client/package.json   packages/client/
 COPY packages/server/package.json   packages/server/
 COPY packages/admin-ui/package.json packages/admin-ui/
+# Root package.json declares `patchedDependencies` (e.g. @optique/core); pnpm
+# reads the referenced patch file during install, so the patches/ dir must be
+# present before `pnpm install` or it fails with ENOENT under
+# --frozen-lockfile (#337).
+COPY patches/ patches/
 
 # Only install deps the client build actually needs (protocol + client),
 # leaving admin-ui/server's native-compile-heavy deps (keccak / etc.) out


### PR DESCRIPTION
## Problem

`Release bundled image` fails at `pnpm install --frozen-lockfile` in `container/bundled/Dockerfile`:

```
ENOENT: no such file or directory, open '/src/patches/@optique__core@1.0.2.patch'
exit code: 254
```

The root `package.json` declares a pnpm patch:

```jsonc
"patchedDependencies": { "@optique/core@1.0.2": "patches/@optique__core@1.0.2.patch" }
```

but the build stage copied the lockfile + per-package `package.json` files and ran `pnpm install` **without** copying the `patches/` dir, so pnpm couldn't read the referenced patch.

Pre-existing — same ENOENT on the bundled-image runs for #332 and #336. The client npm/binary release is a separate workflow and was unaffected (`@vicoop-bridge/client@0.29.2` published fine).

## Fix

`COPY patches/ patches/` before the install (single build stage; the runtime stage does no install).

## Verification

Local `docker build --target build -f container/bundled/Dockerfile .` (linux, host arch) now passes the install step and completes the build stage — image written, zero ENOENT.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)