### PR TITLE
fix(client): start --detach exits immediately on the Bun-compiled binary

### DIFF
--- a/.changeset/fix-detach-bun-argv.md
+++ b/.changeset/fix-detach-bun-argv.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Fix `start --detach` exiting immediately on the released (Bun-compiled) binary. The self re-exec reconstructed the child argv with `process.argv.slice(1)`, which on a Bun single-file executable includes the embedded `/$bunfs/…` virtual entry path — the relaunched daemon then parsed it as a subcommand (`Unexpected option or subcommand: /$bunfs/…`) and died. The reconstruction now drops the embedded entry for compiled binaries while keeping the script path for node, and is covered by tests against both argv shapes. Also drops a stray issue number from the `--detach` `--help` text.

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -63,6 +63,7 @@ import { createLogger, type Logger } from './logger.js';
 import {
   claimPidFile,
   defaultLogPath,
+  detachChildArgv,
   formatUptime,
   inspectDaemon,
   pidFilePath,
@@ -146,7 +147,7 @@ const startCmd = command(
     // `--detach` / `--log-file` only steer *how* the daemon is launched, not
     // what it does once running — see `startDetached`.
     detach: withDefault(flag('--detach', {
-      description: message`Run the daemon in a detached background session (new session/process-group leader) and return immediately. Survives the session/pgrp reaping that kills \`nohup … &\` in agent-driven exec sandboxes (#186). Writes a pidfile so \`stop\` / \`status\` can manage it. POSIX only. Caveat: survives session/pgrp teardown but NOT cgroup/container teardown — for reboot/crash persistence use a real service manager (systemd --user / launchd).`,
+      description: message`Run the daemon in a detached background session (new session/process-group leader) and return immediately. Survives the session/pgrp reaping that kills \`nohup … &\` in agent-driven exec sandboxes. Writes a pidfile so \`stop\` / \`status\` can manage it. POSIX only. Caveat: survives session/pgrp teardown but NOT cgroup/container teardown — for reboot/crash persistence use a real service manager (systemd --user / launchd).`,
     }), false),
     logFile: optional(option('--log-file', string({ metavar: 'PATH' }), {
       description: message`With \`--detach\`, where to redirect the daemon's stdout+stderr. Defaults to \`vicoop.log\` under the canonical home dir. Ignored without \`--detach\`.`,
@@ -625,27 +626,6 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
   process.on('SIGTERM', onSignal);
 }
 
-// Re-exec ourselves with the daemon argv minus the launch-control flags, so
-// the child runs the foreground daemon path inside its own fresh session.
-// process.argv is `[execPath, (scriptPath?), ...args]` — `slice(1)` keeps the
-// script path for node-from-source and is empty for the Bun single-file build
-// (where execPath IS the binary), so the same reconstruction works for both.
-function buildDetachChildArgv(): string[] {
-  const out: string[] = [];
-  const rest = process.argv.slice(1);
-  for (let i = 0; i < rest.length; i++) {
-    const a = rest[i];
-    if (a === '--detach') continue;
-    if (a === '--log-file') {
-      i++; // drop the flag and its value; the child logs to the inherited fd
-      continue;
-    }
-    if (a.startsWith('--log-file=')) continue;
-    out.push(a);
-  }
-  return out;
-}
-
 // Race the spawned child's early exit against a short grace timer. A daemon
 // that dies instantly on bad config / missing credentials should surface as a
 // failed launch (with a pointer to the log) rather than a cheerful "started"
@@ -746,7 +726,7 @@ async function startDetached(
     process.exit(1);
   }
 
-  const childArgv = buildDetachChildArgv();
+  const childArgv = detachChildArgv(process.argv);
   const child = spawnProcess(process.execPath, childArgv, {
     detached: true,
     stdio: ['ignore', logFd, logFd],

--- a/packages/client/src/daemon-control.test.ts
+++ b/packages/client/src/daemon-control.test.ts
@@ -8,8 +8,10 @@ import {
   type LivenessProbe,
   type PidRecord,
   claimPidFile,
+  detachChildArgv,
   formatUptime,
   inspectDaemon,
+  isEmbeddedEntryPoint,
   processAlive,
   processIsOurs,
   processStartId,
@@ -349,6 +351,48 @@ test('claimPidFile: clears a stale pidfile and claims it', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('isEmbeddedEntryPoint detects Bun compiled-binary entry paths', () => {
+  assert.equal(isEmbeddedEntryPoint('/$bunfs/root/vicoop-client-0.30.0-macos-arm64'), true);
+  assert.equal(isEmbeddedEntryPoint('B:\\~BUN\\root\\vicoop-client'), true);
+  assert.equal(isEmbeddedEntryPoint('B:/~BUN/root/vicoop-client'), true);
+  // Real script paths are NOT embedded entries.
+  assert.equal(isEmbeddedEntryPoint('/opt/vicoop/dist/cli.js'), false);
+  assert.equal(isEmbeddedEntryPoint('/usr/local/bin/vicoop-client'), false);
+  assert.equal(isEmbeddedEntryPoint(undefined), false);
+});
+
+test('detachChildArgv reconstructs node argv (keeps the script path)', () => {
+  // node dist/cli.js start --detach --backend echo
+  const argv = ['/usr/bin/node', '/opt/vicoop/dist/cli.js', 'start', '--detach', '--backend', 'echo'];
+  assert.deepEqual(detachChildArgv(argv), [
+    '/opt/vicoop/dist/cli.js',
+    'start',
+    '--backend',
+    'echo',
+  ]);
+});
+
+test('detachChildArgv reconstructs Bun compiled argv (drops the $bunfs entry)', () => {
+  // The 0.30.0 regression: argv[1] is the embedded virtual entry, which must
+  // NOT be passed back or the relaunched CLI parses it as a subcommand.
+  const argv = [
+    '/Users/op/.vicoop/bin/vicoop-client',
+    '/$bunfs/root/vicoop-client-0.30.0-macos-arm64',
+    'start',
+    '--detach',
+    '--backend',
+    'echo',
+  ];
+  assert.deepEqual(detachChildArgv(argv), ['start', '--backend', 'echo']);
+});
+
+test('detachChildArgv strips --log-file and its value (both forms)', () => {
+  const spaced = ['node', 'cli.js', 'start', '--log-file', '/tmp/x.log', '--detach', '--backend', 'echo'];
+  assert.deepEqual(detachChildArgv(spaced), ['cli.js', 'start', '--backend', 'echo']);
+  const eq = ['node', 'cli.js', 'start', '--log-file=/tmp/x.log', '--backend', 'echo', '--detach'];
+  assert.deepEqual(detachChildArgv(eq), ['cli.js', 'start', '--backend', 'echo']);
 });
 
 test('formatUptime renders compact durations', () => {

--- a/packages/client/src/daemon-control.ts
+++ b/packages/client/src/daemon-control.ts
@@ -370,6 +370,54 @@ export async function stopDaemon(
   return { outcome: 'killed', pid };
 }
 
+// True when argv[1] is a runtime-supplied *virtual* entry point rather than a
+// real script path — i.e. we're a Bun single-file compiled binary, whose entry
+// lives in the embedded filesystem (`/$bunfs/...` on POSIX, `B:\~BUN\...` on
+// Windows).
+export function isEmbeddedEntryPoint(entry: string | undefined): boolean {
+  return (
+    typeof entry === 'string' &&
+    (entry.startsWith('/$bunfs/') ||
+      entry.includes('/~BUN/') ||
+      /^[A-Za-z]:[\\/]~BUN[\\/]/.test(entry))
+  );
+}
+
+// Reconstruct the argv to re-exec (via `process.execPath`) for `start
+// --detach`, dropping the launch-control flags so the child runs the plain
+// foreground daemon. The reconstruction has to account for how argv differs by
+// runtime — getting this wrong was the 0.30.0 `--detach` regression:
+//
+//   - node (dev/source):   argv = [node, <cli.js>, ...userArgs]. execPath is
+//     node, so the child needs the script path AND the user args.
+//   - Bun compiled binary: argv = [<self-binary>, '/$bunfs/root/<entry>',
+//     ...userArgs]. execPath is the self-binary, which runs its OWN embedded
+//     entry — passing the '/$bunfs' path back makes the relaunched CLI parse it
+//     as a subcommand ("Unexpected option or subcommand: /$bunfs/...") and die.
+//
+// In every runtime the user args are argv.slice(2) (argv[1] is the real or
+// virtual entry). We re-prepend the entry path ONLY when it's a real script the
+// runtime needs, never the embedded virtual path of a compiled binary.
+export function detachChildArgv(argv: string[]): string[] {
+  const entry = argv[1];
+  const head =
+    isEmbeddedEntryPoint(entry) || typeof entry !== 'string' ? [] : [entry];
+  const userArgs = argv.slice(2);
+
+  const out: string[] = [...head];
+  for (let i = 0; i < userArgs.length; i++) {
+    const a = userArgs[i];
+    if (a === '--detach') continue;
+    if (a === '--log-file') {
+      i++; // drop the flag and its value; the child logs to the inherited fd
+      continue;
+    }
+    if (a.startsWith('--log-file=')) continue;
+    out.push(a);
+  }
+  return out;
+}
+
 // Human-friendly "up 2h 3m 4s" for `status`. Always ends with a seconds
 // component so a sub-minute uptime still reads as a duration. Guards
 // non-finite / negative inputs (e.g. an absent or future `startedAt`).


### PR DESCRIPTION
## The bug (regression in 0.30.0)

`vicoop-client start --detach` on the **released Bun-compiled binary** exits immediately; the log shows only the usage dump and:

```
Error: Unexpected option or subcommand: `/$bunfs/root/vicoop-client-0.30.0-macos-arm64`.
```

### Root cause

`start --detach` re-execs `process.execPath` to relaunch the daemon, building the child argv with `process.argv.slice(1)`. That assumption only holds for node:

| runtime | `process.argv` | correct child argv |
|---|---|---|
| node (dev) | `[node, <cli.js>, ...userArgs]` | `[<cli.js>, ...userArgs]` |
| **Bun compiled** | `[<self-binary>, '/$bunfs/root/<entry>', ...userArgs]` | `[...userArgs]` |

On the Bun single-file binary, `execPath` is the self-binary (which runs its **own** embedded entry), so `argv[1]` is the `/$bunfs/…` virtual path. `slice(1)` passed that path back as a child arg, and the relaunched CLI parsed it as a subcommand → immediate exit.

The earlier smoke tests only ran `node dist/cli.js`, where `slice(1)` is correct — so the regression shipped in 0.30.0.

## The fix

Reconstruct argv runtime-aware: user args are `argv.slice(2)` in every runtime; re-prepend the entry path **only** when it's a real script (node / `bun run`), never the embedded virtual path of a compiled binary (`/$bunfs/…` POSIX, `B:\~BUN\…` Windows).

The logic moved to `daemon-control.ts` (`detachChildArgv` / `isEmbeddedEntryPoint`) so it's unit-testable (cli.ts runs `main()` on import).

## Verification

- **Compiled a real `bun build --compile` binary** and ran the full lifecycle: `start --detach` → `status` (running) → `stop`, pidfile argv free of any `/$bunfs` path. ✅ (this is what was missing before)
- +4 unit tests covering node argv, Bun-compiled argv, and `--log-file` stripping.
- Full client suite green (**692 passing**); typecheck clean.

Also drops a stray `#186` from the `--detach` `--help` text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
