### PR TITLE
fix(claude): stage openai-compat system prompt via --system-prompt-file (E2BIG)

### DIFF
--- a/.changeset/heavy-planes-repair.md
+++ b/.changeset/heavy-planes-repair.md
@@ -1,0 +1,5 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: stage the openai-compat system prompt in a per-task temp file (`--system-prompt-file`) instead of argv, fixing `E2BIG: argument list too long` spawn failures on large system prompts (#437). The file is written 0600 and removed when the spawned process closes.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync, statSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -41,6 +42,12 @@ interface FakeChild extends ClaudeChildHandle {
   readonly args: readonly string[];
   readonly cwd?: string;
   readonly env?: Record<string, string>;
+  // Snapshot of the staged `--system-prompt-file` taken at spawn time — the
+  // backend deletes the file when the child closes, so assertions that run
+  // after handle() resolves can't read it from disk.
+  readonly systemPromptFilePath: string | null;
+  readonly systemPromptFileContent: string | null;
+  readonly systemPromptFileMode: number | null;
   killed: boolean;
   killSignal: NodeJS.Signals | null;
   stdinPayload: string;
@@ -92,11 +99,19 @@ function makeFakeSpawn(configure: (child: FakeChild) => void): FakeSpawn {
         emit() { return false; },
       } as unknown as NodeJS.WritableStream;
 
+      const spIdx = args.indexOf('--system-prompt-file');
+      const systemPromptFilePath = spIdx !== -1 ? String(args[spIdx + 1]) : null;
+
       const child: FakeChild = {
         command,
         args,
         cwd: options.cwd,
         env: options.env,
+        systemPromptFilePath,
+        systemPromptFileContent:
+          systemPromptFilePath !== null ? readFileSync(systemPromptFilePath, 'utf8') : null,
+        systemPromptFileMode:
+          systemPromptFilePath !== null ? statSync(systemPromptFilePath).mode & 0o777 : null,
         stdin,
         stdout: mkReadable(stdoutEmitter),
         stderr: mkReadable(stderrEmitter),
@@ -3392,7 +3407,7 @@ test('probeTimeoutMs:0 with declared models advertises them without a default en
   assert.equal(spawned, 0, 'probeTimeoutMs:0 must skip the probe spawn');
 });
 
-test('spawn argv carries --system-prompt with the native directive when metadata is present', async () => {
+test('spawn stages --system-prompt-file with the native directive when metadata is present', async () => {
   const fake = scriptedSpawn({
     lines: [
       JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
@@ -3417,33 +3432,77 @@ test('spawn argv carries --system-prompt with the native directive when metadata
     NEVER,
   );
 
-  const args = fake.lastChild()?.args ?? [];
-  // The openai-compat path REPLACES claude's default prompt via --system-prompt
-  // (no identity configured here, so this is the only --system-prompt). The
-  // value carries the user's `system` text plus the native-dispatch directive
-  // — NOT the old envelope JSON contract, which #213 removed.
-  const idx = args.findIndex(
-    (a, i) =>
-      args[i - 1] === '--system-prompt' &&
-      typeof a === 'string' &&
-      a.includes('You are concise.'),
+  const child = fake.lastChild();
+  const args = child?.args ?? [];
+  // The openai-compat path REPLACES claude's default prompt, staged via
+  // --system-prompt-file rather than argv — a real-size system prompt on
+  // argv dies with E2BIG at posix_spawn (#437). The staged file carries the
+  // user's `system` text plus the native-dispatch directive — NOT the old
+  // envelope JSON contract, which #213 removed.
+  assert.ok(
+    args.includes('--system-prompt-file'),
+    'expected --system-prompt-file staging the openai-compat system text',
   );
-  assert.ok(idx >= 0, 'expected --system-prompt carrying the openai-compat system text');
+  assert.equal(args.includes('--system-prompt'), false, 'prompt must not ride argv (#437)');
+  const prompt = child?.systemPromptFileContent ?? '';
+  assert.ok(prompt.includes('You are concise.'), 'staged file carries the caller system text');
   // The slim native prompt teaches the model to use the native tool surface
   // and how to read the history block — nothing more.
-  assert.match(args[idx] as string, /native tool list/);
-  assert.match(args[idx] as string, /<chat_history>/);
+  assert.match(prompt, /native tool list/);
+  assert.match(prompt, /<chat_history>/);
   // Envelope contract phrase MUST NOT appear under #213.
-  assert.equal(
-    (args[idx] as string).includes('"tool_calls":[{"id":"call_<unique>"'),
-    false,
-  );
+  assert.equal(prompt.includes('"tool_calls":[{"id":"call_<unique>"'), false);
   // The "stop after invoking" directive was dropped because `--max-turns 1`
   // enforces single-turn semantics mechanically.
   assert.equal(
-    (args[idx] as string).toLowerCase().includes('after invoking'),
+    prompt.toLowerCase().includes('after invoking'),
     false,
     'stop-after-invoke directive should be absent (--max-turns 1 enforces)',
+  );
+});
+
+// #437: openai-compat system prompts can be hundreds of KB (character-chat
+// consumers). On argv they blow the OS per-arg ARG_MAX limit and posix_spawn
+// dies with E2BIG before claude starts. The prompt therefore ALWAYS rides a
+// temp file: written 0600 (caller prompts can carry secrets), passed via
+// --system-prompt-file, and reclaimed once the spawned process closes.
+test('large system prompt is staged 0600 on disk and reclaimed after the task (#437)', async () => {
+  const fake = scriptedSpawn({
+    lines: [
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sid' }),
+      JSON.stringify({ type: 'result', subtype: 'success', result: 'ok' }),
+    ],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit } = collect();
+  // Well past any single-arg comfort zone (macOS caps one argv entry around
+  // 256KB in practice) — this is the size class the argv delivery choked on.
+  const hugeSystem = `character sheet: ${'lore '.repeat(120_000)}`;
+  await backend.handle(
+    assignWithOpenAICompat('hello', { system: hugeSystem }),
+    emit,
+    NEVER,
+  );
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  // Argv stays small: the flag + a path, never the prompt body.
+  assert.ok(child!.args.includes('--system-prompt-file'));
+  assert.equal(child!.args.includes('--system-prompt'), false);
+  for (const a of child!.args) {
+    assert.ok(String(a).length < 4096, 'no argv entry may carry the prompt body');
+  }
+  // The staged file carried the full prompt, owner-read/write only.
+  assert.ok(child!.systemPromptFileContent?.includes('character sheet:'));
+  assert.ok((child!.systemPromptFileContent?.length ?? 0) > hugeSystem.length - 1);
+  assert.equal(child!.systemPromptFileMode, 0o600);
+  // And it is reclaimed (file AND its per-task dir) once the child closed.
+  assert.ok(child!.systemPromptFilePath);
+  await assert.rejects(fs.stat(child!.systemPromptFilePath!), 'prompt file must be deleted');
+  await assert.rejects(
+    fs.stat(path.dirname(child!.systemPromptFilePath!)),
+    'per-task temp dir must be deleted',
   );
 });
 
@@ -3466,6 +3525,9 @@ test('absent metadata → no openai-compat system prompt is injected', async () 
     (a) => typeof a === 'string' && a.includes('"tool_calls":[{"id":"call_<unique>"'),
   );
   assert.equal(hasEnvelope, false);
+  // And no staged system-prompt file either — plain A2A tasks keep claude's
+  // default prompt.
+  assert.equal(args.includes('--system-prompt-file'), false);
 });
 
 test('caller tools active → spawn argv carries `--tools ""` to disable claude built-ins', async () => {
@@ -4483,12 +4545,11 @@ test('argv: openai-compat caller tools wire caller-tools MCP + native prompt + -
   assert.ok(cfg.mcpServers?.['_vb-caller-tools'], '_vb-caller-tools MCP server registered');
   assert.equal(cfg.mcpServers?.['_vb-caller-tools']?.type, 'http');
 
-  // (b) --system-prompt carries the native variant (replacing claude's
+  // (b) --system-prompt-file stages the native variant (replacing claude's
   // default) — the envelope contract block (the literal `{"tool_calls"`
   // substring the legacy prompt teaches) must be absent.
-  const apsIdx = args.indexOf('--system-prompt');
-  assert.notEqual(apsIdx, -1, '--system-prompt present');
-  const prompt = args[apsIdx + 1] as string;
+  assert.ok(args.includes('--system-prompt-file'), '--system-prompt-file present');
+  const prompt = child!.systemPromptFileContent ?? '';
   assert.equal(prompt.includes('{"tool_calls"'), false);
   assert.ok(prompt.startsWith('be terse'));
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process';
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -86,7 +86,7 @@ export interface ClaudeBackendOptions {
   // Working directory for stateless openai-compat spawns, overriding `cwd` for
   // those tasks only. They have no legitimate use for the operator's `cwd`:
   // native dispatch disables claude's built-ins (`--tools ""`) and the path
-  // replaces claude's default prompt via `--system-prompt` (so cwd never even
+  // replaces claude's default prompt via `--system-prompt-file` (so cwd never even
   // reaches the model), while the operator-cwd's CLAUDE.md, project settings,
   // and hooks are all off-target for a generic chat/completions proxy turn —
   // and re-paid on every fresh session. Pointing these spawns at an empty dir
@@ -2081,10 +2081,10 @@ export function createClaudeBackend(
       // read in terms of the model's view ("native tool surface is live").
       const nativeReady = nativeDispatchActive && callerToolsMcp !== null;
 
-      // Per-task `--system-prompt` carrying the openai-compat extension's
-      // system / tools / tool_choice. We *replace* claude's default agent
-      // prompt (rather than `--append-system-prompt`-ing onto it) for two
-      // reasons:
+      // Per-task system-prompt replacement carrying the openai-compat
+      // extension's system / tools / tool_choice. We *replace* claude's
+      // default agent prompt (rather than `--append-system-prompt`-ing onto
+      // it) for two reasons:
       //   - Cost: every openai-compat task spawns a fresh session (no reuse),
       //     so claude's multi-thousand-token coding-agent base prompt is
       //     re-paid on each request. Replacing it with this slim, caller-
@@ -2104,16 +2104,58 @@ export function createClaudeBackend(
       // claude appends onto this base; note the base is therefore the model's
       // first read, ahead of any appended identity directive (a change from the
       // prior append-only ordering, immaterial on the stateless proxy turn).
-      const openaiCompatArgs: readonly string[] = envelope
-        ? [
-            '--system-prompt',
+      //
+      // Delivered via `--system-prompt-file` (the file-sourced twin of
+      // `--system-prompt`, same replacement semantics) rather than argv:
+      // real openai-compat system prompts can run to hundreds of KB
+      // (character-chat consumers ship character+world+scene state in
+      // `system`), and an argv-borne prompt past the OS per-arg ARG_MAX
+      // limit kills the spawn with E2BIG before claude even starts, so the
+      // backend never gets a chance to fail cleanly (#437). The prompt is
+      // staged in a per-task mkdtemp dir (0700) as a 0600 file — caller
+      // system prompts can carry secrets — and reclaimed on process close;
+      // deleting any earlier would race claude's startup read of the file.
+      let openaiCompatSystemPromptDir: string | null = null;
+      const cleanupOpenAICompatSystemPromptFile = (): void => {
+        if (openaiCompatSystemPromptDir === null) return;
+        const dir = openaiCompatSystemPromptDir;
+        openaiCompatSystemPromptDir = null;
+        try {
+          rmSync(dir, { recursive: true, force: true });
+        } catch {
+          // Best effort — the OS tmpdir reaper is the backstop.
+        }
+      };
+      let openaiCompatArgs: readonly string[] = [];
+      if (envelope) {
+        try {
+          openaiCompatSystemPromptDir = mkdtempSync(join(tmpdir(), 'vicoop-claude-sp-'));
+          const promptFile = join(openaiCompatSystemPromptDir, 'system-prompt.txt');
+          writeFileSync(
+            promptFile,
             buildOpenAICompatNativeSystemPrompt(
               envelopeSystem,
               envelopeTools,
               envelopeToolChoice,
             ),
-          ]
-        : [];
+            { mode: 0o600 },
+          );
+          openaiCompatArgs = ['--system-prompt-file', promptFile];
+        } catch (err) {
+          cleanupOpenAICompatSystemPromptFile();
+          rollbackFreshSession();
+          await closeCallerToolsMcp();
+          emit({
+            type: 'task.fail',
+            taskId: task.taskId,
+            error: normalizeTaskFailError({
+              code: 'spawn_failed',
+              message: `failed to stage openai-compat system prompt file: ${errorMessage(err)}`,
+            }),
+          });
+          return;
+        }
+      }
       // Trim the cold-start overhead for openai-compat tasks. Every such task
       // spawns a fresh claude session (no reuse — see the gate above), so any
       // fixed per-request context is re-paid each time. `--disable-slash-commands`
@@ -2316,6 +2358,7 @@ export function createClaudeBackend(
         child = spawnFn(command, args, { cwd: effectiveCwd, env: effectiveEnv });
         recorder.mark('spawn');
       } catch (err) {
+        cleanupOpenAICompatSystemPromptFile();
         rollbackFreshSession();
         await closeCallerToolsMcp();
         timingLogger.debug(
@@ -2328,6 +2371,13 @@ export function createClaudeBackend(
         });
         return;
       }
+
+      // Reclaim the staged system-prompt file once the spawned process is
+      // done with it. `close` covers every post-spawn path (success, failure,
+      // kill, abort); `error` covers a child that never reaches close (e.g.
+      // ENOENT surfacing async). Idempotent, so double-firing is harmless.
+      child.on('close', cleanupOpenAICompatSystemPromptFile);
+      child.on('error', cleanupOpenAICompatSystemPromptFile);
 
       // Write the user message envelope and close stdin so claude sees EOF
       // and proceeds. Errors here are recorded; the close listener still

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2081,6 +2081,18 @@ export function createClaudeBackend(
       // read in terms of the model's view ("native tool surface is live").
       const nativeReady = nativeDispatchActive && callerToolsMcp !== null;
 
+      // Announce `working` BEFORE staging the system-prompt file below: a
+      // caller-provided emit that throws would escape handle() past the
+      // staging block, and firing it while no temp dir exists yet keeps that
+      // escape leak-free (the later emits all run after the child's close
+      // listener owns cleanup). Ordering is also uniform for consumers: every
+      // pre-spawn failure now arrives as working → task.fail.
+      emit({
+        type: 'task.status',
+        taskId: task.taskId,
+        status: { state: 'working', timestamp: new Date().toISOString() },
+      });
+
       // Per-task system-prompt replacement carrying the openai-compat
       // extension's system / tools / tool_choice. We *replace* claude's
       // default agent prompt (rather than `--append-system-prompt`-ing onto
@@ -2307,12 +2319,6 @@ export function createClaudeBackend(
         ...extraArgs,
       ];
 
-      emit({
-        type: 'task.status',
-        taskId: task.taskId,
-        status: { state: 'working', timestamp: new Date().toISOString() },
-      });
-
       // openai-compat tasks spawn in the isolation cwd (no *project* CLAUDE.md /
       // project settings / hooks); plain A2A tasks keep the operator cwd. Note
       // the isolation cwd does not cover the operator's user-global
@@ -2392,6 +2398,11 @@ export function createClaudeBackend(
         } catch {
           /* best effort */
         }
+        // The kill SHOULD surface as `close` and fire the cleanup listener,
+        // but this branch exists precisely because the custom spawn is
+        // misbehaving — don't trust it to emit close either. Idempotent, so
+        // a later close double-fire is harmless.
+        cleanupOpenAICompatSystemPromptFile();
         // The freshly-minted sessionId never reached claude, so a follow-up
         // task on the same contextId must mint a new id rather than --resume.
         rollbackFreshSession();


### PR DESCRIPTION
## Problem

Fixes #437. The openai-compat envelope's system/tools/tool_choice rode a single `--system-prompt <body>` argv entry. Consumer-scale system prompts (character-chat apps: tens–hundreds of KB) blow the OS per-arg ARG_MAX limit, so `posix_spawn` dies with `E2BIG` before claude starts — relayed to the caller as an inscrutable `spawn_failed`.

## Fix

Per the issue discussion, **full file switch** (no size-threshold argv fallback):

- The built prompt is written to a per-task `mkdtemp` dir (0700) as a **0600** file — caller prompts can carry secrets — and only the path rides argv via `--system-prompt-file`.
- The file is reclaimed on child `close`/`error` (deleting right after spawn would race claude's startup read of the file).
- A failed stage (mkdtemp/write error) fails the task cleanly with a descriptive `spawn_failed` message instead of leaking an OS error.

## Verification

- `--system-prompt-file` support + replacement semantics verified empirically against claude CLI 2.1.217 (same behavior as `--system-prompt` on an identical probe).
- Smoke: a **598KB** system prompt — the size class that previously E2BIG'd — spawns fine through the exact backend argv shape (`-p --input-format stream-json … --system-prompt-file … --tools "" --setting-sources project`) and the model demonstrably reads the file's content.
- New regression test: large prompt never rides argv, staged file is 0600, file+dir reclaimed after the task.
- `pnpm --filter @vicoop-bridge/client test`: 825/825 pass; `pnpm -r build` / `typecheck` clean.

## Other spawn-shaped backends (issue item 3)

- **codex**: system prompt goes over JSON-RPC `thread/start.developerInstructions` (stdio) — not affected.
- **openclaw**: folded into the WS user message (`<system_instructions>` block) — not affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)