### PR TITLE
fix(client): defer codex turn/interrupt until tokenUsage lands on tool-call turns

### DIFF
--- a/.changeset/codex-deferred-interrupt-usage-351.md
+++ b/.changeset/codex-deferred-interrupt-usage-351.md
@@ -1,0 +1,20 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+codex backend: recover real token usage on OpenAI-compatible tool-call
+turns by deferring `turn/interrupt` until codex's
+`thread/tokenUsage/updated` lands (#351). Previously the bridge
+interrupted the turn the moment the model invoked a caller tool, which
+raced ahead of codex app-server's token accounting — the accounting only
+runs after the bridge answers the `item/tool/call` request, and an
+interrupt in flight at that point drops the turn's usage everywhere (no
+notification, no `turn/completed` payload, `info: null` even in codex's
+own rollout record), so the router billed the request as
+`total_tokens=0`. The interrupt is now held until the usage notification
+for the turn arrives (measured at 15–40ms on codex 0.139, well ahead of
+the ~500ms a next model iteration needs to start) with a 1s backstop
+timer, configurable via `toolCallUsageWaitMs`. When codex still reports
+nothing, the `{0,0,0}` placeholder remains, and the bridge now logs a
+`tokenUsage unavailable` diagnostic so zero-usage records are
+explainable without `--openai-compat-trace`.

--- a/packages/client/src/backends/codex.test.ts
+++ b/packages/client/src/backends/codex.test.ts
@@ -1395,6 +1395,35 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on
         });
         return;
       }
+      if (id === 'srv-1' && 'result' in (frame as object)) {
+        // codex runs token accounting only after the bridge answers the
+        // tool call (#351) — emit the usage notification at that point,
+        // mirroring the real app-server's ordering.
+        child.emitStdout({
+          method: 'thread/tokenUsage/updated',
+          params: {
+            threadId: 'thr-1',
+            turnId: 'turn-1',
+            tokenUsage: {
+              total: {
+                totalTokens: 1234,
+                inputTokens: 1200,
+                cachedInputTokens: 1000,
+                outputTokens: 34,
+                reasoningOutputTokens: 5,
+              },
+              last: {
+                totalTokens: 1234,
+                inputTokens: 1200,
+                cachedInputTokens: 1000,
+                outputTokens: 34,
+                reasoningOutputTokens: 5,
+              },
+            },
+          },
+        });
+        return;
+      }
       if (method === 'turn/interrupt' && id !== undefined) {
         child.emitStdout({ id, result: {} });
         // After receiving turn/interrupt, codex emits the terminal
@@ -1514,20 +1543,36 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on
     assert.deepEqual(JSON.parse(argsRaw as string), {
       url: 'https://example.com',
     });
+    // Deferred-interrupt usage recovery (#351): the bridge held the
+    // interrupt until codex's post-tool-call `thread/tokenUsage/updated`
+    // landed, so the envelope carries REAL usage — not the `{0,0,0}`
+    // placeholder an immediate interrupt used to force.
+    const usage = envelope.usage as
+      | {
+          prompt_tokens?: number;
+          completion_tokens?: number;
+          total_tokens?: number;
+          prompt_tokens_details?: { cached_tokens?: number };
+          completion_tokens_details?: { reasoning_tokens?: number };
+        }
+      | undefined;
+    assert.ok(usage, 'usage present on tool-call envelope');
+    assert.equal(usage?.prompt_tokens, 1200);
+    assert.equal(usage?.completion_tokens, 34);
+    assert.equal(usage?.total_tokens, 1234);
+    assert.equal(usage?.prompt_tokens_details?.cached_tokens, 1000);
+    assert.equal(usage?.completion_tokens_details?.reasoning_tokens, 5);
   }
 
   // Bridge must have sent `turn/interrupt` for our turn — that, plus
   // codex's terminal `turn/completed` notification, is what unwinds the
-  // turn. (The bridge also sends back a `DynamicToolCallResponse` for the
-  // server-initiated `item/tool/call`, but the async handler's promise
-  // unwrap may schedule that write one microtask after `handle()` returns;
-  // we drain the queue below before asserting it was eventually sent.)
+  // turn.
   const sent = fake.lastChild().stdinFrames();
   const interrupt = findRequest(sent, 'turn/interrupt');
   assert.ok(interrupt, 'turn/interrupt was sent');
 
