### PR TITLE
feat(client): forward Claude extended-thinking on openai-compat reasoning channel

### DIFF
--- a/.changeset/claude-reasoning-channel.md
+++ b/.changeset/claude-reasoning-channel.md
@@ -12,4 +12,6 @@ reasoning turn as alive instead of false-failing-over it
 (planetarium/a2x-internal-router#95, #376). ON by default; disable with
 `--no-claude-reasoning` or `backends.claude.reasoning: false` when the deployed
 oai2a2a codec predates 0.6.0 and can't yet interpret the channel marker.
-Redacted-thinking blocks are never forwarded.
+Redacted-thinking blocks are never forwarded. The injected thinking budget
+(default 8000) is configurable via `--claude-thinking-budget` /
+`backends.claude.thinking_budget`.

--- a/.changeset/claude-reasoning-channel.md
+++ b/.changeset/claude-reasoning-channel.md
@@ -1,0 +1,15 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+feat(client): forward Claude extended-thinking on an openai-compat/v1
+`reasoning` channel. The claude backend surfaces `thinking_delta` stream events
+as a dedicated `claude-reasoning` artifact carrying
+`metadata[openai-compat/v1] = { channel: "reasoning" }`, and injects a
+`MAX_THINKING_TOKENS` budget on openai-compat spawns so Claude Code emits
+thinking on the wire. This lets the a2x-internal-router treat a long silent
+reasoning turn as alive instead of false-failing-over it
+(planetarium/a2x-internal-router#95, #376). ON by default; disable with
+`--no-claude-reasoning` or `backends.claude.reasoning: false` when the deployed
+oai2a2a codec predates 0.6.0 and can't yet interpret the channel marker.
+Redacted-thinking blocks are never forwarded.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -477,6 +477,40 @@ test('injects MAX_THINKING_TOKENS on openai-compat spawns when reasoning is on',
   assert.equal(fake.lastChild()?.env?.MAX_THINKING_TOKENS, '8000');
 });
 
+test('claudeThinkingBudget overrides the injected MAX_THINKING_TOKENS', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    claudeReasoning: true,
+    claudeThinkingBudget: 12000,
+  });
+  const { emit } = collect();
+  const envelopeTask: TaskAssignFrame = {
+    ...assign('hello'),
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'text', text: 'hello' }],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          chat_completions_request: { model: 'gpt', messages: [{ role: 'user', content: 'hello' }] },
+        },
+      },
+    },
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
+  };
+  await backend.handle(envelopeTask, emit, NEVER);
+
+  assert.equal(fake.lastChild()?.env?.MAX_THINKING_TOKENS, '12000');
+});
+
 test('falls back to result artifact when streaming produced nothing', async () => {
   const fake = scriptedSpawn({
     lines: [

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -312,6 +312,171 @@ test('streams Claude stream_event text deltas as append chunks', async () => {
   assert.deepEqual(artifacts.map((a) => a.append), [true, true]);
 });
 
+test('forwards thinking_delta on a reasoning channel when claudeReasoning is on', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'thinking', thinking: 'let me' } },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: ' think' } },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'answer' } },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'answer' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeReasoning: true });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  const reasoning = artifacts.filter((a) => a.artifact.name === 'claude-reasoning');
+  const answer = artifacts.filter((a) => a.artifact.name === 'claude-message');
+
+  // Thinking rides its own channel: separate id, the openai-compat marker,
+  // appended and non-terminal — never co-mingled with the answer artifact.
+  assert.deepEqual(reasoning.map(textOf), ['let me', ' think']);
+  assert.equal(new Set(reasoning.map((a) => a.artifact.artifactId)).size, 1);
+  for (const r of reasoning) {
+    assert.deepEqual(r.artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+    assert.deepEqual(r.artifact.metadata?.[OPENAI_COMPAT_EXTENSION_URI], { channel: 'reasoning' });
+    assert.equal(r.append, true);
+    assert.equal(r.lastChunk, false);
+  }
+  // The answer is a distinct artifact id and carries only the text delta.
+  assert.deepEqual(answer.map(textOf), ['answer']);
+  assert.notEqual(reasoning[0].artifact.artifactId, answer[0].artifact.artifactId);
+});
+
+test('forwards thinking_delta by default (no claudeReasoning option)', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'hmm' } },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: '' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // Reasoning is ON by default — the thinking delta surfaces on its channel.
+  assert.deepEqual(
+    artifacts.filter((a) => a.artifact.name === 'claude-reasoning').map(textOf),
+    ['hmm'],
+  );
+});
+
+test('drops thinking_delta entirely when claudeReasoning is false', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: 'secret' } },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'answer' } },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'answer' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeReasoning: false });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // No reasoning channel, and the thinking text never leaks into the answer.
+  assert.equal(artifacts.filter((a) => a.artifact.name === 'claude-reasoning').length, 0);
+  assert.deepEqual(
+    artifacts.filter((a) => a.artifact.name === 'claude-message').map(textOf),
+    ['answer'],
+  );
+});
+
+test('does not forward redacted_thinking content even with reasoning on', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_start', content_block: { type: 'redacted_thinking', data: 'ENCRYPTED' } },
+      }),
+      JSON.stringify({
+        type: 'stream_event',
+        event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'answer' } },
+      }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'answer' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeReasoning: true });
+  const { emit, frames } = collect();
+  await backend.handle(assign('hello'), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // Encrypted redacted-thinking blob must never reach the wire.
+  assert.equal(artifacts.filter((a) => a.artifact.name === 'claude-reasoning').length, 0);
+  const all = JSON.stringify(artifacts);
+  assert.equal(all.includes('ENCRYPTED'), false);
+});
+
+test('injects MAX_THINKING_TOKENS on openai-compat spawns when reasoning is on', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeReasoning: true });
+  const { emit } = collect();
+  const envelopeTask: TaskAssignFrame = {
+    ...assign('hello'),
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'text', text: 'hello' }],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          chat_completions_request: { model: 'gpt', messages: [{ role: 'user', content: 'hello' }] },
+        },
+      },
+    },
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
+  };
+  await backend.handle(envelopeTask, emit, NEVER);
+
+  assert.equal(fake.lastChild()?.env?.MAX_THINKING_TOKENS, '8000');
+});
+
 test('falls back to result artifact when streaming produced nothing', async () => {
   const fake = scriptedSpawn({
     lines: [

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -204,6 +204,22 @@ export interface ClaudeBackendOptions {
   // fails, every later task falls back to the unsplit block, and a daemon
   // restart re-arms it (so a CLI fix/downgrade self-heals).
   openaiCompatHistoryCache?: boolean;
+  // Forward Claude's extended-thinking as a live `reasoning` channel: an
+  // additive `openai-compat/v1` wire marker (a reasoning-channel artifact with
+  // `metadata[ext-uri] = { channel: 'reasoning' }`) that the oai2a2a codec maps
+  // to `delta.reasoning_content` so the a2x-internal-router stops
+  // false-failing-over long silent reasoning turns
+  // (planetarium/a2x-internal-router#95, vicoop-bridge#376).
+  //
+  // ON by default; set `false` (CLI `--no-claude-reasoning` / config
+  // `backends.claude.reasoning: false`) to disable. Disable when the deployed
+  // oai2a2a codec predates 0.6.0 — an old codec doesn't understand the
+  // `reasoning` channel marker and would fold the thinking artifact into the
+  // answer (the #95 rollout-order hazard). When on, openai-compat spawns also
+  // get `MAX_THINKING_TOKENS` injected so Claude Code actually emits thinking on
+  // the wire (its `-p` headless mode defaults extended thinking off); operators
+  // can override the budget by exporting `MAX_THINKING_TOKENS` themselves.
+  claudeReasoning?: boolean;
 }
 
 interface SessionEntry {
@@ -433,6 +449,13 @@ const TOOL_CALL_SUMMARY_MAX_CHARS = 200;
 // `task.status: working` so bytes keep flowing.
 const DEFAULT_HEARTBEAT_MS = 30_000;
 
+// Thinking budget injected via `MAX_THINKING_TOKENS` on openai-compat spawns
+// when the reasoning channel is enabled (see `claudeReasoning`). Claude Code's
+// `-p` headless mode emits no thinking on the wire unless this is set; the
+// reasoning forwarding is a no-op without it. Only applied when the operator
+// hasn't already exported their own `MAX_THINKING_TOKENS`.
+const DEFAULT_MAX_THINKING_TOKENS = '8000';
+
 // Defensive stringification — `(e as Error).message` is unsafe when the
 // thrown value is null/undefined or a non-Error primitive (common in JS).
 // Always returns a string suitable for logs/frames without throwing.
@@ -628,6 +651,34 @@ function extractClaudeStreamTextDelta(evt: StreamEvent): string {
   if (e.type === 'content_block_start' && e.content_block && typeof e.content_block === 'object') {
     const block = e.content_block as { type?: unknown; text?: unknown };
     if (block.type === 'text' && typeof block.text === 'string') return block.text;
+  }
+  return '';
+}
+
+// Extract a thinking (extended-reasoning) delta from a partial-message
+// `stream_event`. Mirrors `extractClaudeStreamTextDelta` but reads the
+// thinking content block: `content_block_delta` carries `thinking_delta`
+// (`delta.thinking`) and the opening `content_block_start` can prefill a
+// `thinking` block. These ride the wire today (claude spawns with
+// `--include-partial-messages`) but are otherwise dropped, since
+// `extractClaudeStreamTextDelta` only matches text blocks.
+//
+// `redacted_thinking` is deliberately NOT surfaced: its `data` is an encrypted
+// blob, not human-readable reasoning, so forwarding it as `reasoning_content`
+// would emit ciphertext to the caller. We skip it (the answer is unaffected —
+// redacted blocks never carried user-facing text).
+function extractClaudeStreamReasoningDelta(evt: StreamEvent): string {
+  if (evt.type !== 'stream_event') return '';
+  const event = evt.event;
+  if (!event || typeof event !== 'object') return '';
+  const e = event as { type?: unknown; delta?: unknown; content_block?: unknown };
+  if (e.type === 'content_block_delta' && e.delta && typeof e.delta === 'object') {
+    const delta = e.delta as { type?: unknown; thinking?: unknown };
+    if (delta.type === 'thinking_delta' && typeof delta.thinking === 'string') return delta.thinking;
+  }
+  if (e.type === 'content_block_start' && e.content_block && typeof e.content_block === 'object') {
+    const block = e.content_block as { type?: unknown; thinking?: unknown };
+    if (block.type === 'thinking' && typeof block.thinking === 'string') return block.thinking;
   }
   return '';
 }
@@ -1118,6 +1169,10 @@ export function createClaudeBackend(
   const now = opts.now ?? Date.now;
   const heartbeatMs = opts.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
   const openaiCompatTrace = opts.openaiCompatTrace === true;
+  // openai-compat/v1 reasoning channel (#95 / #376). ON by default; disable via
+  // `claudeReasoning: false` (CLI `--no-claude-reasoning` / config) when the
+  // deployed codec predates 0.6.0 and can't yet understand the marker.
+  const reasoningEnabled = opts.claudeReasoning !== false;
   // openai-compat chat_history prompt-cache: ON by default for claude. Hard
   // off via `openaiCompatHistoryCache: false` or VICOOP_DISABLE_OAI_HISTORY_CACHE.
   const historyCacheConfigured =
@@ -1939,8 +1994,17 @@ export function createClaudeBackend(
       // 5-min default. Trade-off: a 1h cache *write* costs 2x base (vs 1.25x for
       // 5m), paid once per prefix; reads stay 0.1x, so it wins whenever the
       // prefix is reused at all within the hour.
+      // When the reasoning channel is on, ensure Claude Code actually emits
+      // thinking on the wire by setting a `MAX_THINKING_TOKENS` budget (its
+      // `-p` headless mode is otherwise silent). Don't clobber an operator's
+      // own export. Scoped to openai-compat spawns — the same path the
+      // reasoning-channel artifact and the router care about.
+      const reasoningBudget =
+        reasoningEnabled && envelope && !process.env.MAX_THINKING_TOKENS
+          ? { MAX_THINKING_TOKENS: DEFAULT_MAX_THINKING_TOKENS }
+          : undefined;
       const effectiveEnv = envelope
-        ? { ENABLE_PROMPT_CACHING_1H: '1' }
+        ? { ENABLE_PROMPT_CACHING_1H: '1', ...reasoningBudget }
         : undefined;
 
       let child: ClaudeChildHandle;
@@ -2042,6 +2106,10 @@ export function createClaudeBackend(
       // init reports claude's resolved default rather than the slug (#348).
       let initModel: string | null = null;
       let responseArtifactId: string | null = null;
+      // Distinct artifact id for the reasoning channel (#95 / #376), kept
+      // separate from `responseArtifactId` so thinking never co-mingles with
+      // the answer artifact. Lazily minted on the first thinking delta.
+      let reasoningArtifactId: string | null = null;
       let streamedResponseText = '';
       let sawCompletedResult = false;
       let sawErrorResult = false;
@@ -2110,6 +2178,34 @@ export function createClaudeBackend(
           },
           ...(append ? { append: true } : {}),
           lastChunk,
+        });
+        emittedAnyArtifact = true;
+      };
+
+      // Emit a thinking delta on the dedicated `reasoning` channel: a separate
+      // `artifactId` carrying the openai-compat/v1 marker
+      // `metadata[OPENAI_COMPAT_EXTENSION_URI] = { channel: 'reasoning' }`,
+      // appended with `lastChunk:false`. The oai2a2a codec maps this to
+      // `delta.reasoning_content`; the a2x-internal-router treats it as a
+      // commit/liveness signal so a healthy long-reasoning turn is never
+      // false-failed-over (#95). NOT a `claude-message` artifact — thinking
+      // must stay out of the answer. Gated by `reasoningEnabled` at the call
+      // site (and emits nothing until thinking is actually on the wire).
+      const emitReasoningArtifact = (text: string): void => {
+        if (!text) return;
+        reasoningArtifactId ??= randomUUID();
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: reasoningArtifactId,
+            name: 'claude-reasoning',
+            parts: [{ kind: 'text', text }],
+            extensions: [OPENAI_COMPAT_EXTENSION_URI],
+            metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { channel: 'reasoning' } },
+          },
+          append: true,
+          lastChunk: false,
         });
         emittedAnyArtifact = true;
       };
@@ -2240,6 +2336,18 @@ export function createClaudeBackend(
           return;
         }
         if (evt.type === 'stream_event') {
+          if (reasoningEnabled && !emittedAskUserQuestion) {
+            const reasoning = extractClaudeStreamReasoningDelta(evt);
+            if (reasoning) {
+              // Liveness: a reasoning byte is "alive and committing" for the
+              // router, so stamp the heartbeat clock too (a long thinking
+              // burst must not look idle). The reasoning artifact rides the
+              // wrapped `emit`, which already refreshes `lastEmitAt`.
+              recorder.mark('firstAssistant');
+              emitReasoningArtifact(reasoning);
+              return;
+            }
+          }
           const delta = extractClaudeStreamTextDelta(evt);
           if (delta && !emittedAskUserQuestion) {
             recorder.mark('firstAssistant');
@@ -2479,6 +2587,13 @@ export function createClaudeBackend(
           // fresh window and skips. Calling `rawEmit` here would leave
           // `lastEmitAt` stale and let several ticks emit back-to-back
           // if the timer fired multiple times after a long pause.
+          // NOTE (#95 / #376): the heartbeat liveness marker
+          // (`metadata[OPENAI_COMPAT_EXTENSION_URI] = { heartbeat: true }`) is
+          // intentionally NOT stamped here. `TaskStatus` has no `metadata`
+          // field in the protocol (it would be stripped), and routing it to the
+          // A2A `TaskStatusUpdateEvent.metadata` needs a protocol + server
+          // change. That lands with the shared-loop heartbeat follow-up; this
+          // bare `working` heartbeat already keeps bytes on the wire today.
           emit({
             type: 'task.status',
             taskId: task.taskId,

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -220,6 +220,13 @@ export interface ClaudeBackendOptions {
   // the wire (its `-p` headless mode defaults extended thinking off); operators
   // can override the budget by exporting `MAX_THINKING_TOKENS` themselves.
   claudeReasoning?: boolean;
+  // Thinking budget (in tokens) injected as `MAX_THINKING_TOKENS` on
+  // openai-compat spawns when the reasoning channel is on. Operator-facing knob
+  // for the default below (CLI `--claude-thinking-budget` / config
+  // `backends.claude.thinking_budget`). Precedence: this option > an operator's
+  // own `MAX_THINKING_TOKENS` env export > `DEFAULT_MAX_THINKING_TOKENS`. Unset
+  // (the default) keeps the env-or-default behaviour.
+  claudeThinkingBudget?: number;
 }
 
 interface SessionEntry {
@@ -449,11 +456,12 @@ const TOOL_CALL_SUMMARY_MAX_CHARS = 200;
 // `task.status: working` so bytes keep flowing.
 const DEFAULT_HEARTBEAT_MS = 30_000;
 
-// Thinking budget injected via `MAX_THINKING_TOKENS` on openai-compat spawns
-// when the reasoning channel is enabled (see `claudeReasoning`). Claude Code's
-// `-p` headless mode emits no thinking on the wire unless this is set; the
-// reasoning forwarding is a no-op without it. Only applied when the operator
-// hasn't already exported their own `MAX_THINKING_TOKENS`.
+// Default thinking budget injected via `MAX_THINKING_TOKENS` on openai-compat
+// spawns when the reasoning channel is enabled (see `claudeReasoning`). Claude
+// Code's `-p` headless mode emits no thinking on the wire unless this is set;
+// the reasoning forwarding is a no-op without it. Used when no explicit
+// `claudeThinkingBudget` override is given and the operator hasn't exported
+// their own `MAX_THINKING_TOKENS`.
 const DEFAULT_MAX_THINKING_TOKENS = '8000';
 
 // Defensive stringification — `(e as Error).message` is unsafe when the
@@ -1173,6 +1181,15 @@ export function createClaudeBackend(
   // `claudeReasoning: false` (CLI `--no-claude-reasoning` / config) when the
   // deployed codec predates 0.6.0 and can't yet understand the marker.
   const reasoningEnabled = opts.claudeReasoning !== false;
+  // Operator-facing override for the injected `MAX_THINKING_TOKENS` budget; a
+  // positive integer or undefined (use env-or-default). Non-positive values are
+  // ignored so a stray `0` / negative can't silently disable thinking.
+  const thinkingBudgetOverride =
+    typeof opts.claudeThinkingBudget === 'number' &&
+    Number.isFinite(opts.claudeThinkingBudget) &&
+    opts.claudeThinkingBudget > 0
+      ? String(Math.floor(opts.claudeThinkingBudget))
+      : undefined;
   // openai-compat chat_history prompt-cache: ON by default for claude. Hard
   // off via `openaiCompatHistoryCache: false` or VICOOP_DISABLE_OAI_HISTORY_CACHE.
   const historyCacheConfigured =
@@ -1996,12 +2013,19 @@ export function createClaudeBackend(
       // prefix is reused at all within the hour.
       // When the reasoning channel is on, ensure Claude Code actually emits
       // thinking on the wire by setting a `MAX_THINKING_TOKENS` budget (its
-      // `-p` headless mode is otherwise silent). Don't clobber an operator's
-      // own export. Scoped to openai-compat spawns — the same path the
-      // reasoning-channel artifact and the router care about.
+      // `-p` headless mode is otherwise silent). Scoped to openai-compat spawns
+      // — the same path the reasoning-channel artifact and the router care
+      // about. Precedence: an explicit `--claude-thinking-budget` / config knob
+      // wins (and overrides the env, since defaultSpawn merges options.env over
+      // process.env); otherwise an operator's own `MAX_THINKING_TOKENS` export
+      // passes through untouched; otherwise the built-in default.
       const reasoningBudget =
-        reasoningEnabled && envelope && !process.env.MAX_THINKING_TOKENS
-          ? { MAX_THINKING_TOKENS: DEFAULT_MAX_THINKING_TOKENS }
+        reasoningEnabled && envelope
+          ? thinkingBudgetOverride !== undefined
+            ? { MAX_THINKING_TOKENS: thinkingBudgetOverride }
+            : !process.env.MAX_THINKING_TOKENS
+              ? { MAX_THINKING_TOKENS: DEFAULT_MAX_THINKING_TOKENS }
+              : undefined
           : undefined;
       const effectiveEnv = envelope
         ? { ENABLE_PROMPT_CACHING_1H: '1', ...reasoningBudget }

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -243,6 +243,56 @@ test('--claude-supported-models with a non-claude backend is a hard error', () =
   );
 });
 
+test('claudeReasoning defaults ON when neither flag nor config sets it', () => {
+  const r = mergeClientArgs({ token: 't', agentId: 'a', backend: 'claude' }, {});
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeReasoning, true);
+});
+
+test('--no-claude-reasoning flag turns the reasoning channel off', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', noClaudeReasoning: true },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeReasoning, false);
+});
+
+test('backends.claude.reasoning:false turns the reasoning channel off', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude' },
+    { backends: { claude: { reasoning: false } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeReasoning, false);
+});
+
+test('--no-claude-reasoning beats config reasoning:true', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', noClaudeReasoning: true },
+    { backends: { claude: { reasoning: true } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeReasoning, false);
+});
+
+test('--no-claude-reasoning with a non-claude backend is a hard error', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'codex', noClaudeReasoning: true },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--no-claude-reasoning') && e.includes('codex')),
+    `expected error mentioning --no-claude-reasoning and codex, got: ${r.errors.join(' | ')}`,
+  );
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -293,6 +293,56 @@ test('--no-claude-reasoning with a non-claude backend is a hard error', () => {
   );
 });
 
+test('claudeThinkingBudget is undefined when neither flag nor config sets it', () => {
+  const r = mergeClientArgs({ token: 't', agentId: 'a', backend: 'claude' }, {});
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeThinkingBudget, undefined);
+});
+
+test('--claude-thinking-budget flag sets the budget', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', claudeThinkingBudget: 16000 },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeThinkingBudget, 16000);
+});
+
+test('--claude-thinking-budget flag beats backends.claude.thinking_budget from config', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', claudeThinkingBudget: 16000 },
+    { backends: { claude: { thinking_budget: 4000 } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeThinkingBudget, 16000);
+});
+
+test('backends.claude.thinking_budget fills in when the flag is absent', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude' },
+    { backends: { claude: { thinking_budget: 4000 } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.claudeThinkingBudget, 4000);
+});
+
+test('--claude-thinking-budget with a non-claude backend is a hard error', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'codex', claudeThinkingBudget: 16000 },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--claude-thinking-budget') && e.includes('codex')),
+    `expected error mentioning --claude-thinking-budget and codex, got: ${r.errors.join(' | ')}`,
+  );
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -93,6 +93,11 @@ export const daemonFlagsFields = {
   claudeSupportedModels: optional(option('--claude-supported-models', string({ metavar: 'MODELS' }), {
     description: message`Comma-separated additional model ids this Claude install can serve, e.g. \`claude-sonnet-4-6,claude-haiku-4-5\`. Advertised alongside the default model and accepted as per-request openai-compat \`model\` overrides (Claude has no headless model listing, so the set is operator-declared and not validated against the account). Only valid with \`--backend claude\`; pairing with another backend exits non-zero.`,
   })),
+  noClaudeReasoning: optional(
+    flag('--no-claude-reasoning', {
+      description: message`Disable forwarding Claude's extended-thinking on the openai-compat/v1 \`reasoning\` channel (on by default). Use when the deployed oai2a2a codec predates 0.6.0 and can't yet interpret the channel marker — otherwise the thinking would fold into the answer (planetarium/a2x-internal-router#95). Mirrors config \`backends.claude.reasoning: false\`.`,
+    }),
+  ),
 
   // Backend-specific (Codex)
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
@@ -149,6 +154,10 @@ export interface DaemonArgs {
   claudeSettingsFile?: string;
   claudeModel?: string;
   claudeSupportedModels?: string[];
+  // Resolved openai-compat/v1 reasoning channel toggle. Defaults ON; the
+  // `--no-claude-reasoning` flag or `backends.claude.reasoning: false` flips it
+  // off (#95 / #376). Always defined after `resolveDaemonArgs`.
+  claudeReasoning?: boolean;
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
   openclawGatewayToken?: string;
@@ -274,6 +283,9 @@ export function mergeClientArgs(
     claudeSupportedModels:
       pickModelsList(flags.claudeSupportedModels) ??
       (backends.claude?.supported_models?.length ? backends.claude.supported_models : undefined),
+    // ON unless the config opts out (`reasoning: false`) or the CLI flag forces
+    // it off; the flag wins over config, matching the other flag>config knobs.
+    claudeReasoning: backends.claude?.reasoning !== false && !flags.noClaudeReasoning,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     openclawGateway:
@@ -339,6 +351,11 @@ export function mergeClientArgs(
   if (pick(flags.claudeSupportedModels) && backend !== 'claude') {
     errors.push(
       `--claude-supported-models is not supported by --backend ${backend}; only the claude backend takes model ids`,
+    );
+  }
+  if (flags.noClaudeReasoning && backend !== 'claude') {
+    errors.push(
+      `--no-claude-reasoning is not supported by --backend ${backend}; only the claude backend forwards a reasoning channel`,
     );
   }
 

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -98,6 +98,11 @@ export const daemonFlagsFields = {
       description: message`Disable forwarding Claude's extended-thinking on the openai-compat/v1 \`reasoning\` channel (on by default). Use when the deployed oai2a2a codec predates 0.6.0 and can't yet interpret the channel marker — otherwise the thinking would fold into the answer (planetarium/a2x-internal-router#95). Mirrors config \`backends.claude.reasoning: false\`.`,
     }),
   ),
+  claudeThinkingBudget: optional(
+    option('--claude-thinking-budget', integer({ metavar: 'TOKENS', min: 1 }), {
+      description: message`Thinking budget in tokens, injected as \`MAX_THINKING_TOKENS\` on openai-compat spawns so Claude emits thinking on the wire (default 8000). Takes precedence over an operator's own \`MAX_THINKING_TOKENS\` export. Only valid with \`--backend claude\`. Mirrors config \`backends.claude.thinking_budget\`.`,
+    }),
+  ),
 
   // Backend-specific (Codex)
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
@@ -158,6 +163,10 @@ export interface DaemonArgs {
   // `--no-claude-reasoning` flag or `backends.claude.reasoning: false` flips it
   // off (#95 / #376). Always defined after `resolveDaemonArgs`.
   claudeReasoning?: boolean;
+  // Resolved `MAX_THINKING_TOKENS` budget override (`--claude-thinking-budget`
+  // / `backends.claude.thinking_budget`). Undefined keeps the backend's
+  // env-or-default behaviour.
+  claudeThinkingBudget?: number;
   codexSandbox?: CodexSandboxMode;
   openclawGateway?: string;
   openclawGatewayToken?: string;
@@ -286,6 +295,7 @@ export function mergeClientArgs(
     // ON unless the config opts out (`reasoning: false`) or the CLI flag forces
     // it off; the flag wins over config, matching the other flag>config knobs.
     claudeReasoning: backends.claude?.reasoning !== false && !flags.noClaudeReasoning,
+    claudeThinkingBudget: flags.claudeThinkingBudget ?? backends.claude?.thinking_budget,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     openclawGateway:
@@ -356,6 +366,11 @@ export function mergeClientArgs(
   if (flags.noClaudeReasoning && backend !== 'claude') {
     errors.push(
       `--no-claude-reasoning is not supported by --backend ${backend}; only the claude backend forwards a reasoning channel`,
+    );
+  }
+  if (flags.claudeThinkingBudget !== undefined && backend !== 'claude') {
+    errors.push(
+      `--claude-thinking-budget is not supported by --backend ${backend}; only the claude backend takes a thinking budget`,
     );
   }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -422,6 +422,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         supportedModels: args.claudeSupportedModels,
         openaiCompatTrace: args.openaiCompatTrace,
         claudeReasoning: args.claudeReasoning,
+        claudeThinkingBudget: args.claudeThinkingBudget,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });
       return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -421,6 +421,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         model: args.claudeModel,
         supportedModels: args.claudeSupportedModels,
         openaiCompatTrace: args.openaiCompatTrace,
+        claudeReasoning: args.claudeReasoning,
         ...(spawn ? { spawn: spawn as ClaudeSpawnFn } : {}),
       });
       return runtime ? { backend, shutdown: () => runtime.stop() } : { backend };

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -135,6 +135,14 @@ export interface ClaudeBackendConfig {
    * flag.
    */
   reasoning?: boolean;
+  /**
+   * Thinking budget (in tokens) injected as `MAX_THINKING_TOKENS` on
+   * openai-compat spawns when `reasoning` is on, so Claude Code emits thinking
+   * on the wire. A positive integer; defaults to 8000. Takes precedence over an
+   * operator's own `MAX_THINKING_TOKENS` env export. Mirrors the
+   * `--claude-thinking-budget` flag.
+   */
+  thinking_budget?: number;
   runtime?: BackendRuntime;
   runtime_name?: string;
 }

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -126,6 +126,15 @@ export interface ClaudeBackendConfig {
    * `model_not_found`. Mirrors the `--claude-supported-models` flag.
    */
   supported_models?: string[];
+  /**
+   * Forward Claude's extended-thinking on the openai-compat/v1 `reasoning`
+   * channel (so the a2x-internal-router stops false-failing-over long silent
+   * reasoning turns — planetarium/a2x-internal-router#95). ON by default; set
+   * `false` to disable when the deployed oai2a2a codec predates 0.6.0 and can't
+   * understand the channel marker yet. Mirrors the `--no-claude-reasoning`
+   * flag.
+   */
+  reasoning?: boolean;
   runtime?: BackendRuntime;
   runtime_name?: string;
 }


### PR DESCRIPTION
Closes #376. Part of planetarium/a2x-internal-router#95 (step 4 — bridge side).

## What

Forwards Claude's extended-thinking to callers as a live **`reasoning` channel**, so the a2x-internal-router stops false-failing-over long silent reasoning turns (the `streaming response stalled … no bytes for 60000ms` → `TIMEOUT` symptom in #95).

Unlike `vicoop-codex` (where `codex-cli serve` drops reasoning on the wire and needs an upstream fix), Claude's thinking already arrives on the wire — the claude backend spawns `--output-format stream-json --include-partial-messages`, so `thinking_delta` frames are already received and merely filtered out today. This PR stops dropping them.

## How

- **`extractClaudeStreamReasoningDelta`** — sibling of the text extractor; pulls `thinking_delta` / opening `thinking` blocks. `redacted_thinking` (encrypted blob) is never forwarded.
- **`emitReasoningArtifact`** — distinct `artifactId`, `extensions: [openai-compat/v1]`, `metadata[openai-compat/v1] = { channel: "reasoning" }`, `append:true`, `lastChunk:false`. Kept separate from the `claude-message` answer artifact so thinking never co-mingles with the answer. The oai2a2a codec maps it to `delta.reasoning_content`.
- **Thinking enablement** — when on, openai-compat spawns get `MAX_THINKING_TOKENS` injected (Claude Code's `-p` headless mode is otherwise silent). Operator's own `MAX_THINKING_TOKENS` export is not clobbered.

## Flag (ON by default)

Configurable flag + config, no env var:

- CLI: `--no-claude-reasoning`
- config.json: `backends.claude.reasoning: false`

⚠️ **Rollout (#95):** ON by default means an operator on a codec **older than oai2a2a 0.6.0** would have thinking folded into the answer (the old codec doesn't understand the channel marker). Disable via the flag/config until the codec+router are deployed.

## Out of scope

The **heartbeat liveness marker** half of #95/#376 (`metadata = { heartbeat: true }` on the `working` status) is intentionally deferred: claude already emits a 30s idle `working` heartbeat, but tagging it needs a `metadata` field on `TaskStatus` (protocol) + the server's A2A `TaskStatusUpdateEvent.metadata` mapping — a cross-package change that lands with the shared-loop heartbeat follow-up noted in #375.

## Tests

- backend: default-on forwarding, `claudeReasoning:false` drops entirely (no answer leak), redacted-thinking not forwarded, `MAX_THINKING_TOKENS` injection
- cli-args: default ON, `--no-claude-reasoning` off, `backends.claude.reasoning:false` off, flag>config precedence, non-claude backend hard error

`pnpm -r typecheck` + client suite (741 tests) green. Changeset included (client minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)