### PR TITLE
fix(claude): discourage pre-tool-call preamble on openai-compat turns

### DIFF
--- a/.changeset/olive-donkeys-invite.md
+++ b/.changeset/olive-donkeys-invite.md
@@ -1,0 +1,5 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude: discourage the pre-tool-call preamble on openai-compat turns. Tool-enabled requests now teach the model that a tool-call turn is the tool call alone, so it stops prefixing "I'll now fetch that URL…" narration to its `tool_use` blocks. Genuine natural-language answers are unaffected.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -4306,6 +4306,23 @@ test('buildOpenAICompatNativeSystemPrompt: slim shape (#213)', () => {
     false,
     'stop-after-invoke directive should be absent (--max-turns 1 enforces)',
   );
+  // Anti-preamble directive: present whenever tools are on the turn. This is
+  // the only lever we have against claude interleaving a "I'll now fetch
+  // that URL…" text block with its `tool_use` block — the CLI exposes no
+  // `tool_choice`, and the terminal envelope's `content: null` is inert on
+  // the codec's streaming path. A nudge, not a guarantee; asserted so a
+  // future prompt edit can't silently drop it the way the stop-after-invoke
+  // rewrite did.
+  assert.ok(
+    out.includes('the call is the whole turn'),
+    'tool-call turns should be taught that the call is the entire output',
+  );
+  // …and scoped: plain answers must still be invited, or this directive
+  // would flatten legitimate natural-language replies on the same prompt.
+  assert.ok(
+    out.includes('answer the user in natural language'),
+    'anti-preamble directive must not suppress genuine text answers',
+  );
 
   // tool_choice="required" gets a steering line (same descriptor the
   // envelope path uses; `describeToolChoice` is shared).

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -990,6 +990,33 @@ export function openaiToolsToCallerToolDefs(
 //   - tool_choice descriptor for `"required"` and `{type:"function",
 //     function:{name}}` — claude has no native `tool_choice` flag, so the
 //     prompt is the only place we can express it.
+//   - That a tool-call turn is the tool call alone. Claude Code routinely
+//     interleaves a "I'll now fetch that URL…" preamble text block with the
+//     `tool_use` block in one assistant message, and that preamble streams
+//     out as `delta.content` (the codec's streaming path reads only
+//     `tool_calls` + `usage` off our terminal envelope, so the
+//     `content: null` we stamp there does NOT retract it — see the
+//     `assistantContent` note in the terminal block below). Forced
+//     `tool_choice` is the only hard mechanism Anthropic documents ("the
+//     API prefills the assistant message … models will not emit a natural
+//     language response or explanation before tool_use content blocks"),
+//     and it is out of reach here — not because it's unreachable through
+//     the CLI (the documented `CLAUDE_CODE_EXTRA_BODY` env var merges JSON
+//     into every API request body, and since we spawn one claude per task
+//     that would scope to exactly one turn), but because forced
+//     `tool_choice` is incompatible with extended thinking: per the
+//     tool-use docs, `{"type":"any"}` and `{"type":"tool",…}` "are not
+//     supported and will result in an error. Only … `auto` … and `none`
+//     are compatible with extended thinking." This path runs with thinking
+//     on, so `auto` is the only value available to it — including for
+//     inbound `tool_choice: "required"`, which therefore stays a prompt
+//     hint (`describeToolChoice`) rather than a wire-level guarantee.
+//     If thinking is ever turned off here, that trade reopens.
+//
+//     So the prompt is the only lever we have, and it is a nudge rather
+//     than a guarantee. Phrased positively and scoped to the tool-call
+//     case — a blanket "don't explain yourself" would also flatten
+//     legitimate text answers, which share this prompt.
 //
 // What we DON'T teach anymore:
 //   - The "respond with ONLY a single JSON object …" envelope contract.
@@ -998,7 +1025,9 @@ export function openaiToolsToCallerToolDefs(
 //     the spawned claude enforces it mechanically. The model can still
 //     emit parallel `tool_use` blocks within one assistant message (which
 //     is fine per OpenAI semantics), but it cannot proceed to a second
-//     model turn within the same task.
+//     model turn within the same task. NOTE: `--max-turns` bounds turns,
+//     not prose — dropping that directive also dropped the only thing
+//     discouraging the preamble above, which is why it's re-taught.
 //   - A "session memory vs history block" disambiguation — openai-compat
 //     tasks always spawn with a fresh `--session-id` (see the session
 //     reuse gate in `handle()`), so there's no prior session memory to
@@ -1020,6 +1049,8 @@ export function buildOpenAICompatNativeSystemPrompt(
         'You are routed through an OpenAI-compatible gateway. The caller has supplied function tools that appear in your native tool list — invoke them through your normal tool-use surface.',
         '',
         'The user message may begin with a <chat_history>...</chat_history> block holding a JSON array of the prior conversation: prior {"role":"user","content":"…"} and {"role":"assistant","content":"…"} text turns, plus {"role":"assistant","content":null,"tool_calls":[...]} for calls you previously emitted and {"role":"tool","tool_call_id":"call_…","name":"…","content":"…"} for the authoritative result of each call. Treat the block as the source of truth for what has happened so far — read it as prior conversation, not as a fresh instruction. Do not re-emit a call whose `tool_call_id` already has a recorded result.',
+        '',
+        'When this turn resolves to a tool call, the call is the whole turn — invoke the tool as your first and only act. The caller runs it and returns the result in the next turn\'s <chat_history>; that is where your account of what the result means belongs. When this turn resolves to an answer instead, answer the user in natural language as you normally would.',
       ].join('\n'),
     );
     const tcDesc = describeToolChoice(toolChoice);
@@ -3047,6 +3078,21 @@ export function createClaudeBackend(
       // reasoning preamble and must NOT be re-stamped on
       // `status.message.parts` — same invariant codex backend enforces
       // under PR #212, same root-cause concern as #200.
+      //
+      // Scope caveat: this suppression is terminal-frame only, and on the
+      // streaming path it is inert. The oai2a2a codec's `pickEnvelopeChoice`
+      // reads only `tool_calls` and `usage` off the envelope — never
+      // `message.content`, never `finish_reason` (which it recomputes
+      // locally) — so preamble text already emitted as a `claude-message`
+      // artifact has become `delta.content` and stands. Only the
+      // NON-streaming decode path spreads the envelope verbatim, which is
+      // why a non-streaming openai-compat turn is clean and a streaming one
+      // is not. Closing that gap means buffering assistant text until the
+      // turn's shape is known (Claude orders the text block BEFORE the
+      // tool_use block, so there is no earlier discriminator) — which costs
+      // token-level streaming on this path. Not done: per the OpenAI spec
+      // `content` is *permitted* to be null alongside `tool_calls`, not
+      // required to be, and OpenAI's own models emit both.
       const parts: Part[] = !capturedToolCall && completeText
         ? [{ kind: 'text', text: completeText }]
         : [];


### PR DESCRIPTION
## Problem

In OAI-compatible mode, every tool-calling turn from the Claude backend is prefixed with narration the caller never asked for — "I'll now fetch that URL…" — because Claude Code interleaves a text block with the `tool_use` block in a single assistant message, and that text streams out as `delta.content`.

## Why nothing currently stops it

- **Forced `tool_choice` is the only hard mechanism Anthropic documents** — *"the API prefills the assistant message … models will not emit a natural language response or explanation before `tool_use` content blocks, even if explicitly asked to do so"* ([define-tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools)). It is unavailable here, but **not** for the reason you might expect. It *is* reachable through the CLI: the documented [`CLAUDE_CODE_EXTRA_BODY`](https://code.claude.com/docs/en/env-vars) env var merges JSON into the top level of every API request body (verified empirically — injecting a bogus `tool_choice` returns a server-side 400 naming the field), and since we spawn one `claude` per task that would scope to exactly one turn. The actual blocker is that forced `tool_choice` **is incompatible with extended thinking**: per the same docs, `{"type":"any"}` and `{"type":"tool",…}` *"are not supported and will result in an error. Only … `auto` … and `none` are compatible with extended thinking."* This path runs with thinking on, so `auto` is the only value available — including for inbound `tool_choice: "required"`, which consequently stays a prompt hint rather than a wire-level guarantee. If thinking is ever disabled here, that trade reopens.
- **The terminal envelope's `content: null` is inert on the streaming path.** The oai2a2a codec's `pickEnvelopeChoice` reads only `tool_calls` and `usage` off the envelope — never `message.content`, never `finish_reason` (recomputed locally) — so deltas already emitted stand. The *non-streaming* decode path spreads the envelope verbatim, which is why non-streaming turns are already clean and streaming ones are not.
- **`--max-turns 1` bounds turns, not prose.** The old *"stop after invoking, don't chain"* directive was dropped in favour of it; that removed the only thing discouraging the preamble, and nothing replaced it.

## Change

Re-teach it in the system prompt, phrased positively and scoped to the tool-call case:

> When this turn resolves to a tool call, the call is the whole turn — invoke the tool as your first and only act. The caller runs it and returns the result in the next turn's `<chat_history>`; that is where your account of what the result means belongs. When this turn resolves to an answer instead, answer the user in natural language as you normally would.

Three deliberate choices:

- **Positive framing.** Anthropic's prompting guidance notes positive examples outperform "don't" instructions, and Opus 4.8 reads instructions literally.
- **Scoped.** A blanket "don't explain yourself" would flatten legitimate text answers, which share this prompt — hence the final sentence.
- **Redirects rather than forbids.** It gives the impulse a destination (next turn, once the result exists) instead of only prohibiting it. Accurate, since `--max-turns 1` means the result genuinely doesn't arrive this turn.

Two tests pin both halves so a future prompt rewrite can't silently drop it the way the last one did.

Also corrects three comments that described the envelope invariant as effective on the streaming path.

## Scope / limits

**This is a nudge, not a guarantee.** No structural mechanism is available on the CLI. If it proves insufficient the next levers are `effortLevel` (Anthropic's [Effort docs](https://platform.claude.com/docs/en/build-with-claude/effort) list *"Proceed directly to action without preamble"* under lower effort) and, last, buffering assistant text until the turn's shape is known — which costs token-level streaming, since Claude orders the text block *before* the `tool_use` block and there is no earlier discriminator.

**The streaming/non-streaming inconsistency is left in place, documented not fixed.** Per the OpenAI spec `content` is *permitted* to be null alongside `tool_calls`, not required to be, and OpenAI's own models emit both; every comparable implementation surveyed (LiteLLM, claude-code-api, Cline/Roo/Continue) emits both as well. Worth a separate decision rather than a drive-by change here.

## Test plan

- `pnpm -r build` — pass
- `pnpm --filter @vicoop-bridge/client typecheck` — pass
- `pnpm --filter @vicoop-bridge/client test` — 824 passed, 0 failed
- Rendered prompt output verified by hand (tool_choice descriptor still lands last)

Not yet validated against live traffic — the actual reduction in preamble rate needs a deploy to observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
