### PR TITLE
feat(client): opt-in crash telemetry (Sentry), off by default

### DIFF
--- a/.changeset/client-opt-in-telemetry.md
+++ b/.changeset/client-opt-in-telemetry.md
@@ -1,0 +1,13 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Add opt-in crash telemetry. Off by default — the client only loads or
+initializes the Sentry SDK when config.json has `"telemetry": "on"`. Opt in
+with `vicoop-client agent register --enable-telemetry` (persists the field) or
+by hand-editing config.json; disable by removing the field. When on, only
+crash reports are sent: exception class + stack trace with the operator's home
+path redacted. Tracing is disabled, breadcrumbs/console capture are suppressed,
+and `sendDefaultPii` is off — so prompts, code, agent output, tokens, and logs
+are never transmitted. The daemon prints a one-line disclosure at registration
+and at startup. DSN is configurable via `VICOOP_CLIENT_SENTRY_DSN`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,3 +77,10 @@ jobs:
       # no `published` signal.
       - name: Upload client release assets
         run: ./scripts/upload-client-release-assets.sh
+        env:
+          # Baked into the cross-compiled client binaries at build time so
+          # opt-in crash telemetry has somewhere to report. A Sentry DSN is a
+          # submit-only credential (safe to ship in a public binary); it's kept
+          # as a secret here only so it stays out of CI logs. Unset (e.g. forks
+          # without the secret) → binaries build with telemetry disabled.
+          VICOOP_CLIENT_SENTRY_DSN: ${{ secrets.VICOOP_CLIENT_SENTRY_DSN }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 .turbo/
 coverage/
 *.tsbuildinfo
+# Bun `--compile` intermediate artifacts (release client build runs from the
+# client package dir; Bun may leave these if a compile is interrupted).
+*.bun-build

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -356,7 +356,9 @@ Turn it back off by removing the field or setting `"telemetry": "off"`. A
 register re-run without `--enable-telemetry` never silently disables a prior
 opt-in. The daemon prints a one-line `telemetry: on …` notice at startup so
 you can confirm the state. The Sentry endpoint is overridable with
-`VICOOP_CLIENT_SENTRY_DSN`.
+`VICOOP_CLIENT_SENTRY_DSN`, and `VICOOP_CLIENT_SENTRY_DEBUG=1` makes the SDK
+log each event it sends to the console — handy to confirm reports are actually
+leaving the host.
 
 > **Top-level vs `backends.*` parity.** Every operator-tunable knob is
 > reachable as a CLI flag and as a `config.json` field — pick whichever

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -332,6 +332,32 @@ runtime config (#189 §5) — secrets and overrides live in `config.json`
 `server_token`, and `agent_id` — hand-edits to the other fields survive
 re-runs.
 
+### Telemetry (opt-in)
+
+Crash telemetry is **off by default**. The client runs on your machine, so
+it never sends anything unless you opt in. When you do, the daemon reports
+**only crash data**: an exception's class and stack trace, with your home
+directory path redacted. It does **not** send prompts, code, agent output,
+tokens, or console logs — tracing is disabled, breadcrumb/console capture is
+suppressed, and no PII is attached. When telemetry is off, the Sentry SDK is
+never even loaded.
+
+Opt in either way:
+
+```bash
+# at registration time (persists "telemetry": "on" into config.json)
+vicoop-client agent register --agent-id <id> --enable-telemetry
+
+# or by hand-editing config.json
+{ "telemetry": "on" }
+```
+
+Turn it back off by removing the field or setting `"telemetry": "off"`. A
+register re-run without `--enable-telemetry` never silently disables a prior
+opt-in. The daemon prints a one-line `telemetry: on …` notice at startup so
+you can confirm the state. The Sentry endpoint is overridable with
+`VICOOP_CLIENT_SENTRY_DSN`.
+
 > **Top-level vs `backends.*` parity.** Every operator-tunable knob is
 > reachable as a CLI flag and as a `config.json` field — pick whichever
 > surface fits the deployment. Top-level fields (`server_url`,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,6 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@optique/core": "1.0.2",
     "@optique/run": "1.0.2",
+    "@sentry/node": "^10.57.0",
     "@vicoop-bridge/protocol": "workspace:*",
     "is-inside-container": "^1.0.0",
     "semver": "^7.8.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -24,7 +24,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@optique/core": "1.0.2",
     "@optique/run": "1.0.2",
-    "@sentry/node": "^10.57.0",
+    "@sentry/bun": "^10.57.0",
     "@vicoop-bridge/protocol": "workspace:*",
     "is-inside-container": "^1.0.0",
     "semver": "^7.8.0",

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -286,6 +286,26 @@ function resolveDaemonArgs(parsed: Extract<CliArgs, { action: 'daemon' }>): Args
   return result.args;
 }
 
+// Resolve whether crash telemetry is opted in, following the same
+// canonical-then-`--config`-overlay precedence as resolveDaemonArgs (CLI has no
+// flag for this — telemetry is operational policy, set once in config.json via
+// `agent register --enable-telemetry`, not a per-launch knob). Returns false
+// unless a readable config explicitly sets `"telemetry": "on"`; any
+// missing/unreadable/typo'd value reads as off.
+function resolveTelemetryEnabled(
+  parsed: Extract<CliArgs, { action: 'daemon' }>,
+): boolean {
+  const canonical = readConfig(defaultConfigPath());
+  let telemetry = canonical?.telemetry;
+  if (parsed.config) {
+    // `resolveDaemonArgs` already ran and exited on an unreadable --config, so
+    // a null here just means the overlay didn't set telemetry — keep canonical.
+    const overlay = readConfig(parsed.config);
+    if (overlay?.telemetry !== undefined) telemetry = overlay.telemetry;
+  }
+  return telemetry === 'on';
+}
+
 // Read & JSON-parse a `--claude-settings-file <path>` flag value. Parse errors
 // exit non-zero so an operator's typo doesn't silently fall through to the
 // next layer with no sandbox.
@@ -555,6 +575,50 @@ async function runWithShutdownTimeout(
 async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promise<void> {
   const args = resolveDaemonArgs(parsed);
   const logger = createLogger();
+
+  // Opt-in crash telemetry. The Sentry SDK is dynamically imported (and only
+  // then initialized) when config opted in, so operators who didn't opt in
+  // never load it. We install the process-level crash handlers only when it's
+  // actually live so default Node crash semantics (print + non-zero exit) are
+  // untouched for everyone else.
+  if (resolveTelemetryEnabled(parsed)) {
+    const { initTelemetry, captureException, flushTelemetry } = await import(
+      './instrument.js'
+    );
+    if (initTelemetry()) {
+      logger.info(
+        'telemetry: on — crash reports (stack traces only) → Sentry. ' +
+          'No prompts, code, agent output, or logs are sent.',
+      );
+      // Capture-then-exit. Preserves Node's default "fatal → exit non-zero"
+      // semantics (the daemon never installed these handlers before, so an
+      // uncaught error already terminated the process); we just flush the
+      // report out first. unhandledRejection is treated as fatal too, matching
+      // Node's modern default.
+      process.on('uncaughtException', (err) => {
+        captureException(err);
+        void flushTelemetry().finally(() => {
+          logger.error('uncaught exception:', err);
+          process.exit(1);
+        });
+      });
+      process.on('unhandledRejection', (reason) => {
+        captureException(reason);
+        void flushTelemetry().finally(() => {
+          logger.error('unhandled rejection:', reason);
+          process.exit(1);
+        });
+      });
+    } else {
+      // Opted in but no DSN is baked in / configured yet — say so rather than
+      // letting the operator believe reports are flowing.
+      logger.warn(
+        'telemetry: on in config but no Sentry DSN is configured; ' +
+          'nothing will be sent (set VICOOP_CLIENT_SENTRY_DSN or ship a build with a baked-in DSN).',
+      );
+    }
+  }
+
   const raw = args.card
     ? JSON.parse(readFileSync(args.card, 'utf8'))
     : resolveBundledCard(args.backend);

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -366,6 +366,30 @@ test('normalizeConfig drops invalid codex approval_decision', (t) => {
   });
 });
 
+test('normalizeConfig keeps telemetry on/off and drops anything else', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-telemetry-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  const onPath = join(dir, 'on.json');
+  writeFileSync(onPath, JSON.stringify({ telemetry: 'on' }));
+  assert.deepEqual(readConfig(onPath), { telemetry: 'on' });
+
+  const offPath = join(dir, 'off.json');
+  writeFileSync(offPath, JSON.stringify({ telemetry: 'off' }));
+  assert.deepEqual(readConfig(offPath), { telemetry: 'off' });
+
+  // A garbage / typo'd / wrong-type value is dropped — and a dropped value
+  // reads as "off" downstream, so a malformed field can never enable reporting.
+  for (const bad of ['true', 'ON', 'enabled', 'yes', '1']) {
+    const p = join(dir, `bad-${bad}.json`);
+    writeFileSync(p, JSON.stringify({ telemetry: bad }));
+    assert.deepEqual(readConfig(p), {}, `telemetry=${bad} should be dropped`);
+  }
+  const boolPath = join(dir, 'bool.json');
+  writeFileSync(boolPath, JSON.stringify({ telemetry: true }));
+  assert.deepEqual(readConfig(boolPath), {});
+});
+
 test('readConfig drops malformed fields and keeps the rest', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-bad-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
@@ -469,12 +493,15 @@ test('overlayConfig: top fields win per key, missing keys fall through from base
     agent_id: 'explicit-agent',
     backend: 'claude',
     card: '/canonical/card.json',
+    // Neither side set telemetry, so it falls through as undefined — the
+    // fixed-shape overlay always carries the key (see the next test).
+    telemetry: undefined,
     backends: { claude: { settings: { sandbox: { enabled: true } } } },
   });
 });
 
 test('overlayConfig: empty top leaves base values intact; empty base passes top through', () => {
-  // The result object always carries the six known keys; missing inputs land
+  // The result object always carries the known keys; missing inputs land
   // as `undefined` rather than absent properties. mergeClientArgs's `||`
   // chain treats both shapes identically, so this is just shape — assert the
   // values rather than the key set.

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -172,6 +172,14 @@ export interface ClientConfig {
   backend?: string;
   card?: string;
   backends?: BackendConfigs;
+  // Opt-in crash telemetry. Absent / 'off' => the daemon never loads or
+  // initializes the Sentry SDK. 'on' => crash reports (stack traces only — no
+  // prompts, code, agent output, or console logs) are sent to the project's
+  // Sentry. Default OFF is deliberate: the client runs on operators' own
+  // machines, so reporting must be an explicit choice, not a silent default.
+  // Flip it on with `agent register --enable-telemetry` or by hand-editing
+  // this field. See packages/client/src/instrument.ts for what is/isn't sent.
+  telemetry?: 'on' | 'off';
 }
 
 // Trim hand-edited values and drop the result when it's whitespace-only.
@@ -255,6 +263,13 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
   if (backend && KNOWN_BACKENDS.has(backend)) c.backend = backend;
   const card = asString(raw.card);
   if (card) c.card = card;
+  // Telemetry is a closed enum: only the two known string literals are
+  // honoured. Anything else (typo, bool, number) is dropped — and a dropped
+  // value reads as "off" downstream, which is the safe, privacy-preserving
+  // default. So a malformed telemetry field can never accidentally *enable*
+  // reporting.
+  const telemetry = asString(raw.telemetry);
+  if (telemetry === 'on' || telemetry === 'off') c.telemetry = telemetry;
   const backends = asRecord(raw.backends);
   if (backends) {
     const out: BackendConfigs = {};
@@ -386,6 +401,7 @@ export function overlayConfig(base: ClientConfig, top: ClientConfig): ClientConf
     agent_id: top.agent_id ?? base.agent_id,
     backend: top.backend ?? base.backend,
     card: top.card ?? base.card,
+    telemetry: top.telemetry ?? base.telemetry,
     backends: mergedBackends,
   };
 }

--- a/packages/client/src/instrument.test.ts
+++ b/packages/client/src/instrument.test.ts
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { homedir } from 'node:os';
+import type { ErrorEvent } from '@sentry/node';
+import { scrubEvent } from './instrument.js';
+
+// scrubEvent is the last line of defense before an event leaves the process.
+// These tests pin the privacy guarantees the feature promises: no identifying
+// metadata, no breadcrumbs, and no operator home path (which embeds a
+// username) in messages or stack frames.
+
+test('scrubEvent strips identifying / network metadata and all breadcrumbs', () => {
+  const event: ErrorEvent = {
+    type: undefined,
+    user: { id: 'op-1', email: 'op@example.com', ip_address: '1.2.3.4' },
+    request: { url: 'https://internal/secret', headers: { cookie: 'x' } },
+    server_name: 'operators-macbook.local',
+    breadcrumbs: [{ message: 'claude said: <prompt + code>' }],
+  } as unknown as ErrorEvent;
+
+  const out = scrubEvent(event);
+  assert.ok(out);
+  assert.equal(out.user, undefined);
+  assert.equal(out.request, undefined);
+  assert.equal(out.server_name, undefined);
+  assert.equal(out.breadcrumbs, undefined);
+});
+
+test('scrubEvent redacts the home path from messages and stack frames', () => {
+  const home = homedir();
+  // homedir() can be empty in some sandboxes; the redaction is a no-op there,
+  // so only assert the redaction when there's actually a home path to redact.
+  const frameFile = `${home}/projects/app/src/index.ts`;
+  const event: ErrorEvent = {
+    type: undefined,
+    message: `boom while reading ${home}/.vicoop/config.json`,
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: `ENOENT: ${home}/secret/file`,
+          stacktrace: {
+            frames: [{ filename: frameFile, abs_path: frameFile }],
+          },
+        },
+      ],
+    },
+  } as unknown as ErrorEvent;
+
+  const out = scrubEvent(event);
+  assert.ok(out);
+
+  if (home) {
+    assert.doesNotMatch(out.message ?? '', new RegExp(escapeRe(home)));
+    const value = out.exception?.values?.[0];
+    assert.doesNotMatch(value?.value ?? '', new RegExp(escapeRe(home)));
+    const frame = value?.stacktrace?.frames?.[0];
+    assert.doesNotMatch(frame?.filename ?? '', new RegExp(escapeRe(home)));
+    assert.doesNotMatch(frame?.abs_path ?? '', new RegExp(escapeRe(home)));
+    // The non-home part of the path is preserved so the trace stays useful.
+    assert.match(frame?.filename ?? '', /~\/projects\/app\/src\/index\.ts/);
+  }
+});
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/client/src/instrument.test.ts
+++ b/packages/client/src/instrument.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { homedir } from 'node:os';
-import type { ErrorEvent } from '@sentry/node';
+import type { ErrorEvent } from '@sentry/bun';
 import { scrubEvent } from './instrument.js';
 
 // scrubEvent is the last line of defense before an event leaves the process.

