### PR TITLE
fix(client): classify context overflows as context_length_exceeded (claude + codex, shared matcher)

### DIFF
--- a/.changeset/claude-exit-cause-classification.md
+++ b/.changeset/claude-exit-cause-classification.md
@@ -14,16 +14,20 @@ empty the pool. Overflow is a non-retryable caller error: the shared
 `normalizeTaskFailError` matcher now classifies it — for every backend —
 as the canonical OpenAI `context_length_exceeded`, which the gateway maps
 to `400` (oai2a2a#114) so OpenAI-compatible clients can compact-and-retry.
-`context_length_exceeded` is also preserved verbatim through normalization
-so backends that tag it directly survive.
+`context_length_exceeded` is also preserved verbatim through normalization.
 
-Two supporting fixes:
+Scope details:
 
-- `claude.ts` captures the run's last `terminal_reason` and passes it (plus
-  the terminal result text) as a classification hint, so an overflow
-  classifies even when the result text is absent — while the caller-facing
-  message stays the verbatim reason (or the diagnostic dump on a real crash).
-- `isQuotaExceeded`'s `usage limit` pattern is guarded so the explicit
+- The overflow matcher uses provider-evidenced phrasings only (Anthropic,
+  OpenAI, codex-relayed, Gemini) — no generic fragments like "context
+  length" or "too many tokens", which would reclassify TPM rate limits or
+  assistant prose quoted in crash diagnostics as caller errors.
+- claude's `terminal_reason: "blocking_limit"` (an overflow signal that can
+  arrive with no result text) is handled in `claude.ts` as a post-
+  classification override: it tags `context_length_exceeded` only when the
+  failure message classified nothing more specific, so explicit quota/rate
+  text always wins over the bare enum token.
+- `isQuotaExceeded`'s `usage limit` pattern is guarded against the explicit
   server-throttle disclaimer "Server is temporarily limiting requests (not
-  your usage limit) · Rate limited" classifies as `rate_limited`, not quota
-  exhaustion.
+  your usage limit)", which now classifies as `rate_limited` (with or
+  without the "· Rate limited" suffix).

--- a/.changeset/claude-exit-cause-classification.md
+++ b/.changeset/claude-exit-cause-classification.md
@@ -1,0 +1,28 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+fix(client): classify claude context overflows as `context_length_exceeded`
+and guard the "not your usage limit" server throttle
+
+A claude context-window overflow (`Prompt is too long` /
+`terminal_reason: blocking_limit`) previously collapsed into the opaque
+`claude_exit_nonzero`, so the gateway surfaced a generic 502 and the router
+cooled the agent down and fanned out a doomed failover that could empty the
+pool. Overflow is a non-retryable caller error: it now classifies as the
+canonical OpenAI `context_length_exceeded` (matching the codex backend's
+tagging), which the gateway maps to `400` (oai2a2a#114) so OpenAI-compatible
+clients can compact-and-retry. `context_length_exceeded` is also preserved
+verbatim through `normalizeTaskFailError` so backends that tag it directly
+survive normalization.
+
+Two supporting fixes:
+
+- `claude.ts` captures the run's last `terminal_reason` and passes it (plus
+  the terminal result text) as a classification hint, so an overflow
+  classifies even when the result text is absent — while the caller-facing
+  message stays the verbatim reason (or the diagnostic dump on a real crash).
+- `isQuotaExceeded`'s `usage limit` pattern is guarded so the explicit
+  server-throttle disclaimer "Server is temporarily limiting requests (not
+  your usage limit) · Rate limited" classifies as `rate_limited`, not quota
+  exhaustion.

--- a/.changeset/claude-exit-cause-classification.md
+++ b/.changeset/claude-exit-cause-classification.md
@@ -2,19 +2,20 @@
 '@vicoop-bridge/client': patch
 ---
 
-fix(client): classify claude context overflows as `context_length_exceeded`
+fix(client): classify context overflows as `context_length_exceeded`
 and guard the "not your usage limit" server throttle
 
