### PR TITLE
fix(vicoop-codex): tag context-window overflows with context_length_exceeded

### DIFF
--- a/.changeset/vicoop-codex-context-overflow-code.md
+++ b/.changeset/vicoop-codex-context-overflow-code.md
@@ -1,0 +1,14 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+fix(vicoop-codex): tag context-window overflows with `context_length_exceeded`
+
+When `vicoop-codex serve` relays an upstream "input exceeds the context window"
+error, the bridge now tags the resulting `task.fail` with the standard
+`context_length_exceeded` code instead of the generic `upstream_error`. The
+codec passes this terminal code through verbatim into the OpenAI error
+envelope, so OpenAI-SDK callers can recognise it as a context overflow (e.g.
+non-streaming opencode classifies it via `parseAPICallError` and can
+compact-and-retry) rather than treating it as an opaque upstream failure. Any
+other in-band error stays `upstream_error`.

--- a/packages/client/src/backends/vicoop-codex.test.ts
+++ b/packages/client/src/backends/vicoop-codex.test.ts
@@ -1219,12 +1219,14 @@ test('handle: non-2xx from serve → task.fail upstream_error', async () => {
   assert.ok(failFrame.error.message.includes('overloaded'));
 });
 
-test('handle: in-band error frame (200 stream) → task.fail upstream_error, not empty complete', async () => {
+test('handle: in-band context-window error frame → task.fail context_length_exceeded, not empty complete', async () => {
   // `vicoop-codex serve` relays an upstream `/responses` error (e.g. an
   // oversized context) as `{"error":{...}}` on a 200 SSE stream. The frame has
   // no `choices`, so before the fix it was dropped and the turn synthesized an
   // empty `finish_reason:"stop"` completion (the silent "Response Generated"
-  // with no body). It must now fail the task carrying the upstream message.
+  // with no body). It must now fail the task carrying the upstream message AND,
+  // for a context overflow, tag it with the standard `context_length_exceeded`
+  // code so OpenAI-SDK callers can compact-and-retry.
   const sse = sseStream([
     { id: 'chatcmpl-x', object: 'chat.completion.chunk', model: 'gpt-5.5', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] },
     { error: { message: 'Your input exceeds the context window of this model. Please adjust your input and try again.', type: 'api_error', code: null } },
@@ -1237,8 +1239,24 @@ test('handle: in-band error frame (200 stream) → task.fail upstream_error, not
   assert.equal(fails.length, 1);
   const failFrame = fails[0];
   if (failFrame.type !== 'task.fail') throw new Error('unreachable');
-  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.equal(failFrame.error.code, 'context_length_exceeded');
   assert.ok(failFrame.error.message.includes('context window'));
+});
+
+test('handle: a NON-context in-band error frame stays upstream_error', async () => {
+  const sse = sseStream([
+    { id: 'chatcmpl-y', object: 'chat.completion.chunk', model: 'gpt-5.5', choices: [{ index: 0, delta: { role: 'assistant', content: '' }, finish_reason: null }] },
+    { error: { message: 'The model is overloaded. Please try again later.', type: 'api_error', code: null } },
+  ]);
+  const frames = await runStreaming(makeTask(), makeSseFetch(sse));
+
+  assert.equal(frames.filter((f) => f.type === 'task.complete').length, 0);
+  const fails = frames.filter((f) => f.type === 'task.fail');
+  assert.equal(fails.length, 1);
+  const failFrame = fails[0];
+  if (failFrame.type !== 'task.fail') throw new Error('unreachable');
+  assert.equal(failFrame.error.code, 'upstream_error');
+  assert.ok(failFrame.error.message.includes('overloaded'));
 });
 
 test('handle: serve is a shared singleton — two tasks reuse one server', async () => {

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -709,6 +709,24 @@ export function parseServeListeningUrl(line: string): string | null {
   return null;
 }
 
+// Recognise an upstream "input exceeds the context window" failure from its
+// message text, so it can be tagged with the standard `context_length_exceeded`
+// code rather than a generic `upstream_error`. The vicoop-codex backend
+// (ChatGPT Codex) returns this as a plain message with no machine code, so a
+// text match is the only signal. Patterns mirror the ones OpenAI-SDK agents
+// (e.g. opencode's `isContextOverflow`) use to detect the same condition.
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /exceeds the context window/i,
+  /context[_ ]length[_ ]exceeded/i,
+  /maximum context length is \d+/i,
+  /reduce the length of the messages/i,
+  /prompt is too long/i,
+  /input is too long/i,
+];
+function isContextOverflowMessage(message: string): boolean {
+  return CONTEXT_OVERFLOW_PATTERNS.some((re) => re.test(message));
+}
+
 // A typed error carrying the A2A `task.fail` code the streaming layer wants
 // the handler to surface, so HTTP/transport failures map cleanly without the
 // handler re-inspecting error shapes.
@@ -924,7 +942,15 @@ async function streamChatCompletions(
         typeof chunk.error.message === 'string' && chunk.error.message.length > 0
           ? chunk.error.message
           : 'vicoop-codex serve reported an upstream error with no message';
-      streamError = new ServeRequestError('upstream_error', `vicoop-codex serve stream error: ${msg}`);
+      // Classify a context-window overflow into the standard OpenAI error code
+      // `context_length_exceeded`. The codec passes this terminal code through
+      // verbatim into the OpenAI error envelope, so OpenAI-SDK callers (and
+      // agents like opencode) can recognise it as a context overflow and react
+      // — e.g. compact the conversation and retry — instead of treating it as a
+      // generic, unrecoverable upstream failure. Any other in-band error stays
+      // `upstream_error`.
+      const code = isContextOverflowMessage(msg) ? 'context_length_exceeded' : 'upstream_error';
+      streamError = new ServeRequestError(code, `vicoop-codex serve stream error: ${msg}`);
       return true; // terminal — stop reading
     }
     applyChunk(acc, chunk, onContentDelta, onReasoningDelta);


### PR DESCRIPTION
## What

When `vicoop-codex serve` relays an upstream **"Your input exceeds the context window of this model"** error as an in-band SSE error frame, the bridge now classifies it from the message and tags the `task.fail` with the standard OpenAI code **`context_length_exceeded`** instead of the generic `upstream_error`. Any other in-band error stays `upstream_error`.

The codec (`@planetarium/oai2a2a-codec`) passes this terminal code through verbatim into the OpenAI error envelope (`mapA2ATerminalError` reads the bridge's `terminal_error.code`), so OpenAI-SDK callers receive `code: "context_length_exceeded"`.

## Why

Follow-up to the in-band-error-frame fix (#400). Standardising the code lets OpenAI-SDK clients recognise a context overflow instead of an opaque upstream failure:
- **Non-streaming opencode** classifies a 502 context-overflow via `parseAPICallError` (matches both the message and `error.code === "context_length_exceeded"`) → can compact-and-retry.
- Any client keying on the OpenAI error code gets a meaningful, standard value.

## Scope note (verified empirically)

This does **not** make *streaming* opencode auto-recover. `@ai-sdk/openai-compatible` collapses an in-band `{error:{...}}` chunk to just its message string (drops `code`/`type`) before opencode sees it, and opencode's `parseStreamError` is code/type-based (never message-matches). So no bridge/router/codec change reaches opencode's classifier on the stream path — that gap is upstream in opencode/the AI SDK. Tracked separately:
- Proactive route (the working lever for opencode): planetarium/vicoop-router#124 (serve `/.well-known/opencode` with per-model `limit.context`), or client-side `opencode.json` `limit`.

This PR is the correct, low-cost standardisation regardless; it's semantically right and helps non-streaming / non-AI-SDK clients.

## Test

- `handle: in-band context-window error frame → task.fail context_length_exceeded, not empty complete`
- `handle: a NON-context in-band error frame stays upstream_error`

Full `vicoop-codex` suite green; `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)