--- a/packages/client/src/instrument.ts
+++ b/packages/client/src/instrument.ts
@@ -1,0 +1,133 @@
+// Opt-in crash telemetry for the bridge client daemon.
+//
+// Unlike the server (packages/server/src/instrument.ts), the client runs on
+// operators' own machines and ships as a distributed binary, so its Sentry
+// posture is deliberately the *opposite* of the server's:
+//
+//   - OFF by default. This module is dynamically imported and `initTelemetry`
+//     called only when config.json has `"telemetry": "on"` (see cli.ts). When
+//     the operator hasn't opted in, the Sentry SDK is never even loaded.
+//   - NO console / log forwarding. The server forwards console.* as structured
+//     logs; doing that here would ship operators' agent output (prompts, code,
+//     task content) to us. We disable breadcrumbs entirely so nothing the
+//     daemon logs is ever attached to an event.
+//   - NO tracing. tracesSampleRate: 0 — we capture crashes, not spans.
+//   - NO PII. sendDefaultPii: false, and `scrubEvent` strips request/user data
+//     and redacts the operator's home path out of stack frames / messages.
+//
+// Net effect when opted in: only an exception's class + stack trace (with home
+// paths redacted) reaches Sentry. Never prompts, code, agent output, tokens,
+// or console logs.
+
+import { homedir } from 'node:os';
+import type { ErrorEvent, EventHint } from '@sentry/node';
+import * as Sentry from '@sentry/node';
+import { clientVersion } from './version.js';
+
+// Baked-in DSN for the client's own Sentry project. A DSN is a *submit-only*
+// credential — it cannot read, list, modify, or delete events — so shipping it
+// inside the distributed binary is safe, the same posture Sentry documents for
+// browser SDKs. Override at runtime with VICOOP_CLIENT_SENTRY_DSN.
+//
+// Left empty until the client Sentry project is provisioned. An empty DSN means
+// `initTelemetry` stays disabled and sends nothing even when an operator opts
+// in, so it is always safe to ship empty: fill this in (or set the env var)
+// when the project exists.
+const BAKED_IN_DSN = '';
+
+function resolveDsn(): string {
+  return process.env.VICOOP_CLIENT_SENTRY_DSN?.trim() || BAKED_IN_DSN;
+}
+
+let initialized = false;
+
+// Redact the operator's home directory out of any string so absolute paths
+// like `/Users/alice/...` or `/home/alice/...` (which leak a username) become
+// `~/...`. Applied to exception messages and stack-frame filenames.
+function redactHome(value: string): string {
+  const home = homedir();
+  if (!home) return value;
+  return value.split(home).join('~');
+}
+
+// Drop everything that could carry operator data, then redact home paths from
+// what's left. Runs on every event right before it leaves the process.
+// Exported for unit-testability; the daemon wires it in via `beforeSend`.
+export function scrubEvent(event: ErrorEvent, _hint?: EventHint): ErrorEvent | null {
+  // Identifying / network metadata we never want.
+  delete event.user;
+  delete event.request;
+  delete event.server_name; // hostname can identify the operator's machine
+  // Breadcrumbs are already suppressed via beforeBreadcrumb, but belt-and-
+  // suspenders: never let any accumulate onto an event.
+  delete event.breadcrumbs;
+
+  if (event.message) event.message = redactHome(event.message);
+  for (const value of event.exception?.values ?? []) {
+    if (value.value) value.value = redactHome(value.value);
+    for (const frame of value.stacktrace?.frames ?? []) {
+      if (frame.filename) frame.filename = redactHome(frame.filename);
+      if (frame.abs_path) frame.abs_path = redactHome(frame.abs_path);
+    }
+  }
+  return event;
+}
+
+// Initialize the Sentry SDK for crash reporting. Idempotent. Returns true when
+// telemetry is actually live (initialized with a DSN), false when there is no
+// DSN to send to — the caller uses this to decide whether to wire up the
+// process-level crash handlers and to log the resolved state.
+export function initTelemetry(opts: { environment?: string } = {}): boolean {
+  if (initialized) return true;
+  const dsn = resolveDsn();
+  if (!dsn) return false;
+
+  Sentry.init({
+    dsn,
+    release: `@vicoop-bridge/client@${clientVersion}`,
+    // Same shared-project tagging convention as the server: the `service` tag
+    // is how client vs. server events are told apart.
+    initialScope: { tags: { service: 'vicoop-bridge-client' } },
+    environment:
+      opts.environment ??
+      process.env.VICOOP_CLIENT_SENTRY_ENVIRONMENT ??
+      'production',
+    // Crash reporting only — no performance tracing/spans.
+    tracesSampleRate: 0,
+    // Never attach IP, cookies, headers, or user identifiers.
+    sendDefaultPii: false,
+    // Suppress ALL breadcrumbs. @sentry/node's default integrations turn
+    // console.* calls into breadcrumbs; for this client those calls carry agent
+    // output, so dropping every breadcrumb is what keeps that data out of
+    // events. (We also filter the Console integration below for good measure.)
+    beforeBreadcrumb: () => null,
+    // Last-line scrub: strip request/user/host data and redact home paths.
+    beforeSend: scrubEvent,
+    // Drop the Console integration so it never even builds breadcrumbs from the
+    // daemon's logging. Keeping the rest of the defaults (e.g. the global error
+    // handlers) intact.
+    integrations: (defaults) =>
+      defaults.filter((i) => i.name !== 'Console'),
+  });
+  initialized = true;
+  return true;
+}
+
+// Capture an exception. No-op when telemetry isn't initialized, so callers can
+// invoke it unconditionally.
+export function captureException(error: unknown): void {
+  if (!initialized) return;
+  Sentry.captureException(error);
+}
+
+// Flush queued events before the process exits. The Sentry transport is async;
+// without a flush a captured crash can be lost when we call process.exit right
+// after. No-op (resolves immediately) when telemetry isn't initialized.
+export async function flushTelemetry(timeoutMs = 2000): Promise<void> {
+  if (!initialized) return;
+  try {
+    await Sentry.flush(timeoutMs);
+  } catch {
+    // Best-effort: a failed flush must never block or crash shutdown.
+  }
+}

