### PR TITLE
feat(client): multi-model support on the claude backend via --claude-supported-models

### DIFF
--- a/.changeset/itchy-pandas-repeat.md
+++ b/.changeset/itchy-pandas-repeat.md
@@ -1,0 +1,18 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+feat(client): multi-model support on the claude backend via `--claude-models`
+
+Claude Code has no headless "list models" interface, so the claude backend
+used to advertise — and accept per-request openai-compat `model` overrides
+for — only a single model (the `--claude-model` pin or the startup-probed
+default). Operators can now declare additional models their install can
+serve with `--claude-models claude-sonnet-4-6,claude-haiku-4-5`
+(comma-separated) or `backends.claude.models` in `config.json`. Declared ids
+are advertised on the openai-compat `params.models[]` block after the
+default, and a matching per-request `model` rides to the spawned `claude` as
+`--model <id>`. The `envelope.model` gate now also matches on the normalized
+(tier-suffix-stripped) form, so a caller selecting e.g.
+`claude-opus-4-8[1m]` against an advertised `claude-opus-4-8` passes through
+with the tier selection intact.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -660,13 +660,14 @@ different repository than the one `vicoop-client` itself runs in:
 vicoop-client start \
   --backend claude \
   --cwd "$HOME/vicoop-bridge" \
