### PR TITLE
refactor(client): rename --claude-models to --claude-supported-models

### DIFF
--- a/.changeset/itchy-pandas-repeat.md
+++ b/.changeset/itchy-pandas-repeat.md
@@ -2,14 +2,14 @@
 '@vicoop-bridge/client': minor
 ---
 
-feat(client): multi-model support on the claude backend via `--claude-models`
+feat(client): multi-model support on the claude backend via `--claude-supported-models`
 
 Claude Code has no headless "list models" interface, so the claude backend
 used to advertise — and accept per-request openai-compat `model` overrides
 for — only a single model (the `--claude-model` pin or the startup-probed
 default). Operators can now declare additional models their install can
-serve with `--claude-models claude-sonnet-4-6,claude-haiku-4-5`
-(comma-separated) or `backends.claude.models` in `config.json`. Declared ids
+serve with `--claude-supported-models claude-sonnet-4-6,claude-haiku-4-5`
+(comma-separated) or `backends.claude.supported_models` in `config.json`. Declared ids
 are advertised on the openai-compat `params.models[]` block after the
 default, and a matching per-request `model` rides to the spawned `claude` as
 `--model <id>`. The `envelope.model` gate now also matches on the normalized

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -661,12 +661,12 @@ vicoop-client start \
   --backend claude \
   --cwd "$HOME/vicoop-bridge" \
   --claude-model claude-opus-4-8 \