-  // Drain pending microtasks, then confirm the bridge eventually replied
-  // to the server-initiated `item/tool/call`. codex would block the turn
+  // Drain pending microtasks, then confirm the bridge replied to the
+  // server-initiated `item/tool/call`. codex would block the turn
   // indefinitely waiting for that response, so it must always be sent —
   // even though the turn/interrupt path means codex won't act on its
   // contents. A few macrotask cycles flush any chained promise resolutions
@@ -1536,15 +1581,32 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on
     await new Promise<void>((r) => setImmediate(r));
   }
   const drained = fake.lastChild().stdinFrames();
-  const toolResp = drained.find(
+  const toolRespIdx = drained.findIndex(
     (f) =>
       f !== null &&
       typeof f === 'object' &&
       (f as { id?: unknown }).id === 'srv-1' &&
       'result' in (f as object),
-  ) as { result?: { contentItems?: unknown[]; success?: boolean } } | undefined;
+  );
+  const toolResp = drained[toolRespIdx] as
+    | { result?: { contentItems?: unknown[]; success?: boolean } }
+    | undefined;
   assert.ok(toolResp, 'bridge responded to item/tool/call');
   assert.equal(typeof toolResp?.result?.success, 'boolean');
+  // Deferred interrupt (#351): the tool-call response must hit the wire
+  // BEFORE turn/interrupt — codex's token accounting is blocked on the
+  // response, and an interrupt ahead of it drops the turn's usage.
+  const interruptIdx = drained.findIndex(
+    (f) =>
+      f !== null &&
+      typeof f === 'object' &&
+      (f as { method?: string }).method === 'turn/interrupt',
+  );
+  assert.ok(interruptIdx !== -1, 'turn/interrupt present in drained frames');
+  assert.ok(
+    toolRespIdx !== -1 && toolRespIdx < interruptIdx,
+    'item/tool/call response precedes the deferred turn/interrupt',
+  );
 
   // dynamicTools must have been included on thread/start.
   const tsFrame = findRequest(sent, 'thread/start') as
@@ -1567,6 +1629,126 @@ test('openai-compat dynamicTools: item/tool/call → chat_completion envelope on
     params.developerInstructions?.includes('tool_calls'),
     false,
     'native path must not teach the JSON envelope contract',
+  );
+});
+
+// Deferred-interrupt backstop (#351): when codex never emits
+// `thread/tokenUsage/updated` after the tool call, the interrupt still
+// fires after `toolCallUsageWaitMs`, the envelope falls back to the
+// `{0,0,0}` placeholder, and the operator gets a diagnostic warn so
+// zero-usage records are explainable without --openai-compat-trace.
+test('deferred interrupt times out without tokenUsage → placeholder usage + diagnostic warn (#351)', async () => {
+  const fake = makeFakeSpawn(() => ({
+    onLine(frame, child) {
+      const id = (frame as { id?: number | string }).id;
+      const method = (frame as { method?: string }).method;
+      if (method === 'initialize' && id !== undefined) {
+        child.emitStdout({ id, result: {} });
+        return;
+      }
+      if (method === 'thread/start' && id !== undefined) {
+        child.emitStdout({ id, result: { thread: { id: 'thr-1' } } });
+        return;
+      }
+      if (method === 'thread/inject_items' && id !== undefined) {
+        child.emitStdout({ id, result: {} });
+        return;
+      }
+      if (method === 'turn/start' && id !== undefined) {
+        child.emitStdout({
+          id,
+          result: { turn: { id: 'turn-1', status: 'inProgress' } },
+        });
+        queueMicrotask(() => {
+          child.emitStdout({
+            id: 'srv-1',
+            method: 'item/tool/call',
+            params: {
+              threadId: 'thr-1',
+              turnId: 'turn-1',
+              callId: 'call_nousage',
+              namespace: null,
+              tool: 'fetch',
+              arguments: { url: 'https://example.com' },
+            },
+          });
+        });
+        return;
+      }
+      // No thread/tokenUsage/updated is ever emitted — the deferred
+      // interrupt must fall back to its timer.
+      if (method === 'turn/interrupt' && id !== undefined) {
+        child.emitStdout({ id, result: {} });
+        queueMicrotask(() => {
+          child.emitStdout({
+            method: 'turn/completed',
+            params: {
+              turn: { id: 'turn-1', status: 'interrupted', items: [], error: null },
+            },
+          });
+        });
+        return;
+      }
+    },
+  }));
+  const warns: string[] = [];
+  const backend = createCodexBackend({
+    spawn: fake.spawn,
+    toolCallUsageWaitMs: 10,
+    logger: {
+      level: 'warn',
+      error: () => {},
+      warn: (...args: unknown[]) => {
+        warns.push(args.map(String).join(' '));
+      },
+      info: () => {},
+      debug: () => {},
+    },
+  });
+  const { emit, frames } = collect();
+  await backend.handle(
+    assign('fetch example.com', 'ctx-oai-timeout', {
+      message: {
+        role: 'user',
+        messageId: 'm',
+        parts: [{ kind: 'text', text: 'fetch example.com' }],
+        metadata: {
+          [OPENAI_COMPAT_EXTENSION_URI]: {
+            chat_completions_request: {
+              messages: [{ role: 'user', content: 'fetch example.com' }],
+              tools: [
+                {
+                  type: 'function',
+                  function: { name: 'fetch', parameters: {} },
+                },
+              ],
+            },
+          },
+        },
+      },
+    }),
+    emit,
+    NEVER,
+  );
+
+  const complete = frames.find((f) => f.type === 'task.complete');
+  assert.ok(complete && complete.type === 'task.complete');
+  assert.equal(complete.status.state, 'completed');
+  const metadata = complete.status.message?.metadata as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const envelope = metadata?.[OPENAI_COMPAT_EXTENSION_URI]?.chat_completion as
+    | Record<string, unknown>
+    | undefined;
+  assert.ok(envelope, 'chat_completion envelope present');
+  assert.deepEqual(envelope.usage, {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  });
+  assert.ok(
+    warns.some((w) => w.includes('tokenUsage unavailable')),
+    `diagnostic warn emitted (got: ${JSON.stringify(warns)})`,
   );
 });
 
