### PR TITLE
fix(client): strip cache_control from replayed openai-compat history

### DIFF
--- a/.changeset/openai-compat-history-cache-control.md
+++ b/.changeset/openai-compat-history-cache-control.md
@@ -1,0 +1,18 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Strip `cache_control` markers from the replayed `<chat_history>` block on the
+openai-compat path. Anthropic-style `cache_control: {"type":"ephemeral"}`
+markers ride inbound on `messages[]` (the gateway / calling agent places one
+ephemeral breakpoint on a recent turn). `formatChatHistory` rendered the history
+verbatim, so the marker — which moves to the latest turn every request — mutated
+an entry in the middle of the otherwise byte-identical history on each follow-up
+turn. That broke the Anthropic prompt-cache prefix match at the marker's
+position, forcing the entire replayed transcript after it to be re-written to
+cache (1.25×) instead of read (0.1×) on every turn. Since openai-compat
+conversations resend the full growing history each turn, this dominated token
+usage on long sessions. The markers are an API-transport hint, not conversation
+content, and were never part of the history shape the model is told to expect —
+they are now deep-stripped before rendering so the block is a stable
+append-only prefix and the replayed history stays cache-readable across turns.

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -442,6 +442,66 @@ test('formatChatHistory: returns empty when the history is empty', () => {
   assert.equal(formatChatHistory([]), '');
 });
 
+test('formatChatHistory: strips cache_control markers wherever they ride', () => {
+  // Anthropic-style cache_control markers ride inbound on messages[] (gateway /
+  // caller places an ephemeral breakpoint). They are transport hints, not
+  // conversation content — rendering them verbatim leaks API noise into the
+  // prompt and, because the marker moves each turn, thrashes the prompt cache.
+  const rendered = formatChatHistory([
+    // marker at message level
+    { role: 'user', content: 'hi', cache_control: { type: 'ephemeral' } } as never,
+    // marker nested inside a tool_calls entry (the shape seen on the wire)
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        {
+          id: 'call_x',
+          function: { name: 'f', arguments: '{}' },
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+    } as never,
+    { role: 'tool', tool_call_id: 'call_x', content: 'ok' },
+  ]);
+  assert.ok(!rendered.includes('cache_control'), 'cache_control must not appear in rendered history');
+  // Semantic content survives the strip.
+  assert.match(rendered, /"role": "user"/);
+  assert.match(rendered, /"name": "f"/);
+  assert.match(rendered, /"tool_call_id": "call_x"/);
+});
+
+test('formatChatHistory: identical history minus a moved marker renders byte-identical', () => {
+  // The core caching invariant: two requests whose only difference is WHERE the
+  // moving cache_control marker sits must produce the same prefix, so an
+  // append-only conversation stays cache-readable across turns.
+  const base = [
+    { role: 'user' as const, content: 'turn 1' },
+    { role: 'assistant' as const, content: 'reply 1' },
+    { role: 'user' as const, content: 'turn 2' },
+  ];
+  const markerOnFirst = formatChatHistory([
+    { ...base[0], cache_control: { type: 'ephemeral' } } as never,
+    base[1] as never,
+    base[2] as never,
+  ]);
+  const markerOnLast = formatChatHistory([
+    base[0] as never,
+    base[1] as never,
+    { ...base[2], cache_control: { type: 'ephemeral' } } as never,
+  ]);
+  assert.equal(markerOnFirst, markerOnLast);
+  assert.equal(markerOnFirst, formatChatHistory(base));
+});
+
+test('formatChatHistory: does not mutate the caller history', () => {
+  const history = [
+    { role: 'user' as const, content: 'hi', cache_control: { type: 'ephemeral' } } as never,
+  ];
+  formatChatHistory(history);
+  assert.deepEqual(history[0], { role: 'user', content: 'hi', cache_control: { type: 'ephemeral' } });
+});
+
 // ───────────────────────────────────────────────────────────────────────────
 // requalifyHistoryToolNames — rename caller-tool references in replayed
 // history to a backend's live tool ids (claude native MCP dispatch, #213).

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -465,9 +465,48 @@ export function formatChatHistory(history: OpenAICompatHistoryEntry[]): string {
   if (history.length === 0) return '';
   return [
     '<chat_history>',
-    JSON.stringify(history, null, 2),
+    JSON.stringify(stripCacheControl(history), null, 2),
     '</chat_history>',
   ].join('\n');
+}
+
+// Deep-strip every `cache_control` key from a value (returns a copy; input is
+// not mutated). Used to scrub the replayed history before it is rendered into
+// the `<chat_history>` text block.
+//
+// Why this matters for caching: Anthropic-style `cache_control`
+// ({"type":"ephemeral"}) markers ride inbound on the OpenAI `messages[]` — the
+// gateway / calling agent places one ephemeral breakpoint on a recent turn.
+// They are an API-transport hint, NOT conversation content, and the documented
+// history shapes (taught in buildOpenAICompat*SystemPrompt) don't include them.
+// Left in, two things go wrong:
+//
+//   1. The marker MOVES to the latest turn on every request and is removed from
+//      the previously-marked entry. Rendering the history verbatim therefore
+//      re-encodes an entry in the MIDDLE of the otherwise byte-identical array
+//      on every follow-up turn. That mutation breaks the Anthropic prompt-cache
+//      prefix match at the marker's position, so the entire replayed transcript
+//      after it is re-written to cache (1.25x) instead of read (0.1x) — the
+//      dominant cost on long openai-compat conversations, which resend the full
+//      growing history every turn.
+//   2. A literal `cache_control` field in the JSON is noise the model has to
+//      read past and was never part of the contract it's told to expect.
+//
+// Stripping it makes the rendered block a stable append-only prefix across
+// turns, restoring cross-request cache reads for the replayed history.
+function stripCacheControl<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripCacheControl(v)) as unknown as T;
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (k === 'cache_control') continue;
+      out[k] = stripCacheControl(v);
+    }
+    return out as unknown as T;
+  }
+  return value;
 }
 
 // Return a copy of `history` with every caller-tool reference renamed via


