### PR TITLE
feat(client): -c/-d short aliases for --config/--detach

### DIFF
--- a/.changeset/short-flags-config-detach.md
+++ b/.changeset/short-flags-config-detach.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Add short aliases for the two most-typed daemon flags: `-c` for `--config` and `-d` for `--detach` (e.g. `vicoop-client start -d -c ./config.json`). The detached child is now kept in the foreground daemon path by the `VICOOP_DETACHED` env guard rather than by argv stripping, so the re-exec stays correct even for optique's bundled short flags (`-dc value` parses as `-d -c value`).

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -63,7 +63,7 @@ export const daemonFlagsFields = {
   card: optional(option('--card', string({ metavar: 'PATH' }), {
     description: message`Agent card JSON override (defaults to the server-published card for the chosen backend).`,
   })),
-  config: optional(option('--config', string({ metavar: 'PATH' }), {
+  config: optional(option('--config', '-c', string({ metavar: 'PATH' }), {
     description: message`Explicit config.json overlaid on the canonical file.`,
   })),
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -146,7 +146,7 @@ const startCmd = command(
     // the runtime-config surface threaded into the backend) because
     // `--detach` / `--log-file` only steer *how* the daemon is launched, not
     // what it does once running — see `startDetached`.
-    detach: withDefault(flag('--detach', {
+    detach: withDefault(flag('--detach', '-d', {
       description: message`Run the daemon in a detached background session (new session/process-group leader) and return immediately. Survives the session/pgrp reaping that kills \`nohup … &\` in agent-driven exec sandboxes. Writes a pidfile so \`stop\` / \`status\` can manage it. POSIX only. Caveat: survives session/pgrp teardown but NOT cgroup/container teardown — for reboot/crash persistence use a real service manager (systemd --user / launchd).`,
     }), false),
     logFile: optional(option('--log-file', string({ metavar: 'PATH' }), {
@@ -972,11 +972,18 @@ async function main(): Promise<void> {
       process.exit(await runContainerRemoveCli(parsed));
       break;
     case 'daemon':
-      // `--detach` re-execs a backgrounded copy and exits the foreground
-      // process; the plain path runs the long-lived daemon in place. Both
-      // are awaited so launch errors surface through main's catch instead
-      // of as unhandled rejections.
-      if (parsed.detach) {
+      // `--detach`/`-d` re-execs a backgrounded copy and exits the foreground
+      // process; the plain path runs the long-lived daemon in place. Both are
+      // awaited so launch errors surface through main's catch instead of as
+      // unhandled rejections.
+      //
+      // The detached child is spawned with VICOOP_DETACHED=1, and we suppress
+      // re-detach when it's set: that, not argv stripping, is what guarantees
+      // the child runs the daemon rather than detaching again. It makes the
+      // re-exec robust against detach flags that survive reconstruction —
+      // notably optique's bundled short flags (`-dc value` parses as
+      // `-d -c value`), which a token-level strip can't reliably remove.
+      if (parsed.detach && process.env.VICOOP_DETACHED !== '1') {
         await startDetached(parsed);
       } else {
         // Long-running. Do not exit — client.start() keeps the event loop

--- a/packages/client/src/daemon-control.test.ts
+++ b/packages/client/src/daemon-control.test.ts
@@ -388,6 +388,13 @@ test('detachChildArgv reconstructs Bun compiled argv (drops the $bunfs entry)', 
   assert.deepEqual(detachChildArgv(argv), ['start', '--backend', 'echo']);
 });
 
+test('detachChildArgv strips the short -d detach flag too', () => {
+  const argv = ['/usr/bin/node', '/opt/vicoop/dist/cli.js', 'start', '-d', '-c', '/tmp/cfg.json'];
+  // `-c` (config) is preserved — the child needs it; only the detach trigger
+  // is dropped.
+  assert.deepEqual(detachChildArgv(argv), ['/opt/vicoop/dist/cli.js', 'start', '-c', '/tmp/cfg.json']);
+});
+
 test('detachChildArgv strips --log-file and its value (both forms)', () => {
   const spaced = ['node', 'cli.js', 'start', '--log-file', '/tmp/x.log', '--detach', '--backend', 'echo'];
   assert.deepEqual(detachChildArgv(spaced), ['cli.js', 'start', '--backend', 'echo']);

--- a/packages/client/src/daemon-control.ts
+++ b/packages/client/src/daemon-control.ts
@@ -398,6 +398,12 @@ export function isEmbeddedEntryPoint(entry: string | undefined): boolean {
 // In every runtime the user args are argv.slice(2) (argv[1] is the real or
 // virtual entry). We re-prepend the entry path ONLY when it's a real script the
 // runtime needs, never the embedded virtual path of a compiled binary.
+//
+// Stripping the launch-control flags here is cosmetic — it keeps the child's
+// process command line and the recorded pidfile argv clean. Correctness (the
+// child must NOT re-detach) is guaranteed by the VICOOP_DETACHED env guard in
+// the dispatch, not by this strip, so a detach flag that slips through (e.g.
+// an optique bundled short flag like `-dc`) is harmless.
 export function detachChildArgv(argv: string[]): string[] {
   const entry = argv[1];
   const head =
@@ -407,7 +413,7 @@ export function detachChildArgv(argv: string[]): string[] {
   const out: string[] = [...head];
   for (let i = 0; i < userArgs.length; i++) {
     const a = userArgs[i];
-    if (a === '--detach') continue;
+    if (a === '--detach' || a === '-d') continue;
     if (a === '--log-file') {
       i++; // drop the flag and its value; the child logs to the inherited fd
       continue;


### PR DESCRIPTION
## What

Short aliases for the two daemon flags operators type most:

```sh
vicoop-client start -d -c ./config.json     # = start --detach --config ./config.json
```

- `-c` → `--config`
- `-d` → `--detach`

optique's `option()`/`flag()` accept multiple names, so the shorts sit alongside the long forms. `-h`/`-v` (help/version) were the only existing short flags, so no collision (`bash -c` in container-init is a shell arg, not an optique option).

## A subtlety adding `-d` surfaced

optique supports **bundled short flags** — `start -dc value` parses as `-d -c value`. The `--detach` re-exec reconstructs the child argv by token-stripping the launch-control flags, which can't reliably remove a bundled `-d`. A surviving detach flag would make the re-execed child detach *again* and exit "already running".

Fixed by making correctness independent of argv stripping: the detached child already carries `VICOOP_DETACHED=1`, so the dispatch now suppresses re-detach when that env is set — the child runs the daemon regardless of any detach flag in its argv. The argv strip (now also dropping standalone `-d`) is kept purely cosmetic (clean child command line / pidfile argv).

## Verification

Compiled an actual `bun build --compile` binary and brought the daemon up via:
- `start -d` (separate) ✅
- `start -d -c <cfg>` ✅
- bundled `start -dc <cfg>` ✅

`--help` now renders `--detach, -d` and `--config, -c`. Full client suite green (**693 passing**); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