--- a/packages/client/src/instrument.ts
+++ b/packages/client/src/instrument.ts
@@ -113,18 +113,27 @@ export function initTelemetry(opts: { environment?: string } = {}): boolean {
     tracesSampleRate: 0,
     // Never attach IP, cookies, headers, or user identifiers.
     sendDefaultPii: false,
-    // Suppress ALL breadcrumbs. @sentry/node's default integrations turn
-    // console.* calls into breadcrumbs; for this client those calls carry agent
-    // output, so dropping every breadcrumb is what keeps that data out of
-    // events. (We also filter the Console integration below for good measure.)
+    // Suppress ALL breadcrumbs. Even with default integrations off (below),
+    // this guarantees nothing the daemon logs — agent prompts, code, task
+    // output — is ever attached to an event as a breadcrumb.
     beforeBreadcrumb: () => null,
     // Last-line scrub: strip request/user/host data and redact home paths.
     beforeSend: scrubEvent,
-    // Drop the Console integration so it never even builds breadcrumbs from the
-    // daemon's logging. Keeping the rest of the defaults (e.g. the global error
-    // handlers) intact.
-    integrations: (defaults) =>
-      defaults.filter((i) => i.name !== 'Console'),
+    // `@sentry/bun` carries the full @sentry/node + OpenTelemetry default
+    // integration set: ~25 auto-instrumentations (Fastify, Postgres, Kafka,
+    // Anthropic, http/undici patching, OTel global registration, …). None of
+    // it is relevant to a CLI that only reports crashes, and on init it would
+    // monkey-patch the daemon's own networking and register OTel globals. Turn
+    // the whole default set off and add back only the two event-shaping
+    // integrations crash reports benefit from. Stack-trace capture is core
+    // client behavior (the stack parser), not an integration, so it's
+    // unaffected — and our own process-level handlers (cli.ts) are what feed
+    // uncaughtException / unhandledRejection, so we don't need Sentry's.
+    defaultIntegrations: false,
+    integrations: [
+      Sentry.dedupeIntegration(), // collapse identical repeated crash reports
+      Sentry.linkedErrorsIntegration(), // unwrap `error.cause` chains
+    ],
   });
   initialized = true;
   return true;

