### PR TITLE
fix(client): fixed-segment splitting for openai-compat history cache

### DIFF
--- a/.changeset/oai-history-cache-fixed-segments.md
+++ b/.changeset/oai-history-cache-fixed-segments.md
@@ -1,0 +1,39 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+fix(client): fixed-segment splitting for openai-compat history cache
+
+The default-on history cache (#372) emitted the frozen prefix as a **single
+growing block** with one `cache_control` breakpoint. When the conversation
+advances a turn the block's bytes change, and because Anthropic's cache matches
+at *block boundaries* (read-lookback walks back up to 20 blocks), there is no
+boundary at the previous turn's freeze point — so the lookback only re-matches
+at the stable system+tools boundary and the **entire history is re-created every
+forward turn**.
+
+A controlled fresh-data A/B (no pre-warm) confirmed this and corrected the #372
+"caching already works" reading, which had measured pre-warmed cache from
+repeated deterministic runs:
+
+| rollover turn (200→210 entries) | non_cached (≈creation) | cache_read |
+|---|---:|---:|
+| single growing block (before) | 220,929 | 0 |
+| fixed segments (after) | 16,013 | 180,468 |
+
+`formatChatHistoryBlocks` now serializes the frozen prefix as **one block per
+`FREEZE_STEP_ENTRIES` entries at absolute boundaries** (so older segments never
+re-flow), with `cache_control` on **only the last complete segment**. On a
+rollover the new breakpoint's read-lookback finds the prior turn's entry one
+block back at the previous segment boundary and reads the whole frozen prefix,
+re-creating only the new segment + tail — i.e. creation becomes O(step) per turn
+instead of O(full history). Validated at production depth (20 segments): the
+lookback match is always one block back, well within the 20-block window.
+
+This is what the rolling-anchor approach was reaching for, but it uses **one**
+breakpoint (reads ride the lookback, not a second explicit anchor) → claude's
+system+tools+1 plus this one = 4, fitting Anthropic's budget. That is why the
+rolling-anchor patch tripped `400 maximum of 4 blocks` and this does not. The
+concatenated text the model reads is byte-identical
+(`serialize(a) + ",\n" + serialize(b) == serialize(a ++ b)`); the existing latch
+still falls back to the unsplit block if a breakpoint is ever rejected.

--- a/packages/client/scripts/ab-fresh-rollover.mjs
+++ b/packages/client/scripts/ab-fresh-rollover.mjs
@@ -1,0 +1,76 @@
+// Fresh-data rollover test: unique nonce per run so the prefix is never
+// pre-warmed by a prior run. turnN and turnN+1 share the SAME first-N entries
+// (byte-identical), turnN+1 appends `step` new entries (a rollover).
+//
+// If the frozen history block can be incrementally READ on growth, turnN+1's
+// non_cached (~creation) ≈ the appended delta. If the monolithic frozen block
+// must be re-created on growth, non_cached ≈ the whole frozen prefix.
+import { createClaudeBackend } from '../dist/backends/claude.js';
+
+const URI = 'https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1';
+// Unique per process run -> guarantees fresh bytes (no pre-warm from prior runs).
+const NONCE = process.env.NONCE ?? `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+const FILLER = 'y'.repeat(760);
+
+// Deterministic given NONCE+i, so turnN's entry i == turnN+1's entry i (byte-identical prefix).
+function history(n) {
+  const h = [];
+  for (let i = 0; i < n; i++) {
+    h.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `[${NONCE}] turn ${i} ${FILLER}` });
+  }
+  return h;
+}
+
+const TOOLS = [
+  { type: 'function', function: { name: 'read', description: 'read a file', parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } } },
+  { type: 'function', function: { name: 'write', description: 'write a file', parameters: { type: 'object', properties: { path: { type: 'string' }, text: { type: 'string' } }, required: ['path', 'text'] } } },
+];
+
+function task(n, label) {
+  const messages = [...history(n), { role: 'user', content: 'Reply with exactly: ok' }];
+  const t0 = `${Date.now()}-${label}`;
+  return {
+    type: 'task.assign',
+    taskId: `fr-${t0}`,
+    contextId: `fr-ctx-${t0}`,
+    message: {
+      role: 'user',
+      messageId: `m-${t0}`,
+      parts: [{ kind: 'text', text: 'Reply with exactly: ok' }],
+      metadata: { [URI]: { chat_completions_request: { messages, tools: TOOLS } } },
+    },
+  };
+}
+
+const backend = createClaudeBackend({ extraArgs: ['--max-turns', '1'] });
+
+async function run(n, label) {
+  const frames = [];
+  await backend.handle(task(n, label), (f) => frames.push(f), new AbortController().signal);
+  const terminal = frames.find((f) => f.type === 'task.complete' || f.type === 'task.fail');
+  if (terminal?.type === 'task.fail') return { label, err: `${terminal.error.code}: ${terminal.error.message}`.slice(0, 120) };
+  let usage = null;
+  for (const f of frames) {
+    const meta = f?.status?.message?.metadata?.[URI];
+    const u = meta?.chat_completion?.usage ?? meta?.usage;
+    if (u) usage = u;
+  }
+  if (!usage) return { label, err: 'no usage in frames' };
+  const pt = usage.prompt_tokens ?? 0;
+  const cached = usage.prompt_tokens_details?.cached_tokens ?? 0;
+  return { label, entries: n, prompt_tokens: pt, cache_read: cached, non_cached: pt - cached };
+}
+
+const N0 = Number(process.env.N0 ?? 48); // turnN entry count
+const N1 = Number(process.env.N1 ?? 58); // turnN+1 entry count (rollover; shares first N0)
+console.log(`[fresh] NONCE=${NONCE} N0=${N0} N1=${N1}`);
+const turnN = await run(N0, 'turnN');
+console.log('  turnN   :', JSON.stringify(turnN));
+// Sequential await: the cache entry is readable only after the first response
+// begins, so turnN must complete before turnN+1 is sent.
+const turnN1 = await run(N1, 'turnN1');
+console.log(`  turnN+1 :`, JSON.stringify(turnN1), ` <- rollover (shares first ${N0} entries)`);
+if (turnN1.non_cached != null && turnN.non_cached != null) {
+  console.log(`[fresh] turnN cold creation=${turnN.non_cached}; ROLLOVER non-cached(~creation)=${turnN1.non_cached}, cache_read=${turnN1.cache_read}`);
+  console.log(`[fresh] If incremental: rollover non_cached should be ~one rollover step of entries, NOT ~the whole frozen prefix.`);
+}

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -3429,15 +3429,22 @@ test('history-cache (default ON): frozen prefix split out with a 1h cache_contro
     NEVER,
   );
   const env = stdinEnvelope(fake.lastChild()!);
-  const [frozen, tail, live] = env.message.content;
-  // Frozen prefix carries the breakpoint; tail and live prompt do not.
-  assert.deepEqual(frozen!.cache_control, { type: 'ephemeral', ttl: '1h' });
-  assert.match(frozen!.text ?? '', /^<chat_history>\n\[\n/);
-  assert.equal(tail!.cache_control, undefined);
-  assert.match(tail!.text ?? '', /<\/chat_history>$/);
-  assert.equal(live!.text, 'go');
-  // The two history pieces re-concatenate to one valid <chat_history> block.
-  const joined = (frozen!.text ?? '') + (tail!.text ?? '');
+  const content = env.message.content;
+  const live = content.at(-1)!;
+  const historyBlocks = content.slice(0, -1); // [...frozen segments, tail]
+  const tail = historyBlocks.at(-1)!;
+  // Exactly one breakpoint, on the LAST frozen segment (not seg0, the tail, or
+  // the live prompt) — so it fits alongside claude's system+tools+1.
+  const cached = content.filter((b) => b.cache_control);
+  assert.equal(cached.length, 1);
+  assert.deepEqual(cached[0]!.cache_control, { type: 'ephemeral', ttl: '1h' });
+  assert.equal(historyBlocks.at(-2), cached[0]); // last frozen segment carries it
+  assert.match(content[0]!.text ?? '', /^<chat_history>\n\[\n/);
+  assert.equal(tail.cache_control, undefined);
+  assert.match(tail.text ?? '', /<\/chat_history>$/);
+  assert.equal(live.text, 'go');
+  // The history pieces re-concatenate to one valid <chat_history> block.
+  const joined = historyBlocks.map((b) => b.text ?? '').join('');
   assert.match(joined, /^<chat_history>\n\[\n/);
   assert.match(joined, /\n\]\n<\/chat_history>$/);
 });
@@ -3499,7 +3506,10 @@ test('history-cache latch: a cache_control 400 disables the split for later task
     NEVER,
   );
   const env1 = stdinEnvelope(fake.lastChild()!);
-  assert.deepEqual(env1.message.content[0].cache_control, { type: 'ephemeral', ttl: '1h' });
+  // Turn 1 used the split: exactly one frozen segment carries the breakpoint.
+  const cached1 = env1.message.content.filter((b) => b.cache_control);
+  assert.equal(cached1.length, 1);
+  assert.deepEqual(cached1[0].cache_control, { type: 'ephemeral', ttl: '1h' });
 
   // Turn 2: latch is set → single unsplit block, no cache_control.
   await backend.handle(

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -480,47 +480,61 @@ test('formatChatHistoryBlocks: split concatenates byte-identically to the single
   // breakpoints, the rendered text it reads is exactly formatChatHistory().
   const h = bigHistory();
   const blocks = formatChatHistoryBlocks(h, { split: true });
-  assert.equal(blocks.length, 2);
+  assert.ok(blocks.length > 2, 'frozen prefix splits into fixed segments + tail');
   assert.equal(blocks.map((b) => b.text).join(''), formatChatHistory(h));
+  // Exactly one cache_control breakpoint (the last frozen segment) -> fits the
+  // 4-block budget alongside claude's own system+tools+1.
+  assert.equal(blocks.filter((b) => b.cache).length, 1);
 });
 
-test('formatChatHistoryBlocks: split marks only the frozen prefix for caching', () => {
-  const h = bigHistory(); // 60 entries → frozen rounds to 50, tail = last 10
-  const [frozen, tail] = formatChatHistoryBlocks(h, { split: true });
-  assert.equal(frozen!.cache, true);
-  assert.equal(tail!.cache, false);
-  assert.match(frozen!.text, /^<chat_history>\n\[\n/);
+test('formatChatHistoryBlocks: split marks only the last frozen segment; tail holds recent turns', () => {
+  const h = bigHistory(); // 60 entries → frozenCount 50, tail = last 10
+  const blocks = formatChatHistoryBlocks(h, { split: true });
+  const tail = blocks.at(-1)!;
+  const frozenSegs = blocks.slice(0, -1);
+  // One breakpoint, on the last frozen segment (not the tail).
+  assert.equal(blocks.filter((b) => b.cache).length, 1);
+  assert.equal(frozenSegs.at(-1)!.cache, true);
+  assert.equal(tail.cache, false);
+  assert.match(blocks[0]!.text, /^<chat_history>\n\[\n/);
   // The most recent turns (incl. the last exchange) live in the uncached tail,
-  // so the frozen prefix can stay byte-stable across turns.
-  assert.ok(!frozen!.text.includes('"content": "q29'), 'last user turn must be in the tail');
-  assert.ok(!frozen!.text.includes('"content": "a29'), 'last assistant turn must be in the tail');
-  assert.ok(tail!.text.includes('q29'));
-  assert.ok(tail!.text.includes('a29'));
-  assert.match(tail!.text, /\n<\/chat_history>$/);
+  // so the frozen segments stay byte-stable across turns.
+  const frozenText = frozenSegs.map((b) => b.text).join('');
+  assert.ok(!frozenText.includes('"content": "q29'), 'last user turn must be in the tail');
+  assert.ok(!frozenText.includes('"content": "a29'), 'last assistant turn must be in the tail');
+  assert.ok(tail.text.includes('q29'));
+  assert.ok(tail.text.includes('a29'));
+  assert.match(tail.text, /\n<\/chat_history>$/);
 });
 
-test('formatChatHistoryBlocks: frozen block is byte-identical as the conversation grows within a step', () => {
+test('formatChatHistoryBlocks: frozen segments are byte-identical as the conversation grows within a step', () => {
   // The property the cache *read* depends on: appending turns must not change
-  // the frozen block until the quantized boundary rolls over. Two histories one
-  // exchange apart (same FREEZE_STEP window) must produce the identical frozen
-  // text — otherwise next turn's breakpoint never matches and nothing caches.
+  // any frozen segment (incl. the breakpoint segment) until the quantized
+  // boundary rolls over — otherwise next turn's lookback never matches.
   const base = bigHistory(28); // 56 entries → frozenCount floor(54/10)*10 = 50
   const grown = [...base, { role: 'user' as const, content: 'next q' }, { role: 'assistant' as const, content: 'next a' }]; // 58 → floor(56/10)*10 = 50
-  const [f1] = formatChatHistoryBlocks(base, { split: true });
-  const [f2] = formatChatHistoryBlocks(grown, { split: true });
-  assert.equal(f1!.cache, true);
-  assert.equal(f2!.cache, true);
-  assert.equal(f1!.text, f2!.text); // identical frozen block → cacheable across turns
+  const b1 = formatChatHistoryBlocks(base, { split: true });
+  const b2 = formatChatHistoryBlocks(grown, { split: true });
+  // Same frozenCount → identical frozen segments (everything but the tail).
+  assert.deepEqual(b1.slice(0, -1).map((b) => b.text), b2.slice(0, -1).map((b) => b.text));
+  // One breakpoint each, byte-identical across the within-step turn.
+  assert.equal(b1.find((b) => b.cache)!.text, b2.find((b) => b.cache)!.text);
 });
 
-test('formatChatHistoryBlocks: frozen boundary advances only on step rollover', () => {
-  const a = bigHistory(); // 60 entries → frozenCount 50
-  const b = bigHistory(35); // 70 entries → frozenCount floor(68/10)*10 = 60
-  const [fa] = formatChatHistoryBlocks(a, { split: true });
-  const [fb] = formatChatHistoryBlocks(b, { split: true });
-  // Different windows → different (longer) frozen prefix.
-  assert.notEqual(fa!.text, fb!.text);
-  assert.ok(fb!.text.length > fa!.text.length);
+test('formatChatHistoryBlocks: frozen prefix advances by one segment on step rollover', () => {
+  const a = bigHistory(); // 60 entries → frozenCount 50 (5 frozen segments + tail)
+  const b = bigHistory(35); // 70 entries → frozenCount floor(68/10)*10 = 60 (6 + tail)
+  const ba = formatChatHistoryBlocks(a, { split: true });
+  const bb = formatChatHistoryBlocks(b, { split: true });
+  // One more frozen segment after rollover; the shared earlier segments stay
+  // byte-identical so the rollover lookback finds the prior entry one block back.
+  assert.equal(bb.length, ba.length + 1);
+  assert.deepEqual(
+    ba.slice(0, -1).map((s) => s.text),
+    bb.slice(0, ba.length - 1).map((s) => s.text),
+  );
+  // The breakpoint advanced to a new, longer prefix.
+  assert.notEqual(ba.find((s) => s.cache)!.text, bb.find((s) => s.cache)!.text);
 });
 
 test('formatChatHistoryBlocks: frozen prefix below threshold falls back to one block', () => {

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -562,6 +562,56 @@ test('formatChatHistoryBlocks: <=2 entries never splits even when split=true', (
   assert.equal(blocks[0]!.cache, false);
 });
 
+test('formatChatHistoryBlocks: byte-identical at non-multiple-of-step lengths (varying tail)', () => {
+  // frozenCount = floor((len-2)/step)*step, so the tail size varies with len.
+  // Exercise lengths whose tail is 1..(2*step) to pin the head/separator/closing
+  // bytes at a partial tail boundary — not just the clean bigHistory()=60 case.
+  for (let n = 26; n <= 32; n++) {
+    const h = bigHistory(n); // 52..64 entries
+    const odd = [...h, { role: 'user' as const, content: 'tail-only ' + 'z'.repeat(40) }]; // make length odd too
+    for (const hist of [h, odd]) {
+      const blocks = formatChatHistoryBlocks(hist, { split: true });
+      assert.equal(
+        blocks.map((b) => b.text).join(''),
+        formatChatHistory(hist),
+        `byte-identity must hold at ${hist.length} entries`,
+      );
+      assert.equal(blocks.filter((b) => b.cache).length, 1, `one breakpoint at ${hist.length} entries`);
+    }
+  }
+});
+
+test('formatChatHistoryBlocks: single frozen segment (frozenCount == step) carries the breakpoint', () => {
+  // Entries large enough that 10 frozen entries alone clear the cache floor, so
+  // the frozen prefix is exactly ONE segment — the edge where seg0 is both first
+  // and last and must still be the (only) cache_control block.
+  const filler = 'q'.repeat(1700); // ~1.7k chars/entry → 10 entries > MIN_CACHEABLE_FROZEN_CHARS
+  const h: OpenAICompatHistoryEntry[] = [];
+  for (let i = 0; i < 7; i++) {
+    h.push({ role: 'user', content: `u${i} ${filler}` });
+    h.push({ role: 'assistant', content: `a${i} ${filler}` }); // 14 entries → frozenCount floor(12/10)*10 = 10
+  }
+  const blocks = formatChatHistoryBlocks(h, { split: true });
+  assert.equal(blocks.length, 2); // single frozen segment + tail
+  assert.equal(blocks[0]!.cache, true);
+  assert.equal(blocks[1]!.cache, false);
+  assert.match(blocks[0]!.text, /^<chat_history>\n\[\n/);
+  assert.match(blocks[1]!.text, /\n<\/chat_history>$/);
+  assert.equal(blocks.map((b) => b.text).join(''), formatChatHistory(h));
+});
+
+test('formatChatHistoryBlocks: exactly one breakpoint and byte-identity at large depth (21 segments)', () => {
+  // The 4-breakpoint budget is the whole point: regardless of segment count, only
+  // the last frozen segment may carry cache_control (claude's system+tools+1 + 1).
+  const h = bigHistory(110); // 220 entries → frozenCount floor(218/10)*10 = 210 → 21 frozen segments
+  const blocks = formatChatHistoryBlocks(h, { split: true });
+  assert.ok(blocks.length >= 22, 'many fixed segments + tail');
+  assert.equal(blocks.filter((b) => b.cache).length, 1);
+  assert.equal(blocks.at(-2)!.cache, true); // breakpoint on the last frozen segment
+  assert.equal(blocks.at(-1)!.cache, false); // tail uncached
+  assert.equal(blocks.map((b) => b.text).join(''), formatChatHistory(h));
+});
+
 // ───────────────────────────────────────────────────────────────────────────
 // requalifyHistoryToolNames — rename caller-tool references in replayed
 // history to a backend's live tool ids (claude native MCP dispatch, #213).

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -537,6 +537,12 @@ function serializeHistoryEntries(entries: OpenAICompatHistoryEntry[]): string {
 // reproduces `formatChatHistory(history)` byte-for-byte
 // (`serialize(a) + ",\n" + serialize(b) == serialize(a ++ b)`), so the rendered
 // text the model reads is unchanged.
+//
+// Scope: this optimizes the pure-append case (one or a few exchanges per turn).
+// A turn that appends > ~20 segments at once (frozenCount jumps > 20*step) pushes
+// the prior boundary past the 20-block lookback window, and editing a past entry
+// changes that segment's hash and every later one — both fall back to recreating
+// the full prefix (the old cost), never to incorrect output.
 export function formatChatHistoryBlocks(
   history: OpenAICompatHistoryEntry[],
   opts: { split?: boolean; minFrozenChars?: number; stepEntries?: number } = {},

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -508,19 +508,34 @@ function serializeHistoryEntries(entries: OpenAICompatHistoryEntry[]): string {
     .join(',\n');
 }
 
-// Split the `<chat_history>` block so the stable prefix can carry its own
-// prompt-cache breakpoint, instead of one blob that grows (and so re-bills at
-// full price) every turn.
+// Split the `<chat_history>` block into fixed, append-only segments so a
+// growing conversation reads its prefix from cache and re-creates only the new
+// turn — instead of re-billing the whole history on every forward turn.
 //
 // `split: false` (default) returns the legacy single block — byte-identical to
-// `formatChatHistory`. With `split: true` we freeze a prefix of the history and
-// give it its own `cache_control` breakpoint. The freeze boundary is the last
-// exchange dropped, then quantized down to a multiple of `FREEZE_STEP_ENTRIES`
-// (see that const): that quantization is what makes the frozen block recur
-// byte-for-byte across consecutive turns so the cache actually *reads* it,
-// rather than shifting every turn. The frozen piece is emitted only when it
-// clears `MIN_CACHEABLE_FROZEN_CHARS`; otherwise we fall back to the single
-// unmarked block. The split is purely about breakpoint placement — the rendered
+// `formatChatHistory`. With `split: true` we serialize the frozen prefix as one
+// block per `FREEZE_STEP_ENTRIES` entries, with boundaries at *absolute*
+// multiples of the step so they never re-flow as the history grows. Only the
+// LAST complete segment carries a `cache_control` breakpoint: that single
+// breakpoint writes one cache entry for the whole frozen prefix and fits
+// alongside claude's own system+tools+1 within Anthropic's 4-breakpoint budget.
+//
+// Why segments and not one growing frozen block: the cache matches at *block
+// boundaries* via prefix-hash, and reads walk back up to 20 blocks looking for a
+// prior entry. A single frozen block has no boundary at the previous turn's
+// freeze point, so when it grows the block's bytes change and the lookback only
+// re-matches at the stable system+tools boundary → the entire history is
+// re-created every turn (measured: rollover cache_read collapses to system+tools
+// only). Fixed segments keep the previous turn's boundary as a byte-stable block
+// edge one step back, so the rollover turn's lookback finds the prior entry and
+// reads the whole prefix, re-creating only the new segment + tail. This is what
+// the rolling-anchor approach was reaching for, without spending a 5th
+// breakpoint (reads use the lookback, not an explicit anchor).
+//
+// Emitted only when the frozen prefix clears `MIN_CACHEABLE_FROZEN_CHARS`;
+// otherwise we fall back to the single unmarked block. Concatenating every piece
+// reproduces `formatChatHistory(history)` byte-for-byte
+// (`serialize(a) + ",\n" + serialize(b) == serialize(a ++ b)`), so the rendered
 // text the model reads is unchanged.
 export function formatChatHistoryBlocks(
   history: OpenAICompatHistoryEntry[],
@@ -539,16 +554,31 @@ export function formatChatHistoryBlocks(
   const frozenCount = Math.floor((history.length - 2) / step) * step;
   if (frozenCount < 1) return single();
 
-  const frozen = history.slice(0, frozenCount);
-  const tail = history.slice(frozenCount);
-  const frozenText = '<chat_history>\n[\n' + serializeHistoryEntries(frozen);
+  // Min-cacheable guard on the *whole* frozen prefix — the `cache_control` sits
+  // on the last segment, whose cached prefix is everything up to `frozenCount`.
+  const frozenText = '<chat_history>\n[\n' + serializeHistoryEntries(history.slice(0, frozenCount));
   if (frozenText.length < (opts.minFrozenChars ?? MIN_CACHEABLE_FROZEN_CHARS)) {
     return single();
   }
-  return [
-    { text: frozenText, cache: true },
-    { text: ',\n' + serializeHistoryEntries(tail) + '\n]\n</chat_history>', cache: false },
-  ];
+
+  // One block per `step` entries at absolute boundaries; cache_control only on
+  // the last complete segment (single breakpoint). Older segment boundaries stay
+  // byte-stable across turns, so the rollover read-lookback finds the prior
+  // turn's entry one block back and only the new segment + tail re-creates.
+  const blocks: ChatHistoryBlock[] = [];
+  for (let start = 0; start < frozenCount; start += step) {
+    const end = Math.min(start + step, frozenCount);
+    const head = start === 0 ? '<chat_history>\n[\n' : ',\n';
+    blocks.push({
+      text: head + serializeHistoryEntries(history.slice(start, end)),
+      cache: end >= frozenCount,
+    });
+  }
+  blocks.push({
+    text: ',\n' + serializeHistoryEntries(history.slice(frozenCount)) + '\n]\n</chat_history>',
+    cache: false,
+  });
+  return blocks;
 }
 
 // Return a copy of `history` with every caller-tool reference renamed via


### PR DESCRIPTION
## Problem

The default-on openai-compat history cache (#372) emits the frozen `<chat_history>` prefix as a **single growing block** with one `cache_control` breakpoint. Anthropic matches the prompt cache at **block boundaries** (the read-lookback walks back ≤20 blocks looking for a prior entry). A single growing block has no boundary at the previous turn's freeze point, so when the conversation advances a turn the block's bytes change and the lookback only re-matches at the stable system+tools boundary → **the entire history is re-created on every forward turn.**

This is the dominant `cache_creation` driver on the live `claude` backend (see #395). A controlled **fresh-data A/B** (unique per-run nonce, so nothing is pre-warmed) confirmed it — and corrected the #372 "caching already works" reading, which had measured pre-warmed cache from repeated deterministic runs rather than a real rollover.

## Fix

`formatChatHistoryBlocks` now serializes the frozen prefix as **one block per `FREEZE_STEP_ENTRIES` entries at absolute boundaries** (so older segments never re-flow), with `cache_control` on **only the last complete segment**. On a rollover the new breakpoint's read-lookback finds the prior turn's entry one block back at the previous segment boundary and reads the whole frozen prefix, re-creating only the new segment + tail. Creation becomes **O(step) per turn** instead of O(full history) — the same incremental behaviour local interactive Claude Code gets from native per-turn message blocks.

Key properties:
- **One breakpoint** (reads ride the lookback, not a second explicit anchor) → claude's system+tools+1 plus this one = 4, fitting Anthropic's budget. This is why the rolling-anchor approach tripped `400 maximum of 4 blocks` and this does not.
- **Byte-identical** rendered text (`serialize(a) + ",\n" + serialize(b) == serialize(a ++ b)`); the model reads the same `<chat_history>`.
- The existing **latch** still falls back to the unsplit block if a breakpoint is ever rejected.

## Validation (real `claude` backend, fresh-data harness)

| rollover turn | non_cached (≈creation) | cache_read |
|---|---:|---:|
| single growing block — **48→58 entries** | 47,317 | 27,868 |
| fixed segments — **48→58 entries** | **14,417** | 60,768 |
| single growing block — **200→210 entries** | 220,929 | 0 |
| fixed segments — **200→210 entries** | **16,013** | 180,468 |

~93% less rollover creation at production depth. The 20-block lookback holds at 20 segments (the match is always one block back).

- `pnpm test` — **788/788 pass**; `pnpm typecheck` clean.
- Tests updated for the new block structure (openai-compat: byte-identity, exactly-one-breakpoint, within-step segment stability, one-segment-advance on rollover; claude: breakpoint lands on the last frozen segment).
- `scripts/ab-fresh-rollover.mjs` — the fresh-data harness used here (no pre-warm), kept for future cache measurement.

Refs #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
