### PR TITLE
fix(server): remove per-frame abort listener leak in AsyncEventQueue.iterate

### DIFF
--- a/packages/server/src/event-queue.test.ts
+++ b/packages/server/src/event-queue.test.ts
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AsyncEventQueue } from './event-queue.js';
+
+const macrotaskGap = () => new Promise<void>((r) => setTimeout(r, 1));
+
+test('iterate yields pushed values FIFO and ends on end()', async () => {
+  const q = new AsyncEventQueue<number>();
+  const seen: number[] = [];
+  const consumer = (async () => {
+    for await (const v of q.iterate()) seen.push(v);
+  })();
+  q.push(1);
+  q.push(2);
+  q.push(3);
+  q.end();
+  await consumer;
+  assert.deepEqual(seen, [1, 2, 3]);
+});
+
+test('iterate does not leak an abort listener per buffered frame (regression)', async () => {
+  // Each blocking read attaches an `abort` listener to the signal; the
+  // normal (push/close) resolution path must remove it. `{ once: true }`
+  // only self-removes when abort actually fires, so before the cleanup
+  // fix a task streaming N frames accumulated N+1 listeners on its
+  // (task-lived) signal — the source of the "11 abort listeners added to
+  // [AbortSignal]" MaxListenersExceededWarning and a listener storm that
+  // fired synchronously on eventual abort.
+  const ac = new AbortController();
+  let net = 0;
+  let peak = 0;
+  const realAdd = ac.signal.addEventListener.bind(ac.signal);
+  const realRemove = ac.signal.removeEventListener.bind(ac.signal);
+  ac.signal.addEventListener = ((type: string, ...rest: unknown[]) => {
+    if (type === 'abort') {
+      net += 1;
+      peak = Math.max(peak, net);
+    }
+    return (realAdd as (...a: unknown[]) => void)(type, ...rest);
+  }) as typeof ac.signal.addEventListener;
+  ac.signal.removeEventListener = ((type: string, ...rest: unknown[]) => {
+    if (type === 'abort') net -= 1;
+    return (realRemove as (...a: unknown[]) => void)(type, ...rest);
+  }) as typeof ac.signal.removeEventListener;
+
+  const q = new AsyncEventQueue<number>();
+  const seen: number[] = [];
+  const consumer = (async () => {
+    for await (const v of q.iterate(ac.signal)) seen.push(v);
+  })();
+
+  // Real macrotask gaps so the consumer fully parks (and attaches a
+  // listener) between frames, faithfully mirroring WebSocket-driven
+  // frames arriving milliseconds apart.
+  for (let i = 0; i < 50; i += 1) {
+    await macrotaskGap();
+    q.push(i);
+  }
+  await macrotaskGap();
+  q.end();
+  await consumer;
+
+  assert.equal(seen.length, 50, 'all frames consumed');
+  assert.ok(peak <= 1, `at most one concurrent abort listener (saw peak=${peak})`);
+  assert.equal(net, 0, 'no abort listeners left attached after drain');
+});
+
+test('iterate stops promptly when the signal aborts', async () => {
+  const ac = new AbortController();
+  const q = new AsyncEventQueue<number>();
+  const seen: number[] = [];
+  const consumer = (async () => {
+    for await (const v of q.iterate(ac.signal)) seen.push(v);
+  })();
+  await macrotaskGap();
+  q.push(1);
+  await macrotaskGap();
+  ac.abort();
+  await consumer;
+  assert.deepEqual(seen, [1]);
+});

--- a/packages/server/src/event-queue.ts
+++ b/packages/server/src/event-queue.ts
@@ -53,6 +53,13 @@ export class AsyncEventQueue<T> {
       }
       if (this.failure) throw this.failure.error;
       if (this.closed) return;
+      // Cleared once the awaited promise settles so the per-iteration
+      // abort listener is removed on the normal (push/close) path too —
+      // `{ once: true }` only self-removes when abort actually fires, so
+      // without this every buffered event would leave a dangling listener
+      // on the (task-lived) signal, leaking closures and accumulating a
+      // listener storm that all fires synchronously on eventual abort.
+      let cleanupAbort: (() => void) | undefined;
       const result = await new Promise<IteratorResult<T> | { error: unknown }>((resolve) => {
         this.waiter = resolve;
         if (signal) {
@@ -63,9 +70,13 @@ export class AsyncEventQueue<T> {
             }
           };
           if (signal.aborted) onAbort();
-          else signal.addEventListener('abort', onAbort, { once: true });
+          else {
+            signal.addEventListener('abort', onAbort, { once: true });
+            cleanupAbort = () => signal.removeEventListener('abort', onAbort);
+          }
         }
       });
+      cleanupAbort?.();
       if ('error' in result) throw result.error;
       if (result.done) return;
       yield result.value;


### PR DESCRIPTION
## What

`AsyncEventQueue.iterate(signal)` attaches an `abort` listener to the signal **every time it blocks** waiting for the next frame, but relied on `{ once: true }` to clean it up — which only self-removes when abort *actually fires*. On the normal push/close resolution path the listener was left dangling.

Each task owns **one task-lived `AbortController`** (`Executor`'s `abortControllers` map, passed as `ac.signal` into `queue.iterate(...)`). So a streaming task that emits N progress frames accumulates **N+1 abort listeners on a single signal**.

## Why it matters (observed in prod)

On `vicoop-bridge-server` (fly, nrt) the server log was steadily emitting:

```
(node:673) MaxListenersExceededWarning: Possible EventTarget memory leak detected.
11 abort listeners added to [AbortSignal]. MaxListeners is 10.
```

i.e. a task that had streamed ~10 frames. Beyond the warning and retained closures, all accumulated listeners fire **synchronously in one tick** when the task is finally aborted (cancel / client disconnect) — a plausible contributor to the ~17-minute event-loop stall we saw (`fly-proxy-p2p/tls/http-backhaul: timed out`, `Error: aborted at socketOnClose`) that served 502s to clients before self-recovering. (Memory pressure was ruled out separately — kernel PSI showed ~0.13s cumulative memory stall over 24h+, peak RSS 278/459MB, no swap, no OOM.)

## Fix

Remove the listener as soon as the awaited promise settles for **any** reason, not just abort.

## Verification

New `packages/server/src/event-queue.test.ts`:

- **regression test** — drives 50 frames through `iterate()` with real macrotask gaps (mirroring WS frames) and asserts no listener accumulation. **Fails on the old code** (`peak=51`), **passes with the fix** (`peak=1, net=0`).
- FIFO ordering + ends on `end()`
- stops promptly when the signal aborts

```
✔ iterate yields pushed values FIFO and ends on end()
✔ iterate does not leak an abort listener per buffered frame (regression)
✔ iterate stops promptly when the signal aborts
pass 3 / fail 0
```

`@vicoop-bridge/server` is in the changesets `ignore` list, so no changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)