### PR TITLE
fix(upgrade): resolve latest release via GitHub Atom feed, not REST API

### DIFF
--- a/.changeset/upgrade-atom-feed.md
+++ b/.changeset/upgrade-atom-feed.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+upgrade: resolve the latest release from the public GitHub Atom feed
+(`github.com/<repo>/releases.atom`) instead of the `api.github.com` REST
+API. The REST API caps unauthenticated requests at 60/hr per IP, so
+`vicoop-client upgrade` / `upgrade --check` would fail with a hard
+`403 rate limit exceeded` on shared provider egress IPs — exactly when
+an operator is rolling out a release (#405). The web feed has its own,
+far more generous anonymous limit and needs no `GITHUB_TOKEN`.

--- a/packages/client/src/upgrade.test.ts
+++ b/packages/client/src/upgrade.test.ts
@@ -7,6 +7,7 @@ import {
   assertLooksLikeInstall,
   assetName,
   normalizeTag,
+  parseAtomTags,
   parseChecksum,
   resolvePlatformAsset,
   runUpgrade,
@@ -51,6 +52,46 @@ test('normalizeTag rejects path-traversal and shell-metacharacter payloads', () 
   ]) {
     assert.throws(() => normalizeTag(bad), /invalid version/, `expected rejection for ${JSON.stringify(bad)}`);
   }
+});
+
+// A trimmed-down copy of the real `releases.atom` shape: a feed-level <id>
+// (which must NOT be mistaken for a release), then entries newest-first whose
+// release tag lives in the entry <id> as `...Repository/<repoId>/<tag>`.
+const ATOM_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>tag:github.com,2008:https://github.com/planetarium/vicoop-bridge/releases</id>
+  <title>Release notes from vicoop-bridge</title>
+  <entry>
+    <id>tag:github.com,2008:Repository/1211055185/@vicoop-bridge/client@0.35.3</id>
+    <title>@vicoop-bridge/client@0.35.3</title>
+  </entry>
+  <entry>
+    <id>tag:github.com,2008:Repository/1211055185/@vicoop-bridge/client@0.35.2</id>
+    <title>a custom release name, not the tag</title>
+  </entry>
+</feed>`;
+
+test('parseAtomTags reads release tags from entry ids, newest first', () => {
+  assert.deepEqual(parseAtomTags(ATOM_FIXTURE), [
+    '@vicoop-bridge/client@0.35.3',
+    '@vicoop-bridge/client@0.35.2',
+  ]);
+});
+
+test('parseAtomTags ignores the feed-level id and prefers the id over a custom title', () => {
+  const tags = parseAtomTags(ATOM_FIXTURE);
+  // The feed-level <id> (the releases URL) must not leak in as a tag.
+  assert.ok(!tags.some((t) => t.includes('https://')));
+  // Second entry has a non-tag <title>; the id still yields the real tag.
+  assert.equal(tags[1], '@vicoop-bridge/client@0.35.2');
+});
+
+test('parseAtomTags returns [] for an empty or entry-less feed', () => {
+  assert.deepEqual(parseAtomTags(''), []);
+  assert.deepEqual(
+    parseAtomTags('<feed><id>tag:github.com,2008:https://x/releases</id></feed>'),
+    [],
+  );
 });
 
 test('parseChecksum extracts hash from `<hash>  <path>` and bare-hash forms', () => {

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -23,9 +23,11 @@ const REPO = 'planetarium/vicoop-bridge';
 // close to this timeout is a regression we'd rather surface than block on.
 const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
-// Short cap for the GitHub release-feed lookup. A stalled DNS resolution or
-// captive portal shouldn't strand the operator on a hung process.
-const API_TIMEOUT_MS = 15_000;
+// Short cap for the small metadata fetches (the release-feed lookup and the
+// checksum file), as opposed to the large binary download below. A stalled
+// DNS resolution or captive portal shouldn't strand the operator on a hung
+// process.
+const METADATA_TIMEOUT_MS = 15_000;
 
 // Generous cap for the actual asset download. `AbortSignal.timeout` is a
 // total-operation timeout, so this has to cover slow-but-real networks
@@ -330,7 +332,7 @@ async function resolveLatestTag(): Promise<string> {
   const res = await fetchWithTimeout(
     url,
     { headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/atom+xml' } },
-    API_TIMEOUT_MS,
+    METADATA_TIMEOUT_MS,
   );
   if (!res.ok) {
     throw new Error(`GitHub releases feed request failed: ${res.status} ${res.statusText} (${url})`);
@@ -381,7 +383,7 @@ async function download(url: string, dest: string): Promise<void> {
 }
 
 async function downloadText(url: string): Promise<string> {
-  const res = await fetchWithTimeout(url, { redirect: 'follow' }, API_TIMEOUT_MS);
+  const res = await fetchWithTimeout(url, { redirect: 'follow' }, METADATA_TIMEOUT_MS);
   if (!res.ok) {
     throw new Error(`download failed: ${res.status} ${res.statusText || ''} (${url})`.trim());
   }

--- a/packages/client/src/upgrade.ts
+++ b/packages/client/src/upgrade.ts
@@ -23,8 +23,8 @@ const REPO = 'planetarium/vicoop-bridge';
 // close to this timeout is a regression we'd rather surface than block on.
 const HEALTHCHECK_TIMEOUT_MS = 10_000;
 
-// Short cap for GitHub API calls. A stalled DNS resolution or captive portal
-// shouldn't strand the operator on a hung process.
+// Short cap for the GitHub release-feed lookup. A stalled DNS resolution or
+// captive portal shouldn't strand the operator on a hung process.
 const API_TIMEOUT_MS = 15_000;
 
 // Generous cap for the actual asset download. `AbortSignal.timeout` is a
@@ -298,31 +298,50 @@ function assertSafeTag(tag: string, raw: string = tag): void {
   }
 }
 
+// Pull release tags out of a GitHub `releases.atom` feed, in feed order
+// (newest first). The tag is read from each `<entry>`'s `<id>`
+// (`tag:github.com,2008:Repository/<repoId>/<TAG>`) rather than `<title>`,
+// because a release title can be a custom name while the id always carries
+// the literal git tag. Exported for unit testing without network IO.
+export function parseAtomTags(xml: string): string[] {
+  const tags: string[] = [];
+  const idRe = /<id>\s*tag:github\.com,\d+:Repository\/\d+\/([\s\S]*?)\s*<\/id>/;
+  for (const entry of xml.matchAll(/<entry\b[\s\S]*?<\/entry>/g)) {
+    const m = idRe.exec(entry[0]);
+    if (m) tags.push(m[1].trim());
+  }
+  return tags;
+}
+
 async function resolveLatestTag(): Promise<string> {
-  const url = `https://api.github.com/repos/${REPO}/releases?per_page=30`;
+  // Resolve the latest release from the public Atom feed on github.com
+  // instead of api.github.com. The REST API caps *unauthenticated* requests
+  // at 60/hr per IP, which bricks self-update on shared provider egress IPs
+  // exactly when an operator is rolling out a release (#405); the web feed
+  // carries its own, far more generous anonymous limit and needs no token.
+  //
+  // Tradeoff vs the old `/releases` API call: the feed doesn't expose
+  // draft/prerelease flags, so we can't filter them out here. That's a
+  // non-issue for this repo — GitHub releases are client-only and always
+  // published as full (non-prerelease) releases via `changeset tag`. The
+  // TAG_PREFIX filter still drops any unrelated tag that shows up in the
+  // feed, and assertSafeTag rejects anything malformed.
+  const url = `https://github.com/${REPO}/releases.atom`;
   const res = await fetchWithTimeout(
     url,
-    { headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/vnd.github+json' } },
+    { headers: { 'User-Agent': 'vicoop-client-upgrade', Accept: 'application/atom+xml' } },
     API_TIMEOUT_MS,
   );
-  if (!res.ok) throw new Error(`GitHub API request failed: ${res.status} ${res.statusText} (${url})`);
-  const body = (await res.json()) as unknown;
-  // GitHub returns an object (`{ message, ... }`) for rate-limit/abuse/auth
-  // errors with 2xx-shaped bodies on some legacy paths, so don't trust the
-  // HTTP status alone — confirm we got an array before iterating.
-  if (!Array.isArray(body)) {
-    const msg = (body as { message?: unknown })?.message;
-    const detail = typeof msg === 'string' ? msg : JSON.stringify(body).slice(0, 200);
-    throw new Error(`GitHub API returned a non-array payload at ${url}: ${detail}`);
+  if (!res.ok) {
+    throw new Error(`GitHub releases feed request failed: ${res.status} ${res.statusText} (${url})`);
   }
-  const releases = body as Array<{ tag_name?: unknown; draft?: unknown; prerelease?: unknown }>;
-  for (const r of releases) {
-    if (typeof r.tag_name !== 'string' || !r.tag_name.startsWith(TAG_PREFIX)) continue;
-    if (r.draft === true || r.prerelease === true) continue;
-    assertSafeTag(r.tag_name);
-    return r.tag_name;
+  const xml = await res.text();
+  for (const tag of parseAtomTags(xml)) {
+    if (!tag.startsWith(TAG_PREFIX)) continue;
+    assertSafeTag(tag);
+    return tag;
   }
-  throw new Error(`no published (non-draft, non-prerelease) ${TAG_PREFIX}* release found in ${REPO}`);
+  throw new Error(`no published ${TAG_PREFIX}* release found in ${REPO} feed (${url})`);
 }
 
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {


### PR DESCRIPTION
Closes #405.

## Problem

`vicoop-client upgrade` / `upgrade --check` resolved the latest release via `api.github.com/repos/planetarium/vicoop-bridge/releases`, whose **unauthenticated** quota is **60 requests/hour per IP**. On a provider host with a shared/busy egress IP that quota is exhausted, so self-update fails with a hard:

```
upgrade failed: GitHub API request failed: 403 rate limit exceeded
```

Setting `GITHUB_TOKEN`/`GH_TOKEN` didn't help — the upgrade code never read it.

## Fix

Resolve the latest tag from the public **`github.com/<repo>/releases.atom`** feed instead of `api.github.com`. The web feed carries its own, far more generous anonymous limit and needs **no token**, so this is a token-free fix rather than the issue's suggested `GITHUB_TOKEN` opt-in (which leaves token-less provider hosts — the exact ones hitting this bug — still broken).

- New `parseAtomTags(xml)` (exported, unit-tested): reads each entry's release tag from `<id>` (`...Repository/<repoId>/<tag>`) rather than `<title>`, which can be a custom release name. The feed-level `<id>` (the releases URL) sits outside `<entry>`, so it's naturally excluded.
- Existing `TAG_PREFIX` filter + `assertSafeTag` validation kept. The feed doesn't expose draft/prerelease flags, but releases here are **client-only and always full (non-prerelease)** via `changeset tag`, so that's a non-issue.
- Asset download was already token-free (`browser_download_url`); only tag resolution changed.
- Container firewall allowlist already includes `github.com`, so no allowlist change needed.

## Verification

- `pnpm -r build`, `pnpm --filter @vicoop-bridge/client typecheck`, `pnpm --filter @vicoop-bridge/client test` — all green (3 new `parseAtomTags` tests, `fail 0`).
- **Live e2e**: fetched the real `releases.atom` and parsed it through `parseAtomTags` → resolved `@vicoop-bridge/client@0.35.3` (HTTP 200, no token, no `api.github.com`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)