### PR TITLE
fix(claude): log every non-init SDK system event

### DIFF
--- a/.changeset/repair-orphaned-caller-tool-calls.md
+++ b/.changeset/repair-orphaned-caller-tool-calls.md
@@ -7,20 +7,23 @@ claude: surface silent model switches in the logs; openai-compat: harden tool-ca
 `model_refusal_fallback` — emitted when the requested model's safeguards flag a
 message and claude silently retries the turn on a different model — reached no
 log at all. A caller asking for model X would get model Y with the only record
-being the on-disk session transcript; one incident ran at 24% of turns before
-anyone noticed. Every non-`init` system event is now logged, with the model
-transition taken from the SDK's structured fields (`originalModel` /
-`fallbackModel` / `trigger` / `apiRefusalCategory`) rather than its prose blurb.
-Severity follows the SDK's own `level`, so anomalies warn while high-frequency
-bookkeeping subtypes such as `thinking_tokens` — measured at 10 events in one
-trivial turn — stay on the debug channel and leave warn usable for alerting.
+being the on-disk session transcript; in one incident it hit 7 of the 8 turns in
+a conversation, every turn after the first, before anyone noticed. Non-`init`
+system events are now logged, carrying the SDK's structured fields
+(`originalModel` / `fallbackModel` / `trigger` / `apiRefusalCategory`) alongside
+its prose blurb, so an operator never has to parse English to learn which model
+actually served a turn. Severity follows the SDK's own `level`: anomalies warn,
+while high-frequency bookkeeping subtypes such as `thinking_tokens` — measured at
+10 events in one trivial turn — go to debug, which the default `info` level
+suppresses. Warn therefore stays usable for alerting, and raising the level to
+`debug` surfaces the rest.
 
 Alongside it, `chatHistoryFromMessages` now synthesizes an error result for any
-`tool_calls` id with no result anywhere in the replayed history, inserted
-directly after the assistant turn that made it. An unanswered call is invalid on
-the wire (the real OpenAI API 400s it) and reads to a model as a dispatch still
-in flight, which can drive it to re-dispatch until the run hits its turn cap.
-This is defensive hardening rather than a fix for an observed failure: an audit
-of 29 production tasks found every call correctly paired, and a well-formed
-history passes through byte-for-byte unchanged. Calls without a usable
-`function.name` are left alone to match how the codex backend already drops them.
+`tool_calls` id that has no result anywhere in the replayed history, inserted
+directly after the assistant turn that made it. An unanswered call is malformed
+on the wire and reads to a model as a dispatch still in flight, which can drive
+it to re-dispatch until the run hits its turn cap. This is defensive hardening
+rather than a fix for an observed failure: an audit of 29 production tasks found
+every call correctly paired, and a well-formed history passes through
+byte-for-byte unchanged. Calls without a usable `function.name` are left alone to
+match how the codex backend already drops them.

--- a/.changeset/repair-orphaned-caller-tool-calls.md
+++ b/.changeset/repair-orphaned-caller-tool-calls.md
@@ -1,0 +1,22 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude: log every non-`init` SDK system event; openai-compat: harden tool-call pairing
+
+`model_refusal_fallback` — emitted when the requested model's safeguards flag a
+message and claude silently retries the turn on a different model — reached no
+log at all. A caller asking for model X would get model Y with the only record
+being the on-disk session transcript; one incident ran at 24% of turns before
+anyone noticed. All non-`init` system subtypes are now logged generically, so a
+subtype added later is never silent either.
+
+Alongside it, `chatHistoryFromMessages` now synthesizes an error result for any
+`tool_calls` id with no result anywhere in the replayed history, inserted
+directly after the assistant turn that made it. An unanswered call is invalid on
+the wire (the real OpenAI API 400s it) and reads to a model as a dispatch still
+in flight, which can drive it to re-dispatch until the run hits its turn cap.
+This is defensive hardening rather than a fix for an observed failure: an audit
+of 29 production tasks found every call correctly paired, and a well-formed
+history passes through byte-for-byte unchanged. Calls without a usable
+`function.name` are left alone to match how the codex backend already drops them.