-A claude context-window overflow (`Prompt is too long` /
-`terminal_reason: blocking_limit`) previously collapsed into the opaque
-`claude_exit_nonzero`, so the gateway surfaced a generic 502 and the router
-cooled the agent down and fanned out a doomed failover that could empty the
-pool. Overflow is a non-retryable caller error: it now classifies as the
-canonical OpenAI `context_length_exceeded` (matching the codex backend's
-tagging), which the gateway maps to `400` (oai2a2a#114) so OpenAI-compatible
-clients can compact-and-retry. `context_length_exceeded` is also preserved
-verbatim through `normalizeTaskFailError` so backends that tag it directly
-survive normalization.
+A context-window overflow previously collapsed into an opaque generic code
+(claude: `Prompt is too long` / `terminal_reason: blocking_limit` →
+`claude_exit_nonzero`; codex: the relayed in-band "input exceeds the context
+window" → `upstream_error`), so the gateway surfaced a generic 502 and the
+router cooled the agent down and fanned out a doomed failover that could
+empty the pool. Overflow is a non-retryable caller error: the shared
+`normalizeTaskFailError` matcher now classifies it — for every backend —
+as the canonical OpenAI `context_length_exceeded`, which the gateway maps
+to `400` (oai2a2a#114) so OpenAI-compatible clients can compact-and-retry.
+`context_length_exceeded` is also preserved verbatim through normalization
+so backends that tag it directly survive.
 
 Two supporting fixes:
 

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1528,47 +1528,11 @@ test('non-zero claude exit carries the terminal reason as a structured code, cle
   }
 });
 
-test('non-zero claude exit on a context overflow classifies as context_length_exceeded', async () => {
-  // A too-long prompt: claude prints "Prompt is too long" in the terminal
-  // result and reports terminal_reason "blocking_limit". The failure must
-  // carry the canonical OpenAI overflow code so the gateway surfaces 400
-  // context_length_exceeded (oai2a2a#114) and the router treats it as a
-  // caller error instead of cooling the agent and failing over the pool.
-  const fake = scriptedSpawn({
-    lines: [
-      JSON.stringify({
-        type: 'result',
-        subtype: 'success',
-        is_error: true,
-        result: 'Prompt is too long',
-        terminal_reason: 'blocking_limit',
-        usage: { input_tokens: 0, output_tokens: 0 },
-        modelUsage: {},
-        permission_denials: [],
-      }),
-    ],
-    exitCode: 1,
-  });
-  const backend = createClaudeBackend({ spawn: fake.spawn });
-  const { emit, frames } = collect();
-
-  await backend.handle(assign('oversized prompt'), emit, NEVER);
-
-  const terminal = frames.at(-1);
-  assert.ok(terminal && terminal.type === 'task.fail');
-  if (terminal.type === 'task.fail') {
-    assert.equal(terminal.error.code, 'context_length_exceeded');
-    assert.equal(terminal.error.message, 'Prompt is too long');
-  }
-});
-
-test('non-zero claude exit classifies off terminal_reason when the result text is absent', async () => {
-  // blocking_limit rides only on terminal_reason here — no result text. The
-  // classification hint still catches it while the caller-facing message
-  // keeps the diagnostic dump for triage. The padding pushes terminal_reason
-  // out of the stdout tail's last 500 bytes, mirroring real result JSON where
-  // the interesting fields ride early — so this test fails if classification
-  // ever falls back to scraping the diagnostic instead of the hint.
+test('non-zero claude exit with terminal_reason blocking_limit classifies as context_length_exceeded', async () => {
+  // A context overflow where blocking_limit rides only on terminal_reason —
+  // no result text. The override tags the canonical OpenAI code (so the
+  // gateway surfaces 400 context_length_exceeded, oai2a2a#114) while the
+  // caller-facing message keeps the diagnostic dump for triage.
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({
@@ -1579,7 +1543,6 @@ test('non-zero claude exit classifies off terminal_reason when the result text i
         usage: { input_tokens: 0, output_tokens: 0 },
         modelUsage: {},
         permission_denials: [],
-        padding: 'x'.repeat(600),
       }),
     ],
     exitCode: 1,
@@ -1594,6 +1557,37 @@ test('non-zero claude exit classifies off terminal_reason when the result text i
   if (terminal.type === 'task.fail') {
     assert.equal(terminal.error.code, 'context_length_exceeded');
     assert.match(terminal.error.message, /claude exited with code 1/);
+  }
+});
+
+test('explicit failure text beats a stale blocking_limit signal', async () => {
+  // blocking_limit is claude's overflow signal, but a message that classifies
+  // on its own (here: the session-limit quota text) must win — the enum token
+  // never overrides a more specific cause.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        result: "You've hit your session limit · resets 3pm (UTC)",
+        terminal_reason: 'blocking_limit',
+        usage: { input_tokens: 0, output_tokens: 0 },
+        modelUsage: {},
+        permission_denials: [],
+      }),
+    ],
+    exitCode: 1,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('session limit with blocking_limit reason'), emit, NEVER);
+
+  const terminal = frames.at(-1);
+  assert.ok(terminal && terminal.type === 'task.fail');
+  if (terminal.type === 'task.fail') {
+    assert.equal(terminal.error.code, 'quota_exceeded');
   }
 });
 

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1528,6 +1528,75 @@ test('non-zero claude exit carries the terminal reason as a structured code, cle
   }
 });
 