### PR DESCRIPTION
## What

On the **openai-compat** path, strip Anthropic-style `cache_control` markers from the replayed `<chat_history>` block before rendering it into the prompt.

## Why

While investigating a Claude-backend usage spike on the provider host, the breakdown of one busy hour (88 sessions, ~25.4M tokens) showed **cache _writes_ were 58% of all tokens** — the dominant cost — even though it's an OpenAI-compatible (stateless) path where every request resends the full growing history, so consecutive requests share a ~99.8%-identical prefix that *should* be cache-**read**.

Per-turn analysis showed every session's first model turn read a **constant 42,327 tokens** (just Claude Code's static system+tools+`CLAUDE.md` prefix) and **wrote** a growing 25k→121k (the whole history). The 100k+ shared history was re-written every turn, never read.

Diffing two consecutive history blocks pinned the cause to a byte mutation **in the middle** of the otherwise-identical array (char 24,841 of 59,726 — ~35k chars before the end):

```diff
           "name": "mcp___vb-caller-tools__read",
           "arguments": "{\"filePath\":\"/home/project/.env\"}"
-        },
-        "cache_control": { "type": "ephemeral" }
+        }
       }
```

An Anthropic `cache_control: {"type":"ephemeral"}` marker rides inbound on `messages[]` (the gateway / calling agent places one ephemeral breakpoint on a recent turn). It **moves to the latest turn every request** and is removed from the previously-marked entry. Because `formatChatHistory` serialized the history verbatim (`JSON.stringify(history, null, 2)`), the marker's movement re-encoded a mid-array entry on every follow-up turn → the Anthropic prompt-cache prefix match broke at the marker's position → the entire replayed transcript after it was re-written to cache (1.25×) instead of read (0.1×).

Compounding it, the openai-compat path intentionally disables claude session reuse (`claude.ts`), so every request is a cold spawn with no warm in-process cache to absorb the miss.

## Fix

Deep-strip every `cache_control` key from the history before rendering. The markers are an API-transport hint, not conversation content, and were never part of the documented history shape the model is told to expect (`buildOpenAICompat*SystemPrompt`). Removing them makes the rendered block a stable append-only prefix, so the replayed history stays cache-readable across turns. The portion that was re-written each turn moves from cache-write (1.25×) to cache-read (0.1×) — ~12× cheaper on that span, and a proportional drop in subscription-quota pressure.

Strip happens at render time in `formatChatHistory` (shared by the claude / openclaw text-prepend backends). codex's native `historyToInjectItems` path is untouched.

## Testing

- `pnpm -r build`, `pnpm --filter @vicoop-bridge/client typecheck` — clean
- `pnpm --filter @vicoop-bridge/client test` — **721 pass / 0 fail**
- New regression tests cover: markers stripped wherever they ride (message-level + nested in `tool_calls`), semantic content preserved, **a moved marker renders byte-identical** (the caching invariant), and the caller's history is not mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
