### PR TITLE
feat(client): forward vicoop-codex reasoning on openai-compat reasoning channel

### DIFF
--- a/.changeset/vicoop-codex-reasoning-channel.md
+++ b/.changeset/vicoop-codex-reasoning-channel.md
@@ -1,0 +1,23 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+feat(client): forward vicoop-codex's reasoning summary on an openai-compat/v1
+`reasoning` channel. The vicoop-codex backend surfaces `delta.reasoning_content`
+stream chunks (emitted serve-side via `summary:"auto"`) as a dedicated
+`vicoop-codex-reasoning` artifact carrying
+`metadata[openai-compat/v1] = { channel: "reasoning" }`, kept on a distinct
+artifact id so reasoning never co-mingles with the answer. This lets the
+a2x-internal-router treat a long silent reasoning turn as alive instead of
+false-failing-over it (planetarium/a2x-internal-router#95, #375). ON by default;
+disable with `--no-vicoop-codex-reasoning` or
+`backends.vicoop-codex.reasoning: false` when the deployed oai2a2a codec predates
+0.6.0 and can't yet interpret the channel marker (otherwise the reasoning would
+fold into the answer). Unlike the claude backend there is no thinking-enablement
+injection — codex reasoning is already enabled serve-side.
+
+The liveness heartbeat half of #375 is intentionally deferred: tagging the
+`working` status with `metadata = { heartbeat: true }` needs a `metadata` field
+on `TaskStatus` (protocol) + the server's A2A `TaskStatusUpdateEvent.metadata`
+mapping — a cross-package change that lands with the shared-loop heartbeat
+follow-up.

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -597,11 +597,13 @@ function driveServeListening(child: FakeChild, port = 8787): void {
 async function runStreaming(
   task: TaskAssignFrame,
   fetchRec: RecordingFetch,
+  opts: { reasoning?: boolean } = {},
 ): Promise<UpFrame[]> {
   const fake = makeFakeSpawn();
   const backend = createVicoopCodexBackend({
     spawn: fake.spawn,
     fetch: fetchRec.fetch,
+    ...(opts.reasoning !== undefined ? { reasoning: opts.reasoning } : {}),
   });
   const frames: UpFrame[] = [];
   const ctrl = new AbortController();
@@ -725,6 +727,196 @@ test('handle: streamed text → one append artifact per delta + complete with me
   assert.equal(choices[0].finish_reason, 'stop');
   const choiceMsg = choices[0].message as Record<string, unknown>;
   assert.equal(choiceMsg.content, 'ok');
+});
+
+test('handle: reasoning_content (default ON) → separate reasoning-channel artifact, never in the answer', async () => {
+  const task = makeTask();
+  // role preamble → two reasoning deltas → two content deltas → finish+usage.
+  const sse = sseStream([
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { reasoning_content: 'think' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { reasoning_content: 'ing' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { content: 'an' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { content: 'swer' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+    },
+  ]);
+  const frames = await runStreaming(task, makeSseFetch(sse));
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  const reasoning = artifacts.filter((a) => a.artifact.name === 'vicoop-codex-reasoning');
+  const answer = artifacts.filter((a) => a.artifact.name === 'vicoop-codex-message');
+
+  // Two reasoning deltas → two reasoning-channel artifacts.
+  assert.equal(reasoning.length, 2);
+  const reasoningTexts: string[] = [];
+  const reasoningIds = new Set<string>();
+  for (const a of reasoning) {
+    assert.equal(a.append, true, 'reasoning deltas are append:true');
+    assert.equal(a.lastChunk, false, 'reasoning deltas are lastChunk:false');
+    assert.deepEqual(a.artifact.extensions, [OPENAI_COMPAT_EXTENSION_URI]);
+    assert.deepEqual(a.artifact.metadata, {
+      [OPENAI_COMPAT_EXTENSION_URI]: { channel: 'reasoning' },
+    });
+    const part = a.artifact.parts[0];
+    if (part.kind !== 'text') throw new Error('unreachable');
+    reasoningTexts.push(part.text);
+    reasoningIds.add(a.artifact.artifactId);
+  }
+  assert.deepEqual(reasoningTexts, ['think', 'ing']);
+  // All reasoning deltas share one (reused) artifactId.
+  assert.equal(reasoningIds.size, 1);
+
+  // The answer artifacts are distinct: different id, no reasoning marker.
+  assert.equal(answer.length, 2);
+  const answerTexts: string[] = [];
+  const answerIds = new Set<string>();
+  for (const a of answer) {
+    assert.equal(a.artifact.metadata, undefined, 'answer artifact carries no reasoning marker');
+    const part = a.artifact.parts[0];
+    if (part.kind !== 'text') throw new Error('unreachable');
+    answerTexts.push(part.text);
+    answerIds.add(a.artifact.artifactId);
+  }
+  assert.deepEqual(answerTexts, ['an', 'swer']);
+  assert.equal(answerIds.size, 1);
+  // Reasoning and answer never share an artifactId.
+  assert.equal(reasoningIds.has([...answerIds][0]), false);
+
+  // Terminal message carries only the answer text — reasoning never leaks in.
+  const completes = frames.filter((f) => f.type === 'task.complete');
+  assert.equal(completes.length, 1);
+  const completeFrame = completes[0];
+  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
+  assert.deepEqual(completeFrame.status.message!.parts, [{ kind: 'text', text: 'answer' }]);
+  const ext = (completeFrame.status.message!.metadata as Record<
+    string,
+    Record<string, unknown>
+  >)[OPENAI_COMPAT_EXTENSION_URI];
+  const envelope = ext.chat_completion as Record<string, unknown>;
+  const choices = envelope.choices as Array<Record<string, unknown>>;
+  const choiceMsg = choices[0].message as Record<string, unknown>;
+  assert.equal(choiceMsg.content, 'answer', 'reasoning never folds into the answer content');
+});
+
+test('handle: reasoning:false drops reasoning entirely, answer unaffected (no leak)', async () => {
+  const task = makeTask();
+  const sse = sseStream([
+    {
+      id: 'chatcmpl-r2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { reasoning_content: 'secret thinking' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { content: 'answer' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r2',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+    },
+  ]);
+  const frames = await runStreaming(task, makeSseFetch(sse), { reasoning: false });
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // No reasoning-channel artifact at all.
+  assert.equal(artifacts.filter((a) => a.artifact.name === 'vicoop-codex-reasoning').length, 0);
+  // The answer streamed normally.
+  const answer = artifacts.filter((a) => a.artifact.name === 'vicoop-codex-message');
+  assert.equal(answer.length, 1);
+  const answerPart = answer[0].artifact.parts[0];
+  if (answerPart.kind !== 'text') throw new Error('unreachable');
+  assert.equal(answerPart.text, 'answer');
+
+  // The reasoning text never appears anywhere — not in artifacts, not in the
+  // terminal answer.
+  const completes = frames.filter((f) => f.type === 'task.complete');
+  const completeFrame = completes[0];
+  if (completeFrame.type !== 'task.complete') throw new Error('unreachable');
+  assert.deepEqual(completeFrame.status.message!.parts, [{ kind: 'text', text: 'answer' }]);
+  const serializedAll = JSON.stringify(frames);
+  assert.equal(serializedAll.includes('secret thinking'), false, 'no reasoning leak anywhere');
+});
+
+test('handle: reasoning-only stream (no content) still finalizes the answer fallback', async () => {
+  // A turn that streamed reasoning but produced its answer non-chunked (no
+  // content deltas): reasoning must NOT satisfy the answer's
+  // `emittedAnyArtifact` gate, so the assembled content still emits once.
+  const task = makeTask();
+  const sse = sseStream([
+    {
+      id: 'chatcmpl-r3',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      choices: [{ index: 0, delta: { reasoning_content: 'pondering' }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-r3',
+      object: 'chat.completion.chunk',
+      model: 'gpt-5.4',
+      // Whole answer arrives on the finish frame (not chunked).
+      choices: [{ index: 0, delta: { content: 'final' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+    },
+  ]);
+  const frames = await runStreaming(task, makeSseFetch(sse));
+
+  const artifacts = frames.filter(
+    (f): f is Extract<UpFrame, { type: 'task.artifact' }> => f.type === 'task.artifact',
+  );
+  // One reasoning artifact + one answer artifact (the content delta path).
+  assert.equal(artifacts.filter((a) => a.artifact.name === 'vicoop-codex-reasoning').length, 1);
+  const answer = artifacts.filter((a) => a.artifact.name === 'vicoop-codex-message');
+  assert.equal(answer.length, 1);
+  const answerPart = answer[0].artifact.parts[0];
+  if (answerPart.kind !== 'text') throw new Error('unreachable');
+  assert.equal(answerPart.text, 'final');
 });
 
 test('handle: serve drops usage on the stream → envelope backfills zero usage (spec-required, no gateway hard-reject)', async () => {

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -64,12 +64,10 @@ export type VicoopCodexFetchFn = (
 ) => Promise<VicoopCodexStreamResponse>;
 
 export interface VicoopCodexBackendOptions {
-  // Test seams only — the production CLI calls `createVicoopCodexBackend()`
-  // with no arguments. We don't expose operator-facing knobs here because
-  // anything an operator could set would have to ride through the existing
-  // CLI / config surface, and we are not extending that surface for this
-  // backend. Defaults below cover the production path; tests inject
-  // `spawn` / `logger` / timing overrides.
+  // Mostly test seams — the production CLI calls `createVicoopCodexBackend()`
+  // with just the operator-facing knobs below (`reasoning`,
+  // `openaiCompatTrace`). Defaults below cover the production path; tests
+  // inject `spawn` / `logger` / `fetch` / timing overrides.
   command?: string;
   cwd?: string;
   extraArgs?: readonly string[];
@@ -97,6 +95,23 @@ export interface VicoopCodexBackendOptions {
   // `chat_history` to stderr on every task. Operator diagnostic exposed
   // via `--openai-compat-trace`. Leave off in production.
   openaiCompatTrace?: boolean;
+  // Forward vicoop-codex's reasoning summary as a live `reasoning` channel: an
+  // additive `openai-compat/v1` wire marker (a reasoning-channel artifact with
+  // `metadata[ext-uri] = { channel: 'reasoning' }`) that the oai2a2a codec maps
+  // to `delta.reasoning_content` so the a2x-internal-router stops
+  // false-failing-over long silent reasoning turns
+  // (planetarium/a2x-internal-router#95, vicoop-bridge#375).
+  //
+  // ON by default; set `false` (CLI `--no-vicoop-codex-reasoning` / config
+  // `backends['vicoop-codex'].reasoning: false`) to disable. Disable when the
+  // deployed oai2a2a codec predates 0.6.0 — an old codec doesn't understand the
+  // `reasoning` channel marker and would fold the reasoning artifact into the
+  // answer (the #95 rollout-order hazard).
+  //
+  // Unlike claude there is NO thinking-enablement injection here: `vicoop-codex
+  // serve` emits `delta.reasoning_content` on the wire serve-side (via
+  // `summary:"auto"`, already shipped), so this is purely forwarding + the flag.
+  reasoning?: boolean;
 }
 
 // `vicoop-codex call` body shape — only the fields this backend actually
@@ -608,6 +623,10 @@ interface ChatCompletionChunk {
     delta?: {
       role?: string;
       content?: string | null;
+      // Reasoning summary streamed by `vicoop-codex serve` (`summary:"auto"`,
+      // vicoop-codex-cli). Forwarded as a `reasoning`-channel artifact, never
+      // folded into `acc.content` — reasoning must stay out of the answer.
+      reasoning_content?: string | null;
       tool_calls?: Array<{
         index?: number;
         id?: string;
@@ -647,6 +666,7 @@ function applyChunk(
   acc: StreamAccumulator,
   chunk: ChatCompletionChunk,
   onContentDelta: (text: string) => void,
+  onReasoningDelta: (text: string) => void,
 ): void {
   if (typeof chunk.id === 'string' && chunk.id.length > 0) acc.id = chunk.id;
   if (typeof chunk.model === 'string' && chunk.model.length > 0) acc.model = chunk.model;
@@ -657,6 +677,12 @@ function applyChunk(
   if (typeof choice.finish_reason === 'string') acc.finishReason = choice.finish_reason;
   const delta = choice.delta;
   if (!delta) return;
+  // Reasoning summary fragment — surfaced on the dedicated `reasoning` channel
+  // by the caller. Deliberately NOT appended to `acc.content`: reasoning must
+  // never co-mingle with the answer artifact / synthesised response text.
+  if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
+    onReasoningDelta(delta.reasoning_content);
+  }
   if (typeof delta.content === 'string' && delta.content.length > 0) {
     acc.content += delta.content;
     onContentDelta(delta.content);
@@ -715,17 +741,20 @@ function synthesizeStreamedResponse(acc: StreamAccumulator): ChatCompletionRespo
 // POST the Chat Completions request (with `stream:true`) to `vicoop-codex
 // serve` and fold the `chat.completion.chunk` SSE stream into a single
 // `ChatCompletionResponse`. `onContentDelta` fires for each incremental text
-// fragment so the caller can emit `append:true` artifacts. `onFirstByte`
-// fires once when the upstream HTTP response resolves OK (before any chunk),
-// letting the caller split connection/model-wait from streaming time. Throws
-// `ServeRequestError` (with an A2A code) on HTTP / transport failure; the
-// caller maps abort separately via `signal.aborted`.
+// fragment so the caller can emit `append:true` artifacts. `onReasoningDelta`
+// fires for each incremental `reasoning_content` fragment so the caller can
+// emit them on the separate `reasoning` channel. `onFirstByte` fires once when
+// the upstream HTTP response resolves OK (before any chunk), letting the caller
+// split connection/model-wait from streaming time. Throws `ServeRequestError`
+// (with an A2A code) on HTTP / transport failure; the caller maps abort
+// separately via `signal.aborted`.
 async function streamChatCompletions(
   fetchFn: VicoopCodexFetchFn,
   url: string,
   body: string,
   signal: AbortSignal,
   onContentDelta: (text: string) => void,
+  onReasoningDelta: (text: string) => void,
   onFirstByte?: () => void,
 ): Promise<ChatCompletionResponse> {
   let res: VicoopCodexStreamResponse;
@@ -764,7 +793,7 @@ async function streamChatCompletions(
       // keep-alive / comment shouldn't abort the turn — skip it.
       return false;
     }
-    applyChunk(acc, chunk, onContentDelta);
+    applyChunk(acc, chunk, onContentDelta, onReasoningDelta);
     return false;
   };
 
@@ -896,6 +925,10 @@ export function createVicoopCodexBackend(
   const logger = opts.logger ?? createLogger();
   const now = opts.now ?? Date.now;
   const openaiCompatTrace = opts.openaiCompatTrace === true;
+  // openai-compat/v1 reasoning channel (#95 / #375). ON by default; disable via
+  // `reasoning: false` (CLI `--no-vicoop-codex-reasoning` / config) when the
+  // deployed codec predates 0.6.0 and can't yet understand the marker.
+  const reasoningEnabled = opts.reasoning !== false;
 
   // Supported-models cache, populated by `resolveCapabilities` at daemon
   // startup and read sync from `handle()` to gate `envelope.model`
@@ -1282,6 +1315,40 @@ export function createVicoopCodexBackend(
         emittedAnyArtifact = true;
       };
 
+      // Distinct artifact id for the reasoning channel (#95 / #375), kept
+      // separate from `responseArtifactId` so reasoning never co-mingles with
+      // the answer artifact. Lazily minted on the first reasoning delta.
+      let reasoningArtifactId: string | null = null;
+      // Emit a reasoning-summary fragment on the dedicated `reasoning` channel:
+      // a separate `artifactId` carrying the openai-compat/v1 marker
+      // `metadata[OPENAI_COMPAT_EXTENSION_URI] = { channel: 'reasoning' }`,
+      // appended with `lastChunk:false`. The oai2a2a codec maps this to
+      // `delta.reasoning_content`; the a2x-internal-router treats it as a
+      // liveness signal so a healthy long-reasoning turn is never
+      // false-failed-over (#95). NOT a `vicoop-codex-message` artifact —
+      // reasoning must stay out of the answer. Deliberately does NOT touch
+      // `emittedAnyArtifact` (the answer's finalization gate): a turn that
+      // streamed only reasoning still hits the `!emittedAnyArtifact` fallback
+      // that emits the assembled answer once. Gated by `reasoningEnabled` at
+      // the call site below.
+      const emitReasoningArtifact = (text: string): void => {
+        if (!text) return;
+        reasoningArtifactId ??= randomUUID();
+        emit({
+          type: 'task.artifact',
+          taskId: task.taskId,
+          artifact: {
+            artifactId: reasoningArtifactId,
+            name: 'vicoop-codex-reasoning',
+            parts: [{ kind: 'text', text }],
+            extensions: [OPENAI_COMPAT_EXTENSION_URI],
+            metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { channel: 'reasoning' } },
+          },
+          append: true,
+          lastChunk: false,
+        });
+      };
+
       let response: ChatCompletionResponse;
       try {
         response = await streamChatCompletions(
@@ -1290,6 +1357,10 @@ export function createVicoopCodexBackend(
           serialized,
           signal,
           emitDelta,
+          // When the reasoning channel is off, swallow reasoning deltas
+          // entirely — no artifact, and (since reasoning never enters
+          // `acc.content`) no leak into the answer.
+          reasoningEnabled ? emitReasoningArtifact : () => {},
           () => recorder.mark('firstByte'),
         );
       } catch (err) {

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -243,6 +243,68 @@ test('--claude-supported-models with a non-claude backend is a hard error', () =
   );
 });
 
+test('vicoopCodexReasoning defaults ON when neither flag nor config sets it', () => {
+  const r = mergeClientArgs({ token: 't', agentId: 'a', backend: 'vicoop-codex' }, {});
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.vicoopCodexReasoning, true);
+});
+
+test('--no-vicoop-codex-reasoning flag turns the reasoning channel off', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'vicoop-codex', noVicoopCodexReasoning: true },
+    {},
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.vicoopCodexReasoning, false);
+});
+
+test('backends.vicoop-codex.reasoning:false turns the reasoning channel off', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'vicoop-codex' },
+    { backends: { 'vicoop-codex': { reasoning: false } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.vicoopCodexReasoning, false);
+});
+
+test('--no-vicoop-codex-reasoning beats config reasoning:true', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'vicoop-codex', noVicoopCodexReasoning: true },
+    { backends: { 'vicoop-codex': { reasoning: true } } },
+  );
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.args.vicoopCodexReasoning, false);
+});
+
+test('--no-vicoop-codex-reasoning with a non-vicoop-codex backend is a hard error', () => {
+  const r = mergeClientArgs(
+    { token: 't', agentId: 'a', backend: 'claude', noVicoopCodexReasoning: true },
+    {},
+  );
+  assert.equal(r.ok, false);
+  if (r.ok) return;
+  assert.ok(
+    r.errors.some((e) => e.includes('--no-vicoop-codex-reasoning') && e.includes('claude')),
+    `expected error mentioning --no-vicoop-codex-reasoning and claude, got: ${r.errors.join(' | ')}`,
+  );
+});
+
+test('parseFlags picks up --no-vicoop-codex-reasoning', () => {
+  const r = parseFlags([
+    '--token', 't',
+    '--agentId', 'a',
+    '--backend', 'vicoop-codex',
+    '--no-vicoop-codex-reasoning',
+  ]);
+  assert.equal(r.ok, true);
+  if (!r.ok) return;
+  assert.equal(r.flags.noVicoopCodexReasoning, true);
+});
+
 test('parseFlags picks up known flags', () => {
   const r = parseFlags([
     '--server', 'wss://x',

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -99,6 +99,13 @@ export const daemonFlagsFields = {
     description: message`Codex sandbox mode.`,
   })),
 
+  // Backend-specific (vicoop-codex)
+  noVicoopCodexReasoning: optional(
+    flag('--no-vicoop-codex-reasoning', {
+      description: message`Disable forwarding vicoop-codex's reasoning summary on the openai-compat/v1 \`reasoning\` channel (on by default). Use when the deployed oai2a2a codec predates 0.6.0 and can't yet interpret the channel marker — otherwise the reasoning would fold into the answer (planetarium/a2x-internal-router#95). Mirrors config \`backends.vicoop-codex.reasoning: false\`.`,
+    }),
+  ),
+
   // Backend-specific (OpenClaw)
   openclawGateway: optional(option('--openclaw-gateway', string({ metavar: 'WS_URL' }), {
     description: message`Gateway WS URL (default ws://127.0.0.1:18789).`,
@@ -150,6 +157,11 @@ export interface DaemonArgs {
   claudeModel?: string;
   claudeSupportedModels?: string[];
   codexSandbox?: CodexSandboxMode;
+  // Resolved openai-compat/v1 reasoning channel toggle for the vicoop-codex
+  // backend. Defaults ON; the `--no-vicoop-codex-reasoning` flag or
+  // `backends['vicoop-codex'].reasoning: false` flips it off (#95 / #375).
+  // Always defined after `resolveDaemonArgs`.
+  vicoopCodexReasoning?: boolean;
   openclawGateway?: string;
   openclawGatewayToken?: string;
   openclawAgent?: string;
@@ -276,6 +288,10 @@ export function mergeClientArgs(
       (backends.claude?.supported_models?.length ? backends.claude.supported_models : undefined),
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
+    // ON unless the config opts out (`reasoning: false`) or the CLI flag forces
+    // it off; the flag wins over config, matching the other flag>config knobs.
+    vicoopCodexReasoning:
+      backends['vicoop-codex']?.reasoning !== false && !flags.noVicoopCodexReasoning,
     openclawGateway:
       pick(flags.openclawGateway) || backends.openclaw?.gateway_url || undefined,
     openclawGatewayToken:
@@ -339,6 +355,11 @@ export function mergeClientArgs(
   if (pick(flags.claudeSupportedModels) && backend !== 'claude') {
     errors.push(
       `--claude-supported-models is not supported by --backend ${backend}; only the claude backend takes model ids`,
+    );
+  }
+  if (flags.noVicoopCodexReasoning && backend !== 'vicoop-codex') {
+    errors.push(
+      `--no-vicoop-codex-reasoning is not supported by --backend ${backend}; only the vicoop-codex backend forwards a reasoning channel`,
     );
   }
 

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -460,6 +460,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       return {
         backend: createVicoopCodexBackend({
           openaiCompatTrace: args.openaiCompatTrace,
+          reasoning: args.vicoopCodexReasoning,
         }),
       };
     default:

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -154,10 +154,23 @@ export interface OpenclawBackendConfig {
   task_timeout_ms?: number;
 }
 
+export interface VicoopCodexBackendConfig {
+  /**
+   * Forward vicoop-codex's reasoning summary on the openai-compat/v1
+   * `reasoning` channel (so the a2x-internal-router stops false-failing-over
+   * long silent reasoning turns — planetarium/a2x-internal-router#95). ON by
+   * default; set `false` to disable when the deployed oai2a2a codec predates
+   * 0.6.0 and can't understand the channel marker yet. Mirrors the
+   * `--no-vicoop-codex-reasoning` flag.
+   */
+  reasoning?: boolean;
+}
+
 export interface BackendConfigs {
   claude?: ClaudeBackendConfig;
   codex?: CodexBackendConfig;
   openclaw?: OpenclawBackendConfig;
+  'vicoop-codex'?: VicoopCodexBackendConfig;
 }
 
 // Mirrors the daemon's CLI flag surface (--server / --token / --agentId /
@@ -199,6 +212,13 @@ function asNumber(v: unknown): number | undefined {
 function asRecord(v: unknown): Record<string, unknown> | undefined {
   if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
   return v as Record<string, unknown>;
+}
+
+// Boolean fields: honour only an actual boolean; anything else (string,
+// number, null) is dropped so a hand-edited typo reads as "unset" and the
+// downstream default applies. Same permissive posture as the scalar pickers.
+function asBoolean(v: unknown): boolean | undefined {
+  return typeof v === 'boolean' ? v : undefined;
 }
 
 // String-array fields: keep the string entries (trimmed, empties dropped),
@@ -311,6 +331,13 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
         if (validApproval) out.codex.approval_decision = validApproval;
         if (runtime) out.codex.runtime = runtime;
         if (runtimeName) out.codex.runtime_name = runtimeName;
+      }
+    }
+    const vcRaw = asRecord(backends['vicoop-codex']);
+    if (vcRaw) {
+      const reasoning = asBoolean(vcRaw.reasoning);
+      if (reasoning !== undefined) {
+        out['vicoop-codex'] = { reasoning };
       }
     }
     const ocRaw = asRecord(backends.openclaw);


### PR DESCRIPTION
Implements the **reasoning-forwarding half** of #375. Part of planetarium/a2x-internal-router#95 (step 5 — bridge side). Sibling of #377 (claude); same wire contract.

## What

Forwards `vicoop-codex`'s reasoning to callers as a live **`reasoning` channel** so the a2x-internal-router stops false-failing-over long silent reasoning turns. Now unblocked: the `vicoop-codex serve` binary that emits `delta.reasoning_content` (`reasoning.summary:"auto"`) has shipped (planetarium/vicoop-codex-cli#26, released).

## How (mirrors #377)

- `reasoning_content?: string | null` on the chunk delta; `applyChunk` → new `onReasoningDelta` (sibling of `onContentDelta`), threaded through `streamChatCompletions`.
- `emitReasoningArtifact` — distinct reused `artifactId`, `extensions:[OPENAI_COMPAT_EXTENSION_URI]`, `metadata:{[uri]:{channel:"reasoning"}}`, `append:true`, `lastChunk:false`. Artifact `vicoop-codex-reasoning`, separate from the `vicoop-codex-message` answer. The oai2a2a codec (0.6.0) maps it to `delta.reasoning_content`.
- **No thinking-enablement injection** (unlike claude): codex reasoning is enabled serve-side via `summary:"auto"`, already shipped — this is pure forwarding + flag.

**Reasoning never reaches the answer** — `reasoning_content` is not appended to `acc.content`, `emitReasoningArtifact` uses its own id and never touches `emittedAnyArtifact`; tests assert no leak (full-frame scan) and that a reasoning-only stream still finalizes the answer fallback.

## Flag (ON by default, mirrors #377)

- CLI `--no-vicoop-codex-reasoning` · config `backends['vicoop-codex'].reasoning: false` (flag beats config).
- Adds the first operator knob for this backend (`VicoopCodexBackendConfig`).

⚠️ **Rollout (#95):** ON-by-default is safe against **a2x-internal-router** (now on codec 0.6.0, Fly v90 — leak gate closed). Any *other* A2A gateway consuming this agent on a pre-0.6.0 codec would fold reasoning into the answer; disable via the flag there.

## Out of scope

The **liveness heartbeat** half of #375 (tag the `working` status with `metadata={heartbeat:true}`) is a cross-package follow-up (needs `TaskStatus.metadata` in protocol + the server's `TaskStatusUpdateEvent.metadata` mapping) — tracked separately, same deferral as #377.

## Tests
`pnpm --filter @vicoop-bridge/client test` **740 pass** (9 new: backend + cli-args); `pnpm -r build` + `pnpm -r typecheck` green. Changeset (client minor) included.

Part of #375 (reasoning half) · planetarium/a2x-internal-router#95 step 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
