### PR TITLE
fix(vicoop-codex): don't let Bun's ~255s fetch timeout kill slow-but-working serve requests

### DIFF
--- a/.changeset/codex-serve-fetch-no-bun-timeout.md
+++ b/.changeset/codex-serve-fetch-no-bun-timeout.md
@@ -1,0 +1,7 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+fix(vicoop-codex): disable Bun's ~255s native fetch timeout on the request to the local `vicoop-codex serve`
+
+A legitimately slow upstream (long reasoning / slow first byte — observed first-byte latencies up to ~440s) made Bun abort the serve request at ~255s with `The operation timed out.`, failing the task even though serve's own 9-minute upstream deadline had not fired and the request would have (and did) succeed. The request is still bounded by the task abort signal and serve's deadline, so it never hangs unbounded.

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -649,12 +649,24 @@ async function defaultFetch(
   url: string,
   init: { body: string; signal: AbortSignal },
 ): Promise<VicoopCodexStreamResponse> {
-  const res = await fetch(url, {
+  const reqInit: RequestInit = {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: init.body,
     signal: init.signal,
-  });
+  };
+  // Disable Bun's native fetch idle timeout (~255s) for the request to the
+  // local `vicoop-codex serve`. A legitimately slow upstream (long reasoning /
+  // slow first byte) can take minutes before serve emits its first SSE bytes —
+  // observed first-byte latencies up to ~440s — and Bun would otherwise abort
+  // at ~255s with "The operation timed out.", failing the task even though
+  // serve's own 9-min upstream deadline has NOT fired and the request would
+  // succeed. The request stays bounded by `init.signal` (the task abort) and by
+  // serve's upstream deadline, so this never hangs unbounded. `timeout` is a Bun
+  // extension to the DOM `RequestInit` type (Node's fetch ignores it), matching
+  // vicoop-codex's own `postUpstream`; hence the cast.
+  (reqInit as { timeout?: boolean }).timeout = false;
+  const res = await fetch(url, reqInit);
   return {
     ok: res.ok,
     status: res.status,


### PR DESCRIPTION
## Symptom

Tasks intermittently failed with `network_error: vicoop-codex serve request failed: The operation timed out.` at ~254s — surfacing to the router/OpenCode client as a hang-then-failure (UI stuck on "Generating Response…" for ~4 min, then error).

## Root cause (proven by instrumentation)

The bridge drives each task through a local `vicoop-codex serve` HTTP call in `defaultFetch` (`packages/client/src/backends/vicoop-codex.ts`). It passed the task abort signal but **not `timeout: false`**, so **Bun's native ~255s fetch idle timeout** fired independently and aborted the request.

The upstream instrumentation added to `vicoop-codex` (`[upstream]` logs) showed the failing requests were **not wedged** — the raw ChatGPT `/responses` call was just **slow**:

```
seq 24  start
seq 24  headers    ms=437952  status=200      ← headers after 437s
seq 24  first_byte ms=437954  bytes=6960
seq 24  end        ms=442129  bytes=394218  chunks=30  firstByte=true   ← completed OK
```

Meanwhile the bridge had already failed the task at 254s. So it's a **timeout mismatch**: bridge→serve fetch (~255s Bun default) < serve→upstream deadline (9 min). serve finished a request nobody was listening to.

## Fix

Set `timeout: false` on the serve fetch (Bun extension to `RequestInit`, matching vicoop-codex's own `postUpstream`). The request stays bounded by the task abort signal and serve's 9-min upstream deadline, so it never hangs unbounded — it just no longer fails a slow-but-working upstream early.

## Verification

- `pnpm --filter @vicoop-bridge/client typecheck` — clean.
- `vicoop-codex.test.ts` — 47/47 pass.
- Changeset added (`@vicoop-bridge/client` patch).

## Follow-ups (not in this PR)

- Investigate *why* the upstream sometimes takes ~440s to first byte (gpt-5.6-sol load / queueing) — 7-min first-byte is a poor UX even when it succeeds.
- Consider a shorter, deliberate cap with a clear "upstream too slow" error rather than the full 9-min wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)