### PR TITLE
diag(#414): instrument the heartbeat delivery path (client hop-1 + server hop-2 + updateTask latency)

### DIFF
--- a/.changeset/heartbeat-emit-instrumentation.md
+++ b/.changeset/heartbeat-emit-instrumentation.md
@@ -1,0 +1,21 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+diag(client): count liveness heartbeats emitted per task and log the count on the
+task lifecycle line (`heartbeats=N` on `task.complete` / `task.canceled` /
+`task.fail`) — issue #414 hop-1 instrumentation.
+
+The router intermittently trips its 300s stream-stall watchdog on a byte-silent
+turn even though the 10s liveness heartbeat should keep it alive. Static analysis
+found every hop individually correct, so this adds a cheap, always-on counter at
+the point the client emits heartbeat `task.status` frames onto the wire. A
+multi-minute task that logs `heartbeats=0` means the beats never fired/left the
+client (hop 1); a healthy count (≈ elapsedMs / 10s) shifts suspicion downstream
+(server forward / router re-arm). Counts only the tagged liveness beat
+(`metadata[openai-compat/v1].heartbeat === true`), not ordinary working-status
+frames. Logging-only; no behavior change.
+
+Pairs with the server-side hop-2 counter (`heartbeatsForwarded` on the bridge's
+`task_completed` / `task_failed_by_client` events) and the `task_store_slow_update`
+latency probe, so a future stall can be localized to a specific hop.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -9,6 +9,7 @@ import { WebSocketServer, type WebSocket } from 'ws';
 import {
   encodeFrame,
   parseUpFrame,
+  OPENAI_COMPAT_EXTENSION_URI,
   type Part,
   type TaskAssignFrame,
   type UpFrame,
@@ -828,6 +829,27 @@ test('processTask: artifacts are deduped by artifactId across chunks', async () 
   const completeLog = c.log.find((l) => l.includes('task.complete'));
   assert.ok(completeLog, 'task.complete log should be emitted');
   assert.match(completeLog, /artifacts=2/);
+});
+
+test('processTask: counts tagged liveness heartbeats and logs the count, ignoring plain working statuses (issue #414 hop-1 instrumentation)', async () => {
+  const c = makeSink();
+  const s = captureSend();
+  const hb = { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } };
+  const backend = backendOf('stub', async (_t, emit: Emit) => {
+    emit({ type: 'task.status', taskId: 'T1', status: { state: 'working' }, metadata: hb });
+    emit({ type: 'task.status', taskId: 'T1', status: { state: 'working' }, metadata: hb });
+    // A plain working status (no heartbeat marker) must NOT count as a beat.
+    emit({ type: 'task.status', taskId: 'T1', status: { state: 'working' } });
+    emit({ type: 'task.complete', taskId: 'T1', status: { state: 'completed' } });
+  });
+  await processTask(makeAssign('T1'), new AbortController().signal, {
+    backend,
+    send: s.send,
+    logger: createLogger('debug', c.sink),
+  });
+  const completeLog = c.log.find((l) => l.includes('task.complete'));
+  assert.ok(completeLog, 'task.complete log should be emitted');
+  assert.match(completeLog, /heartbeats=2/);
 });
 
 test('processTask: backend emits task.fail -> logs task.fail with code and message (#147)', async () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -704,7 +704,7 @@ export async function processTask(
       // bridge server will likely time the task out; surface it at warn so
       // operators see the broken contract instead of a silent gap.
       deps.logger.warn(
-        `backend.end taskId=${taskTok} elapsedMs=${elapsedMs} (no terminal frame)`,
+        `backend.end taskId=${taskTok} elapsedMs=${elapsedMs} heartbeats=${state.heartbeats} (no terminal frame)`,
       );
     } else if (terminal.kind === 'complete') {
       deps.logger.info(

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 import {
   PROTOCOL_VERSION,
+  OPENAI_COMPAT_EXTENSION_URI,
   encodeFrame,
   parseDownFrame,
   withOpenAICompatModelsAdvertise,
@@ -612,6 +613,16 @@ export class Client {
   }
 }
 
+// Diagnostic (issue #414): is this `task.status` frame's metadata the tagged
+// liveness-heartbeat marker (`metadata[<URI>].heartbeat === true`)? Other
+// `task.status` frames (initial working, progress) don't count as beats.
+function isHeartbeatStatusFrame(metadata: unknown): boolean {
+  if (typeof metadata !== 'object' || metadata === null) return false;
+  const ext = (metadata as Record<string, unknown>)[OPENAI_COMPAT_EXTENSION_URI];
+  if (typeof ext !== 'object' || ext === null) return false;
+  return (ext as Record<string, unknown>).heartbeat === true;
+}
+
 export interface ProcessTaskDeps {
   backend: Backend;
   // Wire send. Receives every frame the backend emits, plus a fallback
@@ -641,12 +652,19 @@ export async function processTask(
   // so a per-frame counter would over-report.
   const state: {
     artifactIds: Set<string>;
+    // Diagnostic counter (issue #414): liveness-heartbeat `task.status` frames
+    // this task emitted onto the wire (hop 1). Surfaced on the lifecycle log so
+    // a router stall can be checked against whether the client actually emitted
+    // heartbeats during a long silent turn — a ~0 count over a multi-minute task
+    // means the beats never fired/left; a healthy count (~elapsedMs/10s) shifts
+    // suspicion downstream (server forward / router re-arm).
+    heartbeats: number;
     terminal:
       | { kind: 'complete' }
       | { kind: 'canceled' }
       | { kind: 'fail'; code: string; message: string }
       | null;
-  } = { artifactIds: new Set(), terminal: null };
+  } = { artifactIds: new Set(), heartbeats: 0, terminal: null };
 
   // Wrap emit so we can observe terminal frames the backend sends and
   // report taskId/elapsedMs/artifacts/code from the same code path,
@@ -656,7 +674,9 @@ export async function processTask(
   // distinctly so the lifecycle log doesn't mislabel cancels as completions.
   const emit: Emit = (f) => {
     if (f.type === 'task.artifact') state.artifactIds.add(f.artifact.artifactId);
-    else if (f.type === 'task.complete') {
+    else if (f.type === 'task.status' && isHeartbeatStatusFrame(f.metadata)) {
+      state.heartbeats += 1;
+    } else if (f.type === 'task.complete') {
       state.terminal =
         f.status.state === 'canceled' ? { kind: 'canceled' } : { kind: 'complete' };
     } else if (f.type === 'task.fail') {
@@ -688,11 +708,11 @@ export async function processTask(
       );
     } else if (terminal.kind === 'complete') {
       deps.logger.info(
-        `task.complete taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+        `task.complete taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size} heartbeats=${state.heartbeats}`,
       );
     } else if (terminal.kind === 'canceled') {
       deps.logger.info(
-        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size} heartbeats=${state.heartbeats}`,
       );
     } else {
       // Surface error.message alongside the code so operators can debug
@@ -707,7 +727,7 @@ export async function processTask(
         ? ` message=${safeToken(terminal.message, 4000)}`
         : '';
       deps.logger.info(
-        `task.fail taskId=${taskTok} code=${safeToken(terminal.code)} elapsedMs=${elapsedMs}${msgPart}`,
+        `task.fail taskId=${taskTok} code=${safeToken(terminal.code)} elapsedMs=${elapsedMs} heartbeats=${state.heartbeats}${msgPart}`,
       );
     }
   } catch (err) {
@@ -747,7 +767,7 @@ export async function processTask(
         status: { state: 'canceled', timestamp: new Date().toISOString() },
       });
       deps.logger.info(
-        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size}`,
+        `task.canceled taskId=${taskTok} elapsedMs=${elapsedMs} artifacts=${state.artifactIds.size} heartbeats=${state.heartbeats}`,
       );
     } else {
       const code = 'backend_error';
@@ -758,7 +778,7 @@ export async function processTask(
       });
       const msgPart = message ? ` message=${safeToken(message, 4000)}` : '';
       deps.logger.info(
-        `task.fail taskId=${taskTok} code=${code} elapsedMs=${elapsedMs}${msgPart}`,
+        `task.fail taskId=${taskTok} code=${code} elapsedMs=${elapsedMs} heartbeats=${state.heartbeats}${msgPart}`,
       );
     }
   }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -13,7 +13,23 @@ export type Sql = postgres.Sql;
 export type SqlExecutor = postgres.Sql | postgres.TransactionSql;
 
 export function createDb(databaseUrl: string): Sql {
-  return postgres(databaseUrl);
+  // Opt-in server-side statement timeout (issue #414). Off by default — no
+  // behavior change unless `VICOOP_DB_STATEMENT_TIMEOUT_MS` is set. When set, a
+  // wedged query (e.g. an `updateTask` blocked on a row lock or a saturated
+  // pool) self-aborts with a Postgres error instead of freezing the A2A SSE
+  // stream for the router's full stall window — turning a silent ~300s stall
+  // into a fast, logged failure the router can fail over on. Applies to every
+  // pooled connection (statement_timeout is per-session), so keep it well above
+  // normal write latency; it also bounds `ensureSchema` and retention DELETEs.
+  const statementTimeoutMs = (() => {
+    const raw = process.env.VICOOP_DB_STATEMENT_TIMEOUT_MS;
+    const n = raw ? Number(raw) : Number.NaN;
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
+  })();
+  if (statementTimeoutMs === undefined) return postgres(databaseUrl);
+  return postgres(databaseUrl, {
+    connection: { statement_timeout: statementTimeoutMs },
+  });
 }
 
 export async function ensureSchema(sql: Sql): Promise<void> {

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -438,8 +438,10 @@ test(
       assert.equal(typeof e.totalMs, 'number');
       assert.equal(typeof e.txnMs, 'number');
       // A non-terminal (working) write is heartbeat-shaped: enforceRetention is
-      // a no-op, so its phase time is 0 — the beat's cost is the txn alone.
-      assert.equal(e.retentionMs, 0);
+      // a no-op that returns before any awaited work, so its phase time is ~0
+      // — the beat's cost is the txn alone. (<=1 rather than ===0 to tolerate a
+      // scheduling hiccup crossing a millisecond boundary between the samples.)
+      assert.ok((e.retentionMs as number) <= 1, `retentionMs should be ~0, got ${e.retentionMs}`);
 
       // A high threshold suppresses the log for the same fast write.
       process.env.VICOOP_TASKSTORE_SLOW_MS = '600000';

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -380,3 +380,112 @@ test(
     }
   },
 );
+
+// ── updateTask timing instrumentation (issue #414) ──────────────────────────
+
+// logEvent() writes one JSON object per line to console.log. Capture those
+// lines while `fn` runs and return the parsed events plus any thrown error, so
+// a test can assert on both the emitted telemetry and the rethrow.
+async function captureLogEvents(
+  fn: () => Promise<void>,
+): Promise<{ events: Array<Record<string, unknown>>; error: unknown }> {
+  const events: Array<Record<string, unknown>> = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => {
+    const line = args[0];
+    if (typeof line !== 'string') return;
+    try {
+      const obj = JSON.parse(line) as Record<string, unknown>;
+      if (obj && typeof obj === 'object' && 'event' in obj) events.push(obj);
+    } catch {
+      // non-JSON console output — ignore
+    }
+  };
+  let error: unknown;
+  try {
+    await fn();
+  } catch (err) {
+    error = err;
+  } finally {
+    console.log = original;
+  }
+  return { events, error };
+}
+
+test(
+  'updateTask logs task_store_slow_update with per-phase timing when it crosses the threshold (issue #414)',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const prev = process.env.VICOOP_TASKSTORE_SLOW_MS;
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql);
+      const created = await store.createTask({});
+      const status = { state: TaskState.WORKING, timestamp: new Date().toISOString() };
+
+      // Threshold 0 → every write counts as "slow", so a normal beat is logged.
+      process.env.VICOOP_TASKSTORE_SLOW_MS = '0';
+      const { events, error } = await captureLogEvents(async () => {
+        await store.updateTask(created.id, { status });
+      });
+      assert.equal(error, undefined, 'updateTask must succeed');
+      const slow = events.filter((e) => e.event === 'task_store_slow_update');
+      assert.equal(slow.length, 1, 'exactly one slow-update event per updateTask');
+      const e = slow[0]!;
+      assert.equal(e.taskId, created.id);
+      assert.equal(e.state, TaskState.WORKING);
+      assert.equal(typeof e.totalMs, 'number');
+      assert.equal(typeof e.txnMs, 'number');
+      // A non-terminal (working) write is heartbeat-shaped: enforceRetention is
+      // a no-op, so its phase time is 0 — the beat's cost is the txn alone.
+      assert.equal(e.retentionMs, 0);
+
+      // A high threshold suppresses the log for the same fast write.
+      process.env.VICOOP_TASKSTORE_SLOW_MS = '600000';
+      const quiet = await captureLogEvents(async () => {
+        await store.updateTask(created.id, { status });
+      });
+      assert.equal(
+        quiet.events.filter((ev) => ev.event === 'task_store_slow_update').length,
+        0,
+        'no slow-update event below the threshold',
+      );
+
+      await store.deleteTask(created.id);
+    } finally {
+      if (prev === undefined) delete process.env.VICOOP_TASKSTORE_SLOW_MS;
+      else process.env.VICOOP_TASKSTORE_SLOW_MS = prev;
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'updateTask logs task_store_update_error and rethrows when the write fails (issue #414)',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql);
+      const missingId = `missing-${Date.now()}`;
+      const status = { state: TaskState.WORKING, timestamp: new Date().toISOString() };
+
+      const { events, error } = await captureLogEvents(async () => {
+        // No row exists → the FOR UPDATE read throws "Task not found".
+        await store.updateTask(missingId, { status });
+      });
+
+      assert.ok(error, 'updateTask must rethrow the underlying failure');
+      assert.match(String(error), /Task not found/);
+      const errs = events.filter((ev) => ev.event === 'task_store_update_error');
+      assert.equal(errs.length, 1, 'the failure is logged once');
+      assert.equal(errs[0]!.taskId, missingId);
+      assert.equal(errs[0]!.state, TaskState.WORKING);
+      assert.equal(typeof errs[0]!.totalMs, 'number');
+    } finally {
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -9,7 +9,7 @@ import type {
 import { TaskState, TERMINAL_STATES } from '@a2x/sdk';
 import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { Sql, SqlExecutor } from './db.js';
-import { logEvent } from './log.js';
+import { logEvent, truncate } from './log.js';
 
 const MAX_CONTEXT_TASKS = 10;
 
@@ -152,9 +152,9 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     // cost is purely the transaction below.
     const startedAt = Date.now();
     let txnMs = 0;
+    let retentionStart = 0;
     let retentionMs = 0;
     try {
-      const txnStart = Date.now();
       const merged = await this.sql.begin(async (sql) => {
         const rows = await sql<{ task_json: Task }[]>`
           SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} FOR UPDATE
@@ -171,7 +171,7 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
         await this.writeTask(next, sql);
         return next;
       });
-      txnMs = Date.now() - txnStart;
+      txnMs = Date.now() - startedAt;
       // Retention runs AFTER the transaction commits, on the pool connection —
       // deliberately NOT inside the FOR UPDATE transaction. Two same-context
       // tasks reaching a terminal state at once would otherwise each hold the
@@ -181,7 +181,7 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
       // keeps the state write durable (it has already committed) and confines
       // the row lock to the single task being updated, so two updateTask calls
       // can never deadlock each other.
-      const retentionStart = Date.now();
+      retentionStart = Date.now();
       await this.enforceRetention(merged);
       retentionMs = Date.now() - retentionStart;
       const totalMs = Date.now() - startedAt;
@@ -199,14 +199,21 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
       // Surface the timing on the failure path too. The SDK's streamed
       // updateTask (@a2x/sdk `_handleStreamMessage`) is un-caught, so a throw
       // here otherwise tears down the SSE with no local trace of how long it
-      // ran or which phase it died in.
+      // ran or which phase it died in. Attribute the elapsed time to whichever
+      // phase was in flight when it threw — a `begin()` throw (a wedged FOR
+      // UPDATE / statement_timeout abort, the primary case this exists to
+      // catch) would otherwise be misreported as `txnMs: 0`.
+      if (txnMs === 0) txnMs = Date.now() - startedAt;
+      else if (retentionMs === 0 && retentionStart !== 0) {
+        retentionMs = Date.now() - retentionStart;
+      }
       logEvent('task_store_update_error', {
         taskId,
         state: update.status?.state ?? null,
         totalMs: Date.now() - startedAt,
         txnMs,
         retentionMs,
-        error: String(err),
+        error: truncate(String(err), 500),
       });
       throw err;
     }

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -9,8 +9,25 @@ import type {
 import { TaskState, TERMINAL_STATES } from '@a2x/sdk';
 import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { Sql, SqlExecutor } from './db.js';
+import { logEvent } from './log.js';
 
 const MAX_CONTEXT_TASKS = 10;
+
+// Diagnostic threshold (issue #414): emit a `task_store_slow_update` log event
+// when an `updateTask` takes at least this long. `updateTask` sits on the A2A
+// SSE critical path — the @a2x/sdk `await`s it (un-caught) before yielding each
+// streamed non-terminal status, INCLUDING every 10s liveness heartbeat, to the
+// router's stream — so a slow/blocked write here freezes the outbound stream
+// and can trip the router's stall watchdog while the client runs on to a normal
+// completion. Logging slow writes lets a router stall be correlated against a
+// concrete write duration. Configurable via `VICOOP_TASKSTORE_SLOW_MS`
+// (milliseconds); default 1000. Set to 0 to log every write. Read per call
+// (the cost is nil next to a DB round-trip) so it stays reconfigurable/testable.
+function slowUpdateThresholdMs(): number {
+  const raw = process.env.VICOOP_TASKSTORE_SLOW_MS;
+  const n = raw ? Number(raw) : Number.NaN;
+  return Number.isFinite(n) && n >= 0 ? n : 1000;
+}
 
 type MessageWithMetadata = Message & { metadata?: Record<string, unknown> };
 
@@ -128,33 +145,71 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     // first transaction commits, after which it reads the just-written row —
     // we don't need REPEATABLE READ because the lock, not snapshot isolation,
     // is what serializes the two read-modify-writes.
-    const merged = await this.sql.begin(async (sql) => {
-      const rows = await sql<{ task_json: Task }[]>`
-        SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} FOR UPDATE
-      `;
-      const existing = rows[0]?.task_json ?? null;
-      if (!existing) {
-        throw new Error(`Task not found: ${taskId}`);
+    // Diagnostic timing (issue #414): time the FOR UPDATE transaction and the
+    // (terminal-only) retention DELETE separately so a slow beat can be
+    // attributed to the right phase. `retentionMs` stays 0 for non-terminal
+    // writes (heartbeats), where enforceRetention is a no-op — so a heartbeat's
+    // cost is purely the transaction below.
+    const startedAt = Date.now();
+    let txnMs = 0;
+    let retentionMs = 0;
+    try {
+      const txnStart = Date.now();
+      const merged = await this.sql.begin(async (sql) => {
+        const rows = await sql<{ task_json: Task }[]>`
+          SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} FOR UPDATE
+        `;
+        const existing = rows[0]?.task_json ?? null;
+        if (!existing) {
+          throw new Error(`Task not found: ${taskId}`);
+        }
+        const next: Task = { ...existing };
+        if (update.status !== undefined) next.status = update.status;
+        if (update.artifacts !== undefined) next.artifacts = update.artifacts;
+        if (update.history !== undefined) next.history = update.history;
+        if (update.metadata !== undefined) next.metadata = update.metadata;
+        await this.writeTask(next, sql);
+        return next;
+      });
+      txnMs = Date.now() - txnStart;
+      // Retention runs AFTER the transaction commits, on the pool connection —
+      // deliberately NOT inside the FOR UPDATE transaction. Two same-context
+      // tasks reaching a terminal state at once would otherwise each hold the
+      // lock on their own row while the retention DELETE tries to remove the
+      // OTHER's row, producing a lock-order cycle: Postgres aborts one and
+      // rolls back its task-state write with it. Running retention post-commit
+      // keeps the state write durable (it has already committed) and confines
+      // the row lock to the single task being updated, so two updateTask calls
+      // can never deadlock each other.
+      const retentionStart = Date.now();
+      await this.enforceRetention(merged);
+      retentionMs = Date.now() - retentionStart;
+      const totalMs = Date.now() - startedAt;
+      if (totalMs >= slowUpdateThresholdMs()) {
+        logEvent('task_store_slow_update', {
+          taskId,
+          state: merged.status.state,
+          totalMs,
+          txnMs,
+          retentionMs,
+        });
       }
-      const next: Task = { ...existing };
-      if (update.status !== undefined) next.status = update.status;
-      if (update.artifacts !== undefined) next.artifacts = update.artifacts;
-      if (update.history !== undefined) next.history = update.history;
-      if (update.metadata !== undefined) next.metadata = update.metadata;
-      await this.writeTask(next, sql);
-      return next;
-    });
-    // Retention runs AFTER the transaction commits, on the pool connection —
-    // deliberately NOT inside the FOR UPDATE transaction. Two same-context
-    // tasks reaching a terminal state at once would otherwise each hold the
-    // lock on their own row while the retention DELETE tries to remove the
-    // OTHER's row, producing a lock-order cycle: Postgres aborts one and
-    // rolls back its task-state write with it. Running retention post-commit
-    // keeps the state write durable (it has already committed) and confines
-    // the row lock to the single task being updated, so two updateTask calls
-    // can never deadlock each other.
-    await this.enforceRetention(merged);
-    return merged;
+      return merged;
+    } catch (err) {
+      // Surface the timing on the failure path too. The SDK's streamed
+      // updateTask (@a2x/sdk `_handleStreamMessage`) is un-caught, so a throw
+      // here otherwise tears down the SSE with no local trace of how long it
+      // ran or which phase it died in.
+      logEvent('task_store_update_error', {
+        taskId,
+        state: update.status?.state ?? null,
+        totalMs: Date.now() - startedAt,
+        txnMs,
+        retentionMs,
+        error: String(err),
+      });
+      throw err;
+    }
   }
 
   async deleteTask(taskId: string): Promise<void> {

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -44,6 +44,14 @@ export interface TaskBinding {
   // (AdminA2XExecutor) that never calls registry.bindTask().
   principalId?: string;
   requestedExtensions?: string[];
+  // Diagnostic counter (issue #414): number of liveness-heartbeat `task.status`
+  // frames the server has received from the client and pushed to the sink for
+  // this task. Surfaced on the terminal log so a router stall can be checked
+  // against whether the server was actually forwarding heartbeats (hop 2) — a
+  // high count with a stalled router points downstream (updateTask freeze /
+  // router), a ~0 count points upstream (client never emitted). Lazily
+  // initialized; incremented in ws.ts's `task.status` handler.
+  heartbeats?: number;
 }
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -267,6 +267,65 @@ test('task.status propagates frame metadata onto the top-level TaskStatusUpdateE
   }
 });
 
+test('task.complete log carries the forwarded heartbeat count, ignoring plain working statuses (issue #414 hop-2 instrumentation)', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  const events: Array<Record<string, unknown>> = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => {
+    if (typeof args[0] !== 'string') return;
+    try {
+      const o = JSON.parse(args[0]) as Record<string, unknown>;
+      if (o && typeof o === 'object' && 'event' in o) events.push(o);
+    } catch {
+      // non-JSON console output — ignore
+    }
+  };
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-hbc',
+      contextId: 'ctx-hbc',
+      sink: makeSink(),
+    });
+
+    const ts = '2026-06-18T00:00:00.000Z';
+    const hbMeta = { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } };
+    // Two tagged heartbeats...
+    ws.send(encodeFrame({ type: 'task.status', taskId: 'task-hbc', status: { state: 'working', timestamp: ts }, metadata: hbMeta }));
+    ws.send(encodeFrame({ type: 'task.status', taskId: 'task-hbc', status: { state: 'working', timestamp: ts }, metadata: hbMeta }));
+    // ...and a plain working status that must NOT be counted as a beat.
+    ws.send(encodeFrame({ type: 'task.status', taskId: 'task-hbc', status: { state: 'working', timestamp: ts } }));
+    ws.send(encodeFrame({ type: 'task.complete', taskId: 'task-hbc', status: { state: 'completed', timestamp: ts } }));
+
+    const deadline = Date.now() + 1_000;
+    let ev: Record<string, unknown> | undefined;
+    while (!(ev = events.find((e) => e.event === 'task_completed' && e.taskId === 'task-hbc'))) {
+      assert.ok(Date.now() < deadline, 'timed out waiting for task_completed');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(ev.heartbeatsForwarded, 2);
+  } finally {
+    console.log = origLog;
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('task.status without metadata leaves TaskStatusUpdateEvent.metadata unset', async () => {
   const server = createServer();
   const registry = new Registry();

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, Server } from 'node:http';
 import {
   parseUpFrame,
   PROTOCOL_VERSION,
+  OPENAI_COMPAT_EXTENSION_URI,
   type Part,
   type TaskStatus as WireTaskStatus,
   type Message as WireMessage,
@@ -17,6 +18,16 @@ import { isReservedAgentId } from './reserved-agent-ids.js';
 import { resolveHelloAgentCard } from './card-resolver.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { resolveUsageResponse } from './usage-rpc.js';
+
+// Diagnostic (issue #414): is this `task.status` frame a tagged liveness
+// heartbeat (non-terminal working status carrying
+// `metadata[<URI>].heartbeat === true`)? Used to count beats forwarded per task.
+function isHeartbeatStatusFrame(metadata: unknown): boolean {
+  if (typeof metadata !== 'object' || metadata === null) return false;
+  const ext = (metadata as Record<string, unknown>)[OPENAI_COMPAT_EXTENSION_URI];
+  if (typeof ext !== 'object' || ext === null) return false;
+  return (ext as Record<string, unknown>).heartbeat === true;
+}
 
 interface ClientRow {
   id: string;
@@ -253,6 +264,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       case 'task.status': {
         const b = opts.registry.getBinding(frame.taskId);
         if (!b) return;
+        // Diagnostic (issue #414): count liveness-heartbeat beats forwarded for
+        // this task (hop 2). A heartbeat is a non-terminal working status tagged
+        // `metadata[<URI>].heartbeat === true`; other `task.status` frames don't
+        // count. Surfaced on the terminal log below.
+        if (isHeartbeatStatusFrame(frame.metadata)) {
+          b.heartbeats = (b.heartbeats ?? 0) + 1;
+        }
         b.sink.pushStatus({
           taskId: frame.taskId,
           contextId: b.contextId,
@@ -303,6 +321,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           taskId: frame.taskId,
           contextId: b.contextId,
           state: frame.status.state,
+          heartbeatsForwarded: b.heartbeats ?? 0,
           ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
         });
         break;
@@ -336,6 +355,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           contextId: b.contextId,
           errorCode: frame.error.code,
           errorMessage: truncate(frame.error.message, 256),
+          heartbeatsForwarded: b.heartbeats ?? 0,
           ...(b.principalId !== undefined ? { principalId: b.principalId } : {}),
         });
         break;


### PR DESCRIPTION
## Why

The router trips its 300s stream-stall watchdog on a byte-silent turn even though the client's 10s liveness heartbeat should keep it alive (#414 for claude; the same class recurred on vicoop-codex, see codex-cli#37). Static analysis found **every hop individually correct**, yet the router received 0 bytes for 300s while the client completed normally. This PR adds cheap, always-on instrumentation along the **three hops the heartbeat traverses**, so the next stall can be *localized* instead of inferred.

```
client emit ──hop1──▶ bridge server receive+forward ──hop2──▶ router re-arm (hop3, router repo)
```

## What this instruments

**Hop 1 — client (`packages/client`)**
- Count heartbeat `task.status` frames emitted per task; log `heartbeats=N` on the lifecycle line (`task.complete` / `task.canceled` / `task.fail`).
- Reads: a multi-minute task with `heartbeats=0` = the client never emitted (hop-1 bug / event-loop starvation); a healthy count (≈ elapsedMs/10s) shifts suspicion downstream.
- Counts only the tagged beat (`metadata[openai-compat/v1].heartbeat === true`), never plain working statuses.

**Hop 2 — bridge server (`packages/server`)**
- `ws.ts`: count heartbeat `task.status` frames received from the client and pushed to the sink (`TaskBinding.heartbeats`); surface as `heartbeatsForwarded` on `task_completed` / `task_failed_by_client`.
- `postgres-task-store.ts`: **`task_store_slow_update`** — per-phase `updateTask` latency (the un-caught `await` the SDK runs before yielding each status/heartbeat to the SSE). `task_store_update_error` on the failure path.
- `db.ts`: opt-in `VICOOP_DB_STATEMENT_TIMEOUT_MS` (off by default) so a wedged write fails fast instead of freezing the SSE for the full watchdog window.

Together these split **"client didn't send" (hop-1 `heartbeats=0`)** vs **"server received but froze forwarding" (hop-2 `heartbeatsForwarded>0` + a slow/`error` `task_store_*`)** vs **"reached the router but it didn't re-arm" (both counts healthy → hop-3, router repo)**.

## Config knobs (all default to no behavior change)
- `VICOOP_TASKSTORE_SLOW_MS` (default 1000) — slow-update log threshold; `0` logs every write.
- `VICOOP_DB_STATEMENT_TIMEOUT_MS` (unset = off) — fail-fast wedged queries.

## Deploy targets
- **client** hop-1 → provider box (client release/upgrade). *Carries a patch changeset.*
- **server** hop-2 + updateTask + statement_timeout → `vicoop-bridge-server` (`pnpm deploy:server`). *Server is an ignored package — no changeset.*
- hop-3 (router re-arm) is **out of scope** (a2x-internal-router repo); these counts tell you whether you even need to look there.

## Testing
- `pnpm -r build && pnpm -r typecheck` ✅
- Server: **229 pass / 0 fail** (+ new `ws.test` hop-2 test: `task_completed` carries `heartbeatsForwarded`, plain working statuses not counted; DB-gated `task_store_slow_update` tests verified against a real Postgres).
- Client: **800 pass / 0 fail** (+ new `client.test` hop-1 test: `processTask` counts tagged beats and logs `heartbeats=N`, ignoring plain working statuses).

## How it settles #414
Deploy, then on the next stall (claude or codex) read the one task's `heartbeats=` (client) + `heartbeatsForwarded=` / `task_store_slow_update` (server). One of the three hops will show the drop.

Supersedes the earlier server-only framing of this PR. Related: #414 (claude, dormant), codex-cli#37 (codex upstream stall, fixed), #416 (binding/terminal fix, deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)