### PR TITLE
fix(client): canonicalize rate-limit failure messages for post-content retry

### DIFF
--- a/.changeset/rate-limit-message-canonicalize.md
+++ b/.changeset/rate-limit-message-canonicalize.md
@@ -1,0 +1,21 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Canonicalize `rate_limited` failure messages so post-content OpenAI-compatible
+clients auto-retry.
+
+Once a stream has committed content, a downstream OpenAI-compatible client
+(e.g. opencode) can no longer see the machine `code` — `@ai-sdk/openai-compatible`
+collapses an in-band `{error:{...}}` chunk to just its message string — so its
+retry heuristic classifies on the message text alone. That heuristic keys on the
+literal phrases "rate limit" / "too many requests", but `normalizeTaskFailError`
+classifies rate limits more broadly (a bare `429`, `rate-limited` with a hyphen,
+or `rate_limit` with an underscore). A genuine rate limit whose upstream text
+lacked the exact phrase therefore would not trigger the client's auto-retry.
+
+`normalizeTaskFailError` now prefixes such messages with `rate limit:` when the
+final code is `rate_limited` and the phrase is absent. This is an honest
+translation, not a failure-mode change — the branch is only reached for errors
+already classified as rate limits — and the original upstream detail is preserved
+after the prefix. Messages that already carry the phrase are left untouched.

--- a/packages/client/src/failure-code.test.ts
+++ b/packages/client/src/failure-code.test.ts
@@ -52,6 +52,44 @@ test('normalizeTaskFailError maps quota and rate limit messages before generic u
   );
 });
 