+test('non-zero claude exit on a context overflow classifies as context_length_exceeded', async () => {
+  // A too-long prompt: claude prints "Prompt is too long" in the terminal
+  // result and reports terminal_reason "blocking_limit". The failure must
+  // carry the canonical OpenAI overflow code so the gateway surfaces 400
+  // context_length_exceeded (oai2a2a#114) and the router treats it as a
+  // caller error instead of cooling the agent and failing over the pool.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        result: 'Prompt is too long',
+        terminal_reason: 'blocking_limit',
+        usage: { input_tokens: 0, output_tokens: 0 },
+        modelUsage: {},
+        permission_denials: [],
+      }),
+    ],
+    exitCode: 1,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('oversized prompt'), emit, NEVER);
+
+  const terminal = frames.at(-1);
+  assert.ok(terminal && terminal.type === 'task.fail');
+  if (terminal.type === 'task.fail') {
+    assert.equal(terminal.error.code, 'context_length_exceeded');
+    assert.equal(terminal.error.message, 'Prompt is too long');
+  }
+});
+
+test('non-zero claude exit classifies off terminal_reason when the result text is absent', async () => {
+  // blocking_limit rides only on terminal_reason here — no result text. The
+  // classification hint still catches it while the caller-facing message
+  // keeps the diagnostic dump for triage. The padding pushes terminal_reason
+  // out of the stdout tail's last 500 bytes, mirroring real result JSON where
+  // the interesting fields ride early — so this test fails if classification
+  // ever falls back to scraping the diagnostic instead of the hint.
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        terminal_reason: 'blocking_limit',
+        usage: { input_tokens: 0, output_tokens: 0 },
+        modelUsage: {},
+        permission_denials: [],
+        padding: 'x'.repeat(600),
+      }),
+    ],
+    exitCode: 1,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+
+  await backend.handle(assign('oversized prompt, reason only'), emit, NEVER);
+
+  const terminal = frames.at(-1);
+  assert.ok(terminal && terminal.type === 'task.fail');
+  if (terminal.type === 'task.fail') {
+    assert.equal(terminal.error.code, 'context_length_exceeded');
+    assert.match(terminal.error.message, /claude exited with code 1/);
+  }
+});
+
 test('non-zero claude exit with no terminal reason keeps the diagnostic dump', async () => {
   // No parseable result event → finalText stays empty → fall back to the
   // exit/stdout diagnostic so a real crash is still triageable (#119).

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2145,6 +2145,13 @@ export function createClaudeBackend(
         input: unknown
       } | null = null;
       let finalText: string | null = null;
+      // The run's last `terminal_reason` from the terminal `result` event.
+      // Rides separately from the result text — e.g. a context overflow
+      // reports `terminal_reason: "blocking_limit"` — so a non-zero exit can
+      // be classified by its actual cause even when the result text is absent
+      // or phrased differently. Feeds the classification hint only, never the
+      // caller-facing failure message.
+      let lastTerminalReason: string | null = null;
       // Explicit widening type — without this TS infers a too-narrow type
       // through the `if (parsed) finalUsage = parsed;` assignment when
       // `parseClaudeModelUsageForOpenAICompat` returns `OpenAICompatUsage | null`,
@@ -2568,6 +2575,7 @@ export function createClaudeBackend(
         }
         if (evt.type === 'result') {
           if (typeof evt.result === 'string' && !emittedAskUserQuestion) finalText = evt.result;
+          if (typeof evt.terminal_reason === 'string') lastTerminalReason = evt.terminal_reason;
           if (evt.terminal_reason === 'completed') sawCompletedResult = true;
           if (evt.is_error === true) sawErrorResult = true;
           // Latch off the history prompt-cache split if claude rejected our
@@ -2785,13 +2793,26 @@ export function createClaudeBackend(
         // `completeText` on the success path below) reads the runtime value
         // without tripping control-flow narrowing.
         const reasonText = (finalText ?? '').trim();
+        // Classify off the clean terminal signals — the result text plus the
+        // terminal_reason (e.g. "blocking_limit" for a context overflow, which
+        // never appears in the result text) — rather than the noisy stdout
+        // diagnostic. The hint feeds classification only; the caller-facing
+        // message stays the verbatim reason (or the diagnostic dump when
+        // claude gave no reason, preserving triage data).
+        const terminalReason = (lastTerminalReason ?? '').trim();
+        const classifyHint = [reasonText, terminalReason]
+          .filter((s) => s.length > 0)
+          .join(' ');
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: normalizeTaskFailError({
-            code: 'claude_exit_nonzero',
-            message: reasonText || diagnostic,
-          }),
+          error: normalizeTaskFailError(
+            {
+              code: 'claude_exit_nonzero',
+              message: reasonText || diagnostic,
+            },
+            classifyHint,
+          ),
         });
         return;
       }

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2145,13 +2145,10 @@ export function createClaudeBackend(
         input: unknown
       } | null = null;
       let finalText: string | null = null;
-      // The run's last `terminal_reason` from the terminal `result` event.
-      // Rides separately from the result text — e.g. a context overflow
-      // reports `terminal_reason: "blocking_limit"` — so a non-zero exit can
-      // be classified by its actual cause even when the result text is absent
-      // or phrased differently. Feeds the classification hint only, never the
-      // caller-facing failure message.
-      let lastTerminalReason: string | null = null;
+      // Set when an error result reports terminal_reason "blocking_limit" —
+      // claude's context-window-overflow signal, which rides separately from
+      // the result text. Drives the failure-code override on the exit path.
+      let sawBlockingLimit = false;
       // Explicit widening type — without this TS infers a too-narrow type
       // through the `if (parsed) finalUsage = parsed;` assignment when
       // `parseClaudeModelUsageForOpenAICompat` returns `OpenAICompatUsage | null`,
@@ -2575,9 +2572,13 @@ export function createClaudeBackend(
         }
         if (evt.type === 'result') {
           if (typeof evt.result === 'string' && !emittedAskUserQuestion) finalText = evt.result;
-          if (typeof evt.terminal_reason === 'string') lastTerminalReason = evt.terminal_reason;
           if (evt.terminal_reason === 'completed') sawCompletedResult = true;
-          if (evt.is_error === true) sawErrorResult = true;
+          if (evt.is_error === true) {
+            sawErrorResult = true;
+            // Gated on is_error so a benign reason from an earlier result
+            // can never masquerade as an overflow signal.
+            if (evt.terminal_reason === 'blocking_limit') sawBlockingLimit = true;
+          }
           // Latch off the history prompt-cache split if claude rejected our
           // `cache_control` breakpoint (budget/ordering 400). Gated on this
           // task actually having emitted the marker, so unrelated errors don't
@@ -2793,26 +2794,21 @@ export function createClaudeBackend(
         // `completeText` on the success path below) reads the runtime value
         // without tripping control-flow narrowing.
         const reasonText = (finalText ?? '').trim();
-        // Classify off the clean terminal signals — the result text plus the
-        // terminal_reason (e.g. "blocking_limit" for a context overflow, which
-        // never appears in the result text) — rather than the noisy stdout
-        // diagnostic. The hint feeds classification only; the caller-facing
-        // message stays the verbatim reason (or the diagnostic dump when
-        // claude gave no reason, preserving triage data).
-        const terminalReason = (lastTerminalReason ?? '').trim();
-        const classifyHint = [reasonText, terminalReason]
-          .filter((s) => s.length > 0)
-          .join(' ');
+        const normalized = normalizeTaskFailError({
+          code: 'claude_exit_nonzero',
+          message: reasonText || diagnostic,
+        });
+        // claude signals a context overflow via terminal_reason
+        // "blocking_limit", sometimes with no result text at all. Override
+        // only when the message classified nothing more specific — explicit
+        // quota/rate/overflow text always wins over the bare enum token.
         emit({
           type: 'task.fail',
           taskId: task.taskId,
-          error: normalizeTaskFailError(
-            {
-              code: 'claude_exit_nonzero',
-              message: reasonText || diagnostic,
-            },
-            classifyHint,
-          ),
+          error:
+            normalized.code === 'claude_exit_nonzero' && sawBlockingLimit
+              ? { ...normalized, code: 'context_length_exceeded' }
+              : normalized,
         });
         return;
       }

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -1219,12 +1219,15 @@ test('handle: non-2xx from serve → task.fail upstream_error', async () => {
   assert.ok(failFrame.error.message.includes('overloaded'));
 });
 
-test('handle: in-band error frame (200 stream) → task.fail upstream_error, not empty complete', async () => {
+test('handle: in-band context-window error frame → task.fail context_length_exceeded, not empty complete', async () => {
   // `vicoop-codex serve` relays an upstream `/responses` error (e.g. an
   // oversized context) as `{"error":{...}}` on a 200 SSE stream. The frame has
   // no `choices`, so before the fix it was dropped and the turn synthesized an
   // empty `finish_reason:"stop"` completion (the silent "Response Generated"
-  // with no body). It must now fail the task carrying the upstream message.
+  // with no body). It must now fail the task carrying the upstream message
+  // and, for a context overflow, the canonical `context_length_exceeded`
+  // code (via the shared normalizeTaskFailError matcher) so the gateway
+  // surfaces 400 and OpenAI-SDK callers can compact-and-retry.
   const sse = sseStream([
     { id: 'chatcmpl-x', object: 'chat.completion.chunk', model: 'gpt-5.5', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] },
     { error: { message: 'Your input exceeds the context window of this model. Please adjust your input and try again.', type: 'api_error', code: null } },
@@ -1237,8 +1240,24 @@ test('handle: in-band error frame (200 stream) → task.fail upstream_error, not
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.equal(failFrame.error.code, 'context_length_exceeded');
   assert.ok(failFrame.error.message.includes('context window'));
+});
+
+test('handle: a NON-context in-band error frame stays upstream_error', async () => {
+  const sse = sseStream([
+    { id: 'chatcmpl-y', object: 'chat.completion.chunk', model: 'gpt-5.5', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] },
+    { error: { message: 'The model is overloaded. Please try again later.', type: 'api_error', code: null } },
+  ]);
+  const frames = await runStreaming(makeTask(), makeSseFetch(sse));
+
+  assert.equal(frames.filter((f) => f.type === 'task.complete').length, 0);
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.ok(failFrame.error.message.includes('overloaded'));
 });
 
 test('handle: serve is a shared singleton — two tasks reuse one server', async () => {

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -111,6 +111,85 @@ test('normalizeTaskFailError maps claude subscription/overload terminal reasons'
   );
 });
 
+test('normalizeTaskFailError classifies context overflow with the canonical OpenAI code', () => {
+  // Anthropic phrasing from a claude non-zero exit — a non-retryable CALLER
+  // error. The canonical code lets the gateway surface 400
+  // context_length_exceeded (oai2a2a#114) so clients compact-and-retry, and
+  // keeps the router from cooling the agent / fanning out a doomed failover.
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'claude_exit_nonzero',
+      message: 'Prompt is too long',
+    }).code,
+    'context_length_exceeded',
+  );
+  // OpenAI-style upstream phrasing behind a generic code.
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: "This model's maximum context length is 128000 tokens",
+    }).code,
+    'context_length_exceeded',
+  );
+  // A backend that already tags the canonical code passes through verbatim.
+  assert.deepEqual(
+    normalizeTaskFailError({
+      code: 'context_length_exceeded',
+      message: 'Your input exceeds the context window of this model.',
+    }),
+    {
+      code: 'context_length_exceeded',
+      message: 'Your input exceeds the context window of this model.',
+    },
+  );
+});
+
+test('normalizeTaskFailError classifies claude terminal causes via the classify hint', () => {
+  const noisyMessage = 'claude exited with code 1 [stdout: ..."modelUsage":{}...]';
+  // claude's 5h subscription session window — account exhaustion, not a crash.
+  assert.equal(
+    normalizeTaskFailError(
+      { code: 'claude_exit_nonzero', message: noisyMessage },
+      "You've hit your session limit · resets 12:10pm (UTC)",
+    ).code,
+    'quota_exceeded',
+  );
+  // Server-side throttle: explicitly "not your usage limit" → transient rate
+  // limit, must NOT be misread as quota exhaustion.
+  assert.equal(
+    normalizeTaskFailError(
+      { code: 'claude_exit_nonzero', message: noisyMessage },
+      'API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited',
+    ).code,
+    'rate_limited',
+  );
+  // Context overflow signalled only by the terminal_reason (no result text).
+  assert.equal(
+    normalizeTaskFailError(
+      { code: 'claude_exit_nonzero', message: noisyMessage },
+      'blocking_limit',
+    ).code,
+    'context_length_exceeded',
+  );
+  // Empty hint falls back to matching the message (single-arg behaviour).
+  assert.equal(
+    normalizeTaskFailError(
+      { code: 'claude_exit_nonzero', message: 'Prompt is too long' },
+      '',
+    ).code,
+    'context_length_exceeded',
+  );
+  // The hint feeds classification only — the message is left as-is (modulo
+  // rate-limit phrase canonicalization, which keys off the message itself).
+  assert.equal(
+    normalizeTaskFailError(
+      { code: 'claude_exit_nonzero', message: noisyMessage },
+      'blocking_limit',
+    ).message,
+    noisyMessage,
+  );
+});
+
 test('normalizeTaskFailError maps login and auth failures separately', () => {
   assert.equal(
     normalizeTaskFailError({

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -131,6 +131,16 @@ test('normalizeTaskFailError classifies context overflow with the canonical Open
     }).code,
     'context_length_exceeded',
   );
+  // codex's in-band relay of the upstream overflow, behind the generic
+  // upstream_error code and the serve prefix.
+  assert.equal(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message:
+        'vicoop-codex serve stream error: Your input exceeds the context window of this model. Please adjust your input and try again.',
+    }).code,
+    'context_length_exceeded',
+  );
   // A backend that already tags the canonical code passes through verbatim.
   assert.deepEqual(
     normalizeTaskFailError({

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -131,13 +131,12 @@ test('normalizeTaskFailError classifies context overflow with the canonical Open
     }).code,
     'context_length_exceeded',
   );
-  // codex's in-band relay of the upstream overflow, behind the generic
-  // upstream_error code and the serve prefix.
+  // Gemini phrasing relayed under a generic gateway code (openclaw).
   assert.equal(
     normalizeTaskFailError({
-      code: 'upstream_error',
+      code: 'gateway_chat_error',
       message:
-        'vicoop-codex serve stream error: Your input exceeds the context window of this model. Please adjust your input and try again.',
+        'The input token count (1200000) exceeds the maximum number of tokens allowed (1048576).',
     }).code,
     'context_length_exceeded',
   );
@@ -154,49 +153,43 @@ test('normalizeTaskFailError classifies context overflow with the canonical Open
   );
 });
 