--- a/packages/client/src/instrument.ts
+++ b/packages/client/src/instrument.ts
@@ -30,25 +30,24 @@ import type { ErrorEvent, EventHint } from '@sentry/bun';
 import * as Sentry from '@sentry/bun';
 import { clientVersion } from './version.js';
 
-// Fallback DSN for the client's own Sentry project. A DSN is a *submit-only*
-// credential — it cannot read, list, modify, or delete events — so shipping it
-// inside the distributed binary is safe, the same posture Sentry documents for
-// browser SDKs.
+// Resolve the client's own Sentry DSN. A DSN is a *submit-only* credential —
+// it cannot read, list, modify, or delete events — so baking it into the
+// distributed binary is safe, the same posture Sentry documents for browser
+// SDKs.
 //
-// Kept empty on purpose: the real DSN is injected at *build time*, not stored
-// here. The release build (scripts/package-client-release.sh) passes
-// `--define process.env.VICOOP_CLIENT_SENTRY_DSN="<dsn>"` to `bun build`, which
-// rewrites the lookup in resolveDsn() to a string literal in the compiled
-// binary. The value comes from the VICOOP_CLIENT_SENTRY_DSN GitHub secret (see
-// .github/workflows/release.yml). Builds without that secret (local, forks, CI
-// smoke compiles) leave the lookup as a normal runtime read — undefined there —
-// and fall through to this empty string, so telemetry stays disabled and sends
-// nothing. The same env var also works as a plain runtime override for local
-// testing (`VICOOP_CLIENT_SENTRY_DSN=… vicoop-client start`).
-const BAKED_IN_DSN = '';
-
+// There's a single source: `process.env.VICOOP_CLIENT_SENTRY_DSN`. In the
+// release binary it isn't a runtime read — the build (scripts/
+// package-client-release.sh) passes `--define
+// process.env.VICOOP_CLIENT_SENTRY_DSN="<dsn>"` to `bun build`, which rewrites
+// this lookup to a string literal in the compiled output. The value comes from
+// the VICOOP_CLIENT_SENTRY_DSN GitHub secret (see .github/workflows/
+// release.yml). Builds without that define (local, forks, CI smoke compiles)
+// leave it as a normal runtime read — undefined unless the operator exports the
+// var themselves — so it falls through to '' and telemetry stays disabled,
+// sending nothing. The same env var therefore doubles as a runtime override for
+// local testing (`VICOOP_CLIENT_SENTRY_DSN=… vicoop-client start`).
 function resolveDsn(): string {
-  return process.env.VICOOP_CLIENT_SENTRY_DSN?.trim() || BAKED_IN_DSN;
+  return process.env.VICOOP_CLIENT_SENTRY_DSN?.trim() ?? '';
 }
 
 let initialized = false;

