### PR TITLE
feat(claude): log caller-tool turns that emit no tool call

### DIFF
--- a/.changeset/log-empty-caller-tool-turns.md
+++ b/.changeset/log-empty-caller-tool-turns.md
@@ -1,0 +1,34 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude: log a caller-tool turn that completes without emitting any tool call
+
+Under caller-tool dispatch the bridge runs `--max-turns 1`: the model gets one
+turn, its calls are captured, and the caller executes them and returns results
+next turn. A turn that ends having emitted no tool calls hands the caller
+nothing to run. That is correct when the text was a final answer or a completion
+report, and a silent dead end when it was an announcement of work about to be
+done — the model says it will do something, the run ends, and the user sees an
+agent that stopped mid-task.
+
+The dead-end case has been observed on `claude-fable-5` (#441), where it costs a
+user-visible stall or a full sub-agent restart. It is invisible today: the task
+completes normally with `artifacts=1` and nothing distinguishes it in the logs.
+
+This logs every such turn at `info` without trying to tell the two apart. Both
+renderings seen so far differ completely — one serialized the call as
+`**todowrite**` + `Request` + a fenced block, the other as a bare `Read`
+followed by JSON — so a text matcher tuned on either keeps missing the other,
+and a classifier built on the two sessions observed so far would be overfit.
+Measuring the rate comes first. The line carries `taskId` for joining to the
+session transcript and `textLen` as the one cheap signal separating a 72-char
+"I'll start now" from a 4957-char final report, without copying model output
+into the logs.
+
+The line's `textLen` is resolved through a small `resolveTurnText` helper rather
+than inline, because the rule is `||` and not `??`: a `result` event routinely
+carries `result: ""` on a turn that spent itself on tool calls, and `??` would
+keep that empty string instead of falling back to the text the model streamed —
+reporting an empty turn and discarding the one signal that separates a
+short announcement from a long final report.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -14,6 +14,8 @@ import {
   createClaudeBackend,
   enrichEntriesWithModelLimits,
   describeClaudeSystemEvent,
+  describeEmptyDispatchTurn,
+  resolveTurnText,
   normalizeClaudeModelId,
   openaiToolsToCallerToolDefs,
   parseClaudeModelUsageForOpenAICompat,
@@ -5637,4 +5639,99 @@ test('describeClaudeSystemEvent: tolerates a malformed event', () => {
     assert.equal(level, 'debug');
     assert.match(line, /\[claude\] system event taskId=t subtype=/);
   }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// describeEmptyDispatchTurn — rate instrumentation for #441. Under caller-tool
+// dispatch (`--max-turns 1`) a turn that emits no tool calls hands the caller
+// nothing to run. Legitimate for a final answer, a silent dead end when the
+// text was an announcement. Deliberately unclassified: measure first.
+// ───────────────────────────────────────────────────────────────────────────
+
+const EMPTY_DISPATCH_BASE = {
+  taskId: 'task-1',
+  dispatchActive: true,
+  toolUseCount: 0,
+  completed: true,
+  isError: false,
+  textLength: 3840,
+  model: 'claude-fable-5',
+};
+
+test('describeEmptyDispatchTurn: reports a completed caller-tool turn with no tool calls', () => {
+  const line = describeEmptyDispatchTurn(EMPTY_DISPATCH_BASE);
+  assert.ok(line);
+  assert.match(line, /taskId=task-1/);
+  assert.match(line, /model=claude-fable-5/);
+  // textLen is the one cheap signal separating a short "I'll start now" from a
+  // long final report, without copying model output into the logs.
+  assert.match(line, /textLen=3840/);
+  assert.doesNotMatch(line, /I'll|Let me/);
+});
+
+test('describeEmptyDispatchTurn: silent once any tool call was emitted', () => {
+  assert.equal(
+    describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, toolUseCount: 1 }),
+    null,
+  );
+});
+
+test('describeEmptyDispatchTurn: silent when caller-tool dispatch is not active', () => {
+  // The default agentic path keeps claude's built-ins and is not turn-capped,
+  // so a tool-less turn there carries no signal.
+  assert.equal(
+    describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, dispatchActive: false }),
+    null,
+  );
+});
+
+test('describeEmptyDispatchTurn: silent on a failed or non-terminal run', () => {
+  // Those already surface through the failure path; the interesting case is a
+  // run that reported success while producing nothing executable.
+  assert.equal(describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, isError: true }), null);
+  assert.equal(describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, completed: false }), null);
+});
+
+test('describeEmptyDispatchTurn: does not classify — a long final report reports too', () => {
+  // A 4957-char completion report and a 72-char announcement both produce a
+  // line. Classifying on two observed sessions would be overfit; the rate is
+  // what this exists to measure.
+  const report = describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, textLength: 4957 });
+  const stall = describeEmptyDispatchTurn({ ...EMPTY_DISPATCH_BASE, textLength: 72 });
+  assert.ok(report);
+  assert.ok(stall);
+  assert.match(report, /textLen=4957/);
+  assert.match(stall, /textLen=72/);
+});
+
+test('describeEmptyDispatchTurn: an unknown model cannot forge a log line', () => {
+  const line = describeEmptyDispatchTurn({
+    ...EMPTY_DISPATCH_BASE,
+    model: 'evil\n[client] FAKE',
+  });
+  assert.ok(line);
+  assert.equal(line.includes('\n'), false);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// resolveTurnText — which text a finished turn actually produced. Split out
+// because the `??`-vs-`||` distinction is easy to re-break at a call site and
+// fails silently (a length of 0, never an error).
+// ───────────────────────────────────────────────────────────────────────────
+
+test('resolveTurnText: an empty result falls back to the streamed text', () => {
+  // This is the real shape: a `result` event carrying `result: ""` alongside
+  // text the model streamed earlier in the turn. `??` would keep the empty
+  // string and report an empty turn.
+  assert.equal(resolveTurnText('', '**Tool Call: Glob**'), '**Tool Call: Glob**');
+  assert.equal(resolveTurnText(null, 'streamed'), 'streamed');
+});
+
+test('resolveTurnText: a non-empty result wins over the streamed text', () => {
+  assert.equal(resolveTurnText('final answer', 'partial'), 'final answer');
+});
+
+test('resolveTurnText: both empty yields empty', () => {
+  assert.equal(resolveTurnText(null, ''), '');
+  assert.equal(resolveTurnText('', ''), '');
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -404,6 +404,68 @@ export function describeClaudeSystemEvent(
   return { level, line };
 }
 
+// The text a finished turn actually produced.
+//
+// `||`, deliberately not `??`. A `result` event routinely carries `result: ""`
+// on a turn that spent itself on tool calls, and `??` treats that empty string
+// as a real value — so the streamed text is discarded and every consumer sees
+// an empty turn. `finalText` is authoritative when it has content; otherwise
+// fall back to what was streamed.
+//
+// Exported for unit tests: this rule is easy to re-break at a call site, and
+// the failure is silent (a length of 0, not an error).
+export function resolveTurnText(
+  finalText: string | null,
+  streamedText: string,
+): string {
+  return finalText || streamedText;
+}
+
+// Under caller-tool dispatch the bridge runs `--max-turns 1`: the model gets
+// one turn, its tool calls are captured, and the caller executes them and
+// returns results next turn. A turn that ends having emitted NO tool calls
+// therefore hands the caller nothing to run — the run is simply over.
+//
+// That is correct when the text was a final answer or a completion report, and
+// a silent dead end when it was an announcement of work about to be done. fable
+// produces the second kind: it writes the call out as prose and stops (#441).
+// Two renderings seen so far — `**todowrite**` + `Request` + a fenced block, and
+// a bare `Read` followed by a JSON object — which is why nothing here tries to
+// pattern-match the text.
+//
+// So this deliberately does NOT classify. It logs every caller-tool turn that
+// ended with nothing executable and lets the rate be measured first; a
+// classifier built on the two sessions observed so far would be overfit. The
+// line carries `taskId` so an analyst can join it to the session transcript,
+// and `textLen` as the one cheap signal that separates a 72-char "I'll start
+// now" from a 4957-char final report, without copying model output into logs.
+//
+// `info`, not `warn`: this fires on legitimate final answers too (~15% of turns
+// in the observed window), so it is instrumentation, not an anomaly — warn has
+// to stay alertable.
+//
+// Exported for unit tests.
+export function describeEmptyDispatchTurn(opts: {
+  taskId: string;
+  dispatchActive: boolean;
+  toolUseCount: number;
+  completed: boolean;
+  isError: boolean;
+  textLength: number;
+  model: string | null;
+}): string | null {
+  if (!opts.dispatchActive) return null;
+  if (opts.toolUseCount > 0) return null;
+  // An errored or aborted run already surfaces through the failure path; the
+  // interesting case is a run that reported success while producing nothing to
+  // execute.
+  if (!opts.completed || opts.isError) return null;
+  return (
+    `[claude] caller-tool turn produced no tool calls taskId=${opts.taskId} ` +
+    `model=${safeToken(opts.model ?? 'unknown', 60)} textLen=${opts.textLength}`
+  );
+}
+
 // The 1M-context tier marker Claude Code appends to a model id (`[1m]`). Its
 // presence on an advertised id is the signal that the effective context window
 // is the model's full ceiling rather than the 200k base (see
@@ -2534,6 +2596,11 @@ export function createClaudeBackend(
       let streamedResponseText = '';
       let sawCompletedResult = false;
       let sawErrorResult = false;
+      // Tool calls the model actually emitted this run. Counted separately from
+      // `seenAssistantToolUseIds` so it stays independent of that set's dedup
+      // semantics and still counts a block that arrives without an id.
+      // Feeds the empty-dispatch diagnostic at the terminal `result` (#441).
+      let emittedToolUseCount = 0;
       // Set when a tool_result comes back as claude's "No such tool available:
       // <name>" error. Under native dispatch this is the signature of a
       // tool-name mismatch — the model called a tool by a name claude doesn't
@@ -2813,6 +2880,7 @@ export function createClaudeBackend(
               if (seenAssistantToolUseIds.has(tu.toolUseId)) continue;
               seenAssistantToolUseIds.add(tu.toolUseId);
             }
+            emittedToolUseCount++;
             if (tu.toolName === 'AskUserQuestion' && tu.toolUseId && child.stdin) {
               // Stash for input-required terminal frame (A2A spec §9.4).
               // Placeholder tool_result + stdin.end() flushes CC's session state
@@ -2963,6 +3031,19 @@ export function createClaudeBackend(
           // the gateway falls back to its own estimate.
           const parsed = parseClaudeModelUsageForOpenAICompat(evt.modelUsage);
           if (parsed) finalUsage = parsed;
+          // Rate instrumentation for #441: a caller-tool turn that completed
+          // having emitted nothing for the caller to execute. Unclassified on
+          // purpose — see `describeEmptyDispatchTurn`.
+          const emptyDispatch = describeEmptyDispatchTurn({
+            taskId: task.taskId,
+            dispatchActive: nativeDispatchActive,
+            toolUseCount: emittedToolUseCount,
+            completed: evt.terminal_reason === 'completed',
+            isError: evt.is_error === true,
+            textLength: resolveTurnText(finalText, streamedResponseText).length,
+            model: assistantModel ?? initModel ?? null,
+          });
+          if (emptyDispatch) timingLogger.info?.(emptyDispatch);
           // CC finished — close stdin now that no more tool_results need writing.
           try { child.stdin?.end(); } catch { /* best effort */ }
         }


### PR DESCRIPTION
Refs #441. Instrumentation only — it does not fix the stall, it makes it countable.

## The gap

Under caller-tool dispatch the bridge runs `--max-turns 1`: the model gets one turn, its calls are captured, the caller executes them and returns results next turn. A turn that ends having emitted **no** tool calls hands the caller nothing to run — the run is simply over.

That is correct when the text was a final answer or a completion report. It is a silent dead end when the text was an *announcement of work about to be done*. fable produces the second kind: it writes the call out as prose and stops. Two confirmed occurrences, each with a real cost — one triggered a user complaint mid-session, the other made the parent agent restart an entire sub-agent task from scratch.

Today it is invisible. The task completes normally with `artifacts=1`, and nothing in the logs separates it from a turn that genuinely had nothing left to do. Both known occurrences were found only because a human happened to complain in-band.

## Why this does not classify

The two observed renderings share no surface form:

````
**todowrite**            │   Read
                         │
Request                  │   {
                         │     "path": "/home/project"
```javascript            │   }
{ "todos": [ … ] }       │
```                      │
````

A matcher tuned on either misses the other — my first attempt keyed on the left-hand shape and missed the right-hand one entirely, which surfaced on the very first fable turn after an unrelated deploy. A classifier derived from two sessions would be overfit. So this logs the whole population — every caller-tool turn that completed with zero tool calls — and leaves classification for when there are real numbers to design against.

## What it logs

```
[claude] caller-tool turn produced no tool calls taskId=<id> model=<model> textLen=<n>
```

- **`info`, not `warn`.** It also fires on legitimate final answers (~15% of turns in the observed window), so it is instrumentation, not an anomaly; warn has to stay alertable. At the default `info` level it is visible without config.
- **No model output in the logs.** `taskId` joins to the session transcript when someone needs the text; `textLen` is the one cheap discriminator between a 72-char "I'll start now" and a 4957-char final report.
- **Silent on failures.** An errored or non-terminal run already surfaces through the failure path; the interesting case is a run that reported success while producing nothing executable.
- **Silent off the caller-tool path.** The default agentic path keeps claude's built-ins and is not turn-capped, so a tool-less turn there carries no signal.

Volume: 11 lines across all models in the day I sampled.

## Verification

- `pnpm -r typecheck` clean
- **844/844 client tests pass**, including 6 new ones: the reporting case, the three silence conditions (tool calls present / dispatch inactive / errored run), non-classification (a 4957-char report and a 72-char announcement both report), and log-line forging via a hostile model string
- `describeEmptyDispatchTurn` is a pure exported helper, matching how the other diagnostics in this file are covered

## Next

Once this has run for a few days, the rate tells us whether a detector is worth building and what signal to key it on. The eventual fix — nudging or retrying a turn that announced instead of acting — is out of scope here; #431 already established that the CLI exposes no `tool_choice`, so there is no hard mechanism to force the call, and any mitigation will be heuristic. Better to build it against measurements than against two anecdotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
