### PR TITLE
fix(server): single-flight schema-tools introspection (#367)

### DIFF
--- a/packages/server/src/schema-tools.test.ts
+++ b/packages/server/src/schema-tools.test.ts
@@ -98,12 +98,13 @@ test('invalidateToolCache forces a fresh introspection', async (t) => {
 
 test('invalidation mid-build does not resurrect the stale result into the cache', async (t) => {
   invalidateToolCache();
-  // Two distinct schemas so we can tell which build populated the cache. The
-  // first build is invalidated while its fetch is still in flight; when it
-  // resolves it must NOT write its (now stale) result back into cachedTools.
-  // Build #1's fetch is deliberately slow (40ms) so it resolves *after* the
-  // post-invalidation build #2 (5ms). Without the epoch guard, build #1's late
-  // .then would overwrite cachedTools with its stale result — the bug.
+  // Both builds use the same payload; we distinguish them by the object
+  // identity of the tool set each build() returns. Build #1 is invalidated
+  // while its fetch is still in flight; when it resolves it must NOT write its
+  // (now stale) result back into cachedTools. Build #1's fetch is deliberately
+  // slow (40ms) so it resolves *after* the post-invalidation build #2 (5ms).
+  // Without the epoch guard, build #1's late .then would overwrite cachedTools
+  // with its stale result — the bug.
   const { fn, callCount } = deferredFetch(
     () => EMPTY_SCHEMA,
     (i) => (i === 0 ? 40 : 5),

--- a/packages/server/src/schema-tools.test.ts
+++ b/packages/server/src/schema-tools.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for the schema-tools cache, focused on the single-flight
+// guarantee from #367: a cold cache hit by concurrent callers must trigger
+// exactly one PostGraphile introspection, and a failed introspection must be
+// retryable rather than poisoning the cache.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getSchemaTools, invalidateToolCache } from './schema-tools.js';
+
+// Minimal but valid introspection payload: an empty schema is enough to drive
+// the build path (empty tool defs + SDL) without standing up PostGraphile.
+const EMPTY_SCHEMA = {
+  data: {
+    __schema: {
+      queryType: { fields: [] },
+      mutationType: { fields: [] },
+      types: [],
+    },
+  },
+};
+
+function jsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: { get: (h: string) => (h.toLowerCase() === 'content-type' ? 'application/json' : null) },
+    json: async () => payload,
+  };
+}
+
+// Mock fetch so the introspection round-trip resolves on the next tick,
+// guaranteeing concurrent callers overlap on the in-flight promise.
+function deferredFetch(payloadFor: (callIndex: number) => unknown) {
+  let calls = 0;
+  const fn = async () => {
+    const index = calls++;
+    await new Promise((r) => setTimeout(r, 5));
+    return jsonResponse(payloadFor(index)) as unknown as Response;
+  };
+  return { fn, callCount: () => calls };
+}
+
+test('concurrent first calls trigger exactly one introspection (single-flight)', async (t) => {
+  invalidateToolCache();
+  const { fn, callCount } = deferredFetch(() => EMPTY_SCHEMA);
+  t.mock.method(globalThis, 'fetch', fn);
+
+  const results = await Promise.all([
+    getSchemaTools(),
+    getSchemaTools(),
+    getSchemaTools(),
+    getSchemaTools(),
+    getSchemaTools(),
+  ]);
+
+  assert.equal(callCount(), 1, 'introspection should run once across concurrent callers');
+  // All callers observe the same cached object identity.
+  for (const r of results) {
+    assert.equal(r, results[0]);
+    assert.ok(r.tools.execute_graphql, 'built tools should include the raw escape hatch');
+  }
+
+  // A subsequent call after the cache is warm performs no further fetch.
+  const warm = await getSchemaTools();
+  assert.equal(warm, results[0]);
+  assert.equal(callCount(), 1, 'warm cache must not re-introspect');
+
+  invalidateToolCache();
+});
+
+test('invalidateToolCache forces a fresh introspection', async (t) => {
+  invalidateToolCache();
+  const { fn, callCount } = deferredFetch(() => EMPTY_SCHEMA);
+  t.mock.method(globalThis, 'fetch', fn);
+
+  const first = await getSchemaTools();
+  assert.equal(callCount(), 1);
+
+  invalidateToolCache();
+
+  const second = await getSchemaTools();
+  assert.equal(callCount(), 2, 'invalidation should drop the cache and re-introspect');
+  assert.notEqual(second, first, 'a rebuilt tool set is a new object');
+
+  invalidateToolCache();
+});
+
+test('a failed introspection is retryable (in-flight promise is cleared on error)', async (t) => {
+  invalidateToolCache();
+  // First introspection returns GraphQL errors (buildSchema throws); the
+  // second returns a valid schema. If the rejected promise were cached, the
+  // retry would keep rejecting.
+  const { fn, callCount } = deferredFetch((i) =>
+    i === 0 ? { errors: [{ message: 'introspection boom' }] } : EMPTY_SCHEMA,
+  );
+  t.mock.method(globalThis, 'fetch', fn);
+
+  await assert.rejects(getSchemaTools(), /Introspection failed/);
+  assert.equal(callCount(), 1);
+
+  // Retry succeeds — proves the in-flight promise was reset rather than stuck.
+  const retried = await getSchemaTools();
+  assert.equal(callCount(), 2);
+  assert.ok(retried.tools.execute_graphql);
+
+  invalidateToolCache();
+});

--- a/packages/server/src/schema-tools.test.ts
+++ b/packages/server/src/schema-tools.test.ts
@@ -29,13 +29,17 @@ function jsonResponse(payload: unknown) {
   };
 }
 
-// Mock fetch so the introspection round-trip resolves on the next tick,
-// guaranteeing concurrent callers overlap on the in-flight promise.
-function deferredFetch(payloadFor: (callIndex: number) => unknown) {
+// Mock fetch so the introspection round-trip resolves after a delay,
+// guaranteeing concurrent callers overlap on the in-flight promise. The delay
+// can vary per call so a test can control which build resolves last.
+function deferredFetch(
+  payloadFor: (callIndex: number) => unknown,
+  delayFor: (callIndex: number) => number = () => 5,
+) {
   let calls = 0;
   const fn = async () => {
     const index = calls++;
-    await new Promise((r) => setTimeout(r, 5));
+    await new Promise((r) => setTimeout(r, delayFor(index)));
     return jsonResponse(payloadFor(index)) as unknown as Response;
   };
   return { fn, callCount: () => calls };
@@ -46,13 +50,19 @@ test('concurrent first calls trigger exactly one introspection (single-flight)',
   const { fn, callCount } = deferredFetch(() => EMPTY_SCHEMA);
   t.mock.method(globalThis, 'fetch', fn);
 
-  const results = await Promise.all([
+  // Issue the calls synchronously so they race on the cold cache, and keep the
+  // returned promises so we can assert they are the *same* in-flight promise
+  // (true single-flight, not just "second caller read a warm cache").
+  const pending = [
     getSchemaTools(),
     getSchemaTools(),
     getSchemaTools(),
     getSchemaTools(),
     getSchemaTools(),
-  ]);
+  ];
+  for (const p of pending) assert.equal(p, pending[0], 'concurrent callers share one in-flight promise');
+
+  const results = await Promise.all(pending);
 
   assert.equal(callCount(), 1, 'introspection should run once across concurrent callers');
   // All callers observe the same cached object identity.
@@ -82,6 +92,38 @@ test('invalidateToolCache forces a fresh introspection', async (t) => {
   const second = await getSchemaTools();
   assert.equal(callCount(), 2, 'invalidation should drop the cache and re-introspect');
   assert.notEqual(second, first, 'a rebuilt tool set is a new object');
+
+  invalidateToolCache();
+});
+
+test('invalidation mid-build does not resurrect the stale result into the cache', async (t) => {
+  invalidateToolCache();
+  // Two distinct schemas so we can tell which build populated the cache. The
+  // first build is invalidated while its fetch is still in flight; when it
+  // resolves it must NOT write its (now stale) result back into cachedTools.
+  // Build #1's fetch is deliberately slow (40ms) so it resolves *after* the
+  // post-invalidation build #2 (5ms). Without the epoch guard, build #1's late
+  // .then would overwrite cachedTools with its stale result — the bug.
+  const { fn, callCount } = deferredFetch(
+    () => EMPTY_SCHEMA,
+    (i) => (i === 0 ? 40 : 5),
+  );
+  t.mock.method(globalThis, 'fetch', fn);
+
+  // Start build #1 (captures generation 0) but don't await it yet.
+  const stalePromise = getSchemaTools();
+  // Invalidate while build #1 is parked on its slow fetch → bumps generation.
+  invalidateToolCache();
+  // Build #2 starts fresh under the new generation.
+  const fresh = await getSchemaTools();
+  // Drain build #1 so its .then runs; under the epoch guard it must be a no-op.
+  await stalePromise;
+
+  assert.equal(callCount(), 2, 'invalidation mid-build forces a second introspection');
+  // The warm cache must reflect build #2, not the resurrected build #1.
+  const afterDrain = await getSchemaTools();
+  assert.equal(afterDrain, fresh, 'cache holds the fresh build, not the stale resurrected one');
+  assert.equal(callCount(), 2, 'reading the warm cache after drain must not re-introspect');
 
   invalidateToolCache();
 });

--- a/packages/server/src/schema-tools.ts
+++ b/packages/server/src/schema-tools.ts
@@ -646,24 +646,31 @@ let cachedSchema: CachedSchema | null = null;
 // cache triggers exactly one introspection (single-flight). Cleared on settle
 // so a failed introspection can be retried by the next caller.
 let schemaInFlight: Promise<CachedSchema> | null = null;
+// Bumped by invalidateToolCache(). A build captures the generation at start and
+// only adopts its result (and clears its in-flight slot) if the generation is
+// still current — so an invalidation that fires mid-build cannot be undone by
+// the stale build resolving afterwards and writing back into the cache.
+let cacheGeneration = 0;
 
 export function invalidateToolCache(): void {
   cachedSchema = null;
   cachedTools = null;
   schemaInFlight = null;
   toolsInFlight = null;
+  cacheGeneration++;
 }
 
 function getOrBuildSchema(): Promise<CachedSchema> {
   if (cachedSchema) return Promise.resolve(cachedSchema);
   if (!schemaInFlight) {
+    const generation = cacheGeneration;
     schemaInFlight = buildSchema()
       .then((schema) => {
-        cachedSchema = schema;
+        if (generation === cacheGeneration) cachedSchema = schema;
         return schema;
       })
       .finally(() => {
-        schemaInFlight = null;
+        if (generation === cacheGeneration) schemaInFlight = null;
       });
   }
   return schemaInFlight;
@@ -774,13 +781,14 @@ export function getSchemaTools(): Promise<{
 }> {
   if (cachedTools) return Promise.resolve(cachedTools);
   if (!toolsInFlight) {
+    const generation = cacheGeneration;
     toolsInFlight = buildSchemaTools()
       .then((built) => {
-        cachedTools = built;
+        if (generation === cacheGeneration) cachedTools = built;
         return built;
       })
       .finally(() => {
-        toolsInFlight = null;
+        if (generation === cacheGeneration) toolsInFlight = null;
       });
   }
   return toolsInFlight;

--- a/packages/server/src/schema-tools.ts
+++ b/packages/server/src/schema-tools.ts
@@ -642,15 +642,34 @@ interface CachedSchema {
 }
 
 let cachedSchema: CachedSchema | null = null;
+// In-flight introspection, shared across concurrent first callers so a cold
+// cache triggers exactly one introspection (single-flight). Cleared on settle
+// so a failed introspection can be retried by the next caller.
+let schemaInFlight: Promise<CachedSchema> | null = null;
 
 export function invalidateToolCache(): void {
   cachedSchema = null;
   cachedTools = null;
+  schemaInFlight = null;
+  toolsInFlight = null;
 }
 
-async function getOrBuildSchema(): Promise<CachedSchema> {
-  if (cachedSchema) return cachedSchema;
+function getOrBuildSchema(): Promise<CachedSchema> {
+  if (cachedSchema) return Promise.resolve(cachedSchema);
+  if (!schemaInFlight) {
+    schemaInFlight = buildSchema()
+      .then((schema) => {
+        cachedSchema = schema;
+        return schema;
+      })
+      .finally(() => {
+        schemaInFlight = null;
+      });
+  }
+  return schemaInFlight;
+}
 
+async function buildSchema(): Promise<CachedSchema> {
   // 1. Full introspection (only needs to run once — schema is the same for all users)
   const result = await executeGraphQL<{
     __schema: {
@@ -731,11 +750,10 @@ async function getOrBuildSchema(): Promise<CachedSchema> {
   // 5. Generate SDL
   const sdl = generateSDL(queryFields, mutationFields, typeMap);
 
-  cachedSchema = {
+  return {
     queryFields, mutationFields, allQueryNames, allMutationNames,
     typeMap, sdl, queryToolDefs, mutationToolDefs,
   };
-  return cachedSchema;
 }
 
 // ── Main: build tools + SDL ──────────────────────────────────────
@@ -744,13 +762,34 @@ async function getOrBuildSchema(): Promise<CachedSchema> {
 // Tool execute functions read the bearer token from AsyncLocalStorage
 // at execution time, so a single set of tools works for all users.
 let cachedTools: { tools: Record<string, ReturnType<typeof tool>>; sdl: string } | null = null;
+// In-flight tool build, shared across concurrent first callers (single-flight).
+let toolsInFlight: Promise<{
+  tools: Record<string, ReturnType<typeof tool>>;
+  sdl: string;
+}> | null = null;
 
-export async function getSchemaTools(): Promise<{
+export function getSchemaTools(): Promise<{
   tools: Record<string, ReturnType<typeof tool>>;
   sdl: string;
 }> {
-  if (cachedTools) return cachedTools;
+  if (cachedTools) return Promise.resolve(cachedTools);
+  if (!toolsInFlight) {
+    toolsInFlight = buildSchemaTools()
+      .then((built) => {
+        cachedTools = built;
+        return built;
+      })
+      .finally(() => {
+        toolsInFlight = null;
+      });
+  }
+  return toolsInFlight;
+}
 
+async function buildSchemaTools(): Promise<{
+  tools: Record<string, ReturnType<typeof tool>>;
+  sdl: string;
+}> {
   const schema = await getOrBuildSchema();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -863,6 +902,5 @@ export async function getSchemaTools(): Promise<{
     },
   });
 
-  cachedTools = { tools, sdl: schema.sdl };
-  return cachedTools;
+  return { tools, sdl: schema.sdl };
 }


### PR DESCRIPTION
## What changed

`schema-tools` caches the introspected PostGraphile schema (`cachedSchema`) and the built AI tool set (`cachedTools`) in module-level variables. Both used a check-then-`await`-then-set pattern, so while the cache was `null` any concurrent callers all passed the guard, each ran a full introspection + tool build, and the last result overwrote the cache (thundering herd, #367).

This makes both caches **single-flight**: the first caller starts the build and stores the in-flight promise; concurrent callers `await` the same promise. On settle the in-flight promise is cleared, so a **failed introspection is retryable** instead of caching a rejected promise. `invalidateToolCache()` now also drops any in-flight build.

- `getOrBuildSchema()` → thin single-flight wrapper around a new `buildSchema()`.
- `getSchemaTools()` → thin single-flight wrapper around a new `buildSchemaTools()`.

## Why

Severity is Low (idempotent build, no correctness issue) but it wastes a duplicated PostGraphile introspection round-trip + CPU on tool generation when several admin requests race a cold cache right after boot. Single-flight collapses that to one build. See #367.

## Validation

- `pnpm --filter @vicoop-bridge/server typecheck` — clean.
- New `src/schema-tools.test.ts` (mocks `fetch` with a minimal introspection payload):
  - concurrent first calls trigger **exactly one** introspection and share one cached object;
  - warm cache performs no further fetch;
  - `invalidateToolCache()` forces a fresh introspection;
  - a failed introspection is retryable (in-flight promise cleared on error).
- Confirmed the single-flight test **fails** against the pre-fix code (introspection ran 5×) and passes after.

No changeset: `@vicoop-bridge/server` is in the changeset `ignore` list (ships via `fly deploy`, no published artifact).

Closes #367.

🤖 Generated with [Claude Code](https://claude.com/claude-code)