### PR TITLE
fix(client): report actual response model in claude openai-compat envelope (#348)

### DIFF
--- a/.changeset/claude-envelope-model-348.md
+++ b/.changeset/claude-envelope-model-348.md
@@ -1,0 +1,13 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: report the actual response model in the OpenAI-compatible
+envelope. The envelope's top-level `model` (and its embedded `usage.model`)
+now resolve from the model named on the assistant turn, falling back to the
+requested model id (already forwarded to claude as `--model`). The previous
+`result.modelUsage` largest-output-share heuristic — which on short responses
+could be dominated by an internal sub-model (e.g. `claude-haiku-4-5-*` used
+for title generation) and mislabel the envelope even when the requested
+override model handled the request — has been removed; `modelUsage` is now
+used only to sum token counts (#348).

--- a/.changeset/claude-envelope-model-348.md
+++ b/.changeset/claude-envelope-model-348.md
@@ -4,10 +4,12 @@
 
 claude backend: report the actual response model in the OpenAI-compatible
 envelope. The envelope's top-level `model` (and its embedded `usage.model`)
-now resolve from the model named on the assistant turn, falling back to the
-requested model id (already forwarded to claude as `--model`). The previous
-`result.modelUsage` largest-output-share heuristic — which on short responses
-could be dominated by an internal sub-model (e.g. `claude-haiku-4-5-*` used
-for title generation) and mislabel the envelope even when the requested
-override model handled the request — has been removed; `modelUsage` is now
-used only to sum token counts (#348).
+now resolve from model ids claude itself reports — the model named on the
+`assistant` turn, falling back to the `system/init` resolved model — instead
+of the `result.modelUsage` largest-output-share heuristic, which on short
+responses could be dominated by an internal sub-model (e.g.
+`claude-haiku-4-5-*` used for title generation) and mislabel the envelope even
+when the requested override model handled the request. The requested
+`envelope.model` is deliberately not used as a fallback, since it may be a
+routing slug or an A2A card url rather than a real model id. `modelUsage` is
+now used only to sum token counts (#348).

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -3278,10 +3278,12 @@ test('result.modelUsage is summed across models and forwarded as openai-compat u
   assert.equal(payload.usage.total_tokens, 25287 + 21);
   // cached_tokens mirrors Σ_M cacheRead (lossless): 0 + 18029.
   assert.deepEqual(payload.usage.prompt_tokens_details, { cached_tokens: 18029 });
-  // `model` reports the entry with the largest output share — opus had 8 vs
-  // haiku's 13, so haiku wins by raw output_tokens count. The contract is
-  // "largest output", documenting that the field is telemetry only.
-  assert.equal(payload.usage.model, 'claude-haiku-4-5-20251001');
+  // No `model` label: `parseClaudeModelUsageForOpenAICompat` only sums tokens
+  // now — the model is resolved from the assistant turn / requested id, not a
+  // largest-output-share heuristic over modelUsage (#348). This fixture has
+  // no assistant event and is a plain (non-openai-compat) task, so no model
+  // is resolved and the field is omitted rather than guessed.
+  assert.equal('model' in payload.usage, false);
 });
 
 test('single-model modelUsage maps cleanly and advertises the extension', async () => {
@@ -3317,9 +3319,9 @@ test('single-model modelUsage maps cleanly and advertises the extension', async 
   assert.equal(payload?.usage?.completion_tokens, 8);
   assert.equal(payload?.usage?.total_tokens, 6 + 24933 + 23 + 8);
   assert.deepEqual(payload?.usage?.prompt_tokens_details, { cached_tokens: 24933 });
-  // Normalised to the canonical Anthropic id so it matches what
-  // `params.models[].id` advertises — see `normalizeClaudeModelId`.
-  assert.equal(payload?.usage?.model, 'claude-opus-4-7');
+  // Token sums only — no model label is derived from modelUsage anymore (#348);
+  // this plain task has no assistant event to name one.
+  assert.equal(payload?.usage && 'model' in payload.usage, false);
 });
 
 test('absent modelUsage → no openai-compat metadata is attached', async () => {
@@ -3337,6 +3339,131 @@ test('absent modelUsage → no openai-compat metadata is attached', async () => 
   assert.ok(complete && complete.type === 'task.complete');
   assert.equal(complete.status.message?.metadata, undefined);
   assert.equal(complete.status.message?.extensions, undefined);
+});
+
+test('envelope.model reports the assistant turn model, not the modelUsage winner (#348)', async () => {
+  // Repro for #348: a short response ("router-ok") routes the user-facing
+  // turn through claude-sonnet-4-6, but an internal haiku sub-model
+  // out-produces it in raw output_tokens. The `result.modelUsage`
+  // largest-output heuristic therefore reports haiku — correct for usage
+  // telemetry, WRONG for the envelope's top-level `model`. The assistant
+  // event names the model that actually answered, so the envelope must use
+  // that.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          // CC stamps the running tier suffix; the envelope normalises it off.
+          model: 'claude-sonnet-4-6[1m]',
+          content: [{ type: 'text', text: 'router-ok' }],
+        },
+      }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'router-ok',
+        modelUsage: {
+          // haiku wins by raw output_tokens (13 > 8) — the heuristic trap.
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 348,
+            outputTokens: 13,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+          'claude-sonnet-4-6[1m]': {
+            inputTokens: 6,
+            outputTokens: 8,
+            cacheReadInputTokens: 18029,
+            cacheCreationInputTokens: 6904,
+          },
+        },
+      }),
+    ],
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('reply router-ok', { model: 'claude-sonnet-4-6' }),
+    emit,
+    NEVER,
+  );
+
+  const metadata = completionMessageMetadata(frames);
+  assert.ok(metadata, 'task.complete message should carry metadata');
+  const payload = metadata[OPENAI_COMPAT_EXTENSION_URI] as {
+    chat_completion?: Record<string, unknown>;
+    usage?: Record<string, unknown>;
+  };
+  const envelope = payload?.chat_completion;
+  assert.ok(envelope, 'chat_completion envelope present');
+  // The fix: envelope model is the model that produced the turn, suffix
+  // stripped — NOT the haiku modelUsage winner.
+  assert.equal(envelope.model, 'claude-sonnet-4-6');
+  // The envelope's embedded usage.model is realigned to the same id so the
+  // envelope stays internally consistent (id SHOULD match usage.model)...
+  const envUsage = envelope.usage as { model?: string; prompt_tokens?: number; completion_tokens?: number };
+  assert.equal(envUsage.model, 'claude-sonnet-4-6', 'envelope usage mirrors the response model');
+  // ...while the token SUMS remain the across-sub-model totals (haiku tokens
+  // still counted): Σ output = 13 + 8 = 21, Σ prompt = 348 + (6+18029+6904).
+  assert.equal(envUsage.completion_tokens, 21);
+  assert.equal(envUsage.prompt_tokens, 25287);
+  // Under the envelope contract the bare top-level `usage` sibling is not
+  // emitted — usage lives inside the envelope only.
+  assert.equal(payload.usage, undefined);
+});
+
+test('envelope.model falls back to the requested model id when no assistant event names one (#348)', async () => {
+  // result-only turn: claude emits a `result` event (with modelUsage) but no
+  // `assistant` event carrying a model. The envelope must then report the
+  // requested model id — already forwarded to claude as `--model` (#302) —
+  // not the largest-output sub-model. The requested id carries the `[1m]`
+  // tier suffix on the wire; the envelope normalises it off.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'router-ok',
+        modelUsage: {
+          'claude-haiku-4-5-20251001': {
+            inputTokens: 348,
+            outputTokens: 13,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+          },
+          'claude-opus-4-8[1m]': {
+            inputTokens: 6,
+            outputTokens: 8,
+            cacheReadInputTokens: 18029,
+            cacheCreationInputTokens: 6904,
+          },
+        },
+      }),
+    ],
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assignWithOpenAICompat('reply router-ok', { model: 'claude-opus-4-8[1m]' }),
+    emit,
+    NEVER,
+  );
+
+  const metadata = completionMessageMetadata(frames);
+  assert.ok(metadata, 'task.complete message should carry metadata');
+  const payload = metadata[OPENAI_COMPAT_EXTENSION_URI] as {
+    chat_completion?: Record<string, unknown>;
+  };
+  const envelope = payload?.chat_completion;
+  assert.ok(envelope, 'chat_completion envelope present');
+  // Requested model id, tier suffix stripped — NOT the haiku modelUsage winner.
+  assert.equal(envelope.model, 'claude-opus-4-8');
+  const envUsage = envelope.usage as { model?: string };
+  assert.equal(envUsage.model, 'claude-opus-4-8');
 });
 
 test('zero cacheRead does not surface a cached_tokens breakdown', async () => {
@@ -4466,16 +4593,18 @@ test('probeClaudeModel returns null if the whole id was a bracket tier marker', 
   assert.equal(model, null);
 });
 
-test('parseClaudeModelUsageForOpenAICompat strips bracket tier suffix on usage.model', () => {
-  // The advertise and the usage.model echo MUST resolve to the same
-  // string so the openai-compat/v1 spec's "id SHOULD match usage.model"
-  // cross-check holds for callers doing exact-match routing.
+test('parseClaudeModelUsageForOpenAICompat sums token counts without picking a model', () => {
+  // The model label is resolved by the caller (assistant turn / requested id),
+  // NOT from a largest-output-share heuristic over modelUsage (#348). This
+  // helper now only sums tokens across the per-model entries.
   const usage = parseClaudeModelUsageForOpenAICompat({
     'claude-haiku-4-5-20251001': { inputTokens: 100, outputTokens: 5 },
     'claude-opus-4-7[1m]': { inputTokens: 100, outputTokens: 50 },
   });
   assert.ok(usage);
-  assert.equal(usage!.model, 'claude-opus-4-7');
+  assert.equal(usage!.prompt_tokens, 200);
+  assert.equal(usage!.completion_tokens, 55);
+  assert.equal('model' in usage!, false);
 });
 
 // Envelope shape: text-only turn (no tool calls, with usage) produces a

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -3415,15 +3415,20 @@ test('envelope.model reports the assistant turn model, not the modelUsage winner
   assert.equal(payload.usage, undefined);
 });
 
-test('envelope.model falls back to the requested model id when no assistant event names one (#348)', async () => {
-  // result-only turn: claude emits a `result` event (with modelUsage) but no
-  // `assistant` event carrying a model. The envelope must then report the
-  // requested model id — already forwarded to claude as `--model` (#302) —
-  // not the largest-output sub-model. The requested id carries the `[1m]`
-  // tier suffix on the wire; the envelope normalises it off.
+test('envelope.model falls back to the system/init model when no assistant event names one (#348)', async () => {
+  // result-only turn: claude emits a `system/init` (carrying the resolved
+  // model) and a `result` event (with modelUsage), but no `assistant` event
+  // carrying a model. The envelope must report claude's resolved model — not
+  // the largest-output sub-model. The init model carries the `[1m]` tier
+  // suffix; the envelope normalises it off.
   const fake = scriptedSpawn({
     lines: [
-      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-8[1m]',
+      }),
       JSON.stringify({
         type: 'result',
         subtype: 'success',
@@ -3448,7 +3453,7 @@ test('envelope.model falls back to the requested model id when no assistant even
   const backend = createClaudeBackend({ spawn: fake.spawn });
   const { emit, frames } = collect();
   await backend.handle(
-    assignWithOpenAICompat('reply router-ok', { model: 'claude-opus-4-8[1m]' }),
+    assignWithOpenAICompat('reply router-ok', { model: 'claude-opus-4-8' }),
     emit,
     NEVER,
   );
@@ -3460,10 +3465,42 @@ test('envelope.model falls back to the requested model id when no assistant even
   };
   const envelope = payload?.chat_completion;
   assert.ok(envelope, 'chat_completion envelope present');
-  // Requested model id, tier suffix stripped — NOT the haiku modelUsage winner.
+  // system/init model id, tier suffix stripped — NOT the haiku modelUsage winner.
   assert.equal(envelope.model, 'claude-opus-4-8');
   const envUsage = envelope.usage as { model?: string };
   assert.equal(envUsage.model, 'claude-opus-4-8');
+});
+
+test('envelope.model never reports the requested routing slug / card url (#348)', async () => {
+  // The gateway can send an unresolved routing key (e.g. an A2A card url) as
+  // `envelope.model`; claude drops it before `--model` and runs its own
+  // default (#302). The envelope must report the REAL model claude resolved
+  // (from system/init), never echo the slug back as if it were a model.
+  const slug = 'a2a/https://example.com/agents/x/.well-known/agent-card.json';
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sid',
+        model: 'claude-opus-4-8[1m]',
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'router-ok' }),
+    ],
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assignWithOpenAICompat('reply router-ok', { model: slug }), emit, NEVER);
+
+  const metadata = completionMessageMetadata(frames);
+  assert.ok(metadata, 'task.complete message should carry metadata');
+  const payload = metadata[OPENAI_COMPAT_EXTENSION_URI] as {
+    chat_completion?: Record<string, unknown>;
+  };
+  const envelope = payload?.chat_completion;
+  assert.ok(envelope, 'chat_completion envelope present');
+  assert.equal(envelope.model, 'claude-opus-4-8', 'reports claude resolved model, not the slug');
+  assert.notEqual(envelope.model, slug);
 });
 
 test('zero cacheRead does not surface a cached_tokens breakdown', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -231,6 +231,12 @@ interface StreamEvent {
   message?: {
     role?: unknown;
     content?: unknown;
+    // Present on `assistant` events: the model that produced this turn's
+    // user-facing content. This is the authoritative model id for the
+    // openai-compat envelope — unlike `result.modelUsage`, which can be
+    // dominated by an internal sub-model (e.g. haiku for title generation)
+    // on short responses and so mislabel the envelope's `model` (#348).
+    model?: unknown;
   };
   event?: unknown;
   result?: unknown;
@@ -277,18 +283,20 @@ export function normalizeClaudeModelId(raw: string): string {
 //   prompt_tokens = Σ_M (inputTokens + cacheCreationInputTokens + cacheReadInputTokens)
 //   prompt_tokens_details.cached_tokens = Σ_M cacheReadInputTokens  (lossless mirror)
 //   completion_tokens = Σ_M outputTokens
-// `model` is reported as the entry with the largest output share — usually
-// the user-facing primary model; ties go to whichever Object.entries returns
-// first, which is fine for telemetry.
+//
+// This computes token SUMS only — it does NOT pick a `model` label. The
+// envelope's `model` is resolved by the caller from the model that actually
+// answered (the `assistant` event) or the requested model id, not from a
+// largest-output-share heuristic over `modelUsage` (which mislabels short
+// responses — #348). The caller stamps the resolved id onto the returned
+// usage so `usage.model` stays consistent with the envelope's top-level id.
 export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompatUsage | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
   let promptSum = 0;
   let completionSum = 0;
   let cacheReadSum = 0;
-  let primaryModel: string | null = null;
-  let primaryOutput = -1;
   let saw = false;
-  for (const [modelKey, perModel] of Object.entries(raw as Record<string, unknown>)) {
+  for (const [, perModel] of Object.entries(raw as Record<string, unknown>)) {
     if (!perModel || typeof perModel !== 'object' || Array.isArray(perModel)) continue;
     const m = perModel as Record<string, unknown>;
     const input = typeof m.inputTokens === 'number' ? m.inputTokens : 0;
@@ -299,10 +307,6 @@ export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompat
     promptSum += input + cacheCreate + cacheRead;
     completionSum += output;
     cacheReadSum += cacheRead;
-    if (output > primaryOutput) {
-      primaryOutput = output;
-      primaryModel = modelKey;
-    }
     saw = true;
   }
   if (!saw) return null;
@@ -310,7 +314,6 @@ export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompat
     prompt_tokens: promptSum,
     completion_tokens: completionSum,
     cached_tokens: cacheReadSum > 0 ? cacheReadSum : undefined,
-    model: primaryModel ? normalizeClaudeModelId(primaryModel) : undefined,
   });
 }
 
@@ -1956,6 +1959,15 @@ export function createClaudeBackend(
       // later flow analysis collapses the type. Mirrors codex.ts's
       // `finalUsage` declaration for the same reason.
       let finalUsage: OpenAICompatUsage | null = null as OpenAICompatUsage | null;
+      // The model id reported on `assistant` events — the model that actually
+      // produced the user-facing turn. Preferred over the `result.modelUsage`
+      // heuristic for the openai-compat envelope's `model` field (#348): on
+      // short responses an internal sub-model (haiku for title generation) can
+      // out-produce the response model in token count, so the largest-output
+      // heuristic mislabels the envelope. The assistant event names the right
+      // model directly. Last writer wins — under `--max-turns 1` there is a
+      // single response turn.
+      let assistantModel: string | null = null;
       let responseArtifactId: string | null = null;
       let streamedResponseText = '';
       let sawCompletedResult = false;
@@ -2156,6 +2168,12 @@ export function createClaudeBackend(
         if (evt.type === 'assistant') {
           if (evt.message?.role !== 'assistant') return;
           recorder.mark('firstAssistant');
+          // Record the model that produced this turn for the openai-compat
+          // envelope (#348). Normalised to drop CC's `[1m]` tier suffix so it
+          // matches the advertised model id and `usage.model`.
+          if (typeof evt.message.model === 'string' && evt.message.model.length > 0) {
+            assistantModel = normalizeClaudeModelId(evt.message.model);
+          }
           // A single assistant turn can interleave plain text and tool_use
           // blocks. Emit the text (if any) first so observers see "what the
           // model said" before "what tools it then called", matching the
@@ -2555,18 +2573,40 @@ export function createClaudeBackend(
       const finishReason: 'tool_calls' | 'stop' =
         capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
       const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
+      // Resolve the response model (#348). Two authoritative sources, in
+      // order: (1) the model the `assistant` turn reported — the model that
+      // actually produced the answer; (2) the requested model id, which the
+      // gateway already forwarded to claude as `--model` (#302), used when no
+      // assistant event named a model (e.g. claude emitted only a `result`
+      // event). The old `modelUsage` largest-output-share heuristic is gone —
+      // it mislabelled short responses with an internal sub-model (haiku for
+      // title generation). When neither source is available the envelope falls
+      // back to its `'claude'` placeholder. `envelopeModel` carries the raw
+      // inbound tier suffix; normalise it to match the advertised id form (the
+      // assistant id is already normalised at capture).
+      const responseModel =
+        assistantModel ?? (envelopeModel ? normalizeClaudeModelId(envelopeModel) : undefined);
+      // Stamp the resolved id onto the usage so `usage.model` stays consistent
+      // with the envelope's top-level `model` (the spec's "id SHOULD match
+      // usage.model" cross-check). The token *sums* are untouched — they
+      // remain the across-sub-model totals from `modelUsage`.
+      const envelopeUsage =
+        finalUsage && responseModel ? { ...finalUsage, model: responseModel } : finalUsage;
       const responseEnvelope = envelope
         ? buildClaudeChatCompletionEnvelope({
             taskId: task.taskId,
-            model: finalUsage?.model,
+            model: responseModel,
             content: assistantContent,
             toolCalls: capturedToolCalls.length > 0 ? capturedToolCalls : undefined,
             finishReason,
-            usage: finalUsage,
+            usage: envelopeUsage,
           })
         : undefined;
 
-      const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, finalUsage);
+      // The bare `usage` path (no envelope) gets the same model stamp so plain
+      // A2A telemetry consumers see the response model whenever one was
+      // resolved (#348).
+      const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, envelopeUsage);
       // When parts is empty but we have envelope/usage to convey, still
       // emit the message frame so the metadata reaches the gateway.
       const hasMessage = parts.length > 0 || messageMetadata !== undefined;

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -228,6 +228,15 @@ interface SessionEntry {
 // filter/count tool calls reliably even after the text was clipped.
 interface StreamEvent {
   type?: unknown;
+  // `subtype` + top-level `model` ride on the `system/init` event — the
+  // session metadata claude emits first, before any turn. `model` is the
+  // model claude actually resolved to run with (real model id; a routing
+  // slug / A2A card url is dropped before reaching `--model`, so init
+  // reports claude's resolved default, never the slug). Used as the
+  // openai-compat envelope's model fallback when no assistant turn named one
+  // (e.g. a result-only turn) (#348).
+  subtype?: unknown;
+  model?: unknown;
   message?: {
     role?: unknown;
     content?: unknown;
@@ -1968,6 +1977,12 @@ export function createClaudeBackend(
       // model directly. Last writer wins — under `--max-turns 1` there is a
       // single response turn.
       let assistantModel: string | null = null;
+      // The model claude resolved to run with, from the `system/init` event.
+      // Fallback for the envelope's `model` when no assistant turn named one
+      // (e.g. a result-only turn). Always a real model id — a routing slug /
+      // A2A card url in the request is dropped before reaching `--model`, so
+      // init reports claude's resolved default rather than the slug (#348).
+      let initModel: string | null = null;
       let responseArtifactId: string | null = null;
       let streamedResponseText = '';
       let sawCompletedResult = false;
@@ -2155,6 +2170,16 @@ export function createClaudeBackend(
             `[openai-compat trace] claude event type=${evt.type}` +
               (textLen !== undefined ? ` textLen=${textLen}` : ''),
           );
+        }
+        if (evt.type === 'system' && evt.subtype === 'init') {
+          // Record claude's resolved model for the openai-compat envelope
+          // fallback (#348). Normalised to drop the `[1m]` tier suffix so it
+          // matches the advertised id form and `usage.model`.
+          if (typeof evt.model === 'string' && evt.model.length > 0) {
+            const normalised = normalizeClaudeModelId(evt.model);
+            if (normalised.length > 0) initModel = normalised;
+          }
+          return;
         }
         if (evt.type === 'stream_event') {
           const delta = extractClaudeStreamTextDelta(evt);
@@ -2573,19 +2598,19 @@ export function createClaudeBackend(
       const finishReason: 'tool_calls' | 'stop' =
         capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
       const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
-      // Resolve the response model (#348). Two authoritative sources, in
-      // order: (1) the model the `assistant` turn reported — the model that
-      // actually produced the answer; (2) the requested model id, which the
-      // gateway already forwarded to claude as `--model` (#302), used when no
-      // assistant event named a model (e.g. claude emitted only a `result`
-      // event). The old `modelUsage` largest-output-share heuristic is gone —
-      // it mislabelled short responses with an internal sub-model (haiku for
-      // title generation). When neither source is available the envelope falls
-      // back to its `'claude'` placeholder. `envelopeModel` carries the raw
-      // inbound tier suffix; normalise it to match the advertised id form (the
-      // assistant id is already normalised at capture).
-      const responseModel =
-        assistantModel ?? (envelopeModel ? normalizeClaudeModelId(envelopeModel) : undefined);
+      // Resolve the response model (#348). Both sources come from claude
+      // itself and are always real model ids, in order: (1) the model the
+      // `assistant` turn reported — the model that actually produced the
+      // answer; (2) the `system/init` model — claude's resolved model — used
+      // when no assistant event named one (e.g. claude emitted only a `result`
+      // event). We deliberately do NOT fall back to the requested
+      // `envelope.model`: that is the caller's request, which may be a routing
+      // slug or an A2A card url (dropped before reaching `--model`, #302), not
+      // a real model id. The old `modelUsage` largest-output-share heuristic is
+      // gone — it mislabelled short responses with an internal sub-model (haiku
+      // for title generation). When neither source is available the envelope
+      // falls back to its `'claude'` placeholder.
+      const responseModel = assistantModel ?? initModel ?? undefined;
       // Stamp the resolved id onto the usage so `usage.model` stays consistent
       // with the envelope's top-level `model` (the spec's "id SHOULD match
       // usage.model" cross-check). The token *sums* are untouched — they


### PR DESCRIPTION
Fixes #348.

## Problem

After advertising multiple Claude models via `--claude-supported-models`, requests routed to the correct Claude model, but the OpenAI-compatible response envelope's top-level `model` could report a different, unrelated model (e.g. `claude-haiku-4-5-20251001`) — even though the Claude CLI JSONL log confirmed the requested override model actually handled the request.

### Root cause

The envelope's `model` was derived from `result.modelUsage` by picking the entry with the **largest output-token share** (`parseClaudeModelUsageForOpenAICompat`). On a short response (`router-ok`), the actual response model emits very few output tokens, while an internal sub-model Claude Code uses for things like title generation (`claude-haiku-4-5-*`) can out-produce it — so haiku "won" the heuristic and got stamped on the envelope. This is fine for token accounting but wrong as a "which model answered" label.

## Fix

Resolve the response model from ids **claude itself reports**, in order:

1. **The model named on the `assistant` stream event** — the model that actually produced the user-facing turn (the field the issue itself points at).
2. **The `system/init` model** — claude's own report of the model it resolved to run with — used when no assistant event names one (e.g. a `result`-only turn).

The requested `envelope.model` is **deliberately not** used as a fallback: it can be an unresolved routing key — a slug or an A2A card url — which claude drops before `--model` so it runs its own default (#302). Echoing that back as the model would be the same class of bug. Both chosen sources are always real model ids.

The envelope's embedded `usage.model` is stamped with the same resolved id so the spec's "id SHOULD match usage.model" cross-check holds. Token **sums** are untouched — they remain the across-sub-model totals from `modelUsage`. The old largest-output-share model heuristic is removed; `parseClaudeModelUsageForOpenAICompat` now only sums token counts.

## Tests

- New: envelope reports the assistant-turn model, not the modelUsage winner (the #348 repro).
- New: envelope falls back to the `system/init` model on a result-only turn.
- New: envelope never echoes a requested routing slug / A2A card url — reports claude's resolved model instead.
- Updated: `modelUsage` token-sum tests no longer assert a heuristic model label; the helper unit test asserts sums only.

`pnpm -r build`, client `typecheck`, and the full client suite (708 tests) all pass. Includes a client patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)