### PR TITLE
fix(client): advertise fable-5 (1M-default) at full ceiling, not 200k

### DIFF
--- a/.changeset/claude-1m-default-models.md
+++ b/.changeset/claude-1m-default-models.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Fix the claude backend under-advertising `contextWindow` for models that run 1M by default. The tier correction capped every bare-advertised id at the 200k base, but `claude-fable-5` runs the full 1M window bare in Claude Code (Anthropic documents it as 1M-by-default with no `[1m]` variant), so it was advertised at 200k instead of 1M. Bare-advertised `claude-fable-5` now uses its Models-API ceiling; models where 1M is an opt-in `[1m]` tier (Opus 4.x, Sonnet 4.6) keep the 200k-unless-`[1m]` behavior. The 1M-default classification is a small explicit set (currently just `claude-fable-5`) because there is no reliable runtime signal to tell a 1M-default model from a 1M-opt-in one; a model is added only once released and confirmed, so a 200k-default or not-yet-shipped model is never over-advertised.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -2991,7 +2991,28 @@ const SAMPLE_CATALOG = (): Map<string, ClaudeModelLimits> =>
     ['claude-sonnet-4-5', { maxInputTokens: 1_000_000, maxTokens: 64_000 }],
     ['claude-opus-4-8', { maxInputTokens: 1_000_000, maxTokens: 128_000 }],
     ['claude-opus-4-5', { maxInputTokens: 200_000, maxTokens: 64_000 }],
+    // 1M-by-default (no 200k tier): must NOT be capped even when advertised bare.
+    ['claude-fable-5', { maxInputTokens: 1_000_000, maxTokens: 128_000 }],
+    ['claude-sonnet-5', { maxInputTokens: 1_000_000, maxTokens: 128_000 }],
   ]);
