### PR TITLE
fix(server): tear down zombie agent registration when socket closes during async auth

### DIFF
--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -39,6 +39,24 @@ function mockSql(): Sql {
   return fn as unknown as Sql;
 }
 
+// Like mockSql, but the token lookup blocks on `gate` so a test can close the
+// socket while authenticateAndRegister is mid-await (#364).
+function gatedSql(gate: Promise<void>): Sql {
+  const fn = async () => {
+    await gate;
+    return [
+      {
+        id: 'agent-1',
+        client_id: 'client-1',
+        owner_principal: 'eth:0x0',
+        owner_email: null,
+        allowed_callers: [],
+      },
+    ];
+  };
+  return fn as unknown as Sql;
+}
+
 function makeSink(): TaskSink & {
   statuses: TaskStatusUpdateEvent[];
   artifacts: TaskArtifactUpdateEvent[];
@@ -133,6 +151,56 @@ test('task.fail preserves backend error code and message on status message metad
     assert.equal(registry.getBinding('task-1'), undefined);
   } finally {
     ws.close();
+    await closeServer(server);
+  }
+});
+
+test('a socket closing during async auth does not leave a zombie registration', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  let releaseAuth!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseAuth = resolve;
+  });
+  attachWsServer(server, { db: gatedSql(gate), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: {
+        name: 'agent',
+        version: '0.0.0',
+        protocolVersion: '0.3.0',
+      },
+    }));
+
+    // Let the server enter authenticateAndRegister and block on the gated
+    // token lookup, then close the socket while auth is still in flight.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    ws.close();
+    await once(ws, 'close');
+
+    // Wait for the *server-side* close handler to run — it fires shortly after
+    // the client close and, with agentId still null, skips its own cleanup.
+    // This ordering (close handler before auth resolves) is exactly what makes
+    // the registration a zombie: nothing else will tear it down. Releasing auth
+    // before this point would let the close handler observe a set agentId and
+    // clean up normally, masking the bug.
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    // Release auth: registerAgent now runs against the already-dead socket.
+    // The post-auth reconciliation must tear that entry back out.
+    releaseAuth();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    assert.equal(registry.getAgent('agent-1'), undefined);
+  } finally {
     await closeServer(server);
   }
 });

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -215,6 +215,18 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           ws.close(result.code, result.reason);
           return;
         }
+        // The socket may have closed while authenticateAndRegister was
+        // awaiting (token lookup, etc.). If so, the `close` handler already
+        // ran with agentId still null and skipped cleanup — but registerAgent
+        // has just put this now-dead ws into the registry. Reconcile here so we
+        // don't leave a zombie agent that getAgent() reports as live and
+        // sendToAgent() writes into a dead socket. unregisterAgent is idempotent
+        // (no-ops unless the stored ws is this one), so racing a later close
+        // event is safe. (#364)
+        if (ws.readyState !== ws.OPEN) {
+          opts.registry.unregisterAgent(frame.agentId, ws);
+          return;
+        }
         agentId = frame.agentId;
         authed = true;
         clearTimeout(helloTimeout);


### PR DESCRIPTION
Fixes #364.

## Problem

When a WS handshake closes while `authenticateAndRegister` is still awaiting (token lookup, etc.), the `close` handler in `handleConnection` runs with the local `agentId` still `null` and skips `unregisterAgent`. The auth promise then resolves and `registerAgent` puts the **already-dead ws** into the registry. Since the `close` event already fired, nothing ever cleans this entry up:

- `getAgent()` reports the agent as live → ghost agent in `well-known` / landing
- `sendToAgent()` writes into a dead socket → task assignments silently dropped
- the zombie persists until the same `agentId` reconnects

## Fix

`packages/server/src/ws.ts` — after auth resolves and **before** setting `agentId`, re-check socket liveness. If `ws.readyState !== ws.OPEN`, immediately `unregisterAgent` and bail instead of treating the dead connection as registered. `unregisterAgent` is idempotent (`existing.ws !== ws` guard), so racing a later `close` event is safe.

## Test

Adds a regression test (`ws.test.ts`) that:
1. gates the token lookup so auth blocks mid-handshake,
2. closes the socket and waits for the server-side `close` handler to run with `agentId` still null,
3. releases auth so `registerAgent` runs against the dead socket,
4. asserts `getAgent('agent-1')` is `undefined`.

Verified the test fails without the fix (zombie present) and passes with it. Full server suite: 210/210 pass; `pnpm -r typecheck` clean.

No changeset — `@vicoop-bridge/server` is in the changeset `ignore` list and ships via `fly deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)