### PR TITLE
fix(vicoop-codex): surface in-band SSE error frames as task failures

### DIFF
--- a/.changeset/vicoop-codex-inband-error-frame.md
+++ b/.changeset/vicoop-codex-inband-error-frame.md
@@ -1,0 +1,15 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+fix(vicoop-codex): surface in-band SSE error frames as task failures
+
+`vicoop-codex serve` relays an upstream `/responses` error (e.g. "input
+exceeds the context window") as a `{"error":{...}}` frame on an otherwise-200
+SSE stream. The stream consumer only understood `choices`-bearing chunks, so
+it silently dropped the error frame, accumulated nothing, and synthesized an
+empty `finish_reason:"stop"` completion with no usage — the silent
+"Response Generated" with an empty body (and a `$0`-billed turn).
+
+Detect an in-band error frame and fail the task with `upstream_error`
+carrying the upstream message, instead of completing empty.

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -1219,6 +1219,28 @@ test('handle: non-2xx from serve → task.fail upstream_error', async () => {
   assert.ok(failFrame.error.message.includes('overloaded'));
 });
 
+test('handle: in-band error frame (200 stream) → task.fail upstream_error, not empty complete', async () => {
+  // `vicoop-codex serve` relays an upstream `/responses` error (e.g. an
+  // oversized context) as `{"error":{...}}` on a 200 SSE stream. The frame has
+  // no `choices`, so before the fix it was dropped and the turn synthesized an
+  // empty `finish_reason:"stop"` completion (the silent "Response Generated"
+  // with no body). It must now fail the task carrying the upstream message.
+  const sse = sseStream([
+    { id: 'chatcmpl-x', object: 'chat.completion.chunk', model: 'gpt-5.5', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] },
+    { error: { message: 'Your input exceeds the context window of this model. Please adjust your input and try again.', type: 'api_error', code: null } },
+  ]);
+  const frames = await runStreaming(makeTask(), makeSseFetch(sse));
+
+  // No empty completion slipped through.
+  assert.equal(frames.filter((f) => f.type === 'task.complete').length, 0);
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.ok(failFrame.error.message.includes('context window'));
+});
+
 test('handle: serve is a shared singleton — two tasks reuse one server', async () => {
   const fake = makeFakeSpawn();
   const sse = sseStream([

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -748,6 +748,12 @@ interface ChatCompletionChunk {
     finish_reason?: string | null;
   }>;
   usage?: ChatCompletionResponse['usage'];
+  // In-band error frame. `vicoop-codex serve` relays an upstream `/responses`
+  // error (e.g. "input exceeds the context window") as `{"error":{...}}` on an
+  // otherwise-200 SSE stream. It carries no `choices`, so without explicit
+  // handling the accumulator drops it and the turn synthesizes an empty
+  // `finish_reason:"stop"` completion — a silent empty answer.
+  error?: { message?: string; type?: string; code?: string | null } | null;
 }
 
 // Per-index tool-call assembly buffer. OpenAI streams a tool call's
@@ -892,8 +898,13 @@ async function streamChatCompletions(
   }
 
   const acc: StreamAccumulator = { content: '', toolCalls: new Map() };
-  // Process one `data:` payload; returns true when the stream's `[DONE]`
-  // sentinel is seen so the reader can stop.
+  // Set when an in-band `{"error":{...}}` frame is seen. Thrown after the read
+  // loop (NOT from inside `consume`, whose throws are caught and re-wrapped as
+  // a generic "stream interrupted" transport error below — that would mask the
+  // upstream message and a2a code).
+  let streamError: ServeRequestError | null = null;
+  // Process one `data:` payload; returns true when the stream should stop —
+  // the `[DONE]` sentinel or a terminal error frame.
   const consume = (data: string): boolean => {
     if (data === '[DONE]') return true;
     let chunk: ChatCompletionChunk;
@@ -903,6 +914,18 @@ async function streamChatCompletions(
       // Defensive: OpenAI guarantees valid JSON per data line, but a stray
       // keep-alive / comment shouldn't abort the turn — skip it.
       return false;
+    }
+    // In-band error frame (200 stream): surface it as a task failure carrying
+    // the upstream message instead of dropping it and completing empty. This is
+    // the path the oversized-context "input exceeds the context window" error
+    // takes — serve relays it here, and it has no `choices` for applyChunk.
+    if (chunk.error && typeof chunk.error === 'object') {
+      const msg =
+        typeof chunk.error.message === 'string' && chunk.error.message.length > 0
+          ? chunk.error.message
+          : 'vicoop-codex serve reported an upstream error with no message';
+      streamError = new ServeRequestError('upstream_error', `vicoop-codex serve stream error: ${msg}`);
+      return true; // terminal — stop reading
     }
     applyChunk(acc, chunk, onContentDelta, onReasoningDelta);
     return false;
@@ -943,6 +966,11 @@ async function streamChatCompletions(
       `vicoop-codex serve stream interrupted: ${errorMessage(err)}`,
     );
   }
+
+  // A terminal error frame outranks whatever (empty) content accumulated —
+  // thrown here, outside the transport catch, so its message and a2a code
+  // survive to the handler's `task.fail` instead of a silent empty completion.
+  if (streamError) throw streamError;
 
   return synthesizeStreamedResponse(acc);
 }


### PR DESCRIPTION
## Problem

`vicoop-codex serve` relays an upstream `/responses` error — e.g. **`Your input exceeds the context window of this model`** — as a `{"error":{...}}` frame on an otherwise-**200** SSE stream.

`streamChatCompletions`'s consumer only understood `choices`-bearing chunks: `applyChunk` early-returns on a frame with no `choices`. So the error frame was **silently dropped**, nothing accumulated, and `synthesizeStreamedResponse` produced an empty `finish_reason:"stop"` completion with no usage.

To the user that surfaced as a **"Response Generated" banner with an empty body**; downstream logged the tell-tale `finish_reason="stop"` + "carried no usage" + `artifacts=0` and a `$0`-billed turn.

## Root cause (how it was found)

Operational incident: a vicoop-codex (GPT-5.5) agent returned empty answers around KST 13:05. The captured A2A tasks (`infra.a2a_tasks.task_json`) held the exact model input — accumulated agent sessions of **900 / 1833 messages (~430K–550K est tokens)**. Replaying those transcripts through a dev `serve` reproduced it deterministically: upstream returns this **in-band error frame** ("exceeds the context window"), which `serve` relays correctly. The drop was here, on the client.

## Change

- Detect an in-band `{"error":{...}}` frame in `consume`, stash it as `ServeRequestError('upstream_error', …)`, and throw it **after** the read loop — outside the transport `catch` that would otherwise re-wrap it as a generic "stream interrupted", masking the upstream message + a2a code.
- The turn now fails with the real upstream message instead of completing empty.

## Test

`handle: in-band error frame (200 stream) → task.fail upstream_error, not empty complete` — asserts no `task.complete` slips through and the `task.fail` carries `upstream_error` + the "context window" message. Full `vicoop-codex` suite (46 tests) green; `typecheck` clean.

## Related

Independent hardening in vicoop-codex-cli (planetarium/vicoop-codex-cli#31) handles the separate `response.incomplete` empty-stop path. This PR fixes the actual cause of the empty-response incident. A context-bloat guard (history windowing) to avoid sending 900–1833-message contexts at all is a recommended follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)