-  --claude-model claude-opus-4-8
+  --claude-model claude-opus-4-8 \
+  --claude-models claude-sonnet-4-6,claude-haiku-4-5
 ```
 
 These knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
-(`cwd`, `settings`, `model`) so the foreground command shrinks to just
-`vicoop-client start`; the flag wins over config, mirroring
+(`cwd`, `settings`, `model`, `models`) so the foreground command shrinks to
+just `vicoop-client start`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
 | Flag | `backends.claude.*` |
@@ -674,6 +675,7 @@ the daemon-level precedence (Step 6 intro).
 | `--cwd` | `cwd` |
 | `--claude-settings-file` | `settings` (JSON object) |
 | `--claude-model` | `model` |
+| `--claude-models` | `models` (string array) |
 
 > **Picking a model.** `--claude-model <id>` (e.g. `claude-opus-4-8`) is
 > folded into Claude `--settings` as its `model` field, so it composes with
@@ -682,6 +684,20 @@ the daemon-level precedence (Step 6 intro).
 > (project / user `settings.json`, `ANTHROPIC_MODEL`, built-in default). A
 > per-request openai-compat `model` still overrides it. The flag is
 > claude-only — pairing it with another `--backend` exits non-zero.
+
+> **Serving more than one model.** Claude Code has no headless "list
+> models" interface, so by default the bridge advertises (and accepts
+> per-request `model` overrides for) only the single default model —
+> the `--claude-model` pin or the startup-probed id. To open up more,
+> declare them: `--claude-models claude-sonnet-4-6,claude-haiku-4-5`
+> (comma-separated) or `backends.claude.models` in `config.json`. Declared
+> ids are advertised on the agent card's openai-compat `params.models[]`
+> after the default, and a per-request openai-compat `model` matching one
+> rides to the spawned `claude` as `--model <id>`. The list is **not
+> validated against your account** — a declared model your plan can't
+> access fails at task time with Claude's own `model_not_found` error, so
+> only declare models you've confirmed work in your local `claude`. The
+> flag is claude-only, same as `--claude-model`.
 
 > **Sandbox-on by default.** When neither `--claude-settings-file` nor
 > `backends.claude.settings` is set, the backend forwards

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2658,6 +2658,207 @@ test('envelope.model differing from the --claude-model pin falls back to the pin
   assert.equal(JSON.parse(String(args[settingsIdx + 1])).model, 'claude-opus-4-8');
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Multi-model declarations (`models` option / --claude-models). Claude Code
+// has no headless model listing, so extra models are operator-declared:
+// advertised after the default and accepted by the envelope.model gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test('declared models are advertised after the probed default', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-8',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [
+      { id: 'claude-opus-4-8', default: true },
+      { id: 'claude-sonnet-4-6' },
+      { id: 'claude-haiku-4-5' },
+    ],
+  });
+});
+
+test('declared models are advertised after a --claude-model pin without probing', async () => {
+  let spawned = 0;
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const countingSpawn: typeof fake.spawn = (cmd, a, o) => {
+    spawned += 1;
+    return fake.spawn(cmd, a, o);
+  };
+  const backend = createClaudeBackend({
+    spawn: countingSpawn,
+    model: 'claude-opus-4-8',
+    models: ['claude-sonnet-4-6'],
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [
+      { id: 'claude-opus-4-8', default: true },
+      { id: 'claude-sonnet-4-6' },
+    ],
+  });
+  assert.equal(spawned, 0, 'pinned model must not trigger a probe spawn');
+});
+
+test('declared models deduplicate against the pin and the probed default on the normalized form', async () => {
+  // Pin path: a declared entry that normalizes to the pin must not produce
+  // a second advertise entry (the operator wrote the same canonical model
+  // twice, once with a tier suffix).
+  const fakePin = scriptedSpawn({ lines: [], exitCode: 0 });
+  const pinned = createClaudeBackend({
+    spawn: fakePin.spawn,
+    model: 'claude-opus-4-8',
+    models: ['claude-opus-4-8[1m]', 'claude-sonnet-4-6', 'claude-sonnet-4-6'],
+  });
+  assert.deepEqual(await pinned.resolveCapabilities!(), {
+    openaiCompatModels: [
+      { id: 'claude-opus-4-8', default: true },
+      { id: 'claude-sonnet-4-6' },
+    ],
+  });
+
+  // Probe path: the probed default may collide with a declared entry too —
+  // construction-time dedupe can't see it, so resolveCapabilities drops it.
+  const fakeProbe = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-8',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const probed = createClaudeBackend({
+    spawn: fakeProbe.spawn,
+    models: ['claude-opus-4-8', 'claude-haiku-4-5'],
+  });
+  assert.deepEqual(await probed.resolveCapabilities!(), {
+    openaiCompatModels: [
+      { id: 'claude-opus-4-8', default: true },
+      { id: 'claude-haiku-4-5' },
+    ],
+  });
+});
+
+test('envelope.model matching a declared model rides through as --model', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    model: 'claude-opus-4-8',
+    models: ['claude-sonnet-4-6'],
+  });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-sonnet-4-6' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  const modelIdx = args.indexOf('--model');
+  assert.notEqual(modelIdx, -1, '--model present for a declared model');
+  assert.equal(args[modelIdx + 1], 'claude-sonnet-4-6');
+});
+
+test('envelope.model outside the declared set is still dropped', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    model: 'claude-opus-4-8',
+    models: ['claude-sonnet-4-6'],
+  });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', {
+      model: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
+    }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  assert.equal(args.indexOf('--model'), -1, 'undeclared envelope.model must be dropped');
+});
+
+test('envelope.model gate matches on the normalized form but forwards the raw value', async () => {
+  // A caller selecting the 1M tier of an advertised model
+  // (`claude-opus-4-8[1m]` vs advertised `claude-opus-4-8`) must pass the
+  // gate AND keep the tier suffix on the spawned argv — the suffix is how
+  // Claude Code picks the context tier.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, model: 'claude-opus-4-8' });
+  await backend.resolveCapabilities?.();
+  const { emit } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('hi', { model: 'claude-opus-4-8[1m]' }),
+    emit,
+    NEVER,
+  );
+  const args = fake.lastChild()?.args ?? [];
+  const modelIdx = args.indexOf('--model');
+  assert.notEqual(modelIdx, -1, 'tier-suffixed request for an advertised model must pass');
+  assert.equal(args[modelIdx + 1], 'claude-opus-4-8[1m]', 'raw tiered id rides to the spawn');
+});
+
+test('probeTimeoutMs:0 with declared models advertises them without a default entry', async () => {
+  let spawned = 0;
+  const fake = scriptedSpawn({ lines: [], exitCode: 0 });
+  const countingSpawn: typeof fake.spawn = (cmd, a, o) => {
+    spawned += 1;
+    return fake.spawn(cmd, a, o);
+  };
+  const backend = createClaudeBackend({
+    spawn: countingSpawn,
+    probeTimeoutMs: 0,
+    models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+  });
+  const caps = await backend.resolveCapabilities!();
+  assert.deepEqual(caps, {
+    openaiCompatModels: [{ id: 'claude-sonnet-4-6' }, { id: 'claude-haiku-4-5' }],
+  });
+  assert.equal(spawned, 0, 'probeTimeoutMs:0 must skip the probe spawn');
+});
+
 test('spawn argv carries --system-prompt with the native directive when metadata is present', async () => {
   const fake = scriptedSpawn({
     lines: [

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   OPENAI_COMPAT_EXTENSION_URI,
   TRACEABILITY_EXTENSION_URI,
+  type OpenAICompatModelAdvertise,
   type Part,
 } from '@vicoop-bridge/protocol';
 import type { Backend } from '../backend.js';
@@ -150,6 +151,20 @@ export interface ClaudeBackendOptions {
   // model falls back to claude's own resolution (project/user settings.json,
   // ANTHROPIC_MODEL, built-in default).
   model?: string;
+  // Additional model ids this claude install can serve (e.g.
+  // ['claude-sonnet-4-6', 'claude-haiku-4-5']), exposed via the
+  // `--claude-models` flag. Claude Code has no headless "list models"
+  // interface — the startup probe only reveals the single resolved default
+  // (`system/init.model` echoes whatever `--model` was passed, verbatim,
+  // without validating account access) — so multi-model support is
+  // operator-declared: entries are advertised on the openai-compat/v1
+  // `params.models[]` block after the default (the `--claude-model` pin or
+  // the probed model) and accepted by the `envelope.model` gate, riding to
+  // the spawn as `--model <id>`. The list is NOT validated against the
+  // account: a declared model the account cannot access fails at task time
+  // with claude's own `model_not_found` error, which is the operator's
+  // signal to fix the declaration.
+  models?: readonly string[];
   /**
    * Test seam: invoked once per task with the caller-tools MCP server
    * handle immediately after the bridge stands one up (when the
@@ -167,9 +182,10 @@ export interface ClaudeBackendOptions {
   // user/project settings.json, including its `model` field, which would
   // make the probed model diverge from the model the real task spawn
   // actually loads). Set to 0 to disable the probe entirely — the daemon
-  // will simply not advertise `params.models` in its hello card, which
-  // is harmless (the spec is advisory) but blinds clients that want to
-  // route by declared model.
+  // then advertises only the operator-declared `models` (if any) without a
+  // default entry, or no `params.models` at all, which is harmless (the
+  // spec is advisory) but blinds clients that want to route by declared
+  // model.
   probeTimeoutMs?: number;
   // When true, dump A2A `parts` shape + metadata keys + raw
   // `chat_history` to stderr on every task. Operator diagnostic exposed
@@ -1193,27 +1209,53 @@ export function createClaudeBackend(
 
   const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
 
-  // Probed-model cache, populated by `resolveCapabilities` at daemon
+  // Operator-declared additional models (`opts.models`), deduped on the
+  // normalized form — against each other and against the `--claude-model`
+  // pin — so the advertise never carries the same canonical id twice.
+  // Original (un-normalized) spellings are preserved for the advertise so an
+  // operator declaring `claude-opus-4-8[1m]` advertises the tiered form they
+  // asked for; normalization is applied only where ids are compared.
+  const declaredModels: string[] = [];
+  {
+    const seen = new Set<string>();
+    if (opts.model) seen.add(normalizeClaudeModelId(opts.model));
+    for (const raw of opts.models ?? []) {
+      const id = raw.trim();
+      if (!id) continue;
+      const norm = normalizeClaudeModelId(id);
+      if (!norm || seen.has(norm)) continue;
+      seen.add(norm);
+      declaredModels.push(id);
+    }
+  }
+
+  // Advertised-model cache, populated by `resolveCapabilities` at daemon
   // startup and read sync from `handle()` to gate `envelope.model`
-  // forwarding (#302). `undefined` = "never probed", `null` = "probed but
-  // unavailable", string = "this is the only model id this claude install
-  // advertises". `handle()` deliberately does NOT trigger the probe on a
-  // miss — the probe spawns its own short-lived child, and the daemon
-  // already calls `resolveCapabilities` once at startup, so the cache is
-  // populated before any task lands in production. Tests that want to
-  // exercise the gate populate the cache via `resolveCapabilities`
-  // explicitly.
+  // forwarding (#302). Ids are stored normalized (tier suffix stripped) so
+  // the gate's membership check is canonical-form on both sides.
+  // `undefined` = "never probed", `null` = "probed but unavailable",
+  // Set = "these are the model ids this claude install advertises".
+  // `handle()` deliberately does NOT trigger the probe on a miss — the
+  // probe spawns its own short-lived child, and the daemon already calls
+  // `resolveCapabilities` once at startup, so the cache is populated before
+  // any task lands in production. Tests that want to exercise the gate
+  // populate the cache via `resolveCapabilities` explicitly.
   //
-  // A `--claude-model` pin seeds the cache directly: the pin IS the
-  // advertised model (every spawn loads it via settings.model), so it must
-  // be what the `envelope.model` gate compares against. Without this seed
-  // the probe — which deliberately runs WITHOUT our `--settings` (see
-  // `CLAUDE_PROBE_ARGS`) — would report claude's *unpinned* default, the
-  // gateway would route by that default, and the matching `--model <default>`
-  // argv would then override the pin on the spawn (CLI `--model` beats
-  // settings.model). Seeding here holds the pin even if `resolveCapabilities`
-  // never runs.
-  let cachedProbedModel: string | null | undefined = opts.model ?? undefined;
+  // A `--claude-model` pin (and any `--claude-models` declarations) seeds
+  // the cache directly: the pin IS the advertised default (every spawn
+  // loads it via settings.model), so it must be what the `envelope.model`
+  // gate compares against. Without this seed the probe — which deliberately
+  // runs WITHOUT our `--settings` (see `CLAUDE_PROBE_ARGS`) — would report
+  // claude's *unpinned* default, the gateway would route by that default,
+  // and the matching `--model <default>` argv would then override the pin
+  // on the spawn (CLI `--model` beats settings.model). Seeding here holds
+  // the pin even if `resolveCapabilities` never runs.
+  const seededModelIds = [
+    ...(opts.model ? [opts.model] : []),
+    ...declaredModels,
+  ].map(normalizeClaudeModelId);
+  let cachedAllowedModels: Set<string> | null | undefined =
+    seededModelIds.length > 0 ? new Set(seededModelIds) : undefined;
 
   return {
     name: 'claude',
@@ -1234,14 +1276,28 @@ export function createClaudeBackend(
     async resolveCapabilities() {
       // A pinned model is authoritative — there's nothing to discover, so
       // skip the probe spawn entirely (it can't see our `--settings` anyway)
-      // and advertise the pin, which the construction-time seed already put
-      // in `cachedProbedModel`.
+      // and advertise the pin (plus any operator-declared extra models),
+      // which the construction-time seed already put in
+      // `cachedAllowedModels`.
       if (opts.model) {
-        return { openaiCompatModels: [{ id: opts.model, default: true }] };
+        return {
+          openaiCompatModels: [
+            { id: opts.model, default: true },
+            ...declaredModels.map((id) => ({ id })),
+          ],
+        };
       }
       if (probeTimeoutMs <= 0) {
-        cachedProbedModel = null;
-        return {};
+        // No probe means no discovered default; operator-declared models
+        // (if any) are still advertised — without a `default: true` entry,
+        // which the spec allows (`default` is optional).
+        cachedAllowedModels =
+          declaredModels.length > 0
+            ? new Set(declaredModels.map(normalizeClaudeModelId))
+            : null;
+        return declaredModels.length > 0
+          ? { openaiCompatModels: declaredModels.map((id) => ({ id })) }
+          : {};
       }
       const model = await probeClaudeModel({
         command,
@@ -1249,11 +1305,22 @@ export function createClaudeBackend(
         cwd,
         timeoutMs: probeTimeoutMs,
       });
-      cachedProbedModel = model;
-      if (!model) return {};
-      return {
-        openaiCompatModels: [{ id: model, default: true }],
-      };
+      // The probed default may collide with a declared extra (the
+      // construction-time dedupe can only see the pin); drop the duplicate
+      // declaration so the advertise stays one-entry-per-canonical-id.
+      const extras = declaredModels.filter(
+        (id) => model === null || normalizeClaudeModelId(id) !== model,
+      );
+      const allowed = new Set([
+        ...(model ? [model] : []),
+        ...extras.map(normalizeClaudeModelId),
+      ]);
+      cachedAllowedModels = allowed.size > 0 ? allowed : null;
+      const entries: OpenAICompatModelAdvertise[] = [
+        ...(model ? [{ id: model, default: true }] : []),
+        ...extras.map((id) => ({ id })),
+      ];
+      return entries.length > 0 ? { openaiCompatModels: entries } : {};
     },
 
     async handle(task, rawEmit, signal) {
@@ -1329,21 +1396,27 @@ export function createClaudeBackend(
         envelope && typeof envelope.model === 'string' && envelope.model.length > 0
           ? envelope.model
           : undefined;
-      // Validate against the probed model id (cached by `resolveCapabilities`).
-      // When the gateway sends a value claude doesn't advertise — e.g. an
-      // unresolved routing key like `a2a/<card-url>` — drop the override so
-      // claude falls back to its own default rather than failing the turn
-      // (#302). When the cache is unpopulated (probeTimeoutMs ≤ 0, probe
-      // failed, or `resolveCapabilities` hasn't been called yet) the
-      // validation is skipped and `envelope.model` rides through unchanged.
+      // Validate against the advertised model ids (cached by
+      // `resolveCapabilities` from the probe, the `--claude-model` pin, and
+      // any `--claude-models` declarations). When the gateway sends a value
+      // claude doesn't advertise — e.g. an unresolved routing key like
+      // `a2a/<card-url>` — drop the override so claude falls back to its own
+      // default rather than failing the turn (#302). Membership is checked
+      // on the normalized (tier-suffix-stripped) form so a caller requesting
+      // `claude-opus-4-8[1m]` matches an advertised `claude-opus-4-8`; the
+      // raw inbound value still rides to the spawn so the tier selection
+      // survives. When the cache is unpopulated (probeTimeoutMs ≤ 0 with no
+      // declared models, probe failed, or `resolveCapabilities` hasn't been
+      // called yet) the validation is skipped and `envelope.model` rides
+      // through unchanged.
       let envelopeModel: string | undefined = envelopeModelRaw;
       if (
         envelopeModelRaw !== undefined &&
-        typeof cachedProbedModel === 'string' &&
-        envelopeModelRaw !== cachedProbedModel
+        cachedAllowedModels instanceof Set &&
+        !cachedAllowedModels.has(normalizeClaudeModelId(envelopeModelRaw))
       ) {
         timingLogger.warn?.(
-          `[claude] envelope.model=${JSON.stringify(envelopeModelRaw)} does not match this claude install's advertised model (${JSON.stringify(cachedProbedModel)}); falling back to claude default`,
+          `[claude] envelope.model=${JSON.stringify(envelopeModelRaw)} is not among this claude install's advertised models (${JSON.stringify([...cachedAllowedModels])}); falling back to claude default`,
         );
         envelopeModel = undefined;
       }

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -195,6 +195,54 @@ test('--claude-model with a non-claude backend is a hard error', () => {
   );
 });
 