--- a/.changeset/repair-orphaned-caller-tool-calls.md
+++ b/.changeset/repair-orphaned-caller-tool-calls.md
@@ -2,14 +2,18 @@
 '@vicoop-bridge/client': patch
 ---
 
-claude: log every non-`init` SDK system event; openai-compat: harden tool-call pairing
+claude: surface silent model switches in the logs; openai-compat: harden tool-call pairing
 
 `model_refusal_fallback` — emitted when the requested model's safeguards flag a
 message and claude silently retries the turn on a different model — reached no
 log at all. A caller asking for model X would get model Y with the only record
 being the on-disk session transcript; one incident ran at 24% of turns before
-anyone noticed. All non-`init` system subtypes are now logged generically, so a
-subtype added later is never silent either.
+anyone noticed. Every non-`init` system event is now logged, with the model
+transition taken from the SDK's structured fields (`originalModel` /
+`fallbackModel` / `trigger` / `apiRefusalCategory`) rather than its prose blurb.
+Severity follows the SDK's own `level`, so anomalies warn while high-frequency
+bookkeeping subtypes such as `thinking_tokens` — measured at 10 events in one
+trivial turn — stay on the debug channel and leave warn usable for alerting.
 
 Alongside it, `chatHistoryFromMessages` now synthesizes an error result for any
 `tool_calls` id with no result anywhere in the replayed history, inserted

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -13,6 +13,7 @@ import {
   OPENAI_COMPAT_OPERATOR_PRIVACY_CLAUSE,
   createClaudeBackend,
   enrichEntriesWithModelLimits,
+  describeClaudeSystemEvent,
   normalizeClaudeModelId,
   openaiToolsToCallerToolDefs,
   parseClaudeModelUsageForOpenAICompat,
@@ -5555,4 +5556,85 @@ test('claude backend resolveCapabilities short-circuits when probeTimeoutMs is 0
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {});
   assert.equal(spawned, 0, 'probeTimeoutMs:0 must skip the spawn entirely');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// describeClaudeSystemEvent — non-`init` SDK system events. Previously every
+// one of them fell through the event loop unlogged, so a silent model switch
+// left no trace outside the on-disk session transcript.
+// ───────────────────────────────────────────────────────────────────────────
+
+// Verbatim from a production transcript (vicoop-client 0.36.7 / CC 2.1.215),
+// minus the uuid/session fields the logger never reads.
+const REFUSAL_FALLBACK_EVENT = {
+  type: 'system',
+  subtype: 'model_refusal_fallback',
+  direction: 'retry',
+  content:
+    "Fable 5's safeguards flagged this message. This sometimes happens with safe, " +
+    'normal conversations. Switched to Opus 4.8. Send feedback with /feedback or ' +
+    'learn more: https://support.claude.com/en/articles/15363606',
+  level: 'warning',
+  trigger: 'refusal',
+  originalModel: 'claude-fable-5',
+  fallbackModel: 'claude-opus-4-8',
+  apiRefusalCategory: 'reasoning_extraction',
+};
+
+test('describeClaudeSystemEvent: a refusal fallback warns and names both models', () => {
+  const { level, line } = describeClaudeSystemEvent('task-1', REFUSAL_FALLBACK_EVENT);
+  assert.equal(level, 'warn');
+  assert.match(line, /taskId=task-1/);
+  assert.match(line, /subtype=model_refusal_fallback/);
+  // The model transition must come from the structured fields — an operator
+  // must never have to parse the English blurb to learn what served the turn.
+  assert.match(line, /from=claude-fable-5/);
+  assert.match(line, /to=claude-opus-4-8/);
+  assert.match(line, /trigger=refusal/);
+  assert.match(line, /category=reasoning_extraction/);
+});
+
+test('describeClaudeSystemEvent: high-frequency subtypes stay off the warn channel', () => {
+  // Measured: `thinking_tokens` fires per reasoning-token delta — 10 events in
+  // one trivial turn. Warning on those would bury the fallback signal and make
+  // warn-level alerting useless on a long-running daemon.
+  const { level, line } = describeClaudeSystemEvent('task-2', {
+    type: 'system',
+    subtype: 'thinking_tokens',
+    estimated_tokens: 5,
+    estimated_tokens_delta: 5,
+  });
+  assert.equal(level, 'debug');
+  // Still logged, just quietly — a new subtype is never silent.
+  assert.match(line, /subtype=thinking_tokens/);
+  // No empty `detail=` / `from=` noise when the fields are absent.
+  assert.doesNotMatch(line, /detail=|from=|to=/);
+});
+
+test('describeClaudeSystemEvent: an unknown future subtype escalates on the SDK level', () => {
+  // Shape-driven, not a subtype whitelist: whatever ships next inherits the
+  // routing for free.
+  assert.equal(
+    describeClaudeSystemEvent('t', { subtype: 'not_invented_yet', level: 'error' }).level,
+    'warn',
+  );
+  assert.equal(describeClaudeSystemEvent('t', { subtype: 'not_invented_yet' }).level, 'debug');
+});
+
+test('describeClaudeSystemEvent: hostile content cannot forge a log line', () => {
+  const { line } = describeClaudeSystemEvent('t', {
+    subtype: 'x',
+    level: 'warning',
+    content: 'evil\n[client] FAKE ENTRY',
+  });
+  assert.equal(line.includes('\n'), false);
+  assert.match(line, /detail=/);
+});
+
+test('describeClaudeSystemEvent: tolerates a malformed event', () => {
+  for (const evt of [null, undefined, {}, { subtype: 42 }]) {
+    const { level, line } = describeClaudeSystemEvent('t', evt);
+    assert.equal(level, 'debug');
+    assert.match(line, /\[claude\] system event taskId=t subtype=/);
+  }
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -2709,6 +2709,22 @@ export function createClaudeBackend(
           }
           return;
         }
+        if (evt.type === 'system') {
+          // Every non-`init` system subtype the SDK reports out-of-band. The
+          // one that prompted this: `model_refusal_fallback`, emitted when the
+          // requested model's safeguards flag a message and claude silently
+          // retries the turn on a different model. A caller asking for model X
+          // then gets model Y with no trace anywhere in the bridge's logs —
+          // the only record is the on-disk session transcript. (Measured at
+          // 24% of turns in one incident.) Logged generically rather than by
+          // subtype whitelist so a subtype added later is never silent.
+          timingLogger.warn?.(
+            `[claude] system event taskId=${task.taskId} ` +
+              `subtype=${safeToken(String(evt.subtype ?? ''), 60)} ` +
+              `detail=${safeToken(String((evt as { content?: unknown }).content ?? ''), 300)}`,
+          );
+          return;
+        }
         if (evt.type === 'stream_event') {
           if (reasoningEnabled && !emittedAskUserQuestion) {
             const reasoning = extractClaudeStreamReasoningDelta(evt);

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -349,6 +349,60 @@ export function normalizeClaudeModelId(raw: string): string {
   return raw.replace(/\[[^\]]+\]$/, '');
 }
 
+// Render a non-`init` SDK `system` event into one log line, and decide how
+// loudly to say it.
+//
+// The event that motivated this is `model_refusal_fallback`: the requested
+// model's safeguards flag a message, claude silently retries the turn on a
+// different model, and the caller gets model Y after asking for model X. None
+// of it reached a log — the loop handled only `subtype === 'init'` and every
+// other subtype fell through — so the only record was the on-disk session
+// transcript. One measured window ran at 24% of turns before anyone noticed.
+//
+// Handled by SHAPE, not by a subtype whitelist, so a subtype added later is
+// never silent. Two shape facts drive it:
+//
+//   - The operator-actionable payload rides structured fields
+//     (`originalModel` / `fallbackModel` / `trigger` / `apiRefusalCategory`),
+//     not the prose `content` blurb. Log both, but never make an operator
+//     parse English to learn which model actually served the turn.
+//   - The SDK stamps `level` on the subtypes that represent an anomaly
+//     (`model_refusal_fallback` carries `level: "warning"`). Everything else
+//     goes to debug — `thinking_tokens` alone fires per reasoning-token delta,
+//     measured at 10 events in a single trivial turn, and warning on that
+//     would bury the very signal this exists to surface and make warn-level
+//     alerting useless on a long-running daemon.
+//
+// Exported for unit tests.
+export function describeClaudeSystemEvent(
+  taskId: string,
+  evt: unknown,
+): { level: 'warn' | 'debug'; line: string } {
+  const sys = (evt ?? {}) as {
+    subtype?: unknown;
+    level?: unknown;
+    content?: unknown;
+    trigger?: unknown;
+    originalModel?: unknown;
+    fallbackModel?: unknown;
+    apiRefusalCategory?: unknown;
+  };
+  const field = (label: string, value: unknown, max = 60): string[] =>
+    typeof value === 'string' && value.length > 0 ? [`${label}=${safeToken(value, max)}`] : [];
+  const line =
+    `[claude] system event taskId=${taskId} ` +
+    [
+      `subtype=${safeToken(String(sys.subtype ?? ''), 60)}`,
+      ...field('from', sys.originalModel),
+      ...field('to', sys.fallbackModel),
+      ...field('trigger', sys.trigger),
+      ...field('category', sys.apiRefusalCategory),
+      ...field('detail', sys.content, 300),
+    ].join(' ');
+  const level = sys.level === 'warning' || sys.level === 'error' ? 'warn' : 'debug';
+  return { level, line };
+}
+
 // The 1M-context tier marker Claude Code appends to a model id (`[1m]`). Its
 // presence on an advertised id is the signal that the effective context window
 // is the model's full ceiling rather than the 200k base (see
@@ -2710,19 +2764,9 @@ export function createClaudeBackend(
           return;
         }
         if (evt.type === 'system') {
-          // Every non-`init` system subtype the SDK reports out-of-band. The
-          // one that prompted this: `model_refusal_fallback`, emitted when the
-          // requested model's safeguards flag a message and claude silently
-          // retries the turn on a different model. A caller asking for model X
-          // then gets model Y with no trace anywhere in the bridge's logs —
-          // the only record is the on-disk session transcript. (Measured at
-          // 24% of turns in one incident.) Logged generically rather than by
-          // subtype whitelist so a subtype added later is never silent.
-          timingLogger.warn?.(
-            `[claude] system event taskId=${task.taskId} ` +
-              `subtype=${safeToken(String(evt.subtype ?? ''), 60)} ` +
-              `detail=${safeToken(String((evt as { content?: unknown }).content ?? ''), 300)}`,
-          );
+          const { level, line } = describeClaudeSystemEvent(task.taskId, evt);
+          if (level === 'warn') timingLogger.warn?.(line);
+          else timingLogger.debug?.(line);
           return;
         }
         if (evt.type === 'stream_event') {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -357,7 +357,8 @@ export function normalizeClaudeModelId(raw: string): string {
 // different model, and the caller gets model Y after asking for model X. None
 // of it reached a log — the loop handled only `subtype === 'init'` and every
 // other subtype fell through — so the only record was the on-disk session
-// transcript. One measured window ran at 24% of turns before anyone noticed.
+// transcript. In one measured incident it hit 7 of the 8 turns in a
+// conversation — every turn after the first — before anyone noticed.
 //
 // Handled by SHAPE, not by a subtype whitelist, so a subtype added later is
 // never silent. Two shape facts drive it:

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -804,8 +804,10 @@ test('repairOrphanedToolCalls: synthesized results survive requalifyHistoryToolN
 });
 
 test('chatHistoryFromMessages: repairs orphaned calls in the projected history', () => {
-  // End-to-end: the repair is wired into the shared projection, so all five
-  // backends inherit it rather than each re-implementing the pairing rule.
+  // End-to-end: the repair is wired into the shared projection, so all four
+  // envelope-consuming backends (claude, codex, vicoop-codex, openclaw)
+  // inherit it rather than each re-implementing the pairing rule. `echo` never
+  // touches the envelope, so it is unaffected.
   const history = chatHistoryFromMessages([
     { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
     { role: 'user', content: 'continue' },

--- a/packages/client/src/backends/openai-compat.test.ts
+++ b/packages/client/src/backends/openai-compat.test.ts
@@ -11,7 +11,9 @@ import {
   formatChatHistoryBlocks,
   MIN_CACHEABLE_FROZEN_CHARS,
   type OpenAICompatHistoryEntry,
+  ORPHANED_TOOL_RESULT_CONTENT,
   parseOpenAICompatEnvelope,
+  repairOrphanedToolCalls,
   requalifyHistoryToolNames,
   tryParseToolCallsEnvelope,
 } from './openai-compat.js';
@@ -683,6 +685,139 @@ test('requalifyHistoryToolNames: tolerates malformed tool_calls items', () => {
   const out = requalifyHistoryToolNames(history, (n) => `Q_${n}`);
   // Nothing renamable → structurally equal to the input.
   assert.deepEqual(out, history);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// repairOrphanedToolCalls — close the tool_call/tool_result pairing so a
+// dispatch whose result never came back cannot read as "still in flight".
+// An unanswered call is otherwise replayed on every later turn, the model
+// concludes its work was cut off and re-dispatches, and the run loops until
+// its turn cap. Defensive: no production incident has exercised this, so the
+// no-op-on-well-formed-input cases below matter as much as the repair itself.
+// ───────────────────────────────────────────────────────────────────────────
+
+const orphanCall = (id: string, name = 'read') => ({
+  id,
+  type: 'function' as const,
+  function: { name, arguments: '{}' },
+});
+
+test('repairOrphanedToolCalls: answers an unanswered call right after its assistant turn', () => {
+  const out = repairOrphanedToolCalls([
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+    { role: 'user', content: 'keep going' },
+  ]);
+  assert.deepEqual(out, [
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+    // Inserted directly after the call, not appended at the end — the wire
+    // format requires results to follow the turn that made them.
+    {
+      role: 'tool',
+      tool_call_id: 'call_A',
+      name: 'read',
+      content: ORPHANED_TOOL_RESULT_CONTENT,
+    },
+    { role: 'user', content: 'keep going' },
+  ]);
+});
+
+test('repairOrphanedToolCalls: a fully answered history is returned unchanged', () => {
+  const history: OpenAICompatHistoryEntry[] = [
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+    { role: 'tool', tool_call_id: 'call_A', content: 'real result' },
+  ];
+  // No false positives: a result legitimately follows its call, so the scan
+  // must consider the whole history before declaring an orphan.
+  assert.deepEqual(repairOrphanedToolCalls(history), history);
+});
+
+test('repairOrphanedToolCalls: partially answered turn repairs only the gaps, in call order', () => {
+  const out = repairOrphanedToolCalls([
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [orphanCall('call_A'), orphanCall('call_B'), orphanCall('call_C')],
+    },
+    { role: 'tool', tool_call_id: 'call_B', content: 'real result' },
+  ]);
+  assert.deepEqual(
+    out.map((e) => (e.role === 'tool' ? `tool:${e.tool_call_id}` : e.role)),
+    ['assistant', 'tool:call_A', 'tool:call_C', 'tool:call_B'],
+  );
+  assert.equal(out.filter((e) => e.role === 'tool').length, 3);
+});
+
+test('repairOrphanedToolCalls: is idempotent (prompt-cache prefix stays byte-stable)', () => {
+  // formatChatHistoryBlocks freezes a prefix and relies on it hashing
+  // identically turn over turn; a repair that grew on each pass would
+  // invalidate the cache on every request.
+  const once = repairOrphanedToolCalls([
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+  ]);
+  assert.deepEqual(repairOrphanedToolCalls(once), once);
+  assert.equal(formatChatHistory(repairOrphanedToolCalls(once)), formatChatHistory(once));
+});
+
+test('repairOrphanedToolCalls: skips calls with no usable function.name', () => {
+  // codex's historyToInjectItems drops these, emitting no `function_call`
+  // item; synthesizing a result anyway would inject an unpaired
+  // `function_call_output` that the Responses API rejects.
+  const history: OpenAICompatHistoryEntry[] = [
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [
+        null,
+        { id: 'call_noFn' },
+        { id: 'call_emptyName', function: { name: '' } },
+        { id: 'call_numName', function: { name: 42 } },
+        { function: { name: 'read' } },
+      ],
+    },
+  ];
+  assert.deepEqual(repairOrphanedToolCalls(history), history);
+});
+
+test('repairOrphanedToolCalls: answers a duplicated id once', () => {
+  const out = repairOrphanedToolCalls([
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [orphanCall('call_A'), orphanCall('call_A')],
+    },
+  ]);
+  assert.equal(out.filter((e) => e.role === 'tool').length, 1);
+});
+
+test('repairOrphanedToolCalls: synthesized results survive requalifyHistoryToolNames', () => {
+  // claude applies the rename AFTER the projection. The synthesized result
+  // must carry the same name as the call it answers, or the rename splits the
+  // pair and claude rejects the replayed call ("No such tool available").
+  const repaired = repairOrphanedToolCalls([
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+  ]);
+  const renamed = requalifyHistoryToolNames(repaired, (n) => `mcp___vb-caller-tools__${n}`);
+  const call = renamed[0] as { tool_calls: { function: { name: string } }[] };
+  const result = renamed[1] as { name: string };
+  assert.equal(call.tool_calls[0].function.name, 'mcp___vb-caller-tools__read');
+  assert.equal(result.name, 'mcp___vb-caller-tools__read');
+});
+
+test('chatHistoryFromMessages: repairs orphaned calls in the projected history', () => {
+  // End-to-end: the repair is wired into the shared projection, so all five
+  // backends inherit it rather than each re-implementing the pairing rule.
+  const history = chatHistoryFromMessages([
+    { role: 'assistant', content: null, tool_calls: [orphanCall('call_A')] },
+    { role: 'user', content: 'continue' },
+  ]);
+  assert.ok(history);
+  assert.equal(history.length, 2);
+  assert.deepEqual(history[1], {
+    role: 'tool',
+    tool_call_id: 'call_A',
+    name: 'read',
+    content: ORPHANED_TOOL_RESULT_CONTENT,
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/client/src/backends/openai-compat.ts
+++ b/packages/client/src/backends/openai-compat.ts
@@ -267,7 +267,97 @@ export function chatHistoryFromMessages(
     }
     out.push(parsed);
   }
-  return out.length > 0 ? out : null;
+  return out.length > 0 ? repairOrphanedToolCalls(out) : null;
+}
+
+// The in-band text a synthesized result carries.
+//
+// Deliberately NOT "re-issue the call if you still need it": that invites the
+// re-dispatch storm this repair exists to stop, and worse, invites a second
+// execution of a call whose side effects may already have landed (a write, a
+// send, a spawn). The wording below bounds the retry to read-only calls and
+// tells the model it is free to proceed with what it has.
+export const ORPHANED_TOOL_RESULT_CONTENT =
+  '[vicoop-bridge] The caller returned no result for this call; its outcome ' +
+  'is unknown. Do not repeat calls that have side effects. Re-issue a ' +
+  'read-only call only if its output is still required to finish the current ' +
+  'task; otherwise proceed with what you have.';
+
+// Every `tool_calls` entry an assistant turn emits MUST be answered by a
+// matching `role:"tool"` message — OpenAI Chat Completions rejects an unpaired
+// call, and a model reads one as "that dispatch is still in flight".
+//
+// The caller-tool protocol makes the unpaired state reachable in normal
+// operation: a turn ends with its calls captured by the bridge, and the caller
+// is expected to run them and return results on the next turn. When a result
+// never comes back, the orphan is replayed verbatim on EVERY later turn. The
+// model sees its own dispatch dangling, concludes the work was cut off,
+// re-dispatches — and the new call is orphaned the same way. The loop is
+// structural: nothing in-band ever tells the model the result is not coming,
+// so it can only keep retrying until the run dies at its turn cap. (Same shape
+// as the unqualified-name failure `requalifyHistoryToolNames` below fixes.)
+//
+// Defensive hardening, not a fix for an observed incident: an audit of 29
+// production caller-tool tasks found every call correctly paired, so this has
+// never been seen to fire. It is cheap insurance — a well-formed history is a
+// verified no-op (measured on a real 87-entry transcript: zero synthesized
+// entries, zero rendered-byte delta) — against a state the wire format calls
+// invalid and the real OpenAI API rejects with a 400.
+//
+// So we close the pairing here: any call id with no result anywhere in the
+// history gets a synthesized error result inserted directly after the
+// assistant turn that made it (the position the wire format requires). The
+// model is told the truth and can make a deliberate choice instead of looping.
+//
+// Byte-stability: this is a pure function of the input history and an orphan
+// stays an orphan on later turns, so the frozen prompt-cache prefix in
+// `formatChatHistoryBlocks` keeps hashing identically. A late-arriving real
+// result does change the bytes from that entry onward — correct, and worth the
+// one cache miss.
+export function repairOrphanedToolCalls(
+  history: OpenAICompatHistoryEntry[],
+): OpenAICompatHistoryEntry[] {
+  // Seeded from the WHOLE history: a result legitimately follows its call, so
+  // only an id answered nowhere at all counts as orphaned.
+  const answered = new Set<string>();
+  for (const entry of history) {
+    if (entry.role === 'tool') answered.add(entry.tool_call_id);
+  }
+
+  const out: OpenAICompatHistoryEntry[] = [];
+  for (const entry of history) {
+    out.push(entry);
+    if (entry.role !== 'assistant' || !('tool_calls' in entry)) continue;
+    if (!Array.isArray(entry.tool_calls)) continue;
+    for (const call of entry.tool_calls) {
+      if (!call || typeof call !== 'object') continue;
+      const id = (call as { id?: unknown }).id;
+      if (typeof id !== 'string' || id.length === 0) continue;
+      // Mirror codex's skip predicate (`historyToInjectItems`, codex.ts): it
+      // drops a tool_call with no usable `function.name` and emits no
+      // `function_call` item for it. Synthesizing a result for one would
+      // inject an unpaired `function_call_output` that the Responses API
+      // rejects — turning a silent degradation into a hard failure. A nameless
+      // call is malformed input anyway; leave it exactly as the backends
+      // already treat it. Carrying the name also guarantees the synthesized
+      // result is renamed in lockstep with its call by
+      // `requalifyHistoryToolNames`.
+      const fn = (call as { function?: unknown }).function;
+      const name =
+        fn && typeof fn === 'object' ? (fn as { name?: unknown }).name : undefined;
+      if (typeof name !== 'string' || name.length === 0) continue;
+      if (answered.has(id)) continue;
+      // A duplicated id within one turn is answered once.
+      answered.add(id);
+      out.push({
+        role: 'tool',
+        tool_call_id: id,
+        name,
+        content: ORPHANED_TOOL_RESULT_CONTENT,
+      });
+    }
+  }
+  return out;
 }
 
 // Parse a single envelope `messages[]` entry into the chat_history


### PR DESCRIPTION
Refs #441 — addresses the observability ask, but deliberately does **not** close it. The originating symptom ("fable stops mid-work") turned out to have a different root cause, still unfixed; see [this comment](https://github.com/planetarium/vicoop-bridge/issues/441#issuecomment-5101867918). Two changes here, one of them deliberately unexciting.

## 1. `claude.ts` — log every non-`init` SDK system event

The event loop handled only `subtype === 'init'`; every other system subtype fell through unlogged. The one that prompted this:

```json
{ "type": "system", "subtype": "model_refusal_fallback", "direction": "retry",
  "content": "Fable 5's safeguards flagged this message. This sometimes happens with
              safe, normal conversations. Switched to Opus 4.8." }
```

A caller asks for model X, silently gets model Y, and nothing reaches journald — `vicoop-client` emits only `task.assign` / `backend.start` / `task.complete`. The sole record was `~/.claude/projects/**/*.jsonl` on the provider host. In one incident this hit **7 of the 8 turns in a conversation** — every turn after the first — and was invisible until someone hand-parsed the transcripts. (An earlier revision of this PR cited 24%; that was 7/29 with sub-agent turns wrongly in the denominator. Sub-agent tasks never triggered a refusal.)

Handled by **shape rather than by a subtype whitelist**, so a subtype added later is never silent either. Severity follows the SDK's own `level` field — see the adversarial-review note below for why a blanket `warn` was wrong. The model transition is read from the structured fields (`originalModel` / `fallbackModel` / `trigger` / `apiRefusalCategory`) rather than by parsing the prose blurb, which is still logged alongside them. Note the default `info` level suppresses the debug channel, so the high-frequency subtypes are recorded but only visible at `debug`. Rendering lives in an exported `describeClaudeSystemEvent` so it is directly unit-testable, matching how the other pure helpers in this file are covered.

## 2. `openai-compat.ts` — harden `tool_calls` / `tool` result pairing

`chatHistoryFromMessages` now synthesizes an error result for any call id with no result anywhere in the replayed history, inserted directly after the assistant turn that made it. It lives in the shared projection so all four envelope-consuming backends (`claude`, `codex`, `vicoop-codex`, `openclaw`) inherit the pairing rule rather than each re-implementing it. `echo` never touches the envelope and is unaffected.

**This is defense-in-depth, not a fix for an observed failure.** An audit of 29 production caller-tool tasks found every call correctly paired — 0 orphans across all 29. I originally filed #441 claiming otherwise; that claim came from an analysis bug on my side (I parsed one text block of a cache-split `chat_history` as if it were the whole thing) and is [retracted in full](https://github.com/planetarium/vicoop-bridge/issues/441#issuecomment-5101483044). Keeping the guard anyway because an unpaired call is invalid on the wire — the real OpenAI API 400s it — and reads to a model as a dispatch still in flight, which can drive re-dispatch until the run hits its turn cap. Structurally the same failure class `requalifyHistoryToolNames` already guards against.

Two constraints worth reviewing:

- **Gated on a non-empty `function.name`.** codex's `historyToInjectItems` drops a tool_call lacking one and emits no `function_call` item; answering it anyway would inject an unpaired `function_call_output` that the Responses API rejects — turning a silent degradation into a hard failure. Residual: such a call stays unanswered on the claude/openclaw paths. Malformed input either way, and consistency with codex won.
- **Wording avoids a retry storm.** The result text bounds re-issue to read-only calls (`"Do not repeat calls that have side effects"`) rather than a blanket "re-issue if you still need it", which would invite both the re-dispatch loop this guards against and double-execution of a call whose side effects may already have landed.

## Verification

- `pnpm -r typecheck` clean across all 4 workspace projects
- **838/838 client tests pass**, including 13 new ones. Five cover the system-event logging (severity routing, structured-field extraction, the high-frequency subtype staying off warn, log-line forging via hostile `content`, malformed-event tolerance), using a verbatim production `model_refusal_fallback` record as the fixture. Eight cover the pairing repair:: insertion position, no-op on a fully-answered history, partial repair in call order, idempotency (the prompt-cache frozen prefix depends on byte-stability), the `function.name` gate, duplicate ids, `requalifyHistoryToolNames` round-trip, and the end-to-end wiring
- Replayed a **real 87-entry production transcript** (411KB, 57 tool_calls / 57 results) through the repair: **zero synthesized entries, zero rendered-byte delta, idempotent, original entry order preserved** — a verified no-op on well-formed input

## Not addressed

The upstream safeguard false-positive itself is not ours to fix. Worth reporting to Anthropic separately — the message text points at `/feedback`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