+test('normalizeTaskFailError canonicalizes rate-limit messages to carry the literal phrase', () => {
+  // Bare `429` with no phrase: classified rate_limited, message gets the phrase
+  // a post-content OpenAI-compatible retry heuristic (opencode) matches on.
+  assert.deepEqual(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: 'vicoop-codex serve returned HTTP 429',
+    }),
+    {
+      code: 'rate_limited',
+      message: 'rate limit: vicoop-codex serve returned HTTP 429',
+    },
+  );
+  // Hyphen/underscore spellings the broad classifier accepts but the phrase
+  // matcher would miss are canonicalized too.
+  assert.equal(
+    normalizeTaskFailError({ code: 'turn_failed', message: 'provider rate-limited the request' }).message,
+    'rate limit: provider rate-limited the request',
+  );
+  // A caller that already emits the semantic `rate_limited` code (early-return
+  // path) still gets its bare message canonicalized.
+  assert.equal(
+    normalizeTaskFailError({ code: 'rate_limited', message: 'slow down (429)' }).message,
+    'rate limit: slow down (429)',
+  );
+  // Already carries the phrase: left untouched, no double prefix.
+  assert.deepEqual(
+    normalizeTaskFailError({
+      code: 'upstream_error',
+      message: 'HTTP 429: too many requests',
+    }),
+    {
+      code: 'rate_limited',
+      message: 'HTTP 429: too many requests',
+    },
+  );
+});
+
 test('normalizeTaskFailError maps claude subscription/overload terminal reasons', () => {
   // Claude's "session limit" cap surfaces as a usage/quota exhaustion.
   assert.equal(

--- a/packages/client/src/failure-code.ts
+++ b/packages/client/src/failure-code.ts
@@ -44,25 +44,50 @@ const SEMANTIC_CODES = new Set([
 
 export function normalizeTaskFailError(error: TaskFailError): TaskFailError {
   const { code, message } = error;
-  if (SEMANTIC_CODES.has(code)) return error;
-  if (PRESERVED_INPUT_CODES.has(code)) return error;
+  const normalizedCode = classifyFailureCode(code, message);
+  const normalizedMessage = canonicalizeFailureMessage(normalizedCode, message);
+
+  if (normalizedCode === error.code && normalizedMessage === error.message) {
+    return error;
+  }
+  return { ...error, code: normalizedCode, message: normalizedMessage };
+}
+
+function classifyFailureCode(code: string, message: string): string {
+  if (SEMANTIC_CODES.has(code)) return code;
+  if (PRESERVED_INPUT_CODES.has(code)) return code;
 
   const text = `${code} ${message}`.toLowerCase();
-  let normalizedCode = code;
-  if (isQuotaExceeded(text)) normalizedCode = 'quota_exceeded';
-  else if (isRateLimited(text)) normalizedCode = 'rate_limited';
-  else if (isLoginRequired(text)) normalizedCode = 'login_required';
-  else if (isAuthRequired(text)) normalizedCode = 'auth_required';
-  else if (isAgentUnavailable(text)) normalizedCode = 'agent_unavailable';
-  else if (isModelUnavailable(text)) normalizedCode = 'model_unavailable';
-  else if (DISCONNECTED_CODES.has(code)) normalizedCode = 'disconnected';
-  else if (isNetworkError(text)) normalizedCode = 'network_error';
-  else if (isDisconnected(text)) normalizedCode = 'disconnected';
-  else if (code === 'task_timeout' || isTimeout(text)) normalizedCode = 'timeout';
-  else if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) normalizedCode = 'upstream_error';
+  if (isQuotaExceeded(text)) return 'quota_exceeded';
+  if (isRateLimited(text)) return 'rate_limited';
+  if (isLoginRequired(text)) return 'login_required';
+  if (isAuthRequired(text)) return 'auth_required';
+  if (isAgentUnavailable(text)) return 'agent_unavailable';
+  if (isModelUnavailable(text)) return 'model_unavailable';
+  if (DISCONNECTED_CODES.has(code)) return 'disconnected';
+  if (isNetworkError(text)) return 'network_error';
+  if (isDisconnected(text)) return 'disconnected';
+  if (code === 'task_timeout' || isTimeout(text)) return 'timeout';
+  if (UPSTREAM_CODES.has(code) || isUpstreamError(text)) return 'upstream_error';
+  return code;
+}
 
-  if (normalizedCode === error.code) return error;
-  return { ...error, code: normalizedCode };
+// The machine `code` is dropped before it reaches a downstream OpenAI-compatible
+// client's retry heuristic (@ai-sdk/openai-compatible collapses an in-band
+// `{error:{...}}` chunk to just its message string), so once a stream has
+// committed content the only signal such a client can classify on is the message
+// text. opencode's post-content retry matcher keys on the literal phrases
+// "rate limit" / "too many requests", but `isRateLimited` above also fires on a
+// bare `429`, `rate-limited` (hyphen), or `rate_limit` (underscore) — genuine
+// rate limits whose upstream text lacks the exact phrase. Canonicalize those so
+// the message carries the phrase. This is honest translation, not a mode change:
+// the failure *is* a rate limit (we only reach here when it was classified as
+// one); the upstream detail is preserved after the prefix.
+function canonicalizeFailureMessage(code: string, message: string): string {
+  if (code === 'rate_limited' && !/rate limit|too many requests/i.test(message)) {
+    return message ? `rate limit: ${message}` : 'rate limit';
+  }
+  return message;
 }
 
 function isQuotaExceeded(text: string): boolean {


### PR DESCRIPTION
## Problem

Once a stream has committed content, a downstream OpenAI-compatible client (e.g. **opencode**) can no longer see the machine `code` on a failure: `@ai-sdk/openai-compatible` collapses an in-band `{error:{...}}` chunk to just its **message string** (dropping `code`/`type`). So the client's retry heuristic classifies on the message text alone, keying on the literal phrases **`"rate limit"` / `"too many requests"`**.

But `normalizeTaskFailError` classifies rate limits more broadly than that — a bare `429`, `rate-limited` (hyphen), or `rate_limit` (underscore). A **genuine** rate limit whose upstream text lacked the exact phrase therefore reached the client with an accurate `code: "rate_limited"` that the client never sees, and a message it can't match → **no auto-retry**, user has to manually resubmit.

## Fix

`normalizeTaskFailError` now prefixes the message with `rate limit:` when the final code is `rate_limited` **and** the phrase is absent.

- **Honest translation, not a mode change** — the branch is only reached for errors already classified as rate limits. It never relabels a non-rate-limit (overload, disconnect) as a rate limit, so it doesn't corrupt retry semantics or telemetry (the `code` stays `rate_limited`).
- **Upstream detail preserved** after the prefix (`rate limit: <original>`).
- **No double-prefixing** — messages that already carry `"rate limit"` / `"too many requests"` (Anthropic `Rate limited`, OpenAI `Too Many Requests`) are left untouched.

Closes the `429` / hyphen / underscore gap so a genuine post-content rate limit triggers the client's auto-retry (which re-issues the request through the router and can pool-failover to a healthy member).

The function is also refactored: the `else if` classification chain is extracted to `classifyFailureCode` (behavior-preserving) so the new `canonicalizeFailureMessage` step applies on **both** paths — a freshly classified `rate_limited` **and** a caller that already emits the semantic `rate_limited` code (which previously short-circuited via the `SEMANTIC_CODES` early return).

## Tests

`packages/client/src/failure-code.test.ts` — new case covering bare `429`, hyphen spelling, an already-`rate_limited` incoming code, and the no-double-prefix guard. All 8 tests pass; `tsc --noEmit` clean.

## Context

This is the ship-now honest fix from the client-side retry-UX investigation in planetarium/vicoop-router#94. Other transient codes (`disconnected`, `timeout`, `upstream_error`, …) have **no** honest post-content fix on the openai-compatible path — they need the Responses (`@ai-sdk/openai`) `code:"...unavailable..."` mapping, tracked separately. Rate limit is the one code opencode's post-content vocabulary can match honestly.

Refs planetarium/vicoop-router#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)