### PR TITLE
fix(client): reap vicoop-codex serve child on every non-SIGKILL exit

### DIFF
--- a/.changeset/vicoop-codex-serve-leak-on-exit.md
+++ b/.changeset/vicoop-codex-serve-leak-on-exit.md
@@ -1,0 +1,19 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+client daemon: reap the vicoop-codex `serve` child on every non-SIGKILL exit
+
+The `vicoop-codex` host backend spawns a long-lived `vicoop-codex serve`
+app-server whose only teardown is `backend.stop()`, reached via
+`client.stop()`. But the daemon also exits WITHOUT running the SIGINT/SIGTERM
+handler — on a fatal terminal WS close (`onFatal` → `process.exit(1)`), an
+`uncaughtException`/`unhandledRejection`, or SIGHUP (previously unhandled) —
+so `stop()` never fired and the serve child leaked as an orphan (reparented to
+init, still LISTENing), accumulating one per restart.
+
+Register SIGHUP through the graceful path, and add a `process.once('exit')`
+last-resort that calls `client.stop()` synchronously — it runs on every
+`process.exit()` path, so the child is reliably reaped on all non-SIGKILL
+exits. (SIGKILL can't be trapped; vicoop-codex-cli's `serve` carries its own
+parent-death watchdog for that case.)

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -697,6 +697,37 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
   };
   process.on('SIGINT', onSignal);
   process.on('SIGTERM', onSignal);
+  // SIGHUP — e.g. the controlling terminal / login session going away under a
+  // launcher like cmux — otherwise terminates the daemon with Node's default
+  // disposition, WITHOUT running onSignal, orphaning the backend's long-lived
+  // child (the `vicoop-codex serve` app-server). Route it through the same
+  // graceful path so `backend.stop()` reaps the child.
+  process.on('SIGHUP', onSignal);
+  // Last-resort synchronous cleanup. onSignal covers the graceful signals, but
+  // the daemon also leaves via process.exit() on a fatal terminal WS close
+  // (`onFatal`), an `uncaughtException`, or an `unhandledRejection` — none of
+  // which run onSignal, so `backend.stop()` (which SIGTERMs the serve child)
+  // would never fire and the child would leak as an orphan (reparented to init,
+  // still LISTENing). `process.exit()` runs 'exit' listeners synchronously and
+  // `client.stop()` is synchronous + idempotent, so this reliably reaps the
+  // child on every non-SIGKILL exit. (SIGKILL can't be trapped; the serve side
+  // carries its own parent-death watchdog for that case.)
+  process.once('exit', () => {
+    // Reap the backend's long-lived child FIRST and independently: it is the
+    // whole point of this hook, and `client.stop()` only reaches `backend.stop()`
+    // as its last step (after aborting inflight + closing the WS), so a throw in
+    // one of those earlier steps must not be able to skip the kill.
+    try {
+      backend.stop?.();
+    } catch {
+      // best-effort — never throw out of an exit handler
+    }
+    try {
+      client.stop();
+    } catch {
+      // best-effort — never throw out of an exit handler
+    }
+  });
 }
 
 // Race the spawned child's early exit against a short grace timer. A daemon


### PR DESCRIPTION
## Why

Investigating a process leak on an operator host: **4 `vicoop-codex serve` processes had been running for 14 days, orphaned (reparented to init, ppid=1), still LISTENing on ephemeral ports, with no live `vicoop-client` parent** — one accumulated per client restart.

The `vicoop-codex` host backend spawns a long-lived `vicoop-codex serve` app-server (a lazy singleton). Its **only** teardown is `backend.stop()` (`backends/vicoop-codex.ts`), reached via `Client.stop()`. But `client.stop()` is only called from the SIGINT/SIGTERM handler (`onSignal`). The daemon has **several other exit paths that bypass `onSignal`**:

- **Fatal terminal WS close** → `onFatal: () => process.exit(1)` (e.g. 4014 "client deleted") — a normal operational event
- **`uncaughtException` / `unhandledRejection`** → `process.exit(1)`
- **SIGHUP** — not registered (only SIGINT/SIGTERM were), so Node's default disposition terminates the daemon
- **SIGKILL** — untrappable

The serve child is spawned **without `detached`**, and `process.exit()` sends no signal to children, so on all of the above the child was orphaned and kept LISTENing forever.

## What

- Register **SIGHUP** through the same graceful `onSignal` path (covers a torn-down controlling terminal / login session, e.g. under a launcher like cmux).
- Add a **`process.once('exit')` last-resort** that calls `client.stop()` synchronously. `process.exit()` runs `'exit'` listeners synchronously, and `client.stop()` → `backend.stop()` → `child.kill('SIGTERM')` is synchronous and idempotent, so the child is **reliably reaped on every non-SIGKILL exit** (`onFatal`, uncaught/unhandled, normal exit).

SIGKILL can't be trapped — the complementary **parent-death watchdog** in `vicoop-codex serve` (vicoop-codex-cli) covers that case (and hard crashes) by self-terminating when its parent disappears.

## Test

`packages/client` typecheck clean; `client.test.ts` + `cli-args.test.ts` 80/80 pass. The change is confined to `runDaemon`'s signal/exit wiring in `cli.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)