### PR TITLE
fix(server): unbreak deploy (COPY patches/) + rich connect/agent-call logs

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -8,6 +8,10 @@ RUN apk add --no-cache python3 make g++
 RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml* ./
+# package.json's pnpm.patchedDependencies references files under patches/;
+# they must be present before install or `pnpm install --frozen-lockfile`
+# fails with ENOENT (e.g. patches/@optique__core@1.0.2.patch).
+COPY patches/ patches/
 COPY tsconfig.base.json ./
 COPY packages/protocol/package.json packages/protocol/
 COPY packages/server/package.json packages/server/

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -6,6 +6,7 @@ import { stream } from 'hono/streaming';
 import { html } from 'hono/html';
 import { cors } from 'hono/cors';
 import { sentry } from '@sentry/hono/node';
+import * as Sentry from '@sentry/hono/node';
 import {
   A2XAgent,
   DefaultRequestHandler,
@@ -625,8 +626,23 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     const caller = getCaller(c);
     logEvent('agent_request', {
       agentId: conn.agentId,
+      backend: conn.backendKind ?? 'inline',
+      ownerEmail: conn.ownerEmail ?? undefined,
       hasAuth: !!c.req.header('Authorization'),
-      ...(caller !== undefined ? { principalId: caller.principalId } : {}),
+      ...(caller !== undefined
+        ? {
+            principalId: caller.principalId,
+            ...(caller.email ? { callerEmail: caller.email } : {}),
+          }
+        : {}),
+    });
+    // Tie this request session to its trace: the @sentry/hono transaction wraps
+    // the whole handler (the executor + the WS round-trip to the provider run
+    // within it), so these attributes make the session identifiable in the trace.
+    Sentry.getActiveSpan()?.setAttributes({
+      'bridge.agent': conn.agentId,
+      'bridge.backend': conn.backendKind ?? 'inline',
+      'bridge.caller': caller?.principalId ?? 'public',
     });
 
     const rawBody = await c.req.text();

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -9,6 +9,12 @@ export interface ClientConnection {
   agentId: string;
   clientId: string;
   ownerPrincipal: string;
+  // Owner's email (device-flow registrations); null for SIWE-onboarded clients
+  // that only have a wallet principal. Carried for observability/logging.
+  ownerEmail?: string | null;
+  // Canonical backend kind (e.g. "claude", "codex", "vicoop-codex"); undefined
+  // when the client supplied an inline agent card. Used for logging the backend.
+  backendKind?: string;
   agentCard: AgentCard;
   allowedCallers: string[];
   ws: WebSocket;

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -21,6 +21,7 @@ interface ClientRow {
   id: string;
   client_id: string;
   owner_principal: string;
+  owner_email: string | null;
   allowed_callers: string[];
 }
 
@@ -30,7 +31,7 @@ async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | nu
   // deleted simply matches nothing and the daemon sees the 4005 "bad token"
   // path.
   const rows = await sql<ClientRow[]>`
-    SELECT id, client_id, owner_principal, allowed_callers
+    SELECT id, client_id, owner_principal, owner_email, allowed_callers
     FROM agents
     WHERE token_hash = ${hash}
   `;
@@ -58,7 +59,14 @@ export function attachWsServer(server: Server, opts: ServerWsOptions): void {
 }
 
 type AuthResult =
-  | { ok: true; clientId: string; cardName: string; cardSource: 'inline' | 'canonical' }
+  | {
+      ok: true;
+      clientId: string;
+      cardName: string;
+      cardSource: 'inline' | 'canonical';
+      ownerPrincipal: string;
+      ownerEmail: string | null;
+    }
   | { ok: false; code: number; reason: string };
 
 async function authenticateAndRegister(
@@ -112,6 +120,8 @@ async function authenticateAndRegister(
     agentId: frame.agentId,
     clientId,
     ownerPrincipal,
+    ownerEmail: client.owner_email,
+    backendKind: frame.backendKind,
     agentCard: resolvedCard.agentCard,
     allowedCallers: client.allowed_callers,
     ws,
@@ -131,6 +141,8 @@ async function authenticateAndRegister(
     clientId,
     cardName: resolvedCard.agentCard.name,
     cardSource: resolvedCard.source,
+    ownerPrincipal,
+    ownerEmail: client.owner_email,
   };
 }
 
@@ -208,6 +220,12 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         logEvent('client_connected', {
           agentId,
           clientId: result.clientId,
+          email: result.ownerEmail ?? undefined,
+          ownerPrincipal: result.ownerPrincipal,
+          backend:
+            result.cardSource === 'canonical'
+              ? truncate(frame.backendKind ?? 'unknown', 64)
+              : 'inline',
           name: result.cardName,
           cardSource: result.cardSource,
         });
@@ -262,7 +280,9 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         opts.registry.unbindTask(frame.taskId);
         logEvent('task_completed', {
           agentId: b.agentId,
+          backend: opts.registry.getAgent(b.agentId)?.backendKind ?? 'inline',
           taskId: frame.taskId,
+          contextId: b.contextId,
           state: frame.status.state,
           ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
         });
@@ -292,7 +312,9 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         opts.registry.unbindTask(frame.taskId);
         logEvent('task_failed_by_client', {
           agentId: b.agentId,
+          backend: opts.registry.getAgent(b.agentId)?.backendKind ?? 'inline',
           taskId: frame.taskId,
+          contextId: b.contextId,
           errorCode: frame.error.code,
           errorMessage: truncate(frame.error.message, 256),
           ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
@@ -310,7 +332,21 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   ws.on('close', () => {
     clearTimeout(helloTimeout);
     if (agentId) {
-      logEvent('client_disconnected', { agentId });
+      // Look up the live connection BEFORE unregistering so the disconnect log
+      // carries the same identifying detail as client_connected.
+      const conn = opts.registry.getAgent(agentId);
+      logEvent('client_disconnected', {
+        agentId,
+        ...(conn
+          ? {
+              clientId: conn.clientId,
+              email: conn.ownerEmail ?? undefined,
+              ownerPrincipal: conn.ownerPrincipal,
+              backend: conn.backendKind ?? 'inline',
+              connectedMs: Date.now() - conn.connectedAt,
+            }
+          : {}),
+      });
       opts.registry.unregisterAgent(agentId, ws);
     }
   });


### PR DESCRIPTION
## Two changes

### 1. Unbreak the server deploy (CI + manual)
`package.json` declares `pnpm.patchedDependencies` (`@optique/core@1.0.2` → `patches/@optique__core@1.0.2.patch`), but `packages/server/Dockerfile` never copied `patches/` before `pnpm install --frozen-lockfile`, so every server deploy failed with `ENOENT` on the patch file. **The server hadn't deployed since v78 (2026-06-04)** and the GitHub **Deploy Server** workflow has been failing. Fix: `COPY patches/ patches/` alongside the workspace manifests.

### 2. Rich client/agent observability logs (re-landing)
The connect/disconnect + agent-call logging meant for #356 never reached main (that PR was squash-merged with only its first commit before this was pushed). Re-applied here:
- **`client_connected` / `client_disconnected`**: + `email`, `ownerPrincipal`, `backend` (canonical kind or `inline`), `clientId`, `connectedMs`.
- **`agent_request`**: + `backend`, owner `email`, caller `principalId` / `callerEmail`.
- **`task_completed` / `task_failed_by_client`**: + `backend`, `contextId`.
- **Trace**: `bridge.agent` / `bridge.backend` / `bridge.caller` on the `@sentry/hono` request transaction (executor + WS round-trip run within it → one trace per request session).

## Notes
- `agents.owner_email` is null for SIWE clients → `ownerPrincipal` (`eth:0x…`) identifies them.
- No prompt bodies / tokens logged; caller-controlled strings truncated.
- `pnpm --filter @vicoop-bridge/server typecheck` passes.
- Merging re-runs the now-fixed **Deploy Server** workflow → deploys this to Fly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