+test('--claude-models splits the comma-separated flag into a trimmed list', () => {
+  const r = mergeClientArgs(
+    {
+      token: 't',
+      agentId: 'a',
+      backend: 'claude',
+      claudeModels: ' claude-sonnet-4-6 , claude-haiku-4-5 ,',
+    },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.deepEqual(r.args.claudeModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
+});
+
+test('--claude-models flag beats backends.claude.models from config', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', claudeModels: 'claude-haiku-4-5' },
+    { backends: { claude: { models: ['claude-sonnet-4-6'] } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.deepEqual(r.args.claudeModels, ['claude-haiku-4-5']);
+});
+
+test('backends.claude.models fills in when the flag is absent', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude' },
+    { backends: { claude: { models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.deepEqual(r.args.claudeModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
+});
+
+test('--claude-models with a non-claude backend is a hard error', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'codex', claudeModels: 'claude-haiku-4-5' },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--claude-models') && e.includes('codex')),
+    `expected error mentioning --claude-models and codex, got: ${r.errors.join(' | ')}`,
+  );
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -90,6 +90,9 @@ export const daemonFlagsFields = {
   claudeModel: optional(option('--claude-model', string({ metavar: 'MODEL' }), {
     description: message`Model id for the spawned Claude, e.g. \`claude-opus-4-8\`. Sets the \`model\` field in Claude \`--settings\`; a per-request openai-compat \`model\` still overrides it. Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
   })),
+  claudeModels: optional(option('--claude-models', string({ metavar: 'MODELS' }), {
+    description: message`Comma-separated additional model ids this Claude install can serve, e.g. \`claude-sonnet-4-6,claude-haiku-4-5\`. Advertised alongside the default model and accepted as per-request openai-compat \`model\` overrides (Claude has no headless model listing, so the set is operator-declared and not validated against the account). Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
+  })),
 
   // Backend-specific (Codex)
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
@@ -145,6 +148,7 @@ export interface DaemonArgs {
   runtimeName?: string;
   claudeSettingsFile?: string;
   claudeModel?: string;
+  claudeModels?: string[];
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
   openclawGatewayToken?: string;
@@ -180,6 +184,18 @@ export function parseFlags(argv: string[]): ParseFlagsResult {
 //      connect" mystery.
 function pick(v: string | undefined): string {
   return v?.trim() ?? '';
+}
+
+// Comma-separated model list (--claude-models). Trim entries, drop empties;
+// undefined when nothing usable remains so the merge's `??` fallback to the
+// config layer fires on a blank/whitespace-only flag, matching `pick()`'s
+// empty-means-unset convention.
+function pickModelsList(v: string | undefined): string[] | undefined {
+  const entries = (v ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  return entries.length > 0 ? entries : undefined;
 }
 
 function pickSandbox(v: string | undefined): CodexSandboxMode | undefined {
@@ -255,6 +271,9 @@ export function mergeClientArgs(
     runtimeName: pick(flags.runtimeName) || activeRuntimeName || undefined,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
     claudeModel: pick(flags.claudeModel) || backends.claude?.model || undefined,
+    claudeModels:
+      pickModelsList(flags.claudeModels) ??
+      (backends.claude?.models?.length ? backends.claude.models : undefined),
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     openclawGateway:
@@ -315,6 +334,11 @@ export function mergeClientArgs(
   if (pick(flags.claudeModel) && backend !== 'claude') {
     errors.push(
       `--claude-model is not supported by --backend ${backend}; only the claude backend takes a model id`,
+    );
+  }
+  if (pick(flags.claudeModels) && backend !== 'claude') {
+    errors.push(
+      `--claude-models is not supported by --backend ${backend}; only the claude backend takes model ids`,
     );
   }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -399,6 +399,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         settings,
         model: args.claudeModel,
+        models: args.claudeModels,
         openaiCompatTrace: args.openaiCompatTrace,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -168,6 +168,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
         cwd: '/srv/work',
         settings: { sandbox: { enabled: true } },
         model: 'claude-opus-4-8',
+        models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
       },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
@@ -190,6 +191,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
         cwd: '/srv/work',
         settings: { sandbox: { enabled: true } },
         model: 'claude-opus-4-8',
+        models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
       },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
@@ -393,6 +395,40 @@ test('readConfig drops malformed fields and keeps the rest', (t) => {
     backend: 'claude',
     backends: { openclaw: { gateway_url: 'ws://x' } },
   });
+});
+
+test('normalizeConfig keeps usable backends.claude.models entries and drops the rest', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-models-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      backends: {
+        claude: {
+          // non-string / empty entries dropped, strings trimmed
+          models: [' claude-sonnet-4-6 ', 42, '', null, 'claude-haiku-4-5'],
+        },
+        codex: {
+          cwd: '/srv/work',
+        },
+      },
+    }),
+  );
+  assert.deepEqual(readConfig(path), {
+    backends: {
+      claude: { models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] },
+      codex: { cwd: '/srv/work' },
+    },
+  });
+
+  // A models value of the wrong type (or with no usable entry) drops the
+  // field — and with it the whole claude slot when nothing else is set.
+  writeFileSync(
+    path,
+    JSON.stringify({ backends: { claude: { models: 'claude-haiku-4-5' } } }),
+  );
+  assert.deepEqual(readConfig(path), {});
 });
 
 test('readConfig returns null on completely malformed JSON', (t) => {

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -116,6 +116,16 @@ export interface ClaudeBackendConfig {
    * flag.
    */
   model?: string;
+  /**
+   * Additional model ids this claude install can serve alongside `model` /
+   * the probed default, e.g. `["claude-sonnet-4-6", "claude-haiku-4-5"]`.
+   * Advertised on the openai-compat `params.models[]` block and accepted as
+   * per-request openai-compat `model` overrides (forwarded to the spawn as
+   * `--model <id>`). Not validated against the account — a model the
+   * account cannot access fails at task time with claude's own
+   * `model_not_found`. Mirrors the `--claude-models` flag.
+   */
+  models?: string[];
   runtime?: BackendRuntime;
   runtime_name?: string;
 }
@@ -183,6 +193,19 @@ function asRecord(v: unknown): Record<string, unknown> | undefined {
   return v as Record<string, unknown>;
 }
 
+// String-array fields: keep the string entries (trimmed, empties dropped),
+// silently discard everything else — same permissive posture as the scalar
+// pickers above. A non-array value or an array that yields no usable entry
+// returns undefined so the field is omitted rather than set to [].
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v
+    .filter((e): e is string => typeof e === 'string')
+    .map((e) => e.trim())
+    .filter((e) => e.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
 // Enum surfaces validated at normalize time so a hand-edited typo doesn't
 // reach a downstream parser that does `process.exit(1)`. Anything outside
 // these sets is treated like any other malformed field — dropped, the rest
@@ -240,13 +263,15 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
       const cwd = asString(claudeRaw.cwd);
       const settings = asRecord(claudeRaw.settings);
       const model = asString(claudeRaw.model);
+      const models = asStringArray(claudeRaw.models);
       const runtime = pickBackendRuntime(claudeRaw.runtime);
       const runtimeName = asString(claudeRaw.runtime_name);
-      if (cwd || settings || model || runtime || runtimeName) {
+      if (cwd || settings || model || models || runtime || runtimeName) {
         out.claude = {};
         if (cwd) out.claude.cwd = cwd;
         if (settings) out.claude.settings = settings;
         if (model) out.claude.model = model;
+        if (models) out.claude.models = models;
         if (runtime) out.claude.runtime = runtime;
         if (runtimeName) out.claude.runtime_name = runtimeName;
       }


### PR DESCRIPTION
## Why

The claude backend advertises — and accepts per-request openai-compat `model` overrides for — only a single model: the `--claude-model` pin or the startup-probed default. The constraint is discovery, not execution: the spawn path already forwards `envelope.model` as `--model <id>`, but Claude Code has no headless "list models" interface to enumerate what an install can serve (`system/init.model` echoes whatever `--model` was passed, verbatim, without validating account access — verified against claude 2.1.170), and validating a candidate for real means paying an actual LLM call per candidate at every daemon start.

So multi-model support is **operator-declared** (option A from the preceding investigation): the operator lists the extra models their account can serve, and the bridge advertises + accepts them.

## What

- **`--claude-supported-models <id,id,...>` flag / `backends.claude.supported_models` config key** — additional model ids this claude install can serve. Claude-only flag; pairing with another `--backend` exits non-zero (mirrors `--claude-model`).
- **Advertise**: `resolveCapabilities()` now returns the default entry (pin or probed id, `default: true`) followed by the declared extras, deduped on the normalized form. With `probeTimeoutMs: 0` and no pin, declared models are advertised without a `default` entry (the spec marks `default` optional).
- **Gate**: the `envelope.model` validation (#302) changes from single-id equality to set membership against everything advertised, compared on the normalized (tier-suffix-stripped) form. The raw inbound value still rides to the spawn, so a caller selecting `claude-opus-4-8[1m]` against an advertised `claude-opus-4-8` passes the gate and keeps the 1M-tier selection on argv. Unresolved routing keys (`a2a/<card-url>`) are still dropped to the claude default as before.
- The declared list is **not validated against the account** — a model the plan can't access fails at task time with claude's own `model_not_found` (404, zero tokens), which is the operator's signal to fix the declaration. Documented in `docs/install-client.md`.

## Tests

- claude backend: advertise (probe path / pin path / probe-disabled path), dedupe on normalized ids across pin + probe + declarations, declared-model pass-through as `--model`, undeclared-model drop, tier-suffix normalization on the gate with raw forward.
- cli-args: comma-split + trim, flag-beats-config precedence, config fallback, non-claude-backend hard error.
- config: round-trip with `models`, malformed-entry normalization (non-strings/empties dropped, wrong-type field dropped).
- `pnpm -r typecheck`, client (705 pass), server suites all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

