### PR TITLE
fix(server): drop client-disconnect aborts from Sentry reporting

### DIFF
--- a/packages/server/src/instrument.ts
+++ b/packages/server/src/instrument.ts
@@ -16,6 +16,24 @@ Sentry.init({
   enabled: process.env.SENTRY_ENABLED === 'true',
   // Backend service: trace all requests by default. Tune via SENTRY_TRACES_SAMPLE_RATE.
   tracesSampleRate: Number(process.env.SENTRY_TRACES_SAMPLE_RATE ?? '1.0'),
+  // Drop client-disconnect noise. POST /agents/:id streams its response as
+  // text/event-stream (handleHandlerResult in http.tsx); when an A2A caller
+  // closes the connection mid-stream — task cancel, timeout, or a flaky
+  // network — Node's HTTP server emits `Error: aborted` and the @sentry/hono
+  // context-error handler reports it (mechanism auto.http.hono.context_error).
+  // These are normal client behaviour, not server faults, so they should not
+  // surface as production errors (issue VICOOP-BRIDGE-SERVER-1). Match the exact
+  // message rather than a substring so a genuine error that merely mentions
+  // "aborted" still reports.
+  beforeSend(event, hint) {
+    const err = hint?.originalException as { message?: unknown; code?: unknown } | undefined;
+    const message = typeof err?.message === 'string' ? err.message : '';
+    const code = typeof err?.code === 'string' ? err.code : '';
+    if (message === 'aborted' || code === 'ECONNRESET' || code === 'ERR_STREAM_PREMATURE_CLOSE') {
+      return null;
+    }
+    return event;
+  },
   // A single Sentry.init/DSN sends spans and logs to the same project, so
   // these logs land in "vicoop-bridge-server" alongside the spans above.
   // `enableLogs` only opens the transport; consoleLoggingIntegration is what


### PR DESCRIPTION
## What

Filters out client-disconnect `Error: aborted` events from Sentry in the bridge server.

## Why

`POST /agents/:id` streams its response as `text/event-stream` (`handleHandlerResult` in `http.tsx`). When an A2A caller closes the connection mid-stream — task cancel, timeout, or a flaky network — Node's HTTP server emits `Error: aborted` (stacktrace bottoms out in `node:_http_server` `abortIncoming`/`socketOnClose`), and the `@sentry/hono` context-error handler reports it (mechanism `auto.http.hono.context_error`).

This is normal client behaviour, not a server fault — the captured event even carries `response.status_code: 200`, i.e. the server had already begun a successful streaming response before the caller bailed. Surfacing it as a production error is just noise.

Surfaced as Sentry issue [`VICOOP-BRIDGE-SERVER-1`](https://vicoop-router.sentry.io/issues/VICOOP-BRIDGE-SERVER-1).

## How

Add a `beforeSend` hook to `Sentry.init` (`packages/server/src/instrument.ts`) that returns `null` for:

- exact message `aborted` (Node request abort)
- `code === 'ECONNRESET'`
- `code === 'ERR_STREAM_PREMATURE_CLOSE'`

Exact-message matching (not a substring `ignoreErrors` rule) keeps genuine errors that merely mention "aborted" reporting. `beforeSend` only gates error events — spans and structured logs are unaffected.

## Test

`pnpm --filter @vicoop-bridge/server typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)