### PR TITLE
fix(server): make last_used_at touch best-effort so a read-only DB doesn't 401

### DIFF
--- a/packages/server/src/auth/caller-token.test.ts
+++ b/packages/server/src/auth/caller-token.test.ts
@@ -4,8 +4,10 @@ import postgres from 'postgres';
 import {
   CALLER_TOKEN_PREFIX,
   generateCallerToken,
+  generateSessionToken,
   hashCallerToken,
   issueCallerToken,
+  verifySessionToken,
   verifyCallerToken,
   revokeCallerToken,
   listCallerTokens,
@@ -45,6 +47,42 @@ test('hashCallerToken returns 64-char sha256 hex', () => {
 
 test('different tokens produce different hashes', () => {
   assert.notEqual(hashCallerToken('a'), hashCallerToken('b'));
+});
+
+// A read-only DB (e.g. volume full → Fly postgres-flex flips read-only) makes
+// the last_used_at touch UPDATE throw. That stamp is observability-only and
+// must not fail verification, otherwise callers see a spurious 401 that masks
+// the real cause. See issue #385.
+test('verifySessionToken tolerates a failing last_used_at write (read-only DB)', async () => {
+  const token = generateSessionToken('caller');
+  const validRow = {
+    id: 'caller-id',
+    principal_id: 'google:readonly-test',
+    audience: 'caller',
+    email: 'ro@example.com',
+    expires_at: new Date(Date.now() + 60_000),
+    revoked: false,
+  };
+
+  let updateAttempted = false;
+  const sqlStub = ((strings: TemplateStringsArray) => {
+    const text = strings.join('?');
+    if (/UPDATE callers SET last_used_at/.test(text)) {
+      updateAttempted = true;
+      return Promise.reject(
+        new Error('cannot execute UPDATE in a read-only transaction'),
+      );
+    }
+    if (/SELECT/.test(text)) return Promise.resolve([validRow]);
+    return Promise.resolve([]);
+  }) as unknown as Parameters<typeof verifySessionToken>[0];
+
+  // Verification still succeeds despite the read-only write failure.
+  const caller = await verifySessionToken(sqlStub, token, { expectedAudience: 'caller' });
+  assert.equal(updateAttempted, true);
+  assert.equal(caller.principalId, 'google:readonly-test');
+  assert.equal(caller.email, 'ro@example.com');
+  assert.equal(caller.emailVerified, true);
 });
 
 // ---------- DB-gated tests ----------

--- a/packages/server/src/auth/caller-token.ts
+++ b/packages/server/src/auth/caller-token.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from 'node:crypto';
 import type { Sql } from '../db.js';
+import { logEvent } from '../log.js';
 import type { VerifiedCaller } from './principal.js';
 
 // Bridge-issued opaque session tokens.
@@ -245,9 +246,21 @@ export async function verifySessionToken(
     );
   }
 
-  // Stamp last_used_at. Awaited for test determinism; the write is cheap
-  // and only happens on cache misses (so at most once per 60s per token).
-  await sql`UPDATE callers SET last_used_at = now() WHERE id = ${row.id}`;
+  // Stamp last_used_at — best-effort, observability only. The authorization
+  // decision is already made above (revoked / expired / audience all checked),
+  // so this write must never fail the request. In particular, when the DB is
+  // read-only (e.g. volume full → Fly postgres-flex flips read-only) this
+  // UPDATE would otherwise throw and surface to callers as a spurious 401,
+  // masking the real cause; swallow + log so auth degrades gracefully instead.
+  // See issue #385. Awaited for test determinism; the write is cheap and only
+  // happens on cache misses (so at most once per 60s per token), and the
+  // result is cached below regardless so a failing write isn't retried per
+  // request within the cache window.
+  try {
+    await sql`UPDATE callers SET last_used_at = now() WHERE id = ${row.id}`;
+  } catch (err) {
+    logEvent('caller_last_used_touch_failed', { callerId: row.id, error: String(err) });
+  }
 
   // email_verified inference: we only persist email at issue time when the
   // upstream provider (google-oauth) has already validated it, so a non-null


### PR DESCRIPTION
## What

When the DB goes read-only (e.g. volume full → Fly `postgres-flex` flips read-only), the per-request session-token `last_used_at` touch `UPDATE` threw and propagated out of `verifySessionToken`, surfacing to callers as a spurious **`401 Unauthorized`**. This is exactly the misleading symptom chain in #385: every task dispatch 401'd while the real fault was a full DB volume.

That write is **observability-only** — the authorization decision (`revoked` / `expired` / `audience`) is already made *before* it. It should never fail the request.

## Change

- Wrap the `UPDATE callers SET last_used_at = now()` in try/catch; on failure, log a structured `caller_last_used_touch_failed` event instead of throwing.
- The verified caller is still cached afterward, so a failing write isn't retried per-request within the 60s cache window — under a read-only DB, auth degrades gracefully rather than going fully dark.
- Adds a **DB-free** unit test that stubs the `UPDATE` to reject with a read-only error and asserts verification still succeeds (and that the write was attempted).

## Scope

Deliberately small and self-contained — addresses **follow-up #4** from #385 ("surface read-only as a clear signal rather than a generic 401") at the cheapest point. The deeper drivers from that issue (retention for `infra.a2a_tasks`, trimming the per-task upstream-request blob) are tracked separately.

## Test

```
ℹ tests 12 · pass 8 · fail 0 · skipped 4 (DB-gated)
✔ verifySessionToken tolerates a failing last_used_at write (read-only DB)
```
`pnpm --filter @vicoop-bridge/server typecheck` clean.

No changeset: `@vicoop-bridge/server` is in the changesets `ignore` list (ships via `fly deploy`, no published artifact).

Refs #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)