### PR TITLE
docs(local-testing): note --strict-mcp-config for direct claude CLI probes

### DIFF
--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -338,6 +338,20 @@ DATABASE_URL="postgres://$USER@localhost:5432/vicoop_bridge_dev" \
 - **Caller token LRU cache is 60s**. After `UPDATE callers SET revoked=true`,
   revocation only takes effect on the next verify after ~60s. For immediate
   testing, wait out the window or restart the server.
+- **Probing the `claude` CLI directly? Pass `--strict-mcp-config`.** When you
+  spawn `claude -p ...` by hand to reproduce a claude-backend behavior (e.g.
+  inspecting `stream-json` frames), it otherwise loads *your operator* MCP
+  servers from `~/.claude` / project `.mcp.json` — sentry, github, etc. — which
+  spawn extra child processes and eat CPU/RAM, and aren't part of the bridge's
+  spawn anyway. `--strict-mcp-config` with no `--mcp-config` uses zero MCP
+  servers (`system/init` shows `mcp_servers=[]`):
+  ```bash
+  claude -p "..." --strict-mcp-config \
+    --input-format stream-json --output-format stream-json --verbose \
+    --include-partial-messages --model claude-opus-4-8
+  ```
+  If a probe still leaks server processes, clean up with
+  `pkill -f 'sentry-mcp'` (substitute the server binary).
 
 ## Tear-down
 


### PR DESCRIPTION
## What

Adds a Gotchas note to `docs/local-testing.md`: when reproducing claude-backend behavior by spawning `claude -p ...` directly, pass `--strict-mcp-config` so it doesn't load the operator's MCP servers (sentry, github, etc.).

## Why

Those servers spawn extra child processes and eat CPU/RAM during ad-hoc probing, and aren't part of the bridge's own claude spawn anyway. `--strict-mcp-config` with no `--mcp-config` yields `mcp_servers=[]` (verified via `system/init`). The note includes an example command and a `pkill` cleanup tip for leftover server processes.

Came up while reproducing #382 locally — repeated manual `claude -p` runs left sentry-mcp processes accumulating.

## Notes

Docs-only; no changeset (not a `@vicoop-bridge/client` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)