### PR TITLE
fix(server): pin to a single always-on machine (#363)

### DIFF
--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -19,9 +19,19 @@ primary_region = "nrt"
 [http_service]
   internal_port = 8787
   force_https = true
-  auto_stop_machines = "stop"
-  auto_start_machines = true
-  min_machines_running = 1
+  # TEMPORARY (see #363): the in-memory Registry (WS connections + task
+  # bindings) assumes a single always-on process. Until cross-instance
+  # routing (Fly-Replay affinity) lands:
+  #   - max=1 so the proxy can't scale out and split WS connections from
+  #     the HTTP requests that need them.
+  #   - auto_stop off (+ auto_start off) so the one machine is never
+  #     stopped on idle — stopping it would drop every live client WS and
+  #     force a reconnect storm. (min_machines_running only applies when
+  #     auto_stop is on, so it's inert here and omitted.)
+  # Revert to autoscaling once #363 is resolved.
+  auto_stop_machines = "off"
+  auto_start_machines = false
+  max_machines_running = 1
 
   [[http_service.checks]]
     interval = "30s"


### PR DESCRIPTION
## What

Temporarily pins the bridge server to **a single always-on Fly machine** in `packages/server/fly.toml`:

```toml
auto_stop_machines = "off"
auto_start_machines = false
max_machines_running = 1
```

(`min_machines_running = 1` dropped — it only applies when `auto_stop` is on.)

## Why

The server's in-memory `Registry` holds **live WebSocket connections** (`ClientConnection.ws`) and **task bindings** (`TaskBinding.sink`, an in-process callback into the executor's `AsyncEventQueue`) in process memory. A task's two ends — the HTTP executor that does `bindTask` + `sendToAgent`, and the `ws.on('message')` handler that does `getBinding().sink.push` — must live in the **same process**.

With the previous config (`auto_start_machines = true`, no `max`), the proxy could scale out under load and route an A2A HTTP request to a machine that doesn't hold the agent's WS → `sendToAgent` map miss → spurious `task_unreachable` (`executor.ts:189`).

This is a stopgap. The real fix (cross-instance routing via Fly-Replay affinity) is designed in #363.

- `max=1` blocks scale-out.
- `auto_stop="off"` / `auto_start=false` keep the one machine always on — stopping a stateful WS server out from under live connections would cause a reconnect storm.

## Deploy note

After deploy, verify exactly one machine is running (`fly machines list`); if several already exist, `fly scale count 1`. The single machine now stays on continuously (intended for a stateful WS server).

## Refs

Temporary guard for #363. Revert to autoscaling once cross-instance routing lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)