+
+test('enrichEntriesWithModelLimits: allowlisted 1M-default model gets full ceiling bare; a non-allowlisted 1M-capable one is capped', () => {
+  // fable-5 is allowlisted (1M by default in Claude Code), so a bare-advertised
+  // id gets the ceiling, NOT the 200k Option-B cap. sonnet-5 is 1M-CAPABLE
+  // (ceiling 1M in the catalog) but NOT allowlisted — it stays on Option B and
+  // caps at 200k bare (safe under-advertise for an unconfirmed 1M default).
+  const out = enrichEntriesWithModelLimits(
+    [
+      { entry: { id: 'claude-fable-5', default: true }, tierId: 'claude-fable-5' },
+      { entry: { id: 'claude-sonnet-5' }, tierId: 'claude-sonnet-5' },
+    ],
+    SAMPLE_CATALOG(),
+  );
+  assert.deepEqual(out, [
+    { id: 'claude-fable-5', default: true, contextWindow: 1_000_000, maxOutputTokens: 128_000 },
+    { id: 'claude-sonnet-5', contextWindow: 200_000, maxOutputTokens: 128_000 },
+  ]);
+});
 
 test('enrichEntriesWithModelLimits caps a 1M-capable model to the 200k base without the [1m] tier', () => {
   const out = enrichEntriesWithModelLimits(

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -359,6 +359,29 @@ const ONE_MILLION_TIER_RE = /\[1m\]$/i;
 // prompt+completion tokens even when the model's ceiling is higher.
 const CLAUDE_BASE_CONTEXT_WINDOW = 200_000;
 
+// Canonical ids of models Claude Code serves at 1M by DEFAULT — there is no
+// separate 200k tier and no `[1m]` variant to opt into, so a bare id already
+// runs the full 1M window. For these the 200k base cap must NOT apply; the
+// effective window is the model's ceiling regardless of the `[1m]` marker.
+//
+// This is an explicit set (not probed) on purpose: there is no reliable runtime
+// signal to tell a "1M-default" model from a "200k-default, 1M-opt-in" one. The
+// Anthropic Models API reports only the ceiling (1M for all of these), and
+// Claude Code's own `[1m]`-suffix handling is inconsistent — e.g. it strips
+// `claude-fable-5[1m]` but keeps `claude-sonnet-5[1m]`. So membership is decided
+// per model from documented + verified behaviour, kept deliberately small and
+// conservative: a model is added only when it is BOTH released and confirmed to
+// default to 1M, so we never over-advertise a 200k-default (or not-yet-shipped)
+// model. Models absent from this set fall through to the `[1m]`-gated Option B.
+//
+// Only `claude-fable-5` qualifies today: it is released and serving in
+// production, Anthropic documents it as 1M-by-default, and Claude Code drops its
+// `[1m]` suffix (confirming no separate tier). Other "5"-gen models are left out
+// until each is likewise confirmed — e.g. Sonnet 5 is not yet released and its
+// `[1m]` handling is inconsistent, so it stays on Option B (bare → 200k), which
+// under-advertises safely rather than over-promising an unconfirmed 1M default.
+const CLAUDE_ONE_MILLION_DEFAULT_MODELS = new Set<string>(['claude-fable-5']);
+
 // An advertised entry paired with the string the 1M-tier decision reads. They
 // differ on the probe path: the entry `id` is canonical (must match
 // `usage.model` and must not become a `[1m]` pool slug), while `tierId` is the
@@ -371,25 +394,31 @@ export interface ClaudeAdvertiseEntry {
 
 // Enrich advertised model entries with the openai-compat/v1 `contextWindow` /
 // `maxOutputTokens` hints from the Models API catalog (keyed by canonical id).
-// Option B (tier-corrected effective window): `max_input_tokens` is the model's
-// ceiling, but the effective window is only that large when the `[1m]` tier is
-// active — so an entry whose `tierId` lacks the `[1m]` marker is capped at the
-// 200k base. `max_tokens` is tier-agnostic and maps straight to
-// `maxOutputTokens`. Entries with no catalog match (or an empty catalog) pass
-// through unchanged, so a stale/unknown id degrades to "unspecified" rather
-// than a wrong number. Tier is read from `tierId`, NOT `entry.id`, so a probe
-// default advertised under its canonical id still gets the 1M lift.
+// The effective window is tier-corrected:
+//   - A model in `CLAUDE_ONE_MILLION_DEFAULT_MODELS` runs 1M by default, so it
+//     gets the full ceiling regardless of the `[1m]` marker.
+//   - Otherwise Option B applies: `max_input_tokens` is the model's ceiling, but
+//     the effective window is only that large when the `[1m]` tier is active, so
+//     an entry whose `tierId` lacks the `[1m]` marker is capped at the 200k base.
+// `max_tokens` is tier-agnostic and maps straight to `maxOutputTokens`. Entries
+// with no catalog match (or an empty catalog) pass through unchanged, so a
+// stale/unknown id degrades to "unspecified" rather than a wrong number. Tier is
+// read from `tierId`, NOT `entry.id`, so a probe default advertised under its
+// canonical id still gets the 1M lift.
 export function enrichEntriesWithModelLimits(
   inputs: readonly ClaudeAdvertiseEntry[],
   catalog: Map<string, ClaudeModelLimits>,
 ): OpenAICompatModelAdvertise[] {
   if (catalog.size === 0) return inputs.map((i) => i.entry);
   return inputs.map(({ entry, tierId }) => {
-    const limits = catalog.get(normalizeClaudeModelId(entry.id));
+    const canonicalId = normalizeClaudeModelId(entry.id);
+    const limits = catalog.get(canonicalId);
     if (!limits) return entry;
-    const contextWindow = ONE_MILLION_TIER_RE.test(tierId)
-      ? limits.maxInputTokens
-      : Math.min(CLAUDE_BASE_CONTEXT_WINDOW, limits.maxInputTokens);
+    const oneMillionByDefault = CLAUDE_ONE_MILLION_DEFAULT_MODELS.has(canonicalId);
+    const contextWindow =
+      oneMillionByDefault || ONE_MILLION_TIER_RE.test(tierId)
+        ? limits.maxInputTokens
+        : Math.min(CLAUDE_BASE_CONTEXT_WINDOW, limits.maxInputTokens);
     return { ...entry, contextWindow, maxOutputTokens: limits.maxTokens };
   });
 }


### PR DESCRIPTION
Follow-up to the context-window advertise (#421). The claude tier correction under-advertised `claude-fable-5`, which runs **1M by default**.

## Problem

Option B capped every bare-advertised id at the 200k base (`[1m]` → ceiling, else `min(200k, ceiling)`). That's correct for models where 1M is an **opt-in `[1m]` tier** (Opus 4.x, Sonnet 4.6 — bare = 200k). But **Fable 5 runs 1M by default** in Claude Code (no 200k tier, no `[1m]` variant), so it serves 1M bare — yet was advertised at 200k.

Verified in production: `vicoop-claude-baseline` advertised `claude-fable-5` at `contextWindow: 200000`, though its Anthropic ceiling is 1M and Claude Code serves it at 1M.

## Fix

`enrichEntriesWithModelLimits` advertises the Models-API ceiling for a small explicit `CLAUDE_ONE_MILLION_DEFAULT_MODELS` set (**currently just `claude-fable-5`**) regardless of the `[1m]` marker. Everything else keeps Option B, so the opt-in models (Opus 4.x / Sonnet 4.6) still advertise 200k bare — **no over-advertising**.

## Why an explicit set, not a probe

There is **no reliable runtime signal** to distinguish 1M-default from 1M-opt-in:
- The Anthropic Models API reports only the ceiling (1M for all of these).
- Claude Code's `[1m]`-suffix handling is inconsistent — empirically it **strips** `claude-fable-5[1m]` → `claude-fable-5` but **keeps** `claude-sonnet-5[1m]`. So the suffix tells us whether Claude Code recognizes a `[1m]` variant, not whether bare is 200k or 1M.

So membership is sourced from documented + verified behaviour and kept minimal. **Only `claude-fable-5` qualifies today** — released, serving in prod, documented 1M-default, and `[1m]` dropped by Claude Code. **Sonnet 5 / Mythos 5 are deliberately excluded** (Sonnet 5 is not yet released and its `[1m]` handling is inconsistent) so an unconfirmed 1M default is never over-advertised. Under-advertising is the safe direction; over-advertising causes `context window exceeded` failures.

## Tests

New unit test asserts the allowlisted 1M-default model (fable-5) gets the full ceiling bare, while a non-allowlisted 1M-capable one (sonnet-5) is still capped at 200k. Existing tests (opt-in 200k cap, `[1m]` lift, probe-path canonical-id lift) unchanged. Full suite: **client 823 pass**, typecheck clean.

## Rollout

After release + operator upgrade + a router card-refresh, `fable-5` will advertise 1M instead of 200k. `opus-4-8` (probe `[1m]`) and `sonnet-4-6` (bare, opt-in) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)