### PR TITLE
docs(server): fix Sentry comments to match single-project reality

### DIFF
--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -10,8 +10,9 @@ primary_region = "nrt"
 [env]
   PORT = "8787"
   POSTGRAPHILE_PORT = "5433"
-  # Sentry → shared "vicoop-router-monitoring" project. Enables the SDK in this
-  # deployment (see packages/server/src/instrument.ts; DSN is a baked default).
+  # Sentry → dedicated "vicoop-bridge-server" project (spans + logs both land
+  # there). Enables the SDK in this deployment; the DSN comes from the
+  # SENTRY_DSN Fly secret (see packages/server/src/instrument.ts).
   SENTRY_ENABLED = "true"
   SENTRY_ENVIRONMENT = "production"
 

--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -3,10 +3,11 @@ import * as Sentry from '@sentry/hono/node';
 Sentry.init({
   // DSN from the SENTRY_DSN env var (set as a Fly secret in deployment). No
   // hardcoded fallback: if unset, the SDK initializes disabled and sends nothing.
+  // The deployed DSN points at the dedicated "vicoop-bridge-server" Sentry
+  // project; everything below (spans AND logs) lands there.
   dsn: process.env.SENTRY_DSN,
-  // Same project as a2x-internal-router; the `service` tag is how the two
-  // services are told apart within the one shared Sentry project. (The Hono
-  // wrapper's init type doesn't expose serverName, so we tag instead.)
+  // `service` tag for filtering within the project. (The Hono wrapper's init
+  // type doesn't expose serverName, so we tag instead.)
   initialScope: { tags: { service: 'vicoop-bridge-server' } },
   environment: process.env.SENTRY_ENVIRONMENT ?? 'production',
   // Opt-in via env so local `tsx` runs stay silent. Enabled in the Fly
@@ -15,10 +16,11 @@ Sentry.init({
   enabled: process.env.SENTRY_ENABLED === 'true',
   // Backend service: trace all requests by default. Tune via SENTRY_TRACES_SAMPLE_RATE.
   tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '1.0'),
-  // Send logs to the shared "vicoop-router-monitoring" project. `enableLogs`
-  // only opens the transport; consoleLoggingIntegration is what feeds it —
-  // forwarding the server's console.* output as structured Sentry logs. (No
-  // Fly auto-stop flush concern here: packages/server/fly.toml keeps
+  // A single Sentry.init/DSN sends spans and logs to the same project, so
+  // these logs land in "vicoop-bridge-server" alongside the spans above.
+  // `enableLogs` only opens the transport; consoleLoggingIntegration is what
+  // feeds it — forwarding the server's console.* output as structured Sentry
+  // logs. (No Fly auto-stop flush concern here: packages/server/fly.toml keeps
   // min_machines_running=1, so the periodic log flush always runs.)
   enableLogs: true,
   integrations: [


### PR DESCRIPTION
Closes #361

## What

`instrument.ts`와 `fly.toml`의 Sentry 관련 주석을 실제 동작에 맞게 정정합니다. 코드 동작 변경은 없고 **주석만** 수정합니다.

## Why (#361)

이슈 #361에서 "스팬은 `vicoop-bridge-server`로, 로그는 `vicoop-router-monitoring`으로 분리되어 가는 것 같다"는 정황이 보고됐는데, 이는 **주석이 실제와 어긋나 있어 생긴 혼란**입니다.

- `Sentry.init()` 하나 = DSN 하나 = **프로젝트 하나**. 한 init에서 스팬은 per-service 프로젝트로, 로그는 별도 공유 프로젝트로 나눠 보낼 수 없습니다. 둘 다 같은 DSN이 가리키는 프로젝트로 갑니다.
- 스팬이 `vicoop-bridge-server`에 도달 → DSN은 `vicoop-bridge-server` 프로젝트를 가리킴 → 로그도 거기로 감.
- 기존 주석은 서로 모순됐습니다:
  - `instrument.ts`: "Same project as a2x-internal-router" (7~9줄) vs "Send logs to the shared vicoop-router-monitoring project" (18줄)
  - `fly.toml`: "Sentry → shared vicoop-router-monitoring project"
- `vicoop-router-monitoring`에서 보이던 로그(`admin_access`, `chat.completions completed`, `[failover]...`)는 실제 a2x-internal-router 서비스 출력이지 브릿지 서버 것이 아닙니다.

## 로그 0건이었던 별개 원인

로그 포워딩 코드(`enableLogs` + `consoleLoggingIntegration`, 커밋 `3ee4245`)는 6/11 02:08의 v80에는 없었고, v81/v82(6/12)에 처음 배포됐습니다. 즉 "최근 30일 로그 0건"은 그 기간 대부분의 빌드에 로그 코드 자체가 없었기 때문입니다.

## 검증 완료

- 런타임 머신의 환경변수 직접 확인: `SENTRY_ENABLED=true`, `SENTRY_DSN`의 프로젝트 ID = `4511540211613696` = **`vicoop-bridge-server`** (스팬·로그 모두 이 프로젝트로 감을 확정).
- v82(HEAD `8b91fe3`) 배포 후 probe 요청 유발 → Sentry `vicoop-bridge-server` 프로젝트의 Logs에 `client_connected`/`agent_request`/`task_completed` 등 console 출력이 구조화 로그로 **정상 유입 확인**.

## 변경

- 단일 init/DSN → 스팬·로그 모두 `vicoop-bridge-server` 프로젝트로 전송됨을 명시
- DSN은 `SENTRY_DSN` Fly secret에서 온다는 점 명확화 (기존 "baked default" 표현 정정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
