### PR TITLE
fix(server): return 503 + Retry-After for registered-but-offline agents

### DIFF
--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -39,11 +39,18 @@ async function mintBearer(opts: { domain: string; uri: string }): Promise<string
     .replace(/=+$/, '');
 }
 
-// The reject paths exercised here never touch postgres — the middleware short-
-// circuits on missing/malformed bearer headers before reaching verifyCallerToken
-// (vbc_caller_* branch) or verifySiweBearerToken (SIWE branch). A stub Sql is
-// sufficient.
-const stubSql = {} as Sql;
+// Most reject paths exercised here never touch postgres — the middleware
+// short-circuits on missing/malformed bearer headers before reaching
+// verifyCallerToken (vbc_caller_* branch) or verifySiweBearerToken (SIWE
+// branch). The exception is the missing-agent branch (issue #352), which
+// checks the `agents` table to tell registered-but-offline (503) apart from
+// unknown (404) — fakeSql answers that single query shape.
+function fakeSql(registeredAgentIds: string[]): Sql {
+  return (async (_strings: TemplateStringsArray, ...values: unknown[]) =>
+    registeredAgentIds.includes(values[0] as string)
+      ? [{ '?column?': 1 }]
+      : []) as unknown as Sql;
+}
 
 function fakeAgentCard(name: string): AgentCard {
   return { name, version: '0.0.1', protocolVersion: '0.3.0' };
@@ -66,11 +73,14 @@ function registerAgent(
   registry.registerAgent(conn);
 }
 
-function buildApp(opts: { siweDomain?: string } = {}): { app: Hono; registry: Registry } {
+function buildApp(opts: { siweDomain?: string; sql?: Sql } = {}): {
+  app: Hono;
+  registry: Registry;
+} {
   const registry = new Registry();
   const app = new Hono();
   const mw = agentAuthMiddleware(registry, {
-    sql: stubSql,
+    sql: opts.sql ?? fakeSql([]),
     deviceFlowEnabled: false,
     siweDomain: opts.siweDomain,
   });
@@ -168,6 +178,39 @@ test('unknown agent returns 404 without auth challenge', async () => {
   assert.equal(res.headers.get('WWW-Authenticate'), null);
 });
 
+// Issue #352 — a registered agent whose client is not connected is a
+// transient condition (operator stopped it / mid-restart), signaled as 503 +
+// Retry-After so downstream routers retry shortly instead of applying the
+// long misconfiguration cooldown they reserve for bare 404s.
+test('registered-but-offline agent returns 503 with Retry-After, not 404', async () => {
+  const { app } = buildApp({ sql: fakeSql(['ghost']) });
+
+  const res = await app.request('/agents/ghost', { method: 'POST' });
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get('Retry-After'), '60');
+  // Unavailability is not an auth failure either.
+  assert.equal(res.headers.get('WWW-Authenticate'), null);
+  const body = (await res.json()) as {
+    error: { code: number; message: string; data?: { rejectionId?: string } };
+  };
+  assert.equal(body.error.code, -32000);
+  assert.match(body.error.message, /temporarily unavailable/i);
+});
+
+test('registration lookup failure degrades to 503 (transient), not 404', async () => {
+  // When the agents-table query itself fails, the bridge can't tell offline
+  // from unknown — report transient so a bridge-side DB outage doesn't park
+  // known-good agents in consumers' long misconfiguration cooldown.
+  const failingSql = (async () => {
+    throw new Error('connection refused');
+  }) as unknown as Sql;
+  const { app } = buildApp({ sql: failingSql });
+
+  const res = await app.request('/agents/maybe-registered', { method: 'POST' });
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get('Retry-After'), '60');
+});
+
 test('caller not in allowedCallers responds 403 with WWW-Authenticate error="insufficient_scope"', async () => {
   _resetSiweBearerCacheForTests();
   // The agent only allows a different principal — the bearer's address is
@@ -236,6 +279,18 @@ test('agent_not_connected (404) body carries rejectionId in error.data', async (
 
   const res = await app.request('/agents/missing', { method: 'POST' });
   assert.equal(res.status, 404);
+  const body = (await res.json()) as {
+    error: { code: number; data?: { rejectionId?: string } };
+  };
+  assert.equal(body.error.code, -32000);
+  assert.match(body.error.data?.rejectionId ?? '', REJECTION_ID_RE);
+});
+
+test('agent_unavailable (503) body carries rejectionId in error.data', async () => {
+  const { app } = buildApp({ sql: fakeSql(['ghost']) });
+
+  const res = await app.request('/agents/ghost', { method: 'POST' });
+  assert.equal(res.status, 503);
   const body = (await res.json()) as {
     error: { code: number; data?: { rejectionId?: string } };
   };

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -56,6 +56,35 @@ function rejectionErrorBody(
   };
 }
 
+// Issue #352 — a bare 404 is reserved for agent ids the bridge has never
+// heard of (unknown / unrouteable / misconfigured). A row in `agents` with no
+// live WebSocket route means the agent is registered but currently offline
+// (operator stopped it, mid-restart) — a transient condition that downstream
+// routers should retry shortly, signaled as 503 + Retry-After instead.
+//
+// On a DB error we can't tell the two apart; report 'offline' (503) so a
+// bridge-side outage reads as transient to consumers rather than parking
+// known-good agents in a long misconfiguration cooldown.
+export async function classifyMissingAgent(
+  sql: Sql,
+  agentId: string,
+): Promise<'unknown' | 'offline'> {
+  try {
+    const rows = await sql`SELECT 1 FROM agents WHERE id = ${agentId}`;
+    return rows.length > 0 ? 'offline' : 'unknown';
+  } catch (err) {
+    logEvent('agent_lookup_failed', {
+      agentId,
+      detail: truncate((err as Error).message, 256),
+    });
+    return 'offline';
+  }
+}
+
+// Hint for consumers sizing their retry backoff when an agent is registered
+// but offline. Operator restarts typically complete within a minute.
+export const AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS = 60;
+
 // Cap the error_description so a long upstream err.message can't push the
 // WWW-Authenticate header past common proxy/server limits (often ~8KB total).
 const ERROR_DESCRIPTION_MAX_LEN = 200;
@@ -136,6 +165,22 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const conn = registry.getAgent(agentId);
     if (!conn) {
       const rejectionId = newRejectionId();
+      if ((await classifyMissingAgent(opts.sql, agentId)) === 'offline') {
+        logEvent('agent_request_rejected', {
+          agentId,
+          reason: 'agent_unavailable',
+          rejectionId,
+        });
+        c.header('Retry-After', String(AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS));
+        return c.json(
+          rejectionErrorBody(
+            -32000,
+            'Agent temporarily unavailable (registered but not connected)',
+            rejectionId,
+          ),
+          503,
+        );
+      }
       logEvent('agent_request_rejected', {
         agentId,
         reason: 'agent_not_connected',

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -23,7 +23,13 @@ import {
   listClientsForOwner,
   removeCaller,
 } from './admin-api.js';
-import { agentAuthMiddleware, getAgentConn, getCaller } from './agent-auth.js';
+import {
+  AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS,
+  agentAuthMiddleware,
+  classifyMissingAgent,
+  getAgentConn,
+  getCaller,
+} from './agent-auth.js';
 import { CALLER_TOKEN_PREFIX, OWNER_SESSION_PREFIX, verifySessionToken } from './auth/caller-token.js';
 import { mountDeviceFlow } from './auth/device-flow.js';
 import { mountDeviceUi } from './auth/device-ui.js';
@@ -583,10 +589,18 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   });
 
   // Client agent cards
-  app.get('/agents/:id/.well-known/agent-card.json', (c) => {
+  app.get('/agents/:id/.well-known/agent-card.json', async (c) => {
     const id = c.req.param('id');
     const conn = opts.registry.getAgent(id);
-    if (!conn) return c.json({ error: 'agent not connected' }, 404);
+    if (!conn) {
+      // Issue #352 — the card itself only exists on a live connection, but a
+      // registered-but-offline agent is still a transient 503, not a 404.
+      if ((await classifyMissingAgent(opts.db, id)) === 'offline') {
+        c.header('Retry-After', String(AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS));
+        return c.json({ error: 'agent temporarily unavailable' }, 503);
+      }
+      return c.json({ error: 'agent not connected' }, 404);
+    }
     return c.json(getAgentForConn(conn).getAgentCard() as AgentCardV03);
   });
 


### PR DESCRIPTION
Closes #352

## Problem

When the bridge has no live route for an agent, `POST /agents/:id` (and the agent-card endpoint) returned a bare **404** in two semantically different situations:

1. **Unknown / misconfigured agent id** — never registered or deregistered. Permanent; needs an operator.
2. **Registered agent whose client is currently disconnected** — operator stopped it, or it's mid-restart. Transient; clears on its own.

Downstream routers can't tell these apart, so `a2x-internal-router` had to classify every bridge 404 as a misconfiguration and apply its long (24h) human-action cooldown — over-penalizing agents that were just briefly turned off.

## Change

The `agents` table already persists registrations across WebSocket disconnects (rows are only removed on explicit deletion), so the bridge can distinguish the two cases. The missing-agent branch in `agentAuthMiddleware` now checks it:

- **Registered but offline** → `503 Service Unavailable` with `Retry-After: 60`, JSON-RPC error message "Agent temporarily unavailable (registered but not connected)", rejection logged as `agent_unavailable`.
- **Unknown agent id** → bare `404`, unchanged.
- **Lookup failure** (agents-table query errors) → `503`, so a bridge-side DB outage reads as transient to consumers instead of parking known-good agents in the misconfiguration cooldown.

`GET /agents/:id/.well-known/agent-card.json` gets the same split via the shared `classifyMissingAgent` helper.

The extra DB query only runs on the no-live-route path (a single PK lookup), so the connected-agent hot path is untouched. Existing-agent existence was already observable to unauthenticated callers (401 for connected vs 404 for not), so the 503/404 split introduces no new information leak class.

## Acceptance criteria (from #352)

- [x] A request to a **registered-but-offline** agent returns 503, not a bare 404.
- [x] A request to an **unknown / unregistered** agent still returns 404.
- [x] `Retry-After` on the 503 so consumers can size their backoff.

## Testing

- New unit tests in `agent-auth.test.ts`: registered-but-offline → 503 + `Retry-After: 60` + rejectionId in `error.data`; lookup failure → 503; unknown agent → 404 (existing tests unchanged).
- `pnpm -r build`, `pnpm -r typecheck`, server suite (203 pass / 0 fail), client suite (708 pass / 0 fail).

No changeset — server-only change, `@vicoop-bridge/server` ships via `fly deploy` and is changeset-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)