### PR TITLE
feat(claude): optionally retry a turn that narrated its tool call

### DIFF
--- a/.changeset/retry-narrated-tool-call.md
+++ b/.changeset/retry-narrated-tool-call.md
@@ -1,0 +1,26 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude: optionally retry a caller-tool turn that described its tool call instead of making one
+
+Under caller-tool dispatch the bridge runs `--max-turns 1`, so a turn that ends
+having emitted no tool call leaves the caller nothing to execute and the run is
+over. `claude-fable-5` sometimes writes the call out as prose and stops — the
+user sees an agent that announced work and then quit. Observed at roughly 12% of
+turns under a real harness, costing either a user-visible stall or a full
+sub-agent restart.
+
+With `--claude-retry-narrated-tool-call` (or `backends.claude.retry_narrated_tool_call`)
+the bridge resumes the session once with a short corrective instruction, so the
+call actually runs. **Off by default**, because it spends an extra turn whenever
+it fires and the detection is a heuristic: the turn completed, emitted zero tool
+calls, and its text names one of the tools registered for that task. That is
+tuned for precision — across the observed population it catches 3 of 4 known
+stalls and leaves all 7 legitimate tool-less turns (complete inline deliverables,
+sub-agent completion reports) untouched. The retry happens at most once; a model
+that narrates twice will not be argued out of it.
+
+The narrated text has already streamed to the caller and cannot be recalled, so
+the caller sees prose followed by the real tool calls — the same trade-off
+already accepted for pre-tool-call preamble.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -16,6 +16,8 @@ import {
   describeClaudeSystemEvent,
   describeEmptyDispatchTurn,
   resolveTurnText,
+  NARRATED_TOOL_CALL_NUDGE,
+  shouldRetryNarratedToolCall,
   normalizeClaudeModelId,
   openaiToolsToCallerToolDefs,
   parseClaudeModelUsageForOpenAICompat,
@@ -5734,4 +5736,235 @@ test('resolveTurnText: a non-empty result wins over the streamed text', () => {
 test('resolveTurnText: both empty yields empty', () => {
   assert.equal(resolveTurnText(null, ''), '');
   assert.equal(resolveTurnText('', ''), '');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// shouldRetryNarratedToolCall — narrows the tool-less-turn population to the
+// subset worth a corrective retry (#441). Tuned for precision: a false positive
+// asks a model that legitimately finished to invent a tool call it doesn't need.
+// ───────────────────────────────────────────────────────────────────────────
+
+const REGISTERED = ['read', 'write', 'edit', 'glob', 'grep', 'bash', 'todowrite', 'task'];
+const retry = (text: string) =>
+  shouldRetryNarratedToolCall({ text, registeredToolNames: REGISTERED });
+
+test('shouldRetryNarratedToolCall: catches the three observed stall renderings', () => {
+  // No shared surface form between them — this is why the check is on the tool
+  // name rather than on any markup shape.
+  assert.equal(retry('…리스트업하겠습니다.\n\n**todowrite**\n\nRequest\n\n```javascript\n{"todos":[]}\n```'), true);
+  assert.equal(retry("I'll create the game. Let me first check the template.\n\nRead\n\n{\n  \"path\": \"/home/project\"\n}"), true);
+  assert.equal(retry('**Tool Call: Glob**\n```json\n{ "pattern": "**/*", "path": "/home/project" }\n```'), true);
+});
+
+test('shouldRetryNarratedToolCall: leaves legitimate tool-less answers alone', () => {
+  // Complete inline deliverables and sub-agent completion reports, verbatim in
+  // shape from the observed runs. Retrying these is the expensive mistake.
+  assert.equal(
+    retry("Here's a complete match-3 puzzle game in a single HTML file. Save it as `match3.html` and open it in a browser."),
+    false,
+  );
+  assert.equal(
+    retry('**미해결 항목: 없음** — 14/14 저장 완료. 단, 마법사 coat 2종은 대체 선택입니다.'),
+    false,
+  );
+});
+
+test('shouldRetryNarratedToolCall: a tool name inside a longer word does not count', () => {
+  // `read` must not fire on "already" / "spreadsheet" / "thread".
+  assert.equal(retry('The spreadsheet is already threaded through the loader.'), false);
+  assert.equal(retry('I will read the file.'), true);
+});
+
+test('shouldRetryNarratedToolCall: matches case-insensitively and on the bare wire name', () => {
+  assert.equal(retry('**Tool Call: GLOB**'), true);
+  assert.equal(
+    shouldRetryNarratedToolCall({
+      text: 'Calling read now.',
+      // Live MCP ids carry the caller-tools prefix; the model narrates the short form.
+      registeredToolNames: ['mcp___vb-caller-tools__read'],
+    }),
+    true,
+  );
+});
+
+test('shouldRetryNarratedToolCall: empty text or no registered tools never retries', () => {
+  assert.equal(retry(''), false);
+  assert.equal(shouldRetryNarratedToolCall({ text: 'read the file', registeredToolNames: [] }), false);
+  // Very short names would match far too much; they are skipped.
+  assert.equal(shouldRetryNarratedToolCall({ text: 'go do it', registeredToolNames: ['go'] }), false);
+});
+
+test('NARRATED_TOOL_CALL_NUDGE: names the failure and forbids re-narrating', () => {
+  assert.match(NARRATED_TOOL_CALL_NUDGE, /described a tool call in prose/i);
+  assert.match(NARRATED_TOOL_CALL_NUDGE, /Do not restate, summarise, or re-render/i);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Corrective retry for a narrated tool call (#441), end-to-end through
+// handle(). Opt-in via `claudeRetryNarratedToolCall`.
+// ───────────────────────────────────────────────────────────────────────────
+
+// A task carrying caller tools, which is what turns on native dispatch — the
+// only mode where a tool-less turn is a dead end rather than a plain answer.
+function narratedToolCallTask(): TaskAssignFrame {
+  return {
+    ...assign('build it'),
+    message: {
+      role: 'user',
+      messageId: 'm1',
+      parts: [{ kind: 'text', text: 'build it' }],
+      metadata: {
+        [OPENAI_COMPAT_EXTENSION_URI]: {
+          chat_completions_request: {
+            model: 'claude-fable-5',
+            messages: [{ role: 'user', content: 'build it' }],
+            tools: [
+              {
+                type: 'function',
+                function: {
+                  name: 'glob',
+                  description: 'List files matching a pattern.',
+                  parameters: { type: 'object', properties: { pattern: { type: 'string' } } },
+                },
+              },
+            ],
+            tool_choice: 'auto',
+          },
+        },
+      },
+    },
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
+  };
+}
+
+// Scripts each spawn separately so attempt 1 can narrate and attempt 2 emit a
+// real tool call, and records the argv of every spawn.
+function twoAttemptSpawn(scripts: readonly (readonly string[])[]): FakeSpawn & {
+  argvs: string[][];
+  stdins: string[][];
+} {
+  const argvs: string[][] = [];
+  const stdins: string[][] = [];
+  let n = 0;
+  const base = makeFakeSpawn((child) => {
+    const lines = scripts[Math.min(n, scripts.length - 1)] ?? [];
+    n++;
+    setImmediate(() => {
+      for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
+      setImmediate(() => child.finish(0, null));
+    });
+  });
+  const wrapped = {
+    ...base,
+    spawn(cmd: string, args: readonly string[], options: ClaudeSpawnOptions) {
+      argvs.push([...args]);
+      const handle = base.spawn(cmd, args, options);
+      stdins.push((base.lastChild() as unknown as { stdinChunks?: string[] })?.stdinChunks ?? []);
+      return handle;
+    },
+    argvs,
+    stdins,
+  };
+  return wrapped as FakeSpawn & { argvs: string[][]; stdins: string[][] };
+}
+
+const NARRATED = JSON.stringify({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    model: 'claude-fable-5',
+    content: [{ type: 'text', text: '**Tool Call: Glob**\n```json\n{ "pattern": "**/*" }\n```' }],
+  },
+});
+const REAL_CALL = JSON.stringify({
+  type: 'assistant',
+  message: {
+    role: 'assistant',
+    model: 'claude-fable-5',
+    content: [
+      {
+        type: 'tool_use',
+        id: 'toolu_1',
+        name: 'mcp___vb-caller-tools__glob',
+        input: { pattern: '**/*' },
+      },
+    ],
+  },
+});
+const OK_RESULT = JSON.stringify({ type: 'result', subtype: 'success', terminal_reason: 'completed', result: '' });
+
+test('narrated tool call: opt-in resumes the session once and the retry lands a real call', async () => {
+  const fake = twoAttemptSpawn([
+    [NARRATED, OK_RESULT],
+    [REAL_CALL, OK_RESULT],
+  ]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit, frames } = collect();
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 2, 'expected exactly one corrective retry');
+  // Attempt 1 mints the session, attempt 2 continues it — same id either way.
+  assert.ok(fake.argvs[0].includes('--session-id'));
+  assert.ok(fake.argvs[1].includes('--resume'));
+  assert.equal(fake.argvs[1].includes('--session-id'), false);
+  const id1 = fake.argvs[0][fake.argvs[0].indexOf('--session-id') + 1];
+  const id2 = fake.argvs[1][fake.argvs[1].indexOf('--resume') + 1];
+  assert.equal(id1, id2, 'the corrective turn must land in the session it is correcting');
+  // Everything except the session flag stays byte-identical.
+  assert.deepEqual(
+    fake.argvs[0].map((a) => (a === '--session-id' ? '--resume' : a)),
+    fake.argvs[1],
+  );
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('narrated tool call: off by default — no retry, no extra spawn', async () => {
+  const fake = twoAttemptSpawn([[NARRATED, OK_RESULT]]);
+  const backend = createClaudeBackend({ spawn: fake.spawn });
+  const { emit, frames } = collect();
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 1);
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+});
+
+test('narrated tool call: a turn that did emit a tool call is never retried', async () => {
+  const fake = twoAttemptSpawn([[REAL_CALL, OK_RESULT]]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit } = collect();
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 1);
+});
+
+test('narrated tool call: retries at most once even if the model narrates again', async () => {
+  // A model that narrates twice will not be argued out of it; an unbounded loop
+  // would burn the caller's turn budget invisibly.
+  const fake = twoAttemptSpawn([
+    [NARRATED, OK_RESULT],
+    [NARRATED, OK_RESULT],
+    [NARRATED, OK_RESULT],
+  ]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit } = collect();
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 2);
+});
+
+test('narrated tool call: a tool-less turn that names no tool is left alone', async () => {
+  const answer = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-fable-5',
+      content: [{ type: 'text', text: "Here's a complete match-3 game in a single HTML file." }],
+    },
+  });
+  const fake = twoAttemptSpawn([[answer, OK_RESULT]]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit } = collect();
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 1, 'a legitimate final answer must not be retried');
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -234,6 +234,11 @@ export interface ClaudeBackendOptions {
   // own `MAX_THINKING_TOKENS` env export > `DEFAULT_MAX_THINKING_TOKENS`. Unset
   // (the default) keeps the env-or-default behaviour.
   claudeThinkingBudget?: number;
+  // Opt into the corrective retry for a caller-tool turn that narrated its tool
+  // call instead of making one (#441). Off by default — it spends an extra turn
+  // when it fires and the detection is a heuristic. See
+  // `shouldRetryNarratedToolCall`.
+  claudeRetryNarratedToolCall?: boolean;
   // Remaining-usage (`usage()`) injection seams. The provider reads the
   // Claude subscription OAuth token from the host and calls
   // api.anthropic.com/api/oauth/usage; these let tests stub the network, the
@@ -464,6 +469,58 @@ export function describeEmptyDispatchTurn(opts: {
     `[claude] caller-tool turn produced no tool calls taskId=${opts.taskId} ` +
     `model=${safeToken(opts.model ?? 'unknown', 60)} textLen=${opts.textLength}`
   );
+}
+
+// The corrective turn fed back to claude when it described a tool call instead
+// of making one. Deliberately narrow: it names the failure, forbids re-writing
+// the call as prose, and does not otherwise re-state the task — the model still
+// has the whole conversation via `--resume`, and a longer instruction risks
+// steering the work itself rather than just the call mechanics.
+export const NARRATED_TOOL_CALL_NUDGE =
+  'Your previous message described a tool call in prose instead of invoking it, ' +
+  'so nothing ran. Invoke the tool now through the real tool-call mechanism. ' +
+  'Do not restate, summarise, or re-render the call as text.';
+
+// Decide whether a turn that emitted no tool call was a model that *meant* to
+// call one (#441). Only ever consulted for a completed caller-tool turn that
+// produced zero tool calls — `describeEmptyDispatchTurn` covers that whole
+// population; this narrows it to the retry-worthy subset.
+//
+// Tuned for PRECISION, not recall. A false positive costs a wasted turn AND
+// asks a model that legitimately finished to invent a tool call it does not
+// need, which is worse than missing a stall. The signal: the text names one of
+// the tools actually registered for this task. Measured against the observed
+// population — 3 of 4 known stalls named a registered tool (`todowrite`/`task`,
+// `Read`, `Glob`), while all 7 legitimate tool-less turns (complete inline
+// deliverables of 9.7k–12.5k chars, and sub-agent completion reports) named
+// none.
+//
+// Known miss: one stall ended "…저장을 시작하겠습니다" ("I will start saving")
+// without naming a tool. Recall is deliberately traded away here; the
+// unclassified `describeEmptyDispatchTurn` line still records it, so the gap
+// stays measurable rather than invisible.
+//
+// Exported for unit tests.
+export function shouldRetryNarratedToolCall(opts: {
+  text: string;
+  registeredToolNames: readonly string[];
+}): boolean {
+  const text = opts.text;
+  if (!text) return false;
+  for (const raw of opts.registeredToolNames) {
+    // Compare on the bare wire name; the live id is
+    // `mcp___vb-caller-tools__<name>` and the model narrates the short form.
+    const name = raw.replace(/^mcp___vb-caller-tools__/, '');
+    if (name.length < 3) continue;
+    // Word-ish boundary so `read` does not match "already" / "spreadsheet".
+    const re = new RegExp(`(^|[^A-Za-z0-9_])${escapeRegExp(name)}([^A-Za-z0-9_]|$)`, 'i');
+    if (re.test(text)) return true;
+  }
+  return false;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // The 1M-context tier marker Claude Code appends to a model id (`[1m]`). Its
@@ -1495,6 +1552,8 @@ export function createClaudeBackend(
   // Operator-facing override for the injected `MAX_THINKING_TOKENS` budget; a
   // positive integer or undefined (use env-or-default). Non-positive values are
   // ignored so a stray `0` / negative can't silently disable thinking.
+  // #441 opt-in: corrective retry for a turn that narrated its tool call.
+  const retryNarratedToolCall = opts.claudeRetryNarratedToolCall === true;
   const thinkingBudgetOverride =
     typeof opts.claudeThinkingBudget === 'number' &&
     Number.isFinite(opts.claudeThinkingBudget) &&
@@ -3062,31 +3121,37 @@ export function createClaudeBackend(
       signal.addEventListener('abort', onAbort);
 
       let stdoutBuf = '';
-      child.stdout?.on('data', (chunk: Buffer | string) => {
-        recorder.mark('firstOut');
-        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        stdoutTail += text;
-        if (stdoutTail.length > stderrCap) stdoutTail = stdoutTail.slice(-stderrCap);
-        stdoutBuf += text;
-        let nl: number;
-        while ((nl = stdoutBuf.indexOf('\n')) !== -1) {
-          const line = stdoutBuf.slice(0, nl).trim();
-          stdoutBuf = stdoutBuf.slice(nl + 1);
-          if (!line) continue;
-          let evt: StreamEvent;
-          try {
-            evt = JSON.parse(line) as StreamEvent;
-          } catch {
-            continue;
+      // Extracted so the corrective-retry child (#441) reuses the identical
+      // parsing and the same `handleEvent` closure — its tool calls must land
+      // in the same artifact/counter state as the first attempt's.
+      const attachStreams = (c: ClaudeChildHandle): void => {
+        c.stdout?.on('data', (chunk: Buffer | string) => {
+          recorder.mark('firstOut');
+          const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          stdoutTail += text;
+          if (stdoutTail.length > stderrCap) stdoutTail = stdoutTail.slice(-stderrCap);
+          stdoutBuf += text;
+          let nl: number;
+          while ((nl = stdoutBuf.indexOf('\n')) !== -1) {
+            const line = stdoutBuf.slice(0, nl).trim();
+            stdoutBuf = stdoutBuf.slice(nl + 1);
+            if (!line) continue;
+            let evt: StreamEvent;
+            try {
+              evt = JSON.parse(line) as StreamEvent;
+            } catch {
+              continue;
+            }
+            handleEvent(evt);
           }
-          handleEvent(evt);
-        }
-      });
+        });
 
-      child.stderr?.on('data', (chunk: Buffer | string) => {
-        stderrTail += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-        if (stderrTail.length > stderrCap) stderrTail = stderrTail.slice(-stderrCap);
-      });
+        c.stderr?.on('data', (chunk: Buffer | string) => {
+          stderrTail += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+          if (stderrTail.length > stderrCap) stderrTail = stderrTail.slice(-stderrCap);
+        });
+      };
+      attachStreams(child);
 
       // Shared liveness heartbeat: while the child is alive, every
       // `heartbeatMs` of no outbound traffic produces a tagged
@@ -3106,36 +3171,107 @@ export function createClaudeBackend(
         intervalMs: heartbeatMs,
       });
 
-      const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null; error?: unknown }>((resolve) => {
-        // The `error` event is *typed* with `Error`, but EventEmitter at
-        // runtime can emit any value. Carry it as unknown so the frame
-        // builder routes through `errorMessage` safely.
-        child.on('error', (err) => resolve({ code: null, signal: null, error: err }));
-        child.on('close', (code, sig) => resolve({ code, signal: sig }));
-      });
+      type ChildExit = { code: number | null; signal: NodeJS.Signals | null; error?: unknown };
+      // Await the *current* `child` and drain whatever it left unterminated.
+      // Factored out so the corrective retry (#441) can run a second child
+      // through the identical settle path. The trailing flush MUST stay paired
+      // with the await: `handleEvent` returns early once `settled` is set, and a
+      // swallowed trailing `result` event leaves `sawCompletedResult` false,
+      // which collapses the otherwise-legitimate "exit 1 after completed
+      // result" case into a `claude_exit_nonzero` failure.
+      const awaitChild = async (): Promise<ChildExit> => {
+        const current = child;
+        const e = await new Promise<ChildExit>((resolve) => {
+          // The `error` event is *typed* with `Error`, but EventEmitter at
+          // runtime can emit any value. Carry it as unknown so the frame
+          // builder routes through `errorMessage` safely.
+          current.on('error', (err) => resolve({ code: null, signal: null, error: err }));
+          current.on('close', (code, sig) => resolve({ code, signal: sig }));
+        });
+        // claude normally terminates each event with \n but recent CC builds
+        // can flush the final `result` event without one and exit.
+        const trailing = stdoutBuf.trim();
+        stdoutBuf = '';
+        if (trailing) {
+          try {
+            handleEvent(JSON.parse(trailing) as StreamEvent);
+          } catch {
+            // ignore
+          }
+        }
+        return e;
+      };
+
+      let exit = await awaitChild();
       recorder.mark('closed');
       timingLogger.debug(
         `claude.spawn.close taskId=${safeToken(task.taskId)} command=${safeToken(command)} code=${exit.code === null ? 'null' : String(exit.code)} signal=${exit.signal ? safeToken(exit.signal) : 'null'} stdoutTailChars=${stdoutTail.length} stderrTailChars=${stderrTail.length}${exit.error ? ` error=${safeToken(errorMessage(exit.error), 1000)}` : ''}`,
       );
 
-      signal.removeEventListener('abort', onAbort);
-
-      // Flush any trailing line without a newline. claude normally terminates
-      // each event with \n but recent CC builds can flush the final `result`
-      // event without a trailing newline and exit. This MUST run before
-      // `settled = true` — `handleEvent` returns early when `settled` is
-      // set, and a swallowed trailing `result` event leaves
-      // `sawCompletedResult` false, which then collapses the otherwise-
-      // legitimate "exit 1 after completed result" case into a
-      // `claude_exit_nonzero` failure.
-      const trailing = stdoutBuf.trim();
-      if (trailing) {
+      // #441 — the turn ended having described a tool call instead of making
+      // one, so the caller has nothing to execute and the run is a dead end.
+      // Resume the session once with a corrective instruction. Opt-in
+      // (`--claude-retry-narrated-tool-call`): it spends an extra turn when it
+      // fires, and `shouldRetryNarratedToolCall` is a heuristic.
+      //
+      // Deliberately at most ONE extra attempt — a model that narrates twice is
+      // not going to be argued out of it, and an unbounded loop here would burn
+      // the caller's turn budget invisibly.
+      //
+      // Note the narrated text has already streamed to the caller as an
+      // assistant artifact and cannot be recalled; the caller sees prose
+      // followed by the real tool calls. Cosmetic, and the same trade-off #431
+      // already accepts for pre-tool-call preamble.
+      if (
+        retryNarratedToolCall &&
+        !aborted &&
+        nativeDispatchActive &&
+        emittedToolUseCount === 0 &&
+        sawCompletedResult &&
+        !sawErrorResult &&
+        child.stdin !== null &&
+        shouldRetryNarratedToolCall({
+          text: resolveTurnText(finalText, streamedResponseText),
+          registeredToolNames: [...callerToolNameSet],
+        })
+      ) {
+        // Only the session flag changes: `--session-id` mints, `--resume`
+        // continues. Everything else — mcp config, model, turn cap, system
+        // prompt — must stay byte-identical or the corrective turn lands in a
+        // different context than the one it is correcting.
+        const retryArgs = args.map((a) => (a === '--session-id' ? '--resume' : a));
+        timingLogger.info?.(
+          `[claude] retrying narrated tool call taskId=${task.taskId} ` +
+            `model=${safeToken(assistantModel ?? initModel ?? 'unknown', 60)}`,
+        );
         try {
-          handleEvent(JSON.parse(trailing) as StreamEvent);
-        } catch {
-          // ignore
+          child = spawnFn(command, retryArgs, { cwd: effectiveCwd, env: effectiveEnv });
+          recorder.mark('spawn');
+          attachStreams(child);
+          child.stdin?.on('error', (err: unknown) => {
+            if (!stdinError) stdinError = err;
+          });
+          child.stdin?.write(
+            JSON.stringify({
+              type: 'user',
+              message: {
+                role: 'user',
+                content: [{ type: 'text', text: NARRATED_TOOL_CALL_NUDGE }],
+              },
+            }) + '\n',
+          );
+          exit = await awaitChild();
+        } catch (err) {
+          // A failed retry must not fail the task: the first attempt already
+          // produced a legitimate (if useless) completed result, and surfacing
+          // a spawn error here would turn a degraded turn into a hard failure.
+          timingLogger.warn?.(
+            `[claude] narrated-tool-call retry failed taskId=${task.taskId} error=${safeToken(errorMessage(err), 300)}`,
+          );
         }
       }
+
+      signal.removeEventListener('abort', onAbort);
 
       settled = true;
       sendFileRelease?.();

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -103,6 +103,11 @@ export const daemonFlagsFields = {
       description: message`Thinking budget in tokens, injected as \`MAX_THINKING_TOKENS\` on openai-compat spawns so Claude emits thinking on the wire (default 8000). Takes precedence over an operator's own \`MAX_THINKING_TOKENS\` export. Only valid with \`--backend claude\`. Mirrors config \`backends.claude.thinking_budget\`.`,
     }),
   ),
+  claudeRetryNarratedToolCall: optional(
+    flag('--claude-retry-narrated-tool-call', {
+      description: message`On a caller-tool turn that ends having described a tool call in prose instead of invoking it, resume the session once with a corrective instruction (planetarium/vicoop-bridge#441). Off by default: it costs an extra turn when it fires and the detection is a heuristic. Only valid with \`--backend claude\`.`,
+    }),
+  ),
 
   // Backend-specific (Codex)
   codexSandbox: optional(option('--codex-sandbox', choice([...SANDBOX_MODES]), {
@@ -174,6 +179,7 @@ export interface DaemonArgs {
   // / `backends.claude.thinking_budget`). Undefined keeps the backend's
   // env-or-default behaviour.
   claudeThinkingBudget?: number;
+  claudeRetryNarratedToolCall?: boolean;
   codexSandbox?: CodexSandboxMode;
   // Resolved openai-compat/v1 reasoning channel toggle for the vicoop-codex
   // backend. Defaults ON; the `--no-vicoop-codex-reasoning` flag or
@@ -308,6 +314,8 @@ export function mergeClientArgs(
     // it off; the flag wins over config, matching the other flag>config knobs.
     claudeReasoning: backends.claude?.reasoning !== false && !flags.noClaudeReasoning,
     claudeThinkingBudget: flags.claudeThinkingBudget ?? backends.claude?.thinking_budget,
+    claudeRetryNarratedToolCall:
+      flags.claudeRetryNarratedToolCall ?? backends.claude?.retry_narrated_tool_call,
     codexSandbox:
       flags.codexSandbox ?? pickSandbox(backends.codex?.sandbox_mode),
     // ON unless the config opts out (`reasoning: false`) or the CLI flag forces
@@ -387,6 +395,11 @@ export function mergeClientArgs(
   if (flags.claudeThinkingBudget !== undefined && backend !== 'claude') {
     errors.push(
       `--claude-thinking-budget is not supported by --backend ${backend}; only the claude backend takes a thinking budget`,
+    );
+  }
+  if (flags.claudeRetryNarratedToolCall && backend !== 'claude') {
+    errors.push(
+      `--claude-retry-narrated-tool-call is not supported by --backend ${backend}; only the claude backend runs caller-tool turns`,
     );
   }
   if (flags.noVicoopCodexReasoning && backend !== 'vicoop-codex') {

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -424,6 +424,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
         openaiCompatTrace: args.openaiCompatTrace,
         claudeReasoning: args.claudeReasoning,
         claudeThinkingBudget: args.claudeThinkingBudget,
+        claudeRetryNarratedToolCall: args.claudeRetryNarratedToolCall,
         // Enrich the openai-compat/v1 advertise with contextWindow /
         // maxOutputTokens from the Models API (authenticated with the host's
         // subscription OAuth token — same cred the usage path reads).

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -143,6 +143,15 @@ export interface ClaudeBackendConfig {
    * `--claude-thinking-budget` flag.
    */
   thinking_budget?: number;
+  /**
+   * When a caller-tool turn ends having described a tool call in prose instead
+   * of invoking it, resume the session once with a corrective instruction so
+   * the call actually runs (planetarium/vicoop-bridge#441). OFF by default: it
+   * costs an extra turn whenever it fires, and the detection is a heuristic
+   * (the text naming a registered tool), so it can both miss and — in
+   * principle — misfire. Mirrors the `--claude-retry-narrated-tool-call` flag.
+   */
+  retry_narrated_tool_call?: boolean;
   runtime?: BackendRuntime;
   runtime_name?: string;
 }


### PR DESCRIPTION
Refs #441. **Stacked on #444** (base is `fix/log-empty-caller-tool-turns`) — it builds on the tool-call counter that PR introduces. Retarget to `main` once #444 lands.

This is the first change that actually tries to *fix* the stall rather than measure it.

## What it does

When a caller-tool turn completes having emitted no tool call, and its text names one of the tools registered for that task, the bridge resumes the session once with:

> Your previous message described a tool call in prose instead of invoking it, so nothing ran. Invoke the tool now through the real tool-call mechanism. Do not restate, summarise, or re-render the call as text.

Only the session flag differs between attempts — `--session-id` becomes `--resume`, everything else byte-identical, or the corrective turn would land in a different context than the one it is correcting. A test pins that argv equality.

## Off by default

`--claude-retry-narrated-tool-call`, or `backends.claude.retry_narrated_tool_call`. It spends an extra turn when it fires and the detection is a heuristic, so it should be enabled on one provider and measured before it becomes the default. `handle()` is the path every claude task takes; the flag keeps the blast radius at zero until someone opts in.

## The heuristic, and why precision over recall

A false positive asks a model that legitimately finished to invent a tool call it does not need — worse than missing a stall. So the gate is narrow: the text names a registered tool.

Measured against everything observed so far:

| turn | len | names a tool | retried? |
|---|---|---|---|
| stall — `**todowrite**` + fenced block | 3840 | yes | ✅ |
| stall — bare `Read` + JSON | ~200 | yes | ✅ |
| stall — `**Tool Call: Glob**` | 82 | yes | ✅ |
| stall — "…저장을 시작하겠습니다" | 72 | **no** | ❌ miss |
| complete inline game ×3 | 9.7k–12.5k | no | correctly skipped |
| sub-agent completion report ×3 | 2.6k–5.0k | no | correctly skipped |
| runner deliverable | 11.9k | no | correctly skipped |

3 of 4 stalls, 0 of 7 legitimate turns. The miss is recorded by #444's unclassified log, so the recall gap stays measurable rather than invisible.

Note the three stall renderings share no surface form — this is why the gate is on the *tool name* and not on any markup shape.

## Bounded and non-escalating

- **At most one retry.** A model that narrates twice will not be argued out of it, and an unbounded loop would burn the caller's turn budget invisibly.
- **A failed retry spawn is logged and swallowed.** The first attempt already produced a completed result; turning a degraded turn into a hard failure would be a regression.
- **Skipped** when the run errored, was aborted, was non-terminal, emitted any tool call, or is not on the caller-tool path.

## Known cosmetic cost

The narrated text has already streamed to the caller and cannot be recalled, so the caller sees prose followed by the real tool calls. Same trade-off #431 already accepts for pre-tool-call preamble.

## Verification

- `pnpm -r typecheck` clean across all 4 workspace projects
- **858/858 client tests pass**, including 5 new end-to-end cases through `handle()`: the retry fires and resumes the same session with identical argv; it is off by default; a turn that emitted a tool call is never retried; it retries at most once when the model narrates repeatedly; a tool-less turn naming no tool is left alone. Plus 6 unit tests on the heuristic itself (three renderings, legitimate answers, word-boundary safety so `read` misses "already"/"spreadsheet", the `mcp___vb-caller-tools__` prefix, empty/short-name guards).

## Next

Enable on one provider, run the repro harness (which reproduces the stall on demand — 1 in 5 with a faithful system prompt + project context + real tool surface), and compare before/after. If it holds up, flip the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