--- a/packages/client/src/instrument.ts
+++ b/packages/client/src/instrument.ts
@@ -95,6 +95,12 @@ export function initTelemetry(opts: { environment?: string } = {}): boolean {
 
   Sentry.init({
     dsn,
+    // Operability hatch: `VICOOP_CLIENT_SENTRY_DEBUG=1` makes the SDK log its
+    // own transport (event queued / sent / rejected) to the console. An
+    // operator who opted in but sees nothing in Sentry can flip this to confirm
+    // events are actually leaving the host. Off by default; logs go to the
+    // local console only (they are not themselves telemetry).
+    debug: process.env.VICOOP_CLIENT_SENTRY_DEBUG === '1',
     release: `@vicoop-bridge/client@${clientVersion}`,
     // Same shared-project tagging convention as the server: the `service` tag
     // is how client vs. server events are told apart.

--- a/packages/client/src/instrument.ts
+++ b/packages/client/src/instrument.ts
@@ -20,19 +20,31 @@
 // or console logs.
 
 import { homedir } from 'node:os';
-import type { ErrorEvent, EventHint } from '@sentry/node';
-import * as Sentry from '@sentry/node';
+// `@sentry/bun` (not `@sentry/node`): the released client is a `bun build
+// --compile` single-file binary, so it runs on the Bun runtime — and that's
+// the only context where telemetry is ever live. `@sentry/bun` extends the
+// node SDK with Bun's native fetch transport; it also imports cleanly under
+// Node, so dev (`tsx`) and the test runner are unaffected (telemetry is opt-in
+// and never initialized there anyway).
+import type { ErrorEvent, EventHint } from '@sentry/bun';
+import * as Sentry from '@sentry/bun';
 import { clientVersion } from './version.js';
 
-// Baked-in DSN for the client's own Sentry project. A DSN is a *submit-only*
+// Fallback DSN for the client's own Sentry project. A DSN is a *submit-only*
 // credential — it cannot read, list, modify, or delete events — so shipping it
 // inside the distributed binary is safe, the same posture Sentry documents for
-// browser SDKs. Override at runtime with VICOOP_CLIENT_SENTRY_DSN.
+// browser SDKs.
 //
-// Left empty until the client Sentry project is provisioned. An empty DSN means
-// `initTelemetry` stays disabled and sends nothing even when an operator opts
-// in, so it is always safe to ship empty: fill this in (or set the env var)
-// when the project exists.
+// Kept empty on purpose: the real DSN is injected at *build time*, not stored
+// here. The release build (scripts/package-client-release.sh) passes
+// `--define process.env.VICOOP_CLIENT_SENTRY_DSN="<dsn>"` to `bun build`, which
+// rewrites the lookup in resolveDsn() to a string literal in the compiled
+// binary. The value comes from the VICOOP_CLIENT_SENTRY_DSN GitHub secret (see
+// .github/workflows/release.yml). Builds without that secret (local, forks, CI
+// smoke compiles) leave the lookup as a normal runtime read — undefined there —
+// and fall through to this empty string, so telemetry stays disabled and sends
+// nothing. The same env var also works as a plain runtime override for local
+// testing (`VICOOP_CLIENT_SENTRY_DSN=… vicoop-client start`).
 const BAKED_IN_DSN = '';
 
 function resolveDsn(): string {

--- a/packages/client/src/setup.test.ts
+++ b/packages/client/src/setup.test.ts
@@ -622,7 +622,7 @@ test('setup preserves operator-added / future-version keys via raw round-trip', 
   const configPath = join(process.env.VICOOP_HOME, 'config.json');
   mkdirSync(process.env.VICOOP_HOME, { recursive: true, mode: 0o700 });
   // Hand-edited config with two kinds of unknown keys: a future top-level
-  // section (`telemetry`) and an unknown subkey of a known backend
+  // section (`experimental`) and an unknown subkey of a known backend
   // (`backends.claude.future_flag`). Both should survive the round trip.
   writeFileSync(configPath, JSON.stringify({
     server_url: 'wss://old',
@@ -633,7 +633,7 @@ test('setup preserves operator-added / future-version keys via raw round-trip', 
         future_flag: 'keep me',
       },
     },
-    telemetry: { otel_endpoint: 'http://otel:4317' },
+    experimental: { otel_endpoint: 'http://otel:4317' },
   }));
 
   const originalFetch = globalThis.fetch;
@@ -667,7 +667,7 @@ test('setup preserves operator-added / future-version keys via raw round-trip', 
   assert.equal(after.server_token, 'fresh-token');
   assert.equal(after.agent_id, 'agent-1');
   assert.equal(after.backend, 'claude');
-  assert.deepEqual(after.telemetry, { otel_endpoint: 'http://otel:4317' });
+  assert.deepEqual(after.experimental, { otel_endpoint: 'http://otel:4317' });
   assert.deepEqual(
     (after.backends as Record<string, unknown>).claude,
     { settings: { sandbox: { enabled: true } }, future_flag: 'keep me' },
@@ -754,6 +754,90 @@ test('setup: env-file write failure does NOT trip the canonical-recovery block',
   assert.match(stderr, /CLIENT_TOKEN was persisted/);
   assert.match(stderr, /would mint a NEW CLIENT_TOKEN/);
   assert.doesNotMatch(stderr, /\[recovery\] canonical persistence failed/);
+});
+
+test('agent register --enable-telemetry persists telemetry:on; a re-run without it leaves the opt-in intact', async (t) => {
+  const tmpHome = mkdtempSync(join(tmpdir(), 'vicoop-register-telemetry-'));
+  t.after(() => rmSync(tmpHome, { recursive: true, force: true }));
+
+  const previousHome = process.env.HOME;
+  const previousVicoop = process.env.VICOOP_HOME;
+  process.env.VICOOP_HOME = join(tmpHome, '.vicoop');
+  process.env.HOME = tmpHome;
+  t.after(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousVicoop === undefined) delete process.env.VICOOP_HOME;
+    else process.env.VICOOP_HOME = previousVicoop;
+  });
+
+  saveOwnerSession({
+    bridge: 'https://bridge.test',
+    token: 'vbc_owner_test',
+    principal_id: 'google:123',
+    email: null,
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    saved_at: new Date().toISOString(),
+  });
+
+  // Mint succeeds; an API key is auto-minted (no --caller) — both go through
+  // the same fetch mock, which just echoes a generic success for any POST.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (_url: string, init?: { body?: string }) => {
+    const body = String(init?.body ?? '');
+    if (body.includes('registerClient')) {
+      return new Response(JSON.stringify({
+        data: {
+          registerClient: {
+            clientWithToken: {
+              id: 'client-1',
+              token: 'fresh-token',
+              ownerPrincipal: 'google:123',
+              allowedAgentIds: ['agent-1'],
+            },
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    // apikey mint endpoint
+    return new Response(JSON.stringify({
+      agent_id: 'agent-1',
+      key_id: 'k1',
+      principal: 'apikey:k1',
+      api_key: 'secret',
+      expires_at: new Date(Date.now() + 60_000).toISOString(),
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  let stderr = '';
+  t.mock.method(process.stderr, 'write', (chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  });
+
+  const configPath = join(process.env.VICOOP_HOME, 'config.json');
+
+  // First run WITH the flag: telemetry persisted as 'on', disclosure printed.
+  assert.equal(
+    await runAgentRegister(agentRegisterArgs({ agentId: 'agent-1', enableTelemetry: true })),
+    0,
+  );
+  assert.equal(readConfig(configPath)?.telemetry, 'on');
+  assert.match(stderr, /Telemetry: ON/);
+
+  // Second run WITHOUT the flag must NOT silently flip the prior opt-in off.
+  stderr = '';
+  assert.equal(
+    await runAgentRegister(agentRegisterArgs({ agentId: 'agent-1', enableTelemetry: false })),
+    0,
+  );
+  assert.equal(readConfig(configPath)?.telemetry, 'on');
+  // The no-flag disclosure is phrased around what this command did, not the
+  // resulting state — so it never falsely claims telemetry is off.
+  assert.match(stderr, /Telemetry was not enabled by this command/);
 });
 
 test('setup refuses to overwrite an existing-but-malformed config.json', async (t) => {
@@ -906,6 +990,7 @@ function agentRegisterArgs(
     openclawGateway, openclawGatewayToken, openclawAgent,
     openclawOpenaiCompatAgent, openclawTaskTimeoutMs,
     envFile, envFileAlias, server, token, json = false,
+    enableTelemetry = false,
   } = p;
   return {
     action: 'agent-register',
@@ -922,6 +1007,7 @@ function agentRegisterArgs(
     openclawAgent,
     openclawOpenaiCompatAgent,
     openclawTaskTimeoutMs,
+    enableTelemetry,
     envFile,
     envFileAlias,
     server,

--- a/packages/client/src/setup.ts
+++ b/packages/client/src/setup.ts
@@ -118,6 +118,9 @@ export const agentRegisterCmd = command(
     openclawTaskTimeoutMs: optional(option('--openclaw-task-timeout-ms', integer({ metavar: 'MS', min: 1 }), {
       description: message`OpenClaw per-task timeout in milliseconds. Only valid with --backend openclaw.`,
     })),
+    enableTelemetry: withDefault(flag('--enable-telemetry', {
+      description: message`Opt in to crash telemetry: persists \`"telemetry": "on"\` into config.json so the daemon sends crash reports (stack traces only — never prompts, code, agent output, or logs) to the project's Sentry. Off by default; omit to keep it off. Disable later by removing the field or setting it to "off" in config.json.`,
+    }), false),
     envFile: optional(option('--write-env-file', string({ metavar: 'PATH' }), {
       description: message`Also emit a shell-sourceable env file. Daemon does NOT consume these env vars; the file is purely an operator-side credentials backup / scripting hook.`,
     })),
@@ -356,6 +359,7 @@ function writeConfigForSetup(
   bridgeUrl: string,
   backend: BackendKind | null,
   backendDefaults: BackendConfigs | null,
+  enableTelemetry: boolean,
 ): string {
   const firstAgentId = success.allowed_agent_ids[0];
   if (!firstAgentId) {
@@ -390,6 +394,10 @@ function writeConfigForSetup(
   existing.server_token = success.client_token;
   existing.agent_id = firstAgentId;
   if (backend) existing.backend = backend;
+  // Only ever *enable* on an explicit opt-in flag. A register re-run without
+  // `--enable-telemetry` must not silently flip a prior opt-in back off — so we
+  // leave any existing `telemetry` field untouched when the flag is absent.
+  if (enableTelemetry) existing.telemetry = 'on';
   if (backendDefaults) {
     // Per-slot shallow merge: an operator passing `--backend codex --cwd /foo`
     // should populate `backends.codex.cwd` without disturbing
@@ -426,6 +434,7 @@ function persistCanonical(
     json: boolean;
     backend: BackendKind | null;
     backendDefaults: BackendConfigs | null;
+    enableTelemetry: boolean;
   },
   success: ClientRegisterSuccess,
   bridgeUrl: string,
@@ -446,6 +455,7 @@ function persistCanonical(
     bridgeUrl,
     args.backend,
     args.backendDefaults,
+    args.enableTelemetry,
   );
   process.stderr.write(`Wrote ${configPath} (mode 600).\n`);
   return configPath;
@@ -654,6 +664,11 @@ interface RegistrationLabels {
   // leaving it public + warning. Enabled for `agent register`; the deprecated
   // `setup` alias keeps its historical public-agent warning unchanged.
   autoMintApiKeyWhenNoCaller: boolean;
+  // When true, print the telemetry disclosure (opted-in confirmation, or the
+  // "it's off, here's how to opt in" notice). Enabled for `agent register`;
+  // the deprecated `setup` alias stays quiet — it has no --enable-telemetry
+  // flag and we don't want to grow its surface.
+  showTelemetryNotice: boolean;
   renderSuccessBlock: (s: ClientRegisterSuccess) => string;
   renderRecoveryBlock: (s: ClientRegisterSuccess, serverUrl: string) => string;
 }
@@ -677,6 +692,10 @@ interface ExecuteRegistrationOpts {
   // (claude / codex / openclaw) are preserved as-is. Only the active
   // backend's slot is touched; other slots survive unmodified.
   backendDefaults: BackendConfigs | null;
+  // Opt-in crash telemetry: when true, persist `"telemetry": "on"` into
+  // config.json. Absent flag leaves any existing value untouched (a re-run
+  // never silently disables a prior opt-in).
+  enableTelemetry: boolean;
   json: boolean;
   labels: RegistrationLabels;
 }
@@ -784,6 +803,7 @@ async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<numbe
         json: opts.json,
         backend: opts.backend,
         backendDefaults: opts.backendDefaults,
+        enableTelemetry: opts.enableTelemetry,
       },
       success,
       bridge,
@@ -817,6 +837,30 @@ async function executeRegistration(opts: ExecuteRegistrationOpts): Promise<numbe
           `  Re-running \`${opts.labels.cmdName} --write-env-file ...\` would mint a NEW ${opts.labels.tokenLabel} and invalidate the one just written.\n`,
       );
       return 1;
+    }
+  }
+
+  // Telemetry disclosure. Required transparency for opt-in crash reporting:
+  // confirm when opted in, and otherwise tell the operator the toggle exists
+  // and exactly what it would (and would not) send. Skipped under --json so the
+  // scripting contract stays machine-clean.
+  if (opts.labels.showTelemetryNotice && !opts.json) {
+    if (opts.enableTelemetry) {
+      process.stderr.write(
+        'Telemetry: ON. Crash reports (stack traces only — never prompts, code,\n' +
+          '  agent output, or logs) will be sent to help debug the client. Turn it\n' +
+          '  off anytime by removing the `telemetry` field from config.json.\n\n',
+      );
+    } else {
+      // Phrased around what THIS command did (it didn't enable telemetry)
+      // rather than claiming the resulting state is off — a prior run may have
+      // already opted in, and we don't re-read config here to find out.
+      process.stderr.write(
+        'Telemetry was not enabled by this command (off by default). To send crash\n' +
+          '  reports, re-run with `--enable-telemetry`, or set `"telemetry": "on"` in\n' +
+          '  config.json. Only crash stack traces are sent — never prompts, code, agent\n' +
+          '  output, or logs.\n\n',
+      );
     }
   }
 
@@ -921,6 +965,9 @@ export async function runSetup(args: SetupArgs): Promise<number> {
     token: args.token ?? null,
     backend: null,
     backendDefaults: null,
+    // The deprecated `setup` alias has no --enable-telemetry flag; never
+    // touches the telemetry field.
+    enableTelemetry: false,
     json: args.json,
     labels: {
       cmdName: 'setup',
@@ -928,6 +975,7 @@ export async function runSetup(args: SetupArgs): Promise<number> {
       tokenLabel: 'CLIENT_TOKEN',
       addCallerHint: 'vicoop-client add-caller',
       autoMintApiKeyWhenNoCaller: false,
+      showTelemetryNotice: false,
       renderSuccessBlock: renderSetupSuccessBlock,
       renderRecoveryBlock: renderSetupRecoveryBlock,
     },
@@ -961,6 +1009,7 @@ export async function runAgentRegister(args: AgentRegisterArgs): Promise<number>
     token: args.token ?? null,
     backend,
     backendDefaults: built.defaults,
+    enableTelemetry: args.enableTelemetry,
     json: args.json,
     labels: {
       cmdName: 'agent register',
@@ -968,6 +1017,7 @@ export async function runAgentRegister(args: AgentRegisterArgs): Promise<number>
       tokenLabel: 'AGENT_TOKEN',
       addCallerHint: 'vicoop-client agent callers add',
       autoMintApiKeyWhenNoCaller: true,
+      showTelemetryNotice: true,
       renderSuccessBlock: renderAgentRegisterSuccessBlock,
       renderRecoveryBlock: renderAgentRegisterRecoveryBlock,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
       '@optique/run':
         specifier: 1.0.2
         version: 1.0.2
-      '@sentry/node':
+      '@sentry/bun':
         specifier: ^10.57.0
         version: 10.57.0
       '@vicoop-bridge/protocol':
@@ -140,7 +140,7 @@ importers:
         version: 1.19.14(hono@4.12.12)
       '@sentry/hono':
         specifier: ^10.57.0
-        version: 10.57.0(@sentry/node@10.57.0)(hono@4.12.12)
+        version: 10.57.0(@sentry/bun@10.57.0)(@sentry/node@10.57.0)(hono@4.12.12)
       '@sentry/node':
         specifier: ^10.57.0
         version: 10.57.0
@@ -1000,7 +1000,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@rainbow-me/rainbowkit@2.2.10':
     resolution: {integrity: sha512-8+E4die1A2ovN9t3lWxWnwqTGEdFqThXDQRj+E4eDKuUKyymYD+66Gzm6S9yfg8E95c6hmGlavGUfYPtl1EagA==}
@@ -1206,6 +1206,10 @@ packages:
 
   '@sentry-internal/server-utils@10.57.0':
     resolution: {integrity: sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bun@10.57.0':
+    resolution: {integrity: sha512-bh62U3UiXYs0Uu37DX0vfO+JdwXXG16KvMUUHi/KfQdFO5VMuCDTdtLEMt+1fEXnjOi7DfQaaItoNPkagQc52w==}
     engines: {node: '>=18'}
 
   '@sentry/core@10.57.0':
@@ -6636,14 +6640,23 @@ snapshots:
     dependencies:
       '@sentry/core': 10.57.0
 
+  '@sentry/bun@10.57.0':
+    dependencies:
+      '@sentry/core': 10.57.0
+      '@sentry/node': 10.57.0
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
   '@sentry/core@10.57.0': {}
 
-  '@sentry/hono@10.57.0(@sentry/node@10.57.0)(hono@4.12.12)':
+  '@sentry/hono@10.57.0(@sentry/bun@10.57.0)(@sentry/node@10.57.0)(hono@4.12.12)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@sentry/core': 10.57.0
       hono: 4.12.12
     optionalDependencies:
+      '@sentry/bun': 10.57.0
       '@sentry/node': 10.57.0
 
   '@sentry/node-core@10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,10 @@ importers:
     dependencies:
       '@a2x/sdk':
         specifier: ^0.11.0
-        version: 0.11.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.11.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10))(zod@4.3.6)
       '@rainbow-me/rainbowkit':
         specifier: ^2
-        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
       '@tanstack/react-query':
         specifier: ^5
         version: 5.99.0(react@19.2.5)
@@ -57,10 +57,10 @@ importers:
         version: 2.3.2(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       viem:
         specifier: ^2
-        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: ^2
-        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
@@ -95,6 +95,9 @@ importers:
       '@optique/run':
         specifier: 1.0.2
         version: 1.0.2
+      '@sentry/node':
+        specifier: ^10.57.0
+        version: 10.57.0
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
@@ -4710,17 +4713,17 @@ packages:
 
 snapshots:
 
-  '@a2x/sdk@0.11.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10))(zod@3.25.76)':
-    optionalDependencies:
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      x402: 1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      zod: 3.25.76
-
   '@a2x/sdk@0.11.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10))(zod@3.25.76)':
     optionalDependencies:
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       x402: 1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       zod: 3.25.76
+
+  '@a2x/sdk@0.11.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10))(zod@4.3.6)':
+    optionalDependencies:
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      x402: 1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      zod: 4.3.6
 
   '@adraffy/ens-normalize@1.10.1': {}
 
@@ -4865,6 +4868,53 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      preact: 10.24.2
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      preact: 10.24.2
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - debug
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@base-org/account@2.4.0(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
@@ -5083,6 +5133,47 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
+    optional: true
+
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
+      preact: 10.24.2
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
+
+  '@coinbase/wallet-sdk@4.3.6(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+    dependencies:
+      '@noble/hashes': 1.4.0
+      clsx: 1.2.1
+      eventemitter3: 5.0.1
+      idb-keyval: 6.2.1
+      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      preact: 10.24.2
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    transitivePeerDependencies:
+      - '@types/react'
+      - bufferutil
+      - immer
+      - react
+      - typescript
+      - use-sync-external-store
+      - utf-8-validate
+      - zod
 
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
@@ -5271,6 +5362,14 @@ snapshots:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      '@metamask/rpc-errors': 7.0.2
+      eventemitter3: 5.0.1
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -5632,7 +5731,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
+  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@vanilla-extract/css': 1.17.3
@@ -5644,8 +5743,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.6.2(@types/react@19.2.14)(react@19.2.5)
       ua-parser-js: 1.0.41
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -5673,6 +5772,17 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      big.js: 6.2.2
+      dayjs: 1.11.13
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -5680,6 +5790,42 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5749,6 +5895,43 @@ snapshots:
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      lit: 3.3.0
+      valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
@@ -5855,6 +6038,44 @@ snapshots:
       - utf-8-validate
       - valtio
       - zod
+    optional: true
+
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - valtio
+      - zod
 
   '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)':
     dependencies:
@@ -5897,6 +6118,42 @@ snapshots:
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      lit: 3.3.0
+      qrcode: 1.5.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -6000,6 +6257,45 @@ snapshots:
       - uploadthing
       - utf-8-validate
       - zod
+    optional: true
+
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
 
   '@reown/appkit-utils@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)':
     dependencies:
@@ -6065,6 +6361,50 @@ snapshots:
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-polyfills': 1.7.8
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      bs58: 6.0.0
+      valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6223,10 +6563,30 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@safe-global/safe-gateway-typescript-sdk': 3.23.1
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -7042,19 +7402,73 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@3.25.76)':
     dependencies:
       '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/react-query'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react
+      - react-native
+      - supports-color
+      - uploadthing
+      - use-sync-external-store
+      - utf-8-validate
+      - wagmi
+      - zod
+    optional: true
+
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -7097,13 +7511,13 @@ snapshots:
 
   '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@base-org/account': 2.4.0(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@coinbase/wallet-sdk': 4.3.6(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
@@ -7148,14 +7562,28 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.9.3)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.99.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
-      '@tanstack/query-core': 5.99.0
       typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/react'
@@ -7188,6 +7616,50 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
       '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.33.0
+      events: 3.3.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -7261,6 +7733,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.16(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/window-getters': 1.0.1
+      es-toolkit: 1.33.0
+      events: 3.3.0
+      uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -7277,6 +7793,48 @@ snapshots:
       '@walletconnect/types': 2.21.1
       '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7476,6 +8034,42 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -7486,6 +8080,42 @@ snapshots:
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
       '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.2
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7614,6 +8244,46 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      es-toolkit: 1.33.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@walletconnect/events': 1.0.1
@@ -7626,6 +8296,46 @@ snapshots:
       '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/types': 2.21.1
       '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      es-toolkit: 1.33.0
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - encoding
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/jsonrpc-http-connection': 1.0.8
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7698,6 +8408,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.0
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@noble/ciphers': 1.2.1
@@ -7742,6 +8496,50 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
+    dependencies:
+      '@noble/ciphers': 1.2.1
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/keyvaluestorage': 1.1.1
+      '@walletconnect/relay-api': 1.0.11
+      '@walletconnect/relay-auth': 1.1.0
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.21.1
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      bs58: 6.0.0
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.0
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - ioredis
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - zod
+
   '@walletconnect/window-getters@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -7760,6 +8558,11 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
       zod: 3.25.76
+
+  abitype@1.0.8(typescript@5.9.3)(zod@4.3.6):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.3.6
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -9533,6 +10336,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.17(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -9547,6 +10365,20 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -9555,6 +10387,20 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -9702,21 +10548,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -9724,7 +10570,7 @@ snapshots:
 
   porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
@@ -10508,6 +11354,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.6.7(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4):
     dependencies:
       '@noble/curves': 1.9.1
@@ -10542,6 +11405,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.17(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -10557,14 +11437,60 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76):
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@3.25.76)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bufferutil
+      - db0
+      - debug
+      - encoding
+      - expo-auth-session
+      - expo-crypto
+      - expo-web-browser
+      - fastestsmallesttextencoderdecoder
+      - immer
+      - ioredis
+      - react-native
+      - supports-color
+      - uploadthing
+      - utf-8-validate
+      - zod
+    optional: true
+
+  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
+    dependencies:
+      '@tanstack/react-query': 5.99.0(react@19.2.5)
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10606,7 +11532,7 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -10720,7 +11646,7 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -49,6 +49,24 @@ mkdir -p "$OUT_DIR"
 
 CLIENT_DIR="$ROOT_DIR/packages/client"
 
+# Build-time injection of the opt-in crash-telemetry Sentry DSN. The client is
+# a distributed binary, so it can't read a runtime secret on the operator's
+# host — the DSN has to be baked into the binary at compile time. When
+# $VICOOP_CLIENT_SENTRY_DSN is set (release.yml passes it from a GitHub
+# secret), Bun's `--define` rewrites the `process.env.VICOOP_CLIENT_SENTRY_DSN`
+# lookup in src/instrument.ts to this string literal. When it's unset (local
+# builds, forks, CI smoke compiles), no define is added and the daemon falls
+# back to the empty BAKED_IN_DSN — i.e. telemetry stays disabled. A DSN is a
+# submit-only credential, so baking it into the public binary is expected and
+# safe (see docs/install-client.md → Telemetry).
+BUILD_DEFINES=()
+if [[ -n "${VICOOP_CLIENT_SENTRY_DSN:-}" ]]; then
+  BUILD_DEFINES+=( --define "process.env.VICOOP_CLIENT_SENTRY_DSN=\"${VICOOP_CLIENT_SENTRY_DSN}\"" )
+  echo "==> telemetry: injecting Sentry DSN at build time"
+else
+  echo "==> telemetry: no VICOOP_CLIENT_SENTRY_DSN set; building with telemetry disabled"
+fi
+
 # (bun-target, asset-slug, file-extension) — keep this table identical to
 # resolvePlatformAsset() in upgrade.ts. Anything added here also needs a
 # matching branch there, otherwise `vicoop-client upgrade` will fail to
@@ -82,7 +100,12 @@ for entry in "${TARGETS[@]}"; do
   asset="vicoop-client-${VERSION}-${slug}${ext}"
 
   echo "==> building $target -> $asset"
-  ( cd "$CLIENT_DIR" && bun build --compile --target="$target" src/cli.ts --outfile "$OUT_DIR/$asset" )
+  # `${BUILD_DEFINES[@]+...}` guards the empty-array expansion under `set -u`
+  # on bash 3.2 (macOS dev hosts); on the CI runner the array carries the
+  # --define pair built above.
+  ( cd "$CLIENT_DIR" && bun build --compile --target="$target" \
+      ${BUILD_DEFINES[@]+"${BUILD_DEFINES[@]}"} \
+      src/cli.ts --outfile "$OUT_DIR/$asset" )
   chmod +x "$OUT_DIR/$asset"
 
   # Write the checksum file with a *bare filename*, not the absolute build

--- a/scripts/package-client-release.sh
+++ b/scripts/package-client-release.sh
@@ -55,8 +55,8 @@ CLIENT_DIR="$ROOT_DIR/packages/client"
 # $VICOOP_CLIENT_SENTRY_DSN is set (release.yml passes it from a GitHub
 # secret), Bun's `--define` rewrites the `process.env.VICOOP_CLIENT_SENTRY_DSN`
 # lookup in src/instrument.ts to this string literal. When it's unset (local
-# builds, forks, CI smoke compiles), no define is added and the daemon falls
-# back to the empty BAKED_IN_DSN — i.e. telemetry stays disabled. A DSN is a
+# builds, forks, CI smoke compiles), no define is added and that lookup stays a
+# runtime read that resolves to '' — i.e. telemetry stays disabled. A DSN is a
 # submit-only credential, so baking it into the public binary is expected and
 # safe (see docs/install-client.md → Telemetry).
 BUILD_DEFINES=()


### PR DESCRIPTION
## What

Adds **opt-in crash telemetry** to `@vicoop-bridge/client`. The server already reports to Sentry (#356); this brings the same visibility to the client — but with the opposite posture, because the client is a distributed binary running on **operators' own machines**.

Default is **off**. Nothing is sent unless the operator explicitly opts in, and even then only crash data leaves the process.

## Why the client config differs from the server

| | server (existing) | client (this PR) |
|---|---|---|
| default | env-gated on | **off, opt-in** |
| console/log forwarding | ✅ all levels | **❌ removed** |
| `enableLogs` | ✅ | ❌ |
| tracing | 1.0 | 0 |
| breadcrumbs | default | **all dropped** |
| `sendDefaultPii` | default | explicit `false` |
| scrubbing | — | home-path redaction + user/request/host stripped |

Copying the server's `consoleLoggingIntegration` to the client would have shipped operators' agent output (prompts, code, task content) to our Sentry — exactly the leak that bit [claude-task-master#1681](https://github.com/eyaltoledano/claude-task-master/issues/1681). So console capture is removed and breadcrumbs are suppressed entirely.

## What gets sent when opted in

Only an exception's **class + stack trace**, with the operator's home directory redacted to `~`. Never prompts, code, agent output, tokens, or console logs.

## How operators opt in

```bash
# at registration time (persists "telemetry": "on" into config.json)
vicoop-client agent register --agent-id <id> --enable-telemetry

# or hand-edit config.json
{ "telemetry": "on" }
```

Off by default; remove the field or set `"off"` to disable. A register re-run **without** the flag never silently disables a prior opt-in. The daemon prints a one-line disclosure at registration and at startup.

## Implementation notes

- **New `src/instrument.ts`** — privacy-first `Sentry.init`: `tracesSampleRate: 0`, `beforeBreadcrumb: () => null`, Console integration filtered out, `sendDefaultPii: false`, and a `beforeSend` scrub (strips `user`/`request`/`server_name`, redacts home path in messages + stack frames).
- **`config.ts`** — closed-enum `telemetry: 'on' | 'off'`; any other value is dropped, so a malformed field can never *enable* reporting.
- **`cli.ts`** — dynamically imports `instrument.ts` **only when opted in** (the SDK never loads otherwise), then installs `uncaughtException` / `unhandledRejection` handlers that capture → flush → exit, preserving Node's default crash semantics for everyone else.
- **`setup.ts`** — `--enable-telemetry` flag + disclosure output.
- **Docs** — "Telemetry (opt-in)" section in `docs/install-client.md`.

## Before merge / deploy

- The Sentry **DSN is not baked in yet** (`BAKED_IN_DSN = ''` in `instrument.ts`) — so opting in is currently a safe no-op until the client Sentry project is provisioned. Fill it in (or inject `VICOOP_CLIENT_SENTRY_DSN` at build) when ready. A DSN is submit-only and safe to ship in the binary; recommend enabling Sentry inbound rate-limit / spike protection against DSN-spam.

## Testing

- `config` normalization (on/off accepted, everything else dropped)
- `agent register --enable-telemetry` persistence + re-run-keeps-opt-in
- `scrubEvent` privacy guarantees (metadata stripped, breadcrumbs dropped, home path redacted)
- Client suite **713 pass**; repo `pnpm -r typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