-test('normalizeTaskFailError classifies claude terminal causes via the classify hint', () => {
-  const noisyMessage = 'claude exited with code 1 [stdout: ..."modelUsage":{}...]';
-  // claude's 5h subscription session window — account exhaustion, not a crash.
-  assert.equal(
-    normalizeTaskFailError(
-      { code: 'claude_exit_nonzero', message: noisyMessage },
-      "You've hit your session limit · resets 12:10pm (UTC)",
-    ).code,
-    'quota_exceeded',
-  );
+test('normalizeTaskFailError keeps throttles and generic fragments out of the overflow class', () => {
   // Server-side throttle: explicitly "not your usage limit" → transient rate
   // limit, must NOT be misread as quota exhaustion.
   assert.equal(
-    normalizeTaskFailError(
-      { code: 'claude_exit_nonzero', message: noisyMessage },
-      'API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited',
-    ).code,
+    normalizeTaskFailError({
+      code: 'claude_exit_nonzero',
+      message:
+        'API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited',
+    }).code,
     'rate_limited',
   );
-  // Context overflow signalled only by the terminal_reason (no result text).
+  // The same throttle without the "· Rate limited" suffix still classifies
+  // as a rate limit — the quota guard hands the text off, never drops it.
   assert.equal(
-    normalizeTaskFailError(
-      { code: 'claude_exit_nonzero', message: noisyMessage },
-      'blocking_limit',
-    ).code,
-    'context_length_exceeded',
+    normalizeTaskFailError({
+      code: 'claude_exit_nonzero',
+      message: 'API Error: Server is temporarily limiting requests (not your usage limit)',
+    }).code,
+    'rate_limited',
   );
-  // Empty hint falls back to matching the message (single-arg behaviour).
+  // A TPM-style throttle mentioning tokens is a rate limit, not an overflow.
   assert.equal(
-    normalizeTaskFailError(
-      { code: 'claude_exit_nonzero', message: 'Prompt is too long' },
-      '',
-    ).code,
-    'context_length_exceeded',
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: '429 Too Many Requests: too many tokens per minute, retry after 20s',
+    }).code,
+    'rate_limited',
   );
-  // The hint feeds classification only — the message is left as-is (modulo
-  // rate-limit phrase canonicalization, which keys off the message itself).
+  // Assistant prose quoted in a crash diagnostic must not classify: generic
+  // fragments ("context length", "too many tokens") are not overflow signals.
   assert.equal(
-    normalizeTaskFailError(
-      { code: 'claude_exit_nonzero', message: noisyMessage },
-      'blocking_limit',
-    ).message,
-    noisyMessage,
+    normalizeTaskFailError({
+      code: 'claude_exit_nonzero',
+      message:
+        'claude exited with code 1 [stdout: ..."text":"we discussed context length limits and too many tokens"...]',
+    }).code,
+    'claude_exit_nonzero',
   );
 });
 

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -6,6 +6,11 @@ export interface TaskFailError {
 const PRESERVED_INPUT_CODES = new Set([
   'empty_prompt',
   'invalid_input',
+  // Canonical OpenAI code for a context-window overflow. Backends tag it
+  // directly (codex: in-band "exceeds the context window" frames, #402) and
+  // the gateway maps it to 400 (oai2a2a#114/#115) so OpenAI-compatible
+  // clients can compact-and-retry. Must survive normalization verbatim.
+  'context_length_exceeded',
   'invalid_file_part',
   'unsupported_file_uri',
   'unsupported_file_mime',
@@ -42,9 +47,18 @@ const SEMANTIC_CODES = new Set([
   'timeout',
 ]);
 
-export function normalizeTaskFailError(error: TaskFailError): TaskFailError {
+// `classifyText`, when provided, is matched INSTEAD of the (often noisy) human
+// message — callers that have a clean terminal signal (e.g. claude's terminal
+// `result` error string + `terminal_reason`) pass it so classification keys
+// off the actual cause rather than an opaque stdout dump. Falls back to
+// `message` when the hint is empty, preserving the single-arg behaviour.
+export function normalizeTaskFailError(
+  error: TaskFailError,
+  classifyText?: string,
+): TaskFailError {
   const { code, message } = error;
-  const normalizedCode = classifyFailureCode(code, message);
+  const basis = classifyText && classifyText.trim() ? classifyText : message;
+  const normalizedCode = classifyFailureCode(code, basis);
   const normalizedMessage = canonicalizeFailureMessage(normalizedCode, message);
 
   if (normalizedCode === error.code && normalizedMessage === error.message) {
@@ -58,6 +72,14 @@ function classifyFailureCode(code: string, message: string): string {
   if (PRESERVED_INPUT_CODES.has(code)) return code;
 
   const text = `${code} ${message}`.toLowerCase();
+  // A context overflow is a non-retryable CALLER error: no pool member can
+  // serve the same oversized prompt, so it must not look like quota/agent
+  // unavailability (which would cool the agent down and fan out a doomed
+  // failover). Match it first — overflow texts mention limits/tokens that
+  // later matchers could misread — and use the canonical OpenAI code so the
+  // gateway surfaces 400 context_length_exceeded (oai2a2a#114) and clients
+  // can compact-and-retry.
+  if (isContextOverflow(text)) return 'context_length_exceeded';
   if (isQuotaExceeded(text)) return 'quota_exceeded';
   if (isRateLimited(text)) return 'rate_limited';
   if (isLoginRequired(text)) return 'login_required';
@@ -90,12 +112,31 @@ function canonicalizeFailureMessage(code: string, message: string): string {
   return message;
 }
 
+function isContextOverflow(text: string): boolean {
+  // Claude surfaces "Prompt is too long" and the terminal result carries
+  // terminal_reason "blocking_limit"; OpenAI-style upstreams say "context
+  // length" / "maximum context" / "too many tokens".
+  return (
+    text.includes('prompt is too long') ||
+    text.includes('prompt too long') ||
+    text.includes('input is too long') ||
+    text.includes('blocking_limit') ||
+    text.includes('context length') ||
+    text.includes('context_length_exceeded') ||
+    text.includes('maximum context') ||
+    text.includes('too many tokens')
+  );
+}
+
 function isQuotaExceeded(text: string): boolean {
   return (
     /\bquota\b/.test(text) ||
     text.includes('insufficient_quota') ||
     text.includes('exceeded your current quota') ||
-    text.includes('usage limit') ||
+    // "usage limit", but NOT the server-throttle disclaimer "Server is
+    // temporarily limiting requests (not your usage limit)" — that's a
+    // transient rate limit (classified below), not account exhaustion.
+    (text.includes('usage limit') && !text.includes('not your usage limit')) ||
     // Claude subscription cap: "You've hit your session limit · resets 3pm (UTC)".
     text.includes('session limit')
   );

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -6,10 +6,8 @@ export interface TaskFailError {
 const PRESERVED_INPUT_CODES = new Set([
   'empty_prompt',
   'invalid_input',
-  // Canonical OpenAI code for a context-window overflow. Backends tag it
-  // directly (codex: in-band "exceeds the context window" frames, #402) and
-  // the gateway maps it to 400 (oai2a2a#114/#115) so OpenAI-compatible
-  // clients can compact-and-retry. Must survive normalization verbatim.
+  // Canonical OpenAI overflow code — tagged by backends and mapped to 400
+  // by the gateway (oai2a2a#114); must survive normalization verbatim.
   'context_length_exceeded',
   'invalid_file_part',
   'unsupported_file_uri',
@@ -47,18 +45,9 @@ const SEMANTIC_CODES = new Set([
   'timeout',
 ]);
 
-// `classifyText`, when provided, is matched INSTEAD of the (often noisy) human
-// message — callers that have a clean terminal signal (e.g. claude's terminal
-// `result` error string + `terminal_reason`) pass it so classification keys
-// off the actual cause rather than an opaque stdout dump. Falls back to
-// `message` when the hint is empty, preserving the single-arg behaviour.
-export function normalizeTaskFailError(
-  error: TaskFailError,
-  classifyText?: string,
-): TaskFailError {
+export function normalizeTaskFailError(error: TaskFailError): TaskFailError {
   const { code, message } = error;
-  const basis = classifyText && classifyText.trim() ? classifyText : message;
-  const normalizedCode = classifyFailureCode(code, basis);
+  const normalizedCode = classifyFailureCode(code, message);
   const normalizedMessage = canonicalizeFailureMessage(normalizedCode, message);
 
   if (normalizedCode === error.code && normalizedMessage === error.message) {
@@ -72,13 +61,8 @@ function classifyFailureCode(code: string, message: string): string {
   if (PRESERVED_INPUT_CODES.has(code)) return code;
 
   const text = `${code} ${message}`.toLowerCase();
-  // A context overflow is a non-retryable CALLER error: no pool member can
-  // serve the same oversized prompt, so it must not look like quota/agent
-  // unavailability (which would cool the agent down and fan out a doomed
-  // failover). Match it first — overflow texts mention limits/tokens that
-  // later matchers could misread — and use the canonical OpenAI code so the
-  // gateway surfaces 400 context_length_exceeded (oai2a2a#114) and clients
-  // can compact-and-retry.
+  // Overflow first — its texts mention limits/tokens that later matchers
+  // could misread. Full rationale at CONTEXT_OVERFLOW_PATTERNS.
   if (isContextOverflow(text)) return 'context_length_exceeded';
   if (isQuotaExceeded(text)) return 'quota_exceeded';
   if (isRateLimited(text)) return 'rate_limited';
@@ -112,22 +96,29 @@ function canonicalizeFailureMessage(code: string, message: string): string {
   return message;
 }
 
+// Context-window overflow. This matcher is the effective classifier for the
+// gateway's 400 `context_length_exceeded` mapping — a tagged code bypasses
+// the gateway's own (deliberately narrow) message-rescue gate — and it runs
+// before the quota/rate matchers, so every entry must be a phrase a provider
+// actually emits for overflow, never a generic fragment: bare substrings
+// like "context length" or "too many tokens" would reclassify TPM rate
+// limits or assistant prose quoted in crash diagnostics as non-retryable
+// caller errors. Matched against lowercased text.
+// (claude's terminal_reason "blocking_limit" signal is handled in claude.ts,
+// the layer that knows that enum — not here.)
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /prompt is too long/, // Anthropic
+  /input is too long for requested model/, // Anthropic (Bedrock)
+  /input length and max_tokens exceed context limit/, // Anthropic
+  /exceeds the context window/, // OpenAI /responses (relayed by codex serve)
+  /maximum context length is \d+ tokens/, // OpenAI chat completions
+  /reduce the length of the messages/, // OpenAI (second half of the same message)
+  /input token count.*exceeds the maximum/, // Gemini
+  /context[_ ]?length[_ ]?exceeded/, // the code token quoted in relayed error bodies
+];
+
 function isContextOverflow(text: string): boolean {
-  // Claude surfaces "Prompt is too long" and the terminal result carries
-  // terminal_reason "blocking_limit"; codex relays the upstream "Your input
-  // exceeds the context window of this model"; other OpenAI-style upstreams
-  // say "context length" / "maximum context" / "too many tokens".
-  return (
-    text.includes('prompt is too long') ||
-    text.includes('prompt too long') ||
-    text.includes('input is too long') ||
-    text.includes('blocking_limit') ||
-    text.includes('exceeds the context window') ||
-    text.includes('context length') ||
-    text.includes('context_length_exceeded') ||
-    text.includes('maximum context') ||
-    text.includes('too many tokens')
-  );
+  return CONTEXT_OVERFLOW_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 function isQuotaExceeded(text: string): boolean {
@@ -151,6 +142,11 @@ function isRateLimited(text: string): boolean {
     text.includes('rate-limited') ||
     text.includes('rate limited') ||
     text.includes('too many requests') ||
+    // Anthropic server-side throttle: "Server is temporarily limiting
+    // requests (not your usage limit)" — a transient rate limit even when
+    // the "· Rate limited" suffix is absent (the quota guard above hands
+    // this text off rather than dropping it).
+    text.includes('temporarily limiting requests') ||
     /\b429\b/.test(text)
   );
 }

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -114,13 +114,15 @@ function canonicalizeFailureMessage(code: string, message: string): string {
 
 function isContextOverflow(text: string): boolean {
   // Claude surfaces "Prompt is too long" and the terminal result carries
-  // terminal_reason "blocking_limit"; OpenAI-style upstreams say "context
-  // length" / "maximum context" / "too many tokens".
+  // terminal_reason "blocking_limit"; codex relays the upstream "Your input
+  // exceeds the context window of this model"; other OpenAI-style upstreams
+  // say "context length" / "maximum context" / "too many tokens".
   return (
     text.includes('prompt is too long') ||
     text.includes('prompt too long') ||
     text.includes('input is too long') ||
     text.includes('blocking_limit') ||
+    text.includes('exceeds the context window') ||
     text.includes('context length') ||
     text.includes('context_length_exceeded') ||
     text.includes('maximum context') ||


### PR DESCRIPTION
> **Rescoped** (2026-07-07): rebuilt on top of #403 and switched the overflow code from `invalid_input` to the canonical **`context_length_exceeded`**, aligned with the gateway-side mapping in planetarium/oai2a2a#115 (merged). #403 already absorbed this PR's original terminal-reason capture and session-limit/overload classification. The overflow matcher lives in the **shared** `normalizeTaskFailError`, so it also covers the codex backend's in-band relay — **supersedes #402** (its backend-level tests are ported here).
>
> **Hardened** (2026-07-08) by a multi-agent deep review (8 angles → 23 candidates → verified): the classify-hint plumbing was dropped entirely, `blocking_limit` moved to a claude.ts post-classification override, the pattern list tightened to provider-evidenced phrasings (+ Gemini), and the throttle-disclaimer hole closed — details below.

## Problem

A context-window overflow collapses into an opaque generic code — claude: `Prompt is too long` / `terminal_reason: blocking_limit` → `claude_exit_nonzero`; codex: the relayed in-band `Your input exceeds the context window …` → `upstream_error`. The gateway surfaces a generic 502, OpenAI-compatible clients can't classify it as an overflow (no compact-and-retry), and the router treats it as agent unavailability — cooling the member down and fanning out a doomed failover that can **empty the whole pool** for a single oversized prompt.

Separately, `isQuotaExceeded`'s `usage limit` pattern mis-tags the explicit server-throttle disclaimer `… (not your usage limit) · Rate limited` as **quota exhaustion** — it's a transient rate limit.

## Fix

**`failure-code.ts`**
- New context-overflow matcher, checked **first** among the text matchers → **`context_length_exceeded`**, for every backend that routes failures through `normalizeTaskFailError`. Patterns are **provider-evidenced phrasings only** (Anthropic ×3, OpenAI digit-anchored ×2, codex-relayed `exceeds the context window`, Gemini `input token count … exceeds the maximum`, plus the quoted code token) — no generic fragments: `too many tokens` would convert TPM throttles into caller errors, and `context length`/`maximum context` would match assistant prose quoted in crash diagnostics. This matters because a bridge-assigned code bypasses the gateway's own narrow message-rescue gate (code → 400 unconditionally).
- `context_length_exceeded` added to the preserved codes so a backend that tags it directly survives normalization verbatim.
- `usage limit` guarded against `not your usage limit`, and `temporarily limiting requests` added to `isRateLimited` — the throttle classifies as `rate_limited` with or without its `· Rate limited` suffix (previously the suffix-less variant fell to a generic code).

**`claude.ts`**
- claude's `terminal_reason: "blocking_limit"` (an overflow signal that can arrive with **no result text**) is a **post-classification override**, latched only from `is_error` results: it tags `context_length_exceeded` only when the failure message classified nothing more specific — explicit quota/rate/overflow text always beats the bare enum token (whose overflow-exclusivity is unverified), and a stale reason can't hijack an unrelated failure.
- `normalizeTaskFailError` stays single-arg: the review showed the original classify-hint design both regressed message classification (a reason-only hint suppressed diagnostic signals like `econnreset`/`401`) and was redundant post-#403 (the message already *is* the clean reason text when one exists).

No codex backend change needed — its in-band error reaches the shared matcher as `upstream_error` + message.

## Tests

- `failure-code.test.ts`: overflow matrix (claude / OpenAI digit-anchored / Gemini / tagged passthrough); negatives (TPM throttle → `rate_limited`, assistant-prose diagnostic stays `claude_exit_nonzero`, suffix-less throttle → `rate_limited`).
- `claude.test.ts`: e2e `blocking_limit`-only overflow → `context_length_exceeded` with the diagnostic message; e2e session-limit text + stale `blocking_limit` → `quota_exceeded` (text beats token).
- `vicoop-codex.test.ts` (ported from #402): in-band context-window frame → `context_length_exceeded`; non-context in-band error stays `upstream_error`.

`pnpm -C packages/client typecheck` clean; full client suite **804/804** pass.

Refs planetarium/oai2a2a#114 · planetarium/oai2a2a#115 · #402 · #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)