### PR TITLE
feat(server): send rich logs + traces to the shared Sentry project

### DIFF
--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -15,4 +15,13 @@ Sentry.init({
   enabled: process.env.SENTRY_ENABLED === 'true',
   // Backend service: trace all requests by default. Tune via SENTRY_TRACES_SAMPLE_RATE.
   tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '1.0'),
+  // Send logs to the shared "vicoop-router-monitoring" project. `enableLogs`
+  // only opens the transport; consoleLoggingIntegration is what feeds it —
+  // forwarding the server's console.* output as structured Sentry logs. (No
+  // Fly auto-stop flush concern here: packages/server/fly.toml keeps
+  // min_machines_running=1, so the periodic log flush always runs.)
+  enableLogs: true,
+  integrations: [
+    Sentry.consoleLoggingIntegration({ levels: ['log', 'info', 'warn', 'error'] }),
+  ],
 });


### PR DESCRIPTION
## What
Make `@vicoop-bridge/server` log richly to the shared **`vicoop-router-monitoring`** Sentry project (same project a2x uses), with detailed client/agent context, and tie each agent call to its trace.

## Commits
1. **enableLogs + console forwarding** — `enableLogs: true` + `consoleLoggingIntegration` so the server's `console.*` / structured `logEvent` JSON flow to Sentry Logs.
2. **Rich connect/disconnect + agent-call logs + trace session attrs.**

## What's logged now (Logs, `service: vicoop-bridge-server`)
- **`client_connected` / `client_disconnected`**: `agentId`, `clientId`, `email` (owner email; null for SIWE), `ownerPrincipal`, `backend` (canonical backendKind e.g. `claude`/`codex`/`vicoop-codex`, or `inline`), plus connection duration (`connectedMs`) on disconnect.
- **`agent_request`**: `agentId`, `backend`, owner `email`, caller `principalId` + `callerEmail` (when the caller is Google-authenticated).
- **`task_completed` / `task_failed_by_client`**: `agentId`, `backend`, `taskId`, `contextId`, `principalId`.

## Traces
On agent invocation the `@sentry/hono` transaction (one per HTTP request) gets `bridge.agent` / `bridge.backend` / `bridge.caller` attributes. The executor + the WS round-trip to the provider run **synchronously within the HTTP request**, so the whole request session is already one trace — these attributes make it identifiable.

## Notes
- `email` comes from `agents.owner_email` (device-flow / Google registrations); **SIWE-onboarded clients have no email** — `ownerPrincipal` (`eth:0x…`) identifies them instead.
- `ClientConnection` gained `ownerEmail` + `backendKind` (threaded at register) so the info is available at every lifecycle point.
- No prompt/message bodies or tokens logged; caller-controlled strings are truncated.
- `min_machines_running=1`, so no Fly auto-stop flush concern.
- Activation requires a **manual deploy** (`fly deploy -c packages/server/fly.toml .`) with the `SENTRY_DSN` secret applied — bridge does not auto-deploy on merge.
- `pnpm --filter @vicoop-bridge/server typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
