### PR TITLE
feat(server): opt-in retention of the inbound request envelope for forensics (#419)

### DIFF
--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -20,6 +20,16 @@ primary_region = "nrt"
   # reclaimed by the hourly cleanup job; "0" disables it. Complements the
   # count-based per-context cap in upsert().
   A2A_TASK_RETENTION_DAYS = "30"
+  # Forensics switch for the inbound request envelope (see #419 / #408 / #409).
+  # Unset/false (the default) strips the full `chat_completions_request` from
+  # every persisted task row — the lean post-#409 behavior. Set to "1"/"true" to
+  # retain it, making each stored task a complete, replayable record of its input
+  # (inspect via getTask / SQL: `task_json`). This re-introduces the #408
+  # near-quadratic growth for as long as it is on, so it is an ON-DEMAND
+  # debugging toggle to enable for a window and turn back off — NOT a steady
+  # state. Left off here on purpose; flip it with `fly secrets set` / a deploy
+  # when investigating, then revert (and VACUUM FULL to reclaim the disk).
+  # A2A_PERSIST_REQUEST_ENVELOPE = "1"
   # Server-authoritative inactivity backstop (ms) for an in-flight task's SSE
   # stream: if the connected daemon sends NO frame — content, artifact, or
   # heartbeat task.status — for this long, the bridge fabricates a terminal

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -483,7 +483,16 @@ export function createAdminA2XAgent(opts: AdminAgentOptions): {
   handler: DefaultRequestHandler;
   taskStore: PostgresTaskStore;
 } {
-  const taskStore = new PostgresTaskStore(opts.db);
+  // Operational forensics switch (issue #419): when A2A_PERSIST_REQUEST_ENVELOPE
+  // is truthy, retain the full inbound request envelope on persisted task rows
+  // instead of stripping it (the lean post-#409 default). Left on it re-creates
+  // the #408 growth, so it is an on-demand debugging toggle, not a steady state.
+  // This store is shared by the admin agent and every WS-forwarding agent (see
+  // buildAgentA2XAgent in http.tsx), so the flag governs all persisted tasks.
+  const persistRequestEnvelope = /^(1|true|yes|on)$/i.test(
+    process.env.A2A_PERSIST_REQUEST_ENVELOPE ?? '',
+  );
+  const taskStore = new PostgresTaskStore(opts.db, { persistRequestEnvelope });
   const executor = new AdminA2XExecutor(opts.db, opts.registry, taskStore);
 
   const a2xAgent = new A2XAgent({

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -24,7 +24,11 @@ import type { Sql } from './db.js';
 import { getSchemaTools } from './schema-tools.js';
 import { runWithBearerToken } from './graphql-client.js';
 import type { Registry } from './registry.js';
-import { PostgresTaskStore, type ContextAwareTaskStore } from './postgres-task-store.js';
+import {
+  PostgresTaskStore,
+  parsePersistRequestEnvelope,
+  type ContextAwareTaskStore,
+} from './postgres-task-store.js';
 import { listCallerTokens, revokeCallerToken } from './auth/caller-token.js';
 import { logEvent } from './log.js';
 import { isAdmin } from './admin-scope.js';
@@ -489,8 +493,8 @@ export function createAdminA2XAgent(opts: AdminAgentOptions): {
   // the #408 growth, so it is an on-demand debugging toggle, not a steady state.
   // This store is shared by the admin agent and every WS-forwarding agent (see
   // buildAgentA2XAgent in http.tsx), so the flag governs all persisted tasks.
-  const persistRequestEnvelope = /^(1|true|yes|on)$/i.test(
-    process.env.A2A_PERSIST_REQUEST_ENVELOPE ?? '',
+  const persistRequestEnvelope = parsePersistRequestEnvelope(
+    process.env.A2A_PERSIST_REQUEST_ENVELOPE,
   );
   const taskStore = new PostgresTaskStore(opts.db, { persistRequestEnvelope });
   const executor = new AdminA2XExecutor(opts.db, opts.registry, taskStore);

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -11,7 +11,11 @@ import postgres from 'postgres';
 import { TaskState } from '@a2x/sdk';
 import type { Message, Task } from '@a2x/sdk';
 import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
-import { PostgresTaskStore, stripSensitiveMetadata } from './postgres-task-store.js';
+import {
+  PostgresTaskStore,
+  stripSensitiveMetadata,
+  parsePersistRequestEnvelope,
+} from './postgres-task-store.js';
 import { ensureSchema } from './db.js';
 
 const hasDb = !!process.env.DATABASE_URL;
@@ -24,9 +28,13 @@ function msg(id: string, text: string): Message {
 // owner_principal is derived (extractOwnerPrincipal reads status.message
 // .metadata._principalId). Needed for the count-based retention path, which
 // only fires for owned terminal tasks.
-function ownedTerminalStatus(principalId: string, id: string) {
+function ownedTerminalStatus(
+  principalId: string,
+  id: string,
+  state: TaskState = TaskState.COMPLETED,
+) {
   return {
-    state: TaskState.COMPLETED,
+    state,
     timestamp: new Date().toISOString(),
     message: {
       messageId: id,
@@ -160,14 +168,25 @@ test('stripSensitiveMetadata does not throw on absent or malformed metadata', ()
 // path. `stripSensitiveMetadata`'s preserveEnvelope option is the write-side
 // primitive the flag drives.
 
-test('stripSensitiveMetadata with preserveEnvelope keeps the request envelope', () => {
+test('parsePersistRequestEnvelope: truthy spellings enable, everything else (incl. unset) stays off', () => {
+  for (const on of ['1', 'true', 'TRUE', 'yes', 'Yes', 'on', 'ON']) {
+    assert.equal(parsePersistRequestEnvelope(on), true, `${on} must enable`);
+  }
+  for (const off of [undefined, '', '0', 'false', 'off', 'no', 'nope', ' 1', '1 ', 'enabled']) {
+    assert.equal(parsePersistRequestEnvelope(off), false, `${String(off)} must stay off (safe default)`);
+  }
+});
+
+test('stripSensitiveMetadata with preserveEnvelope keeps the request envelope intact', () => {
   const task = taskWithRequestEnvelope();
+  const original = (task.metadata as Record<string, Record<string, unknown>>)[OAI]
+    .chat_completions_request;
   const persisted = stripSensitiveMetadata(task, { preserveEnvelope: true });
   const ext = (persisted.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
-  assert.ok(
-    ext && 'chat_completions_request' in ext,
-    'the envelope must be retained when preserveEnvelope is set',
-  );
+  assert.ok(ext, 'the openai-compat extension must survive');
+  // Content equality, not just presence — a shallow-copy bug that dropped
+  // messages[] would pass a presence-only check.
+  assert.deepEqual(ext.chat_completions_request, original);
 });
 
 test('stripSensitiveMetadata with preserveEnvelope still scrubs bearer/principal from message metadata', () => {
@@ -409,6 +428,85 @@ test(
           undefined,
           'loadByContextId must strip the envelope even when persistRequestEnvelope is on',
         );
+      }
+    } finally {
+      await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'persistRequestEnvelope retains the envelope on a FAILED terminal row (the named forensics case, #419)',
+  { skip: !hasDb },
+  async () => {
+    // The feature exists for failures — drive a task all the way to FAILED with
+    // the flag on and confirm getTask still hands back its full input.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const contextId = `ctx-envelope-fail-${Date.now()}`;
+    const principalId = `eth:0xenvelope-fail-${Date.now()}`;
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql, { persistRequestEnvelope: true });
+
+      const envelope = { model: 'gpt-4', messages: [{ role: 'user', content: 'kaboom'.repeat(400) }] };
+      const task = await store.createTask({
+        contextId,
+        metadata: { [OAI]: { chat_completions_request: envelope } },
+      });
+      await store.updateTask(task.id, {
+        status: ownedTerminalStatus(principalId, 'boom', TaskState.FAILED),
+      });
+
+      const failed = await store.getTask(task.id);
+      assert.equal(failed?.status.state, TaskState.FAILED, 'task reached FAILED');
+      const ext = (failed?.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+      assert.deepEqual(ext?.chat_completions_request, envelope, 'failed row retains its full input');
+    } finally {
+      await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'persistRequestEnvelope keeps each row\'s own envelope across a multi-turn context (no cross-contamination)',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const contextId = `ctx-envelope-multi-${Date.now()}`;
+    const principalId = `eth:0xenvelope-multi-${Date.now()}`;
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql, { persistRequestEnvelope: true });
+
+      // Three turns in one context, each with a distinct envelope.
+      const ids: string[] = [];
+      const envelopes: Record<string, unknown>[] = [];
+      for (let i = 0; i < 3; i++) {
+        const envelope = { model: 'gpt-4', messages: [{ role: 'user', content: `turn-${i}` }] };
+        envelopes.push(envelope);
+        const t = await store.createTask({
+          contextId,
+          metadata: { [OAI]: { chat_completions_request: envelope } },
+        });
+        await store.updateTask(t.id, { status: ownedTerminalStatus(principalId, `m-${i}`) });
+        ids.push(t.id);
+      }
+
+      // Each stored row must carry ITS OWN envelope, not a neighbour's.
+      for (let i = 0; i < ids.length; i++) {
+        const stored = await store.getTask(ids[i]!);
+        const ext = (stored?.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+        assert.deepEqual(ext?.chat_completions_request, envelopes[i], `row ${i} keeps its own envelope`);
+      }
+
+      // Replay of the whole context stays lean regardless.
+      const replay = await store.loadByContextId(contextId, principalId);
+      assert.equal(replay.length, 3, 'all three turns replayed');
+      for (const t of replay) {
+        const ext = (t.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+        assert.equal(ext?.chat_completions_request, undefined, 'replay strips every row');
       }
     } finally {
       await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -153,6 +153,48 @@ test('stripSensitiveMetadata does not throw on absent or malformed metadata', ()
   );
 });
 
+// ── issue #419: opt-in retention of the request envelope ────────────────────
+// Stripping is the default (post-#409, keeps the table lean). The
+// persistRequestEnvelope store flag flips it into a forensics mode that keeps
+// the full envelope on every persisted row; reads still strip on the hot replay
+// path. `stripSensitiveMetadata`'s preserveEnvelope option is the write-side
+// primitive the flag drives.
+
+test('stripSensitiveMetadata with preserveEnvelope keeps the request envelope', () => {
+  const task = taskWithRequestEnvelope();
+  const persisted = stripSensitiveMetadata(task, { preserveEnvelope: true });
+  const ext = (persisted.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+  assert.ok(
+    ext && 'chat_completions_request' in ext,
+    'the envelope must be retained when preserveEnvelope is set',
+  );
+});
+
+test('stripSensitiveMetadata with preserveEnvelope still scrubs bearer/principal from message metadata', () => {
+  const task = {
+    id: 't5',
+    contextId: 'c5',
+    status: {
+      state: TaskState.FAILED,
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: {
+        messageId: 'm',
+        role: 'agent',
+        parts: [{ kind: 'text', text: 'x' }],
+        metadata: { _bearerToken: 'secret', _principalId: 'eth:0x1', keep: 1 },
+      },
+    },
+    metadata: { [OAI]: { chat_completions_request: { model: 'gpt-4', messages: [] } } },
+  } as unknown as Task;
+  const persisted = stripSensitiveMetadata(task, { preserveEnvelope: true });
+  const ext = (persisted.metadata as Record<string, Record<string, unknown>>)[OAI];
+  assert.ok(ext && 'chat_completions_request' in ext, 'envelope retained');
+  const sm = (persisted.status.message as { metadata: Record<string, unknown> }).metadata;
+  assert.equal(sm._bearerToken, undefined, 'bearer token scrubbed even with preserveEnvelope');
+  assert.equal(sm._principalId, undefined, 'principal scrubbed even with preserveEnvelope');
+  assert.equal(sm.keep, 1, 'non-sensitive message metadata retained');
+});
+
 // ── updateTask concurrency (issue #366) ─────────────────────────────────────
 
 test(
@@ -287,6 +329,86 @@ test(
             }`,
           );
         }
+      }
+    } finally {
+      await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;
+      await sql.end();
+    }
+  },
+);
+
+// ── request-envelope retention end-to-end (issue #419) ──────────────────────
+
+test(
+  'default store strips the request envelope from persisted rows',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const contextId = `ctx-envelope-off-${Date.now()}`;
+    const principalId = `eth:0xenvelope-off-${Date.now()}`;
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql); // persistRequestEnvelope defaults to false
+
+      const envelope = { model: 'gpt-4', messages: [{ role: 'user', content: 'x'.repeat(2000) }] };
+      const metadata = { [OAI]: { chat_completions_request: envelope } };
+
+      const task = await store.createTask({ contextId, metadata });
+      await store.updateTask(task.id, { status: ownedTerminalStatus(principalId, 'done') });
+
+      const stored = await store.getTask(task.id);
+      assert.equal(
+        (stored?.metadata as Record<string, unknown> | undefined)?.[OAI],
+        undefined,
+        'default store must strip the request envelope even for getTask',
+      );
+    } finally {
+      await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'persistRequestEnvelope store retains the envelope for getTask/SQL but still strips it from replay (issue #419)',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const contextId = `ctx-envelope-on-${Date.now()}`;
+    const principalId = `eth:0xenvelope-on-${Date.now()}`;
+    try {
+      await ensureSchema(sql);
+      const store = new PostgresTaskStore(sql, { persistRequestEnvelope: true });
+
+      const envelope = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'boom'.repeat(500) }],
+      };
+      const metadata = { [OAI]: { chat_completions_request: envelope } };
+
+      // createTask persists SUBMITTED with the envelope; the terminal update
+      // merges onto that row. The envelope must survive into the stored row even
+      // though the update itself carries only status (the merge reads the raw
+      // row, so the carrier envelope is preserved regardless of terminal state).
+      const task = await store.createTask({ contextId, metadata });
+      await store.updateTask(task.id, { status: ownedTerminalStatus(principalId, 'done') });
+
+      // Forensic read (getTask): full envelope retained.
+      const stored = await store.getTask(task.id);
+      const ext = (stored?.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+      assert.ok(ext?.chat_completions_request, 'getTask must retain the request envelope when on');
+      assert.deepEqual(ext.chat_completions_request, envelope);
+
+      // Hot replay (loadByContextId): envelope stripped regardless of the flag.
+      const replay = await store.loadByContextId(contextId, principalId);
+      assert.ok(replay.length >= 1, 'the owned task is replayed');
+      for (const t of replay) {
+        const rext = (t.metadata as Record<string, Record<string, unknown>> | undefined)?.[OAI];
+        assert.equal(
+          rext?.chat_completions_request,
+          undefined,
+          'loadByContextId must strip the envelope even when persistRequestEnvelope is on',
+        );
       }
     } finally {
       await sql`DELETE FROM infra.a2a_tasks WHERE context_id = ${contextId}`;

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -117,6 +117,15 @@ export interface PostgresTaskStoreOptions {
   persistRequestEnvelope?: boolean;
 }
 
+// Parse the A2A_PERSIST_REQUEST_ENVELOPE env value into the store flag. Accepts
+// the usual truthy spellings (case-insensitive); anything else — including
+// unset, empty, "0", "false", "off", or garbage — is false, so the lean,
+// disk-safe default (issue #419) holds unless it is explicitly turned on. Kept
+// pure (no process.env read) so both the caller and its unit test drive it.
+export function parsePersistRequestEnvelope(raw: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test(raw ?? '');
+}
+
 export class PostgresTaskStore implements ContextAwareTaskStore {
   private readonly persistRequestEnvelope: boolean;
 

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -73,8 +73,16 @@ function stripPersistedEnvelope(task: Task): Task {
   return { ...task, metadata: hasMetadata ? nextMetadata : undefined };
 }
 
-export function stripSensitiveMetadata(task: Task): Task {
-  const result = { ...stripPersistedEnvelope(task) };
+export function stripSensitiveMetadata(
+  task: Task,
+  opts?: { preserveEnvelope?: boolean },
+): Task {
+  // `preserveEnvelope` keeps the request envelope on the persisted row (see
+  // PostgresTaskStore's persistRequestEnvelope flag / issue #419); the
+  // message-metadata scrub below (bearer token / principal) always runs
+  // regardless — those must never be persisted.
+  const base = opts?.preserveEnvelope ? task : stripPersistedEnvelope(task);
+  const result = { ...base };
   if (result.history?.length) {
     result.history = result.history.map(stripMessageMetadata);
   }
@@ -88,8 +96,36 @@ export interface ContextAwareTaskStore extends TaskStore {
   loadByContextId(contextId: string, principalId: string, excludeTaskId?: string): Promise<Task[]>;
 }
 
+export interface PostgresTaskStoreOptions {
+  // Retain the full inbound request envelope (`chat_completions_request`) on the
+  // persisted task row instead of stripping it at write time (issue #419).
+  //
+  // Default (false) strips the envelope on every write — the post-#409 behavior
+  // that keeps the table lean. The envelope is redundant by design (the gateway
+  // re-sends the full conversation every turn) and, re-persisted per turn up to
+  // MAX_CONTEXT_TASKS times per context, was the near-quadratic source of the
+  // #408 disk-full incident, so stripping stays the safe default.
+  //
+  // Flipping it to true is an operational forensics switch: it makes every
+  // persisted task a complete, replayable record of its input — needed when a
+  // failure only surfaces at the very end (e.g. an error carried inside an
+  // otherwise-"completed" terminal frame, which a task-state test would miss),
+  // so we cannot reliably decide per-task at write time whether to keep it.
+  // Ops turns it on for a debugging window and off again; it re-introduces the
+  // #408 growth for as long as it is on, so it is NOT meant to be left on.
+  // (Reads still strip on the hot replay path regardless — see loadByContextId.)
+  persistRequestEnvelope?: boolean;
+}
+
 export class PostgresTaskStore implements ContextAwareTaskStore {
-  constructor(private readonly sql: Sql) {}
+  private readonly persistRequestEnvelope: boolean;
+
+  constructor(
+    private readonly sql: Sql,
+    options?: PostgresTaskStoreOptions,
+  ) {
+    this.persistRequestEnvelope = options?.persistRequestEnvelope ?? false;
+  }
 
   async createTask(params: CreateTaskParams): Promise<Task> {
     const task: Task = {
@@ -108,6 +144,12 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     const rows = await this.sql<{ task_json: Task }[]>`
       SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} LIMIT 1
     `;
+    // Returns the stored row verbatim — including the request envelope when
+    // persistRequestEnvelope is on (issue #419); this is the forensic read path.
+    // Unlike loadByContextId (hot per-turn replay), this is a single on-demand
+    // fetch, so carrying the envelope here is not a bloat concern. The envelope
+    // is never read back for request forwarding (the gateway re-sends it every
+    // turn), so returning it here changes no execution behavior.
     return rows[0]?.task_json ?? null;
   }
 
@@ -182,7 +224,14 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
           ORDER BY created_at DESC, task_id DESC
           LIMIT ${MAX_CONTEXT_TASKS}
         `;
-    return rows.map((r) => r.task_json).reverse();
+    // Strip the request envelope from replayed tasks unconditionally — even
+    // when persistRequestEnvelope is on and the stored rows carry it (issue
+    // #419). The per-turn context replay must stay lean: re-reading a large
+    // cumulative envelope for up to MAX_CONTEXT_TASKS rows every turn is exactly
+    // the read amplification #409 removed, and replay never needs it (the
+    // gateway re-sends the envelope every turn). Forensic access to the retained
+    // envelope is via getTask / SQL instead.
+    return rows.map((r) => stripPersistedEnvelope(r.task_json)).reverse();
   }
 
   /**
@@ -232,7 +281,9 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
   // row write participates in the same FOR UPDATE transaction that read it.
   private async writeTask(task: Task, sql: SqlExecutor = this.sql): Promise<void> {
     const ownerPrincipal = extractOwnerPrincipal(task);
-    const sanitized = stripSensitiveMetadata(task);
+    const sanitized = stripSensitiveMetadata(task, {
+      preserveEnvelope: this.persistRequestEnvelope,
+    });
     const contextId = task.contextId ?? task.id;
 
     await sql`


### PR DESCRIPTION
Closes #419.

## Problem

`#409` stripped `metadata[].chat_completions_request` (the full inbound OpenAI request — system prompt + entire `messages[]` + tools) from every persisted A2A task to stop the near-quadratic growth that tripped Fly's disk read-only protection (`#408`). Correct for storage, but it removed our only forensic trail of **what a task's actual input was** — exactly what we need for root-cause work (e.g. the recent `context_length_exceeded` on `vicoop-codex-baseline`, whose prompt is now unrecoverable anywhere).

## Approach: a plain operational flag, not per-state logic

Stripping stays the default. A single env flag lets ops retain the full envelope on demand:

- **`A2A_PERSIST_REQUEST_ENVELOPE`** (default off) — keeps stripping on every write, the lean post-`#409` behavior. Truthy flips `PostgresTaskStore` into a forensics mode that retains the full envelope on every persisted row, making each stored task a complete, replayable record of its input.
- **Why a flag rather than keying on `state === FAILED`:** a failure can surface only at the very end (e.g. an error carried inside an otherwise-`completed` terminal frame), so we can't reliably decide per-task at write time whether to keep the envelope. Ops turns it on for a debugging window and off again.
- **`loadByContextId` strips the envelope on read unconditionally** — even when the flag is on — so a retained envelope never re-enters the hot per-turn context replay (the read amplification `#409` removed). Forensic access is `getTask` / direct SQL on `task_json`.

Leaving the flag on re-introduces the `#408` growth, so it is an on-demand toggle, not a steady state — `fly.toml` documents this (including `VACUUM FULL` to reclaim disk afterwards) and ships it **off**.

## Changes

| File | Change |
| --- | --- |
| `postgres-task-store.ts` | `preserveEnvelope` option on `stripSensitiveMetadata`; `persistRequestEnvelope` constructor option; write honors the flag, replay always strips, `getTask` returns raw |
| `admin.ts` | parses the env flag into the shared task store (used by the admin agent and every WS-forwarding agent) |
| `postgres-task-store.test.ts` | 2 pure tests + 2 DB integration tests (default strips; flag on → `getTask` retains, replay still strips) |
| `fly.toml` | documents the flag as an on-demand forensics toggle |

## Testing

- `pnpm -r build`, `pnpm -r typecheck` — clean.
- `pnpm --filter @vicoop-bridge/server test` against a local Postgres — all envelope tests + existing retention/concurrency tests pass. (The 2 unrelated SIWE auth tests fail only on an env/audience-config dependency of that suite; this diff doesn't touch auth.)

## Release

Server-only — no changeset (server is `ignore`d and ships via `fly deploy`).

Refs: `#408` (disk read-only), `#409` (envelope strip), `#389` (time-based retention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)