@@ -1826,7 +2008,9 @@ test('dynamicTools handler is registered on every openai-compat turn (#209, #233
       }
     },
   }));
-  const backend = createCodexBackend({ spawn: fake.spawn });
+  // This fake never emits thread/tokenUsage/updated, so the deferred
+  // interrupt (#351) only fires on its backstop timer — keep it short.
+  const backend = createCodexBackend({ spawn: fake.spawn, toolCallUsageWaitMs: 5 });
 
   const oaiMetaFor = (text: string): Record<string, unknown> => ({
     [OPENAI_COMPAT_EXTENSION_URI]: {

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -84,6 +84,15 @@ export interface CodexBackendOptions {
   // (no client-side timeout — the server is authoritative). Set to a
   // positive value to fail-fast against a hung agent.
   turnTimeoutMs?: number;
+  // How long to hold the `turn/interrupt` after an `item/tool/call`,
+  // waiting for codex's `thread/tokenUsage/updated` to land first (#351).
+  // Interrupting immediately races ahead of codex's token accounting and
+  // the turn's usage is dropped entirely; the notification arrives within
+  // tens of ms of the tool call once the bridge has answered it, while the
+  // next model iteration takes ~500ms to start — so a short hold recovers
+  // real usage at no extra model cost. On timeout the interrupt is sent
+  // anyway and the `{0,0,0}` placeholder path applies. Default 1s.
+  toolCallUsageWaitMs?: number;
   // Test seam — overrides the default codex config.toml reader used by
   // `resolveCapabilities` to advertise the underlying model on the
   // openai-compat/v1 extension. Returning `null` (or rejecting) keeps the
@@ -671,6 +680,7 @@ export function createCodexBackend(
   const logger = opts.logger ?? createLogger();
   const initializeTimeoutMs = opts.initializeTimeoutMs ?? 10_000;
   const turnTimeoutMs = opts.turnTimeoutMs ?? 0;
+  const toolCallUsageWaitMs = opts.toolCallUsageWaitMs ?? 1_000;
   // Precomputed once at construction (identity is per-daemon, not per-task).
   // Prepended to `developerInstructions` on every `thread/start` so the model
   // recognises its own mention / acct in user messages. See PR #129.
@@ -1443,6 +1453,38 @@ export function createCodexBackend(
           // `tool_calls` artifact, matching OpenAI Chat Completions'
           // `finish_reason: "tool_calls"` semantics.
           let capturedToolCall = false;
+          // Deferred `turn/interrupt` for tool-call turns (#351). codex
+          // app-server runs its token accounting (and the resulting
+          // `thread/tokenUsage/updated`) only AFTER the bridge has answered
+          // the `item/tool/call` server request — and an interrupt that
+          // lands before that point aborts the turn task with the usage
+          // dropped everywhere (no notification, no `turn/completed`
+          // payload, `info: null` even in codex's own rollout record). So
+          // instead of interrupting inside the tool-call handler, we arm a
+          // deferred interrupt here: it fires as soon as the usage
+          // notification for this turn arrives, or after
+          // `toolCallUsageWaitMs` as a backstop. Measured against codex
+          // 0.139, usage lands within tens of ms of the tool-call response
+          // while the next model iteration needs ~500ms to start, so the
+          // hold recovers real usage without letting the model continue.
+          let interruptRequested = false;
+          let interruptSent = false;
+          let interruptTimer: ReturnType<typeof setTimeout> | null = null;
+          const sendDeferredInterrupt = (): void => {
+            if (interruptSent) return;
+            interruptSent = true;
+            if (interruptTimer !== null) {
+              clearTimeout(interruptTimer);
+              interruptTimer = null;
+            }
+            if (activeTurnId) {
+              void client
+                .request('turn/interrupt', { threadId, turnId: activeTurnId })
+                .catch(() => {
+                  // Best-effort; the turn loop watches for turn/completed.
+                });
+            }
+          };
           // OpenAI Chat Completions tool_calls accumulated from codex's
           // server-initiated `item/tool/call` events. Surfaced to the gateway
           // via the terminal `chat_completion` envelope on
@@ -1480,17 +1522,27 @@ export function createCodexBackend(
                 type: 'function',
                 function: { name: p.tool, arguments: argsString },
               });
-              // Best-effort `turn/interrupt` so codex unwinds the turn —
-              // the model's function_call is already surfaced upstream and
-              // we don't want it generating further text or chaining into
-              // another tool call before the caller has had a chance to
-              // reply via `chat_history`.
-              if (activeTurnId) {
-                void client
-                  .request('turn/interrupt', { threadId, turnId: activeTurnId })
-                  .catch(() => {
-                    // Best-effort; the turn loop watches for turn/completed.
-                  });
+              // Arm the deferred `turn/interrupt` so codex unwinds the
+              // turn — the model's function_call is already surfaced
+              // upstream and we don't want it generating further text or
+              // chaining into another tool call before the caller has had
+              // a chance to reply via `chat_history`. The interrupt is
+              // NOT sent here: codex only runs token accounting after our
+              // tool-call response below, and an interrupt in flight at
+              // that point drops the turn's usage entirely (#351). The
+              // tokenUsage notification handler fires it the moment usage
+              // lands; the timer is the no-usage backstop.
+              // Always wait for the NEXT usage notification, even when an
+              // earlier model iteration already populated `finalUsage`:
+              // accounting for the iteration that produced THIS
+              // function_call only runs after our response below, so its
+              // notification is always still ahead of us at this point.
+              if (!interruptRequested) {
+                interruptRequested = true;
+                interruptTimer = setTimeout(
+                  sendDeferredInterrupt,
+                  toolCallUsageWaitMs,
+                );
               }
               // codex still expects a structured answer to the server
               // request; success=false signals the model that the result
@@ -1561,6 +1613,13 @@ export function createCodexBackend(
               if (settled) return;
               settled = true;
               cleanupNotifications();
+              // Disarm a pending deferred interrupt — the turn already
+              // reached a terminal state, so firing it later would only
+              // poke a dead turn.
+              if (interruptTimer !== null) {
+                clearTimeout(interruptTimer);
+                interruptTimer = null;
+              }
               if (heartbeatHandle !== null) clearIntervalImpl(heartbeatHandle);
               signal.removeEventListener('abort', onAbort);
               resolve(o);
@@ -1584,6 +1643,9 @@ export function createCodexBackend(
                   );
                 }
                 if (parsed) finalUsage = parsed;
+                // Usage is in — release any interrupt held back by the
+                // tool-call handler (#351).
+                if (parsed && interruptRequested) sendDeferredInterrupt();
                 return;
               }
               if (method === 'item/completed') {
@@ -1821,16 +1883,27 @@ export function createCodexBackend(
           const finishReason: 'tool_calls' | 'stop' =
             capturedToolCalls.length > 0 ? 'tool_calls' : 'stop';
           const assistantContent = capturedToolCalls.length > 0 ? null : completeText;
-          // Placeholder fallback for codex app-server's known limitation:
-          // `thread/tokenUsage/updated` does not fire on tool-call-only
-          // (interrupted) turns, and `turn/completed` carries no usage
-          // payload for those turns either. The openai-compat/v1 envelope
-          // contract requires `usage` to be present — when codex genuinely
-          // didn't surface it, emit `{0,0,0}` as a placeholder rather than
-          // omit the field (which would trip the gateway's strict
-          // missing_usage 502). The zeros honestly signal "runtime did
-          // not report" rather than fabricating a tokenizer estimate the
-          // codex runtime never produced.
+          // Placeholder fallback: with the deferred interrupt above,
+          // tool-call turns normally get real usage before unwinding, but
+          // codex can still end a turn without ever emitting
+          // `thread/tokenUsage/updated` (usage held past
+          // `toolCallUsageWaitMs`, or an upstream accounting drop — #351).
+          // The openai-compat/v1 envelope contract requires `usage` to be
+          // present — when codex genuinely didn't surface it, emit
+          // `{0,0,0}` as a placeholder rather than omit the field (which
+          // would trip the gateway's strict missing_usage 502). The zeros
+          // honestly signal "runtime did not report" rather than
+          // fabricating a tokenizer estimate the codex runtime never
+          // produced.
+          if (envelope && !finalUsage) {
+            logger?.warn?.(
+              `[codex] tokenUsage unavailable for task ${task.taskId}: ` +
+                (capturedToolCall
+                  ? `codex emitted no thread/tokenUsage/updated within ${toolCallUsageWaitMs}ms of the tool call before the turn was interrupted`
+                  : 'codex emitted no thread/tokenUsage/updated for this turn') +
+                '; emitting {0,0,0} placeholder usage',
+            );
+          }
           const finalUsageSnapshot: OpenAICompatUsage | null = envelope && !finalUsage
             ? buildOpenAICompatUsage({
                 prompt_tokens: 0,


### PR DESCRIPTION
Fixes #351.

## Root cause

For OpenAI-compat tool-call turns the bridge sent `turn/interrupt` the moment `item/tool/call` arrived. codex app-server runs its token accounting only **after** the bridge answers the tool-call request, and an interrupt in flight at that point aborts the turn task with the usage dropped everywhere:

- no `thread/tokenUsage/updated` notification
- no usage payload on `turn/completed` (the 0.139 protocol has no usage field on `Turn`/`Thread`, and `account/usage/read` is account-level only)
- `"type":"token_count","info":null` even in codex's own rollout record
- the usage-bearing OTel event (`codex.sse_event` kind=`response.completed`) is emitted from the same processing path, so telemetry loses it too — only the raw transport `codex.websocket_event` proves the API actually delivered the usage

So the router billed successful streamed tool requests as `total_tokens=0`. The symptom looked intermittent because text-final turns (and the occasional tool-call turn where accounting won the race) reported usage fine.

## Verification against codex 0.139 app-server (direct JSON-RPC probes)

| strategy | usage recovered | notes |
|---|---|---|
| interrupt immediately (current bridge) | 0/8 | matches #351 zero-usage records |
| answer tool call → wait for `thread/tokenUsage/updated` → interrupt | **4/4** | usage arrived **15–40ms** after the response |
| withhold the tool response while waiting | 0/4 within the wait | accounting is blocked on the response — confirms the response must go first |

The next model iteration needs ~500ms to start (websocket request → first output item), so the deferred interrupt at +15–40ms lands long before the model can generate anything extra; probes observed zero post-tool-call items and no added output tokens.

## Change

- `item/tool/call` handler no longer fires `turn/interrupt` inline. It arms a deferred interrupt: released by the turn's next `thread/tokenUsage/updated`, with a backstop timer (`toolCallUsageWaitMs`, default 1s, test seam). Timer is disarmed on turn settle.
- Always waits for the **next** usage notification even if an earlier model iteration already populated usage — the accounting for the iteration that produced the function_call is always still ahead at that point.
- `{0,0,0}` placeholder path unchanged as the safety net, now with the diagnostic asked for in #351: `[codex] tokenUsage unavailable for task <id>: …; emitting {0,0,0} placeholder usage`.

## Tests

- Tool-call envelope test now mirrors the real app-server ordering (usage emitted only after the tool-call response) and asserts the envelope carries the real usage plus the wire order (response precedes interrupt).
- New test: no usage → interrupt fires on the backstop timer, placeholder `{0,0,0}` ships, diagnostic warn emitted.
- `pnpm -r typecheck` clean; client suite 709/709 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)