### PR TITLE
fix(server): drop request-scoped openai-compat envelope from persisted tasks

### DIFF
--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -9,8 +9,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import postgres from 'postgres';
 import { TaskState } from '@a2x/sdk';
-import type { Message } from '@a2x/sdk';
-import { PostgresTaskStore } from './postgres-task-store.js';
+import type { Message, Task } from '@a2x/sdk';
+import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { PostgresTaskStore, stripSensitiveMetadata } from './postgres-task-store.js';
 import { ensureSchema } from './db.js';
 
 const hasDb = !!process.env.DATABASE_URL;
@@ -52,6 +53,70 @@ async function seed(
     )
   `;
 }
+
+// ── stripSensitiveMetadata: openai-compat request-envelope strip (issue #408) ─
+// Pure (no DB), so these always run. The persisted copy must drop the
+// request-scoped `chat_completions_request` envelope (~half of task_json) while
+// leaving the live object, the response envelope, and everything else intact.
+
+const OAI = OPENAI_COMPAT_EXTENSION_URI;
+
+function taskWithRequestEnvelope(extra?: Record<string, unknown>): Task {
+  return {
+    id: 't1',
+    contextId: 'c1',
+    status: { state: TaskState.COMPLETED, timestamp: '2026-01-01T00:00:00.000Z' },
+    metadata: {
+      [OAI]: {
+        chat_completions_request: {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'x'.repeat(1000) }],
+        },
+        ...extra,
+      },
+    },
+  } as unknown as Task;
+}
+
+test('stripSensitiveMetadata drops the openai-compat chat_completions_request from the persisted copy', () => {
+  const task = taskWithRequestEnvelope();
+  const persisted = stripSensitiveMetadata(task);
+  const ext = (persisted.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+  // The whole extension key is gone because the request envelope was its only member.
+  assert.equal(ext, undefined, 'request envelope must not be persisted');
+  // Empty metadata collapses to undefined rather than `{}`.
+  assert.equal(persisted.metadata, undefined);
+});
+
+test('stripSensitiveMetadata does not mutate the live task object', () => {
+  const task = taskWithRequestEnvelope();
+  stripSensitiveMetadata(task);
+  const liveExt = (task.metadata as Record<string, Record<string, unknown>>)[OAI];
+  assert.ok(
+    liveExt && 'chat_completions_request' in liveExt,
+    'the in-flight task the caller still forwards from must keep the envelope',
+  );
+});
+
+test('stripSensitiveMetadata keeps sibling openai-compat keys (e.g. response envelope) while dropping only the request', () => {
+  const task = taskWithRequestEnvelope({ chat_completion: { id: 'resp-1', usage: { total_tokens: 5 } } });
+  const persisted = stripSensitiveMetadata(task);
+  const ext = (persisted.metadata as Record<string, Record<string, unknown>>)[OAI];
+  assert.ok(ext, 'extension key survives when a sibling key remains');
+  assert.equal('chat_completions_request' in ext, false, 'request envelope dropped');
+  assert.deepEqual(ext.chat_completion, { id: 'resp-1', usage: { total_tokens: 5 } });
+});
+
+test('stripSensitiveMetadata leaves a non-openai-compat task untouched', () => {
+  const task = {
+    id: 't2',
+    contextId: 'c2',
+    status: { state: TaskState.COMPLETED, timestamp: '2026-01-01T00:00:00.000Z' },
+    metadata: { someOtherKey: { a: 1 } },
+  } as unknown as Task;
+  const persisted = stripSensitiveMetadata(task);
+  assert.deepEqual(persisted.metadata, { someOtherKey: { a: 1 } });
+});
 
 // ── updateTask concurrency (issue #366) ─────────────────────────────────────
 

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -118,6 +118,41 @@ test('stripSensitiveMetadata leaves a non-openai-compat task untouched', () => {
   assert.deepEqual(persisted.metadata, { someOtherKey: { a: 1 } });
 });
 
+test('stripSensitiveMetadata preserves an openai-compat key that has no request envelope (e.g. response-only / heartbeat marker)', () => {
+  const ext = { chat_completion: { id: 'resp-2' } };
+  const task = {
+    id: 't3',
+    contextId: 'c3',
+    status: { state: TaskState.COMPLETED, timestamp: '2026-01-01T00:00:00.000Z' },
+    metadata: { [OAI]: ext },
+  } as unknown as Task;
+  const persisted = stripSensitiveMetadata(task);
+  // No `chat_completions_request` to strip → the key (and its contents) is left as-is.
+  assert.deepEqual((persisted.metadata as Record<string, unknown>)[OAI], ext);
+});
+
+test('stripSensitiveMetadata does not throw on absent or malformed metadata', () => {
+  const base = {
+    id: 't4',
+    contextId: 'c4',
+    status: { state: TaskState.COMPLETED, timestamp: '2026-01-01T00:00:00.000Z' },
+  };
+  // metadata entirely absent
+  assert.doesNotThrow(() => stripSensitiveMetadata({ ...base } as unknown as Task));
+  // openai-compat value is null
+  assert.doesNotThrow(() =>
+    stripSensitiveMetadata({ ...base, metadata: { [OAI]: null } } as unknown as Task),
+  );
+  // openai-compat value is an array
+  assert.doesNotThrow(() =>
+    stripSensitiveMetadata({ ...base, metadata: { [OAI]: [1, 2, 3] } } as unknown as Task),
+  );
+  // openai-compat value is a primitive
+  assert.doesNotThrow(() =>
+    stripSensitiveMetadata({ ...base, metadata: { [OAI]: 'x' } } as unknown as Task),
+  );
+});
+
 // ── updateTask concurrency (issue #366) ─────────────────────────────────────
 
 test(

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -7,6 +7,7 @@ import type {
   TaskStore,
 } from '@a2x/sdk';
 import { TaskState, TERMINAL_STATES } from '@a2x/sdk';
+import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { Sql, SqlExecutor } from './db.js';
 
 const MAX_CONTEXT_TASKS = 10;
@@ -36,8 +37,41 @@ function stripMessageMetadata(msg: Message): Message {
   return m as Message;
 }
 
-function stripSensitiveMetadata(task: Task): Task {
-  const result = { ...task };
+// Drop the request-scoped `chat_completions_request` envelope from the
+// persisted copy of an openai-compat task. Per the openai-compat/v1 extension
+// (planetarium/oai2a2a), the gateway is stateless and re-emits the full
+// request envelope on EVERY turn, so the agent/server is never expected to read
+// it back from storage — persisting it just bloats the row (it is ~half of
+// task_json on this deployment, see issue #408). The response side of the
+// envelope (`chat_completion` / `terminal_error`, carried on message metadata)
+// is the codec's read-back source and is intentionally left untouched.
+//
+// Non-mutating: returns the input unchanged when there is no envelope to strip
+// (non-openai-compat tasks, admin agent), and otherwise returns a shallow copy
+// with a pruned `metadata` so the live task object the caller still forwards
+// from is never altered.
+function stripPersistedEnvelope(task: Task): Task {
+  const metadata = task.metadata as Record<string, unknown> | undefined;
+  const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI] as
+    | Record<string, unknown>
+    | undefined;
+  if (!ext || typeof ext !== 'object' || !('chat_completions_request' in ext)) {
+    return task;
+  }
+  const { chat_completions_request: _drop, ...restExt } = ext;
+  void _drop;
+  const nextMetadata = { ...metadata };
+  if (Object.keys(restExt).length > 0) {
+    nextMetadata[OPENAI_COMPAT_EXTENSION_URI] = restExt;
+  } else {
+    delete nextMetadata[OPENAI_COMPAT_EXTENSION_URI];
+  }
+  const hasMetadata = Object.keys(nextMetadata).length > 0;
+  return { ...task, metadata: hasMetadata ? nextMetadata : undefined };
+}
+
+export function stripSensitiveMetadata(task: Task): Task {
+  const result = { ...stripPersistedEnvelope(task) };
   if (result.history?.length) {
     result.history = result.history.map(stripMessageMetadata);
   }

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -52,10 +52,13 @@ function stripMessageMetadata(msg: Message): Message {
 // from is never altered.
 function stripPersistedEnvelope(task: Task): Task {
   const metadata = task.metadata as Record<string, unknown> | undefined;
-  const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI] as
-    | Record<string, unknown>
-    | undefined;
-  if (!ext || typeof ext !== 'object' || !('chat_completions_request' in ext)) {
+  const ext: unknown = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
+  if (
+    !ext ||
+    typeof ext !== 'object' ||
+    Array.isArray(ext) ||
+    !('chat_completions_request' in ext)
+  ) {
     return task;
   }
   const { chat_completions_request: _drop, ...restExt } = ext;


### PR DESCRIPTION
## Problem

`vicoop-bridge-server-db` hit Fly's 90% disk read-only protection (#408). Investigating the 3+ GB `infra.a2a_tasks` table:

- `task_json` TOAST = ~3.1 GB across ~7.4k rows (~420 KB/row).
- Breakdown of `task_json`: **`history` ~50%**, **`metadata` ~50%**, `status`/`artifacts` negligible.
- The entire `metadata` half is a single key: the openai-compat/v1 extension's **`chat_completions_request`** — the full inbound OpenAI request (system prompt + entire `messages[]` + tools), persisted verbatim on every task.

## Why this is safe to drop

Per the openai-compat/v1 extension spec (planetarium/oai2a2a), the gateway is **stateless** and re-emits the full `chat_completions_request` envelope on **every turn** — the server is never expected to read it back from storage. Persisting it is pure bloat (and arguably *less* spec-aligned than not persisting it).

Verified the consumer side, not just the spec:
- **Router** (`a2x-internal-router`): the forwarding path reads only `task.status` and `task.artifacts` from the returned task — never `task.metadata` / `chat_completions_request`.
- **oai2a2a codec**: response decoding reads solely the `chat_completion` envelope (on terminal **message** metadata); `chat_completions_request` appears only in the encode (outbound) path, never in decode.

So removing the request envelope from the persisted copy affects no read path.

## Change

`stripPersistedEnvelope` removes only `metadata[<openai-compat uri>].chat_completions_request` from the copy written to disk. It is folded into the existing `stripSensitiveMetadata`, which already runs on every write via `writeTask` (so it covers both the initial `createTask` SUBMITTED row and every `updateTask`).

- **Non-mutating** — returns the input unchanged when there's no envelope (non-openai-compat tasks, admin agent), and otherwise a shallow copy with pruned `metadata`. The live task object the executor still forwards from is untouched.
- **Surgical** — drops only the request envelope; the response envelope (`chat_completion` / `terminal_error` on message metadata), `history`, and all other metadata are left intact.

Expected effect: ~50% smaller `task_json` on new writes.

## Tests

4 new **pure** unit tests (run without a DB, unlike the existing integration tests):
- request envelope dropped from the persisted copy
- live task object not mutated
- sibling openai-compat keys (e.g. response envelope) preserved, only request dropped
- non-openai-compat task left untouched

`pnpm -r build`, `pnpm -r typecheck`, and `pnpm --filter @vicoop-bridge/server test` (275 tests, 0 fail) all green.

## Follow-up (not in this PR)

- One-time **backfill** of existing rows (`UPDATE ... task_json #- '{metadata,<uri>,chat_completions_request}'`, batched) + `VACUUM`/`pg_repack` to reclaim the ~1.5 GB already on disk. Runbook to follow.
- Disk monitoring/alert at ~75–80% (#408 follow-up).
- The `history` half is a separate, A2A-standard concern (the spec does **not** require persisting full history); can be addressed later via an ephemeral/in-memory store for openai-compat tasks.

Refs #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)