-  --claude-models claude-sonnet-4-6,claude-haiku-4-5
+  --claude-supported-models claude-sonnet-4-6,claude-haiku-4-5
 ```
 
 These knobs can also live in the canonical `config.json` (resolved per Step
 4 — `~/.vicoop/config.json` by default) under `backends.claude`
-(`cwd`, `settings`, `model`, `models`) so the foreground command shrinks to
+(`cwd`, `settings`, `model`, `supported_models`) so the foreground command shrinks to
 just `vicoop-client start`; the flag wins over config, mirroring
 the daemon-level precedence (Step 6 intro).
 
@@ -675,7 +675,7 @@ the daemon-level precedence (Step 6 intro).
 | `--cwd` | `cwd` |
 | `--claude-settings-file` | `settings` (JSON object) |
 | `--claude-model` | `model` |
-| `--claude-models` | `models` (string array) |
+| `--claude-supported-models` | `supported_models` (string array) |
 
 > **Picking a model.** `--claude-model <id>` (e.g. `claude-opus-4-8`) is
 > folded into Claude `--settings` as its `model` field, so it composes with
@@ -689,8 +689,8 @@ the daemon-level precedence (Step 6 intro).
 > models" interface, so by default the bridge advertises (and accepts
 > per-request `model` overrides for) only the single default model —
 > the `--claude-model` pin or the startup-probed id. To open up more,
-> declare them: `--claude-models claude-sonnet-4-6,claude-haiku-4-5`
-> (comma-separated) or `backends.claude.models` in `config.json`. Declared
+> declare them: `--claude-supported-models claude-sonnet-4-6,claude-haiku-4-5`
+> (comma-separated) or `backends.claude.supported_models` in `config.json`. Declared
 > ids are advertised on the agent card's openai-compat `params.models[]`
 > after the default, and a per-request openai-compat `model` matching one
 > rides to the spawned `claude` as `--model <id>`. The list is **not

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2659,7 +2659,7 @@ test('envelope.model differing from the --claude-model pin falls back to the pin
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Multi-model declarations (`models` option / --claude-models). Claude Code
+// Multi-model declarations (`models` option / --claude-supported-models). Claude Code
 // has no headless model listing, so extra models are operator-declared:
 // advertised after the default and accepted by the envelope.model gate.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2679,7 +2679,7 @@ test('declared models are advertised after the probed default', async () => {
   });
   const backend = createClaudeBackend({
     spawn: fake.spawn,
-    models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+    supportedModels: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
   });
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {
@@ -2707,7 +2707,7 @@ test('declared models are advertised after a --claude-model pin without probing'
   const backend = createClaudeBackend({
     spawn: countingSpawn,
     model: 'claude-opus-4-8',
-    models: ['claude-sonnet-4-6'],
+    supportedModels: ['claude-sonnet-4-6'],
   });
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {
@@ -2727,7 +2727,7 @@ test('declared models deduplicate against the pin and the probed default on the 
   const pinned = createClaudeBackend({
     spawn: fakePin.spawn,
     model: 'claude-opus-4-8',
-    models: ['claude-opus-4-8[1m]', 'claude-sonnet-4-6', 'claude-sonnet-4-6'],
+    supportedModels: ['claude-opus-4-8[1m]', 'claude-sonnet-4-6', 'claude-sonnet-4-6'],
   });
   assert.deepEqual(await pinned.resolveCapabilities!(), {
     openaiCompatModels: [
@@ -2752,7 +2752,7 @@ test('declared models deduplicate against the pin and the probed default on the 
   });
   const probed = createClaudeBackend({
     spawn: fakeProbe.spawn,
-    models: ['claude-opus-4-8', 'claude-haiku-4-5'],
+    supportedModels: ['claude-opus-4-8', 'claude-haiku-4-5'],
   });
   assert.deepEqual(await probed.resolveCapabilities!(), {
     openaiCompatModels: [
@@ -2773,7 +2773,7 @@ test('envelope.model matching a declared model rides through as --model', async 
   const backend = createClaudeBackend({
     spawn: fake.spawn,
     model: 'claude-opus-4-8',
-    models: ['claude-sonnet-4-6'],
+    supportedModels: ['claude-sonnet-4-6'],
   });
   await backend.resolveCapabilities?.();
   const { emit } = collect();
@@ -2799,7 +2799,7 @@ test('envelope.model outside the declared set is still dropped', async () => {
   const backend = createClaudeBackend({
     spawn: fake.spawn,
     model: 'claude-opus-4-8',
-    models: ['claude-sonnet-4-6'],
+    supportedModels: ['claude-sonnet-4-6'],
   });
   await backend.resolveCapabilities?.();
   const { emit } = collect();
@@ -2850,7 +2850,7 @@ test('probeTimeoutMs:0 with declared models advertises them without a default en
   const backend = createClaudeBackend({
     spawn: countingSpawn,
     probeTimeoutMs: 0,
-    models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+    supportedModels: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
   });
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -153,7 +153,7 @@ export interface ClaudeBackendOptions {
   model?: string;
   // Additional model ids this claude install can serve (e.g.
   // ['claude-sonnet-4-6', 'claude-haiku-4-5']), exposed via the
-  // `--claude-models` flag. Claude Code has no headless "list models"
+  // `--claude-supported-models` flag. Claude Code has no headless "list models"
   // interface — the startup probe only reveals the single resolved default
   // (`system/init.model` echoes whatever `--model` was passed, verbatim,
   // without validating account access) — so multi-model support is
@@ -164,7 +164,7 @@ export interface ClaudeBackendOptions {
   // account: a declared model the account cannot access fails at task time
   // with claude's own `model_not_found` error, which is the operator's
   // signal to fix the declaration.
-  models?: readonly string[];
+  supportedModels?: readonly string[];
   /**
    * Test seam: invoked once per task with the caller-tools MCP server
    * handle immediately after the bridge stands one up (when the
@@ -182,7 +182,7 @@ export interface ClaudeBackendOptions {
   // user/project settings.json, including its `model` field, which would
   // make the probed model diverge from the model the real task spawn
   // actually loads). Set to 0 to disable the probe entirely — the daemon
-  // then advertises only the operator-declared `models` (if any) without a
+  // then advertises only the operator-declared `supportedModels` (if any) without a
   // default entry, or no `params.models` at all, which is harmless (the
   // spec is advisory) but blinds clients that want to route by declared
   // model.
@@ -1209,7 +1209,7 @@ export function createClaudeBackend(
 
   const probeTimeoutMs = opts.probeTimeoutMs ?? 10_000;
 
-  // Operator-declared additional models (`opts.models`), deduped on the
+  // Operator-declared additional models (`opts.supportedModels`), deduped on the
   // normalized form — against each other and against the `--claude-model`
   // pin — so the advertise never carries the same canonical id twice.
   // Original (un-normalized) spellings are preserved for the advertise so an
@@ -1219,7 +1219,7 @@ export function createClaudeBackend(
   {
     const seen = new Set<string>();
     if (opts.model) seen.add(normalizeClaudeModelId(opts.model));
-    for (const raw of opts.models ?? []) {
+    for (const raw of opts.supportedModels ?? []) {
       const id = raw.trim();
       if (!id) continue;
       const norm = normalizeClaudeModelId(id);
@@ -1241,7 +1241,7 @@ export function createClaudeBackend(
   // any task lands in production. Tests that want to exercise the gate
   // populate the cache via `resolveCapabilities` explicitly.
   //
-  // A `--claude-model` pin (and any `--claude-models` declarations) seeds
+  // A `--claude-model` pin (and any `--claude-supported-models` declarations) seeds
   // the cache directly: the pin IS the advertised default (every spawn
   // loads it via settings.model), so it must be what the `envelope.model`
   // gate compares against. Without this seed the probe — which deliberately
@@ -1398,7 +1398,7 @@ export function createClaudeBackend(
           : undefined;
       // Validate against the advertised model ids (cached by
       // `resolveCapabilities` from the probe, the `--claude-model` pin, and
-      // any `--claude-models` declarations). When the gateway sends a value
+      // any `--claude-supported-models` declarations). When the gateway sends a value
       // claude doesn't advertise — e.g. an unresolved routing key like
       // `a2a/<card-url>` — drop the override so claude falls back to its own
       // default rather than failing the turn (#302). Membership is checked

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -195,51 +195,51 @@ test('--claude-model with a non-claude backend is a hard error', () => {
   );
 });
 
-test('--claude-models splits the comma-separated flag into a trimmed list', () => {
+test('--claude-supported-models splits the comma-separated flag into a trimmed list', () => {
   const r = mergeClientArgs(
     {
       token: 't',
       agentId: 'a',
       backend: 'claude',
-      claudeModels: ' claude-sonnet-4-6 , claude-haiku-4-5 ,',
+      claudeSupportedModels: ' claude-sonnet-4-6 , claude-haiku-4-5 ,',
     },
     {},
   );
   assert.equal(r.ok, true);
   if (!r.ok) return;
-  assert.deepEqual(r.args.claudeModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
+  assert.deepEqual(r.args.claudeSupportedModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
 });
 
-test('--claude-models flag beats backends.claude.models from config', () => {
+test('--claude-supported-models flag beats backends.claude.supported_models from config', () => {
   const r = mergeClientArgs(
-    { token: 't', agentId: 'a', backend: 'claude', claudeModels: 'claude-haiku-4-5' },
-    { backends: { claude: { models: ['claude-sonnet-4-6'] } } },
+    { token: 't', agentId: 'a', backend: 'claude', claudeSupportedModels: 'claude-haiku-4-5' },
+    { backends: { claude: { supported_models: ['claude-sonnet-4-6'] } } },
   );
   assert.equal(r.ok, true);
   if (!r.ok) return;
-  assert.deepEqual(r.args.claudeModels, ['claude-haiku-4-5']);
+  assert.deepEqual(r.args.claudeSupportedModels, ['claude-haiku-4-5']);
 });
 
-test('backends.claude.models fills in when the flag is absent', () => {
+test('backends.claude.supported_models fills in when the flag is absent', () => {
   const r = mergeClientArgs(
     { token: 't', agentId: 'a', backend: 'claude' },
-    { backends: { claude: { models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] } } },
+    { backends: { claude: { supported_models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] } } },
   );
   assert.equal(r.ok, true);
   if (!r.ok) return;
-  assert.deepEqual(r.args.claudeModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
+  assert.deepEqual(r.args.claudeSupportedModels, ['claude-sonnet-4-6', 'claude-haiku-4-5']);
 });
 
-test('--claude-models with a non-claude backend is a hard error', () => {
+test('--claude-supported-models with a non-claude backend is a hard error', () => {
   const r = mergeClientArgs(
-    { token: 't', agentId: 'a', backend: 'codex', claudeModels: 'claude-haiku-4-5' },
+    { token: 't', agentId: 'a', backend: 'codex', claudeSupportedModels: 'claude-haiku-4-5' },
     {},
   );
   assert.equal(r.ok, false);
   if (r.ok) return;
   assert.ok(
-    r.errors.some((e) => e.includes('--claude-models') && e.includes('codex')),
-    `expected error mentioning --claude-models and codex, got: ${r.errors.join(' | ')}`,
+    r.errors.some((e) => e.includes('--claude-supported-models') && e.includes('codex')),
+    `expected error mentioning --claude-supported-models and codex, got: ${r.errors.join(' | ')}`,
   );
 });
 

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -90,7 +90,7 @@ export const daemonFlagsFields = {
   claudeModel: optional(option('--claude-model', string({ metavar: 'MODEL' }), {
     description: message`Model id for the spawned Claude, e.g. \`claude-opus-4-8\`. Sets the \`model\` field in Claude \`--settings\`; a per-request openai-compat \`model\` still overrides it. Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
   })),
-  claudeModels: optional(option('--claude-models', string({ metavar: 'MODELS' }), {
+  claudeSupportedModels: optional(option('--claude-supported-models', string({ metavar: 'MODELS' }), {
     description: message`Comma-separated additional model ids this Claude install can serve, e.g. \`claude-sonnet-4-6,claude-haiku-4-5\`. Advertised alongside the default model and accepted as per-request openai-compat \`model\` overrides (Claude has no headless model listing, so the set is operator-declared and not validated against the account). Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
   })),
 
@@ -148,7 +148,7 @@ export interface DaemonArgs {
   runtimeName?: string;
   claudeSettingsFile?: string;
   claudeModel?: string;
-  claudeModels?: string[];
+  claudeSupportedModels?: string[];
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
   openclawGatewayToken?: string;
@@ -186,7 +186,7 @@ function pick(v: string | undefined): string {
   return v?.trim() ?? '';
 }
 
-// Comma-separated model list (--claude-models). Trim entries, drop empties;
+// Comma-separated model list (--claude-supported-models). Trim entries, drop empties;
 // undefined when nothing usable remains so the merge's `??` fallback to the
 // config layer fires on a blank/whitespace-only flag, matching `pick()`'s
 // empty-means-unset convention.
@@ -271,9 +271,9 @@ export function mergeClientArgs(
     runtimeName: pick(flags.runtimeName) || activeRuntimeName || undefined,
     claudeSettingsFile: pick(flags.claudeSettingsFile) || undefined,
     claudeModel: pick(flags.claudeModel) || backends.claude?.model || undefined,
-    claudeModels:
-      pickModelsList(flags.claudeModels) ??
-      (backends.claude?.models?.length ? backends.claude.models : undefined),
+    claudeSupportedModels:
+      pickModelsList(flags.claudeSupportedModels) ??
+      (backends.claude?.supported_models?.length ? backends.claude.supported_models : undefined),
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     openclawGateway:
@@ -336,9 +336,9 @@ export function mergeClientArgs(
       `--claude-model is not supported by --backend ${backend}; only the claude backend takes a model id`,
     );
   }
-  if (pick(flags.claudeModels) && backend !== 'claude') {
+  if (pick(flags.claudeSupportedModels) && backend !== 'claude') {
     errors.push(
-      `--claude-models is not supported by --backend ${backend}; only the claude backend takes model ids`,
+      `--claude-supported-models is not supported by --backend ${backend}; only the claude backend takes model ids`,
     );
   }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -399,7 +399,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         identity: deriveIdentity(args.agentId, args.server) ?? undefined,
         settings,
         model: args.claudeModel,
-        models: args.claudeModels,
+        supportedModels: args.claudeSupportedModels,
         openaiCompatTrace: args.openaiCompatTrace,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -168,7 +168,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
         cwd: '/srv/work',
         settings: { sandbox: { enabled: true } },
         model: 'claude-opus-4-8',
-        models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+        supported_models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
       },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
@@ -191,7 +191,7 @@ test('writeConfig writes JSON at mode 0600 and readConfig round-trips', (t) => {
         cwd: '/srv/work',
         settings: { sandbox: { enabled: true } },
         model: 'claude-opus-4-8',
-        models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
+        supported_models: ['claude-sonnet-4-6', 'claude-haiku-4-5'],
       },
       codex: { cwd: '/srv/work', sandbox_mode: 'workspace-write', runtime_name: 'work' },
       openclaw: {
@@ -397,7 +397,7 @@ test('readConfig drops malformed fields and keeps the rest', (t) => {
   });
 });
 
-test('normalizeConfig keeps usable backends.claude.models entries and drops the rest', (t) => {
+test('normalizeConfig keeps usable backends.claude.supported_models entries and drops the rest', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-models-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   const path = join(dir, 'config.json');
@@ -407,7 +407,7 @@ test('normalizeConfig keeps usable backends.claude.models entries and drops the 
       backends: {
         claude: {
           // non-string / empty entries dropped, strings trimmed
-          models: [' claude-sonnet-4-6 ', 42, '', null, 'claude-haiku-4-5'],
+          supported_models: [' claude-sonnet-4-6 ', 42, '', null, 'claude-haiku-4-5'],
         },
         codex: {
           cwd: '/srv/work',
@@ -417,7 +417,7 @@ test('normalizeConfig keeps usable backends.claude.models entries and drops the 
   );
   assert.deepEqual(readConfig(path), {
     backends: {
-      claude: { models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] },
+      claude: { supported_models: ['claude-sonnet-4-6', 'claude-haiku-4-5'] },
       codex: { cwd: '/srv/work' },
     },
   });
@@ -426,7 +426,7 @@ test('normalizeConfig keeps usable backends.claude.models entries and drops the 
   // field — and with it the whole claude slot when nothing else is set.
   writeFileSync(
     path,
-    JSON.stringify({ backends: { claude: { models: 'claude-haiku-4-5' } } }),
+    JSON.stringify({ backends: { claude: { supported_models: 'claude-haiku-4-5' } } }),
   );
   assert.deepEqual(readConfig(path), {});
 });

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -123,9 +123,9 @@ export interface ClaudeBackendConfig {
    * per-request openai-compat `model` overrides (forwarded to the spawn as
    * `--model <id>`). Not validated against the account — a model the
    * account cannot access fails at task time with claude's own
-   * `model_not_found`. Mirrors the `--claude-models` flag.
+   * `model_not_found`. Mirrors the `--claude-supported-models` flag.
    */
-  models?: string[];
+  supported_models?: string[];
   runtime?: BackendRuntime;
   runtime_name?: string;
 }
@@ -263,7 +263,7 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
       const cwd = asString(claudeRaw.cwd);
       const settings = asRecord(claudeRaw.settings);
       const model = asString(claudeRaw.model);
-      const models = asStringArray(claudeRaw.models);
+      const models = asStringArray(claudeRaw.supported_models);
       const runtime = pickBackendRuntime(claudeRaw.runtime);
       const runtimeName = asString(claudeRaw.runtime_name);
       if (cwd || settings || model || models || runtime || runtimeName) {
@@ -271,7 +271,7 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
         if (cwd) out.claude.cwd = cwd;
         if (settings) out.claude.settings = settings;
         if (model) out.claude.model = model;
-        if (models) out.claude.models = models;
+        if (models) out.claude.supported_models = models;
         if (runtime) out.claude.runtime = runtime;
         if (runtimeName) out.claude.runtime_name = runtimeName;
       }


### PR DESCRIPTION
Follow-up to #345. The rename commit was authored during that PR's review but failed to reach the branch before the squash merge, so `main` landed with the original flag name. This applies the intended rename before 0.32.0 ships:

- CLI flag: `--claude-models` → `--claude-supported-models`
- config key: `backends.claude.models` → `backends.claude.supported_models`
- backend option: `ClaudeBackendOptions.models` → `supportedModels` (`DaemonArgs.claudeModels` → `claudeSupportedModels`)

The unreleased changeset is updated in place so the 0.32.0 CHANGELOG documents the final name. No release has shipped the old name, so nothing here is breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)