### PR TITLE
feat(server): charge per call with x402 (exact + metered upto)

### DIFF
--- a/.changeset/x402-pricing-cli-and-task-usage.md
+++ b/.changeset/x402-pricing-cli-and-task-usage.md
@@ -1,0 +1,28 @@
+---
+'@vicoop-bridge/client': minor
+---
+
+Manage an agent's x402 pricing from the CLI, and report per-task token usage
+on the wire.
+
+`vicoop-client agent x402 {show, set, clear}` sits alongside `agent callers`
+and uses the same owner-session bearer, so pricing is managed from your
+machine while staying server-side state — a stolen agent token cannot reprice
+an agent or redirect its payments. `set` takes either field flags for the
+common flat fee (`--amount`, `--asset`, `--pay-to`, `--network`) or
+`--file <path|->` for a whole pricing object, which is how the metered `upto`
+scheme with its per-MTok rate table is configured. The bridge validates the
+body and rejects unrecognized keys, so a typo like `minamount` fails with a
+400 naming the field instead of silently changing what the agent charges.
+`show` flags the one configuration that quietly gives work away: a metered
+agent with no floor set.
+
+The claude, codex, and vicoop-codex backends now also report per-turn token
+counts as `usage` on the `task.complete` frame. The same numbers already rode
+under the openai-compat extension URI, and still do for that extension's
+consumers — but a bridge that bills on consumption should not read its input
+from an unrelated extension's namespace, where renaming or versioning it would
+silently turn every charge into "unreported". Absent stays absent rather than
+becoming a zero: when a runtime drops its accounting for a turn, the field is
+omitted, which is what lets a consumer tell "reported nothing" from "reported
+zero".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,4 @@ authoring or cleaning up changesets.**
 - [`docs/local-testing.md`](./docs/local-testing.md), [`docs/remote-testing.md`](./docs/remote-testing.md) — testing flows
 - [`docs/claude-e2e.md`](./docs/claude-e2e.md), [`docs/openclaw-e2e.md`](./docs/openclaw-e2e.md) — backend-specific E2E
 - [`docs/container.md`](./docs/container.md) — container runtime profiles (bundled-direct + external-runtime)
+- [`docs/x402-payments.md`](./docs/x402-payments.md) — per-agent x402 pricing, the payment round-trip, and settlement

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -192,12 +192,17 @@ Not every completed call can be priced:
 
 - **openclaw reports no token usage at any layer.** Metered pricing is not
   possible for that backend — leave it on `exact`.
-- **codex and vicoop-codex can emit `{0,0,0}`** when their runtime dropped its
-  accounting for a turn. Both log a warning when they do.
+- **codex and vicoop-codex omit the counts** when their runtime dropped its
+  accounting for a turn. Both log a warning when they do. (They still emit a
+  `{0,0,0}` placeholder into the openai-compat metadata, which that
+  extension's contract requires — but the protocol's `usage` field is left
+  absent, so the meter is not fooled.)
 
-`total_tokens: 0` therefore means "the runtime did not report", not "the call
-was free". The bridge treats both cases identically: it charges `minAmount`
-(zero if unset) and logs `x402_usage_unavailable` with what it charged.
+Both cases arrive as "no usage reported", which is **not** "the call was
+free". The bridge charges `minAmount` (zero if unset) and logs
+`x402_usage_unavailable` with what it charged. A reported zero is treated the
+same way, since a runtime that genuinely consumed nothing did no billable
+work either.
 
 The default direction is deliberately payer-favourable. Billing the authorized
 ceiling because *our* instrumentation lost the token count would be a
@@ -252,6 +257,7 @@ All events are structured JSON on stdout (see
 | `x402_verify_failed` | the facilitator rejected the payload |
 | `x402_metered` | `upto` only — what the call priced to, with the token counts and the `basis` (`metered` / `floor` / `no-usage`) |
 | `x402_usage_unavailable` | `upto` only — work was delivered that could not be priced; carries what was charged instead |
+| `x402_usage_legacy_source` | `upto` only — the counts came from the openai-compat fallback because the client is too old to send `TaskCompleteFrame.usage`. Chase the client upgrade; the fallback is meant to be retired |
 | `x402_settled` | settled on-chain; carries the transaction hash and the facilitator-confirmed amount |
 | `x402_settle_failed` / `x402_settle_error` | settlement was refused or unreachable |
 | `x402_gate_error` | the payment rail was unavailable; the call was refused rather than served free |
@@ -274,23 +280,38 @@ verifiable without a chain or a database.
 
 ## Where the token counts come from
 
-Metering needs no protocol extension. The claude, codex, and vicoop-codex
-backends already stamp per-turn token counts onto the `task.complete` frame,
-under the openai-compat extension URI in `status.message.metadata` — and they
-do it even when the caller did not activate that extension, precisely so
-"billing telemetry" can read them. `wireMessageToA2X` carries the metadata
-through untouched, so the counts are already on the terminal event the
-settlement path receives.
+`TaskCompleteFrame.usage` — a first-class, optional field on the bridge's own
+wire protocol:
 
-Two wire shapes appear there depending on whether the caller activated the
-openai-compat extension, and `readTaskUsage` handles both:
-
-```
-{ usage: {...} }                        plain A2A callers
-{ chat_completion: { usage: {...} } }   openai-compat envelope
+```ts
+{ promptTokens, completionTokens, cachedInputTokens?, model? }
 ```
 
-Note this is **not** the `usage.request` / `usage.response` RPC. That returns
-a cumulative account-level quota snapshot (rolling subscription windows,
-overage budget) and is rate-limited and cached — useful for capacity
+The claude, codex, and vicoop-codex backends populate it from the counts they
+already have at the end of a turn. `ws.ts` stashes it on the task binding, and
+the settlement path prices from there.
+
+**This is deliberately independent of the openai-compat extension.** The same
+counts do also ride under `OPENAI_COMPAT_EXTENSION_URI` in
+`status.message.metadata`, for that extension's own consumers — but billing
+does not read them from there by choice. Deriving revenue from another
+extension's namespace would mean that renaming or versioning that extension
+turns every charge into "unreported", which bills the floor, silently, with
+nothing failing. Usage is a transport-level fact about a task, so the protocol
+owns it.
+
+`readTaskUsage` still falls back to the openai-compat key when the frame field
+is absent, purely so a client too old to send it stays priceable during a
+rollout. That fallback logs `x402_usage_legacy_source` and is meant to be
+retired once no such clients remain.
+
+One consequence worth knowing: the openai-compat envelope *requires* a `usage`
+block, so codex and vicoop-codex substitute `{0,0,0}` there when their runtime
+reported nothing. The protocol field has no such requirement, so it is simply
+**absent** in that case — which is the truth, and is what lets the meter tell
+"reported zero" apart from "reported nothing".
+
+Note this is also **not** the `usage.request` / `usage.response` RPC. That
+returns a cumulative account-level quota snapshot (rolling subscription
+windows, overage budget), rate-limited and cached — useful for capacity
 dashboards, useless for metering a single call.

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -141,8 +141,15 @@ A malformed pricing row does not take the agent offline: it is logged
 (`x402_pricing_invalid`) and the agent connects as free, so nobody is charged
 against a configuration the server could not read.
 
-Repricing takes effect on the next call — the executor reads the live
-connection each turn rather than caching pricing at connect time.
+Repricing takes effect on the next call, on every instance. The executor reads
+the live connection each turn rather than caching pricing at connect time, and
+because the agent's WebSocket usually lives on a different instance than the
+one that served the admin write, the write also emits a Postgres `NOTIFY` that
+makes the holding instance re-read the row. Without that an agent you just made
+free would keep billing from somewhere else until it reconnected.
+
+If the notification is lost the deployment degrades to the old behavior —
+pricing refreshes when the agent reconnects — rather than failing the write.
 
 ## Metered pricing (`upto`)
 
@@ -248,12 +255,32 @@ the payer is not charged, but the call fails for no reason the caller can act
 on. Restarts do the same to a single instance.
 
 Rows are deleted when the task terminates. Expiry is lazy (a `WHERE` clause on
-read), so no background reaper is required; `PostgresX402Store.sweepExpired()`
-exists to reclaim rows whose task never terminated at all.
+read), and the hourly cleanup job sweeps lapsed rows so that callers who walk
+away at the `input-required` turn cannot grow the table indefinitely — on a
+public paid agent that would otherwise be an unauthenticated write.
 
-The row's `entry` column is the audit record of what was charged — the
-advertised offering, the lifecycle status, and on success the receipt
-(transaction hash, payer, settled amount).
+The row's `entry` column is the advertised offering plus its lifecycle status
+and, on success, the receipt (transaction hash, payer, settled amount).
+
+Three properties of this table are load-bearing rather than incidental:
+
+- **Keyed on `(agent_id, task_id)`, not `task_id`.** Tasks resolve by id from a
+  store shared across every agent (#453), so a task created at agent A can be
+  resumed at agent B's endpoint. Keyed on the task alone, B's gate would find
+  A's offering and accept A's cheap signature as payment for B's work. Every
+  store operation filters on the agent.
+- **`pricing` freezes the terms the offering was published under.** Settlement
+  prices from this, never from the agent's live pricing: the two turns are
+  separate requests, and a reprice in between would otherwise meter turn 2
+  against terms turn 1 never signed. A missing snapshot refuses the call rather
+  than guessing.
+- **`claimed_at` makes a submission usable once.** The SDK's `classify()` does
+  not inspect the entry's status, so a replayed `payment-submitted` classifies
+  valid every time; the claim is a conditional `UPDATE` and the loser is
+  refused before the backend is reached. It is never released — a failed verify
+  leaves the offering spent and the payer starts a new task, because re-opening
+  the window would restore the double-spend it exists to prevent. Nothing has
+  been charged at that point.
 
 ## Observability
 
@@ -272,8 +299,12 @@ All events are structured JSON on stdout (see
 | `x402_settled` | settled on-chain; carries the transaction hash and the facilitator-confirmed amount |
 | `x402_settle_failed` / `x402_settle_error` | settlement was refused or unreachable |
 | `x402_gate_error` | the payment rail was unavailable; the call was refused rather than served free |
-| `x402_pricing_invalid` | a malformed pricing row; the agent connected as free |
+| `x402_submission_replayed` | a payment already used for this task was submitted again; refused before the backend was reached |
+| `x402_pricing_snapshot_missing` | the offering's frozen terms were gone at settle time; the call was refused rather than priced from live pricing |
+| `x402_pricing_invalid` | a malformed pricing row; the agent is treated as free |
 | `x402_config_invalid` | `upto` pricing on a V1 deployment; every call is refused until fixed |
+| `x402_pricing_refreshed` | this instance re-read an agent's pricing after another instance changed it |
+| `x402_offerings_swept` | the hourly job reclaimed lapsed offerings |
 
 Two worth alerting on: `x402_usage_unavailable` means revenue is being left on
 the table, and a sustained `x402_settle_failed` means work is being delivered

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -52,6 +52,24 @@ If settlement itself fails, the task is reported `failed` rather than
 `completed`: the caller got the work but the merchant was not paid, and
 reporting success would hide that.
 
+### The accepted window: output ships before settlement
+
+Artifacts stream to the caller as the agent produces them, and settlement
+cannot start until the work is done — under `upto` there is nothing to meter
+before then. **A payer who invalidates their authorization between `verify` and
+settlement therefore receives the full result and a `failed` status.**
+
+This window is accepted rather than closed, because both ways of closing it are
+worse. Buffering output until settlement lands would remove streaming from
+exactly the agents people pay for. Settling before the work would charge for
+tasks that fail — and on a bridge fronting coding agents, timeouts and backend
+errors are far more common than an adversarial payer. Undercharging in a rare
+attack beats overcharging on routine failure.
+
+The exposure is one task's work per occurrence, and `x402_unpaid_delivery`
+counts it. A rising rate is worth investigating; a flat zero is the expected
+state.
+
 ## Configuring an agent's price
 
 From the operator's machine, with the same owner-session bearer `agent callers`
@@ -236,6 +254,13 @@ event is the only thing telling you so.
 | `BRIDGE_X402_FACILITATOR_URL` | SDK default (`https://x402.org/facilitator`) | Facilitator running verify + settle. |
 | `BRIDGE_X402_OFFER_TTL_SECONDS` | `600` | How long a payer has to sign and resubmit. Past it the offering lapses and the submission is refused; the payer is not charged, they just start over. |
 
+**`PUBLIC_URL` is required for paid agents.** The x402 `resource` must be an
+absolute URL — strict facilitators reject anything else — so without it an
+agent would publish offerings that can never verify or settle. The bridge
+withholds the payment gate in that case and logs `x402_config_invalid`: the
+agent serves for free with a visible misconfiguration, rather than running a
+payment loop that cannot complete. Its card advertises no price either.
+
 The AgentCard advertises `X402_FOUNDATION_EXTENSION_URI` with the price in
 `params` when — and only when — pricing is configured, so a caller can decide
 whether it is willing to pay before spending a turn. It is advertised
@@ -301,6 +326,9 @@ All events are structured JSON on stdout (see
 | `x402_gate_error` | the payment rail was unavailable; the call was refused rather than served free |
 | `x402_submission_replayed` | a payment already used for this task was submitted again; refused before the backend was reached |
 | `x402_pricing_snapshot_missing` | the offering's frozen terms were gone at settle time; the call was refused rather than priced from live pricing |
+| `x402_scheme_mismatch` | the frozen terms and the signed requirement named different schemes; refused rather than mispriced |
+| `x402_unpaid_delivery` | settlement failed after the caller already had the output — the accepted window above, made countable |
+| `x402_wire_advertisement_dropped` | a connecting agent tried to advertise its own x402 terms on its card; discarded |
 | `x402_pricing_invalid` | a malformed pricing row; the agent is treated as free |
 | `x402_config_invalid` | `upto` pricing on a V1 deployment; every call is refused until fixed |
 | `x402_pricing_refreshed` | this instance re-read an agent's pricing after another instance changed it |

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -54,6 +54,47 @@ reporting success would hide that.
 
 ## Configuring an agent's price
 
+From the operator's machine, with the same owner-session bearer `agent callers`
+uses (`vicoop-client auth login --server <URL>` first):
+
+```bash
+# What does this agent charge?
+vicoop-client agent x402 show <AGENT_ID>
+
+# Flat fee: 0.01 USDC per call on Base Sepolia
+vicoop-client agent x402 set <AGENT_ID> \
+  --network eip155:84532 \
+  --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+  --pay-to 0xYourWallet \
+  --amount 10000
+
+# Metered: $3/MTok in, $15/MTok out, 1 USDC ceiling, 0.001 USDC floor
+vicoop-client agent x402 set <AGENT_ID> \
+  --scheme upto \
+  --network eip155:84532 \
+  --asset 0x036CbD53842c5426634e7929541eC2318f3dCF7e \
+  --pay-to 0xYourWallet \
+  --facilitator 0xFacilitatorAddress \
+  --max-amount 1000000 --min-amount 1000 \
+  --rate-input 3000000 --rate-output 15000000
+
+# Or supply the whole object (also reads stdin with `-`)
+vicoop-client agent x402 set <AGENT_ID> --file pricing.json
+
+# Back to free
+vicoop-client agent x402 clear <AGENT_ID>
+```
+
+These call `GET`/`PUT`/`DELETE /admin-api/agents/:id/x402`. The body is
+validated server-side against the same schema the payment gate uses, so a bad
+address or a dollars-instead-of-atomic amount is rejected at write time rather
+than silently disabling payments at the agent's next connect. Changes are
+hot-reloaded — no daemon restart, no reconnect.
+
+Note the auth boundary: these take the **owner-session** bearer, not the agent
+token. A stolen agent token can impersonate the agent but cannot reprice it or
+redirect its payments.
+
 Pricing lives in `agents.x402_pricing` (JSONB, NULL by default). A row with no
 `scheme` is `exact`:
 

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -1,0 +1,158 @@
+# x402 payments
+
+The bridge can charge callers per invocation using
+[x402](https://github.com/x402-foundation/x402), settling on-chain through a
+facilitator. Pricing is configured per agent; an agent with no pricing row is
+free and takes no payment code path at all.
+
+Only the **`exact`** scheme is implemented today — a fixed price per call,
+agreed before the work happens. See [Roadmap](#roadmap) for usage-based
+billing.
+
+## How a paid call runs
+
+```
+turn 1   caller → bridge          message/send (no payment)
+         bridge → caller          Task(input-required)
+                                    metadata['x402.payment.required']
+                                      = { x402Version: 2, resource, accepts: [...] }
+         (the connected agent is never contacted; no capacity is consumed)
+
+         caller signs the payload with its wallet
+
+turn 2   caller → bridge          message/send { message.taskId: <same task> }
+                                    metadata['x402.payment.status'] = 'payment-submitted'
+                                    metadata['x402.payment.payload'] = <signed>
+         bridge                   classify → facilitator.verify
+         bridge → agent           task.assign        (only now does work start)
+         agent  → bridge          task.complete
+         bridge                   facilitator.settle
+         bridge → caller          Task(completed)
+                                    metadata['x402.payment.receipts'] = [{ transaction, ... }]
+```
+
+Two properties that follow from the ordering, and are worth stating because
+they are the ones an operator gets asked about:
+
+- **Unpaid calls never reach the agent.** The gate runs before the task is
+  bound or forwarded, so an unpaid or invalid request costs the backend
+  nothing.
+- **Failed work is not charged.** Settlement happens only on a `completed`
+  task. If the agent fails, is cancelled, or times out, the payer's signed
+  authorization simply goes unused — it expires on its own.
+
+If settlement itself fails, the task is reported `failed` rather than
+`completed`: the caller got the work but the merchant was not paid, and
+reporting success would hide that.
+
+## Configuring an agent's price
+
+Pricing lives in `agents.x402_pricing` (JSONB, NULL by default):
+
+```json
+{
+  "network": "eip155:84532",
+  "amount": "10000",
+  "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "payTo": "0x1111111111111111111111111111111111111111",
+  "description": "Premium research agent"
+}
+```
+
+| field | meaning |
+| --- | --- |
+| `network` | CAIP-2 chain id under x402 V2 (`eip155:84532` = Base Sepolia); a bare name (`base-sepolia`) under V1. |
+| `amount` | Price in the asset's **smallest unit**, as a decimal string. USDC has 6 decimals, so `"10000"` is 0.01 USDC. |
+| `asset` | Token contract address. |
+| `payTo` | Wallet that receives the payment. |
+| `description` | Shown in the payer's wallet consent prompt. Optional. |
+| `extra` | EIP-712 domain override (`{ name, version }`). Only needed for tokens outside the well-known USDC deployments the SDK special-cases — a wrong domain produces signatures the facilitator can never verify. Optional. |
+
+`amount` is a string on purpose. It is atomic units, not dollars: writing
+`0.01` when you meant one cent of USDC is the classic mistake, and 18-decimal
+assets exceed the exact integer range of a JavaScript number. The server
+rejects anything that is not a positive decimal integer string at startup of
+the connection rather than at payment time.
+
+**Pricing is read from the database, never from the client's `hello` frame.**
+`payTo` decides who gets paid, and the hello frame is authored by the
+connecting agent — so it carries the same trust boundary as `allowed_callers`.
+A malformed pricing row does not take the agent offline: it is logged
+(`x402_pricing_invalid`) and the agent connects as free, so nobody is charged
+against a configuration the server could not read.
+
+Repricing takes effect on the next call — the executor reads the live
+connection each turn rather than caching pricing at connect time.
+
+## Deployment settings
+
+| env var | default | purpose |
+| --- | --- | --- |
+| `BRIDGE_X402_VERSION` | `2` | Wire version this deployment emits. Set to `1` only to serve clients built against the older reference lineage. A server speaks exactly one version — there is no per-request negotiation, because the activation URI is version-neutral. |
+| `BRIDGE_X402_FACILITATOR_URL` | SDK default (`https://x402.org/facilitator`) | Facilitator running verify + settle. |
+| `BRIDGE_X402_OFFER_TTL_SECONDS` | `600` | How long a payer has to sign and resubmit. Past it the offering lapses and the submission is refused; the payer is not charged, they just start over. |
+
+The AgentCard advertises `X402_FOUNDATION_EXTENSION_URI` with the price in
+`params` when — and only when — pricing is configured, so a caller can decide
+whether it is willing to pay before spending a turn. It is advertised
+`required: false`: a caller that cannot pay still gets a well-formed
+`input-required` response naming the price, which is more useful than being
+refused at extension activation.
+
+## Offering storage
+
+Offerings live in the `x402_offerings` table, not in process memory.
+
+This is not an optimization. The round-trip spans two HTTP requests and the
+bridge runs several Fly instances behind a load balancer, so turn 2 regularly
+lands on an instance that never saw turn 1. With the SDK's default in-memory
+store that reads as "no offering for this task" and the payment is refused —
+the payer is not charged, but the call fails for no reason the caller can act
+on. Restarts do the same to a single instance.
+
+Rows are deleted when the task terminates. Expiry is lazy (a `WHERE` clause on
+read), so no background reaper is required; `PostgresX402Store.sweepExpired()`
+exists to reclaim rows whose task never terminated at all.
+
+The row's `entry` column is the audit record of what was charged — the
+advertised offering, the lifecycle status, and on success the receipt
+(transaction hash, payer, settled amount).
+
+## Observability
+
+All events are structured JSON on stdout (see
+[`vicoop-bridge-logs`](./remote-testing.md) for how to read them):
+
+| event | when |
+| --- | --- |
+| `x402_payment_required` | turn 1 — an offering was published |
+| `x402_payment_verified` | turn 2 — the facilitator accepted the payload |
+| `x402_payment_refused` | the submission was invalid (no offering, wrong network, bad shape) |
+| `x402_verify_failed` | the facilitator rejected the payload |
+| `x402_settled` | settled on-chain; carries the transaction hash |
+| `x402_settle_failed` / `x402_settle_error` | settlement was refused or unreachable |
+| `x402_gate_error` | the payment rail was unavailable; the call was refused rather than served free |
+| `x402_pricing_invalid` | a malformed pricing row; the agent connected as free |
+
+## Testing locally
+
+Base Sepolia + the default hosted facilitator is the intended sandbox. Set
+pricing on a test agent, then drive it with the `a2a-wallet` CLI, which signs
+x402 payloads and handles the resubmission.
+
+The gate's own tests (`packages/server/src/x402/gate.test.ts`) run against a
+stub facilitator, so the full round-trip — including the refusal paths — is
+verifiable without a chain or a database.
+
+## Roadmap
+
+**Usage-based billing (the `upto` scheme).** Conceptually the better fit for
+an LLM bridge: the payer signs a Permit2 authorization up to a ceiling, and
+the merchant settles only the metered consumption. The SDK supports it (x402
+V2 only), and the settlement clamp means a metering bug can only ever
+undercharge.
+
+It is blocked on one thing: the bridge has no per-task usage signal. The
+`usage.request` RPC returns a per-agent snapshot, and `TaskCompleteFrame`
+carries only `status`. Adding an optional `usage` field to that frame, filled
+in by the backends, is the prerequisite.

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -5,9 +5,16 @@ The bridge can charge callers per invocation using
 facilitator. Pricing is configured per agent; an agent with no pricing row is
 free and takes no payment code path at all.
 
-Only the **`exact`** scheme is implemented today — a fixed price per call,
-agreed before the work happens. See [Roadmap](#roadmap) for usage-based
-billing.
+Two pricing schemes are supported:
+
+| scheme | what the caller pays | when to use it |
+| --- | --- | --- |
+| `exact` | a flat fee per call, agreed before the work happens | predictable pricing; the only option for backends that can't report token usage |
+| `upto` | the tokens actually consumed, up to a ceiling they authorize | metered LLM access, where a one-line question and a long research task shouldn't cost the same |
+
+`exact` is the default and works on every backend. `upto` needs two things
+the caller and the backend must both supply — see
+[Metered pricing](#metered-pricing-upto) before choosing it.
 
 ## How a paid call runs
 
@@ -47,7 +54,8 @@ reporting success would hide that.
 
 ## Configuring an agent's price
 
-Pricing lives in `agents.x402_pricing` (JSONB, NULL by default):
+Pricing lives in `agents.x402_pricing` (JSONB, NULL by default). A row with no
+`scheme` is `exact`:
 
 ```json
 {
@@ -68,11 +76,11 @@ Pricing lives in `agents.x402_pricing` (JSONB, NULL by default):
 | `description` | Shown in the payer's wallet consent prompt. Optional. |
 | `extra` | EIP-712 domain override (`{ name, version }`). Only needed for tokens outside the well-known USDC deployments the SDK special-cases — a wrong domain produces signatures the facilitator can never verify. Optional. |
 
-`amount` is a string on purpose. It is atomic units, not dollars: writing
-`0.01` when you meant one cent of USDC is the classic mistake, and 18-decimal
-assets exceed the exact integer range of a JavaScript number. The server
-rejects anything that is not a positive decimal integer string at startup of
-the connection rather than at payment time.
+Every amount is a string on purpose. They are atomic units, not dollars:
+writing `0.01` when you meant one cent of USDC is the classic mistake, and
+18-decimal assets exceed the exact integer range of a JavaScript number. The
+server rejects anything that is not a decimal integer string when the agent
+connects, rather than at payment time.
 
 **Pricing is read from the database, never from the client's `hello` frame.**
 `payTo` decides who gets paid, and the hello frame is authored by the
@@ -83,6 +91,78 @@ against a configuration the server could not read.
 
 Repricing takes effect on the next call — the executor reads the live
 connection each turn rather than caching pricing at connect time.
+
+## Metered pricing (`upto`)
+
+Under `upto` the payer signs a Permit2 authorization for a **ceiling**, the
+agent does the work, and the bridge settles only what the call actually
+consumed.
+
+```json
+{
+  "scheme": "upto",
+  "network": "eip155:84532",
+  "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+  "payTo": "0x1111111111111111111111111111111111111111",
+  "facilitatorAddress": "0x3333333333333333333333333333333333333333",
+  "maxAmount": "1000000",
+  "rates": { "input": "3000000", "output": "15000000", "cachedInput": "300000" },
+  "minAmount": "1000"
+}
+```
+
+| field | meaning |
+| --- | --- |
+| `maxAmount` | The ceiling the payer authorizes. Also the blast radius of a pricing mistake — the charge is clamped to it. |
+| `rates` | Price per **million tokens**, in atomic units — the unit model vendors quote in, so a price list transcribes directly. `"3000000"` at 6 decimals is $3.00/MTok. |
+| `rates.cachedInput` | Rate for cache-read prompt tokens. **Absent means "same as `input`", not "free"** — treating an unstated discount as 100% would give away most of a cache-heavy call. |
+| `minAmount` | Floor for a completed call, and what is charged when usage is unavailable (below). Absent means zero. |
+| `facilitatorAddress` | The payer's Permit2 witness binds to this, so it must match the facilitator that settles. Read it from the facilitator's `GET /supported` (`extra.facilitatorAddress`). The SDK substitutes no default here. |
+
+The charge is `ceil((fresh_input×input + cached×cachedInput + output×output) / 1e6)`,
+computed in BigInt. `cached_tokens` is a *breakdown* of `prompt_tokens` and
+`reasoning_tokens` a breakdown of `completion_tokens` — neither is additive,
+so neither is double-counted. Rounding is up, which keeps a very small call
+from pricing to zero.
+
+The SDK clamps the settled amount to the minimum of what we metered, the
+ceiling we offered, and the payer's signed cap. **A metering bug can therefore
+only ever undercharge** — the clamp is defence in depth on top of the
+facilitator enforcing the same bound on-chain.
+
+### Two prerequisites
+
+**x402 V2.** `upto` does not exist in V1. This deployment defaults to V2, but
+if `BRIDGE_X402_VERSION=1` an `upto` agent refuses every call with
+`invalid_x402_version` and logs `x402_config_invalid` — a permanent
+misconfiguration, reported as one rather than as a transient outage.
+
+**The caller has to opt in.** Signing `upto` authorizes spending up to the
+maximum at the merchant's discretion, which is broader consent than `exact`.
+The SDK's default requirement selector therefore *never* auto-picks an `upto`
+offer: clients must pass `allowUpto` (on `A2XClient`'s `x402` config or
+`signX402Payment`) or select the requirement explicitly. An `upto`-only agent
+is unusable by a default-configured client, so check your callers before
+switching an existing agent over.
+
+### When the backend reports no usage
+
+Not every completed call can be priced:
+
+- **openclaw reports no token usage at any layer.** Metered pricing is not
+  possible for that backend — leave it on `exact`.
+- **codex and vicoop-codex can emit `{0,0,0}`** when their runtime dropped its
+  accounting for a turn. Both log a warning when they do.
+
+`total_tokens: 0` therefore means "the runtime did not report", not "the call
+was free". The bridge treats both cases identically: it charges `minAmount`
+(zero if unset) and logs `x402_usage_unavailable` with what it charged.
+
+The default direction is deliberately payer-favourable. Billing the authorized
+ceiling because *our* instrumentation lost the token count would be a
+user-visible wrong; undercharging is our own loss to fix. **If you run a
+metered agent, set `minAmount`** — otherwise those calls are free, and the log
+event is the only thing telling you so.
 
 ## Deployment settings
 
@@ -129,10 +209,17 @@ All events are structured JSON on stdout (see
 | `x402_payment_verified` | turn 2 — the facilitator accepted the payload |
 | `x402_payment_refused` | the submission was invalid (no offering, wrong network, bad shape) |
 | `x402_verify_failed` | the facilitator rejected the payload |
-| `x402_settled` | settled on-chain; carries the transaction hash |
+| `x402_metered` | `upto` only — what the call priced to, with the token counts and the `basis` (`metered` / `floor` / `no-usage`) |
+| `x402_usage_unavailable` | `upto` only — work was delivered that could not be priced; carries what was charged instead |
+| `x402_settled` | settled on-chain; carries the transaction hash and the facilitator-confirmed amount |
 | `x402_settle_failed` / `x402_settle_error` | settlement was refused or unreachable |
 | `x402_gate_error` | the payment rail was unavailable; the call was refused rather than served free |
 | `x402_pricing_invalid` | a malformed pricing row; the agent connected as free |
+| `x402_config_invalid` | `upto` pricing on a V1 deployment; every call is refused until fixed |
+
+Two worth alerting on: `x402_usage_unavailable` means revenue is being left on
+the table, and a sustained `x402_settle_failed` means work is being delivered
+without payment landing.
 
 ## Testing locally
 
@@ -144,15 +231,25 @@ The gate's own tests (`packages/server/src/x402/gate.test.ts`) run against a
 stub facilitator, so the full round-trip — including the refusal paths — is
 verifiable without a chain or a database.
 
-## Roadmap
+## Where the token counts come from
 
-**Usage-based billing (the `upto` scheme).** Conceptually the better fit for
-an LLM bridge: the payer signs a Permit2 authorization up to a ceiling, and
-the merchant settles only the metered consumption. The SDK supports it (x402
-V2 only), and the settlement clamp means a metering bug can only ever
-undercharge.
+Metering needs no protocol extension. The claude, codex, and vicoop-codex
+backends already stamp per-turn token counts onto the `task.complete` frame,
+under the openai-compat extension URI in `status.message.metadata` — and they
+do it even when the caller did not activate that extension, precisely so
+"billing telemetry" can read them. `wireMessageToA2X` carries the metadata
+through untouched, so the counts are already on the terminal event the
+settlement path receives.
 
-It is blocked on one thing: the bridge has no per-task usage signal. The
-`usage.request` RPC returns a per-agent snapshot, and `TaskCompleteFrame`
-carries only `status`. Adding an optional `usage` field to that frame, filled
-in by the backends, is the prerequisite.
+Two wire shapes appear there depending on whether the caller activated the
+openai-compat extension, and `readTaskUsage` handles both:
+
+```
+{ usage: {...} }                        plain A2A callers
+{ chat_completion: { usage: {...} } }   openai-compat envelope
+```
+
+Note this is **not** the `usage.request` / `usage.response` RPC. That returns
+a cumulative account-level quota snapshot (rolling subscription windows,
+overage budget) and is rate-limited and cached — useful for capacity
+dashboards, useless for metering a single call.

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -7,10 +7,10 @@ free and takes no payment code path at all.
 
 Two pricing schemes are supported:
 
-| scheme | what the caller pays | when to use it |
-| --- | --- | --- |
-| `exact` | a flat fee per call, agreed before the work happens | predictable pricing; the only option for backends that can't report token usage |
-| `upto` | the tokens actually consumed, up to a ceiling they authorize | metered LLM access, where a one-line question and a long research task shouldn't cost the same |
+| scheme | what the caller pays | charged | when to use it |
+| --- | --- | --- | --- |
+| `exact` | a flat fee per call, agreed before the work happens | up front | predictable pricing; the only option for backends that can't report token usage |
+| `upto` | the tokens actually consumed, up to a ceiling they authorize | after the work | metered LLM access, where a one-line question and a long research task shouldn't cost the same |
 
 `exact` is the default and works on every backend. `upto` needs two things
 the caller and the backend must both supply — see
@@ -31,44 +31,45 @@ turn 2   caller → bridge          message/send { message.taskId: <same task> }
                                     metadata['x402.payment.status'] = 'payment-submitted'
                                     metadata['x402.payment.payload'] = <signed>
          bridge                   classify → facilitator.verify
-         bridge → agent           task.assign        (only now does work start)
+         bridge                   facilitator.settle   (exact only — see below)
+         bridge → agent           task.assign          (only now does work start)
          agent  → bridge          task.complete
-         bridge                   facilitator.settle
+         bridge                   facilitator.settle   (upto only — needs the meter)
          bridge → caller          Task(completed)
                                     metadata['x402.payment.receipts'] = [{ transaction, ... }]
 ```
 
-Two properties that follow from the ordering, and are worth stating because
-they are the ones an operator gets asked about:
+**Unpaid calls never reach the agent.** The gate runs before the task is bound
+or forwarded, so an unpaid or invalid request costs the backend nothing.
 
-- **Unpaid calls never reach the agent.** The gate runs before the task is
-  bound or forwarded, so an unpaid or invalid request costs the backend
-  nothing.
-- **Failed work is not charged.** Settlement happens only on a `completed`
-  task. If the agent fails, is cancelled, or times out, the payer's signed
-  authorization simply goes unused — it expires on its own.
+### When each scheme settles, and who carries the risk
 
-If settlement itself fails, the task is reported `failed` rather than
-`completed`: the caller got the work but the merchant was not paid, and
+The two schemes settle at opposite ends of the work, and the difference decides
+what happens when something goes wrong.
+
+**`exact` settles first, before the agent is contacted.** The amount was fixed
+at offer time and the payer signed for exactly it, so there is nothing to learn
+by doing the work first. A drained or invalidated authorization then costs
+nobody: no charge, no work, and the turn halts before `task.assign`.
+
+The price is that a task which fails *after* payment is a real loss to the
+payer — they paid and got an error. That is the accepted trade for closing the
+give-away-the-work window, and `x402_paid_task_failed` counts it. The receipt is
+still attached to the failed task, so the payer has proof of what they paid.
+
+**`upto` settles last, because the charge does not exist until the work does.**
+There is nothing to meter before the agent has run, so settlement can only
+follow it — and artifacts have already streamed to the caller by then. A payer
+who invalidates their authorization mid-task therefore receives the result and
+a `failed` status. That window is inherent to metered billing rather than a
+choice, and `x402_unpaid_delivery` counts it.
+
+Under `upto`, a task that fails is not charged at all: the authorization simply
+goes unused.
+
+If settlement fails on the `upto` path the task is reported `failed` rather
+than `completed` — the caller got the work but the merchant was not paid, and
 reporting success would hide that.
-
-### The accepted window: output ships before settlement
-
-Artifacts stream to the caller as the agent produces them, and settlement
-cannot start until the work is done — under `upto` there is nothing to meter
-before then. **A payer who invalidates their authorization between `verify` and
-settlement therefore receives the full result and a `failed` status.**
-
-This window is accepted rather than closed, because both ways of closing it are
-worse. Buffering output until settlement lands would remove streaming from
-exactly the agents people pay for. Settling before the work would charge for
-tasks that fail — and on a bridge fronting coding agents, timeouts and backend
-errors are far more common than an adversarial payer. Undercharging in a rare
-attack beats overcharging on routine failure.
-
-The exposure is one task's work per occurrence, and `x402_unpaid_delivery`
-counts it. A rising rate is worth investigating; a flat zero is the expected
-state.
 
 ## Configuring an agent's price
 
@@ -327,7 +328,8 @@ All events are structured JSON on stdout (see
 | `x402_submission_replayed` | a payment already used for this task was submitted again; refused before the backend was reached |
 | `x402_pricing_snapshot_missing` | the offering's frozen terms were gone at settle time; the call was refused rather than priced from live pricing |
 | `x402_scheme_mismatch` | the frozen terms and the signed requirement named different schemes; refused rather than mispriced |
-| `x402_unpaid_delivery` | settlement failed after the caller already had the output — the accepted window above, made countable |
+| `x402_unpaid_delivery` | `upto` only — settlement failed after the caller already had the output |
+| `x402_paid_task_failed` | `exact` only — the payer was charged up front and the task then failed |
 | `x402_wire_advertisement_dropped` | a connecting agent tried to advertise its own x402 terms on its card; discarded |
 | `x402_pricing_invalid` | a malformed pricing row; the agent is treated as free |
 | `x402_config_invalid` | `upto` pricing on a V1 deployment; every call is refused until fixed |

--- a/docs/x402-payments.md
+++ b/docs/x402-payments.md
@@ -86,10 +86,21 @@ vicoop-client agent x402 clear <AGENT_ID>
 ```
 
 These call `GET`/`PUT`/`DELETE /admin-api/agents/:id/x402`. The body is
-validated server-side against the same schema the payment gate uses, so a bad
-address or a dollars-instead-of-atomic amount is rejected at write time rather
-than silently disabling payments at the agent's next connect. Changes are
-hot-reloaded — no daemon restart, no reconnect.
+validated server-side, so a bad address or a dollars-instead-of-atomic amount
+is rejected at write time rather than silently disabling payments at the
+agent's next connect. Changes are hot-reloaded — no daemon restart, no
+reconnect.
+
+**Writes reject unrecognized keys.** Every optional field here changes what is
+charged, so a dropped typo is a wrong price rather than a no-op: `minamount`
+would leave the floor unset and make unmeterable calls free, `cachedinput`
+would charge cache reads at the full input rate. Both fail with a 400 naming
+the key.
+
+Reads are deliberately lenient about the same thing — a row written by a newer
+server must keep pricing correctly on an older one. Rejecting it would make
+the agent connect as free, so a rollback would quietly stop charging for every
+paid agent.
 
 Note the auth boundary: these take the **owner-session** bearer, not the agent
 token. A stolen agent token can impersonate the agent but cannot reprice it or

--- a/packages/client/src/admin-cli.test.ts
+++ b/packages/client/src/admin-cli.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { parse } from '@optique/core/parser';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -17,7 +17,11 @@ import {
   runListClients,
   runRemoveCaller,
   runRevokeClient,
+  runAgentX402Show,
+  runAgentX402Set,
+  runAgentX402Clear,
   agentCmd,
+  type AgentX402SetArgs,
   type AddCallerArgs,
   type AgentCallersIssueArgs,
   type AgentCallersAddArgs,
@@ -156,12 +160,22 @@ function withEnv(
   });
 }
 
+// Captures stdout for assertions while still forwarding to the real stream.
+//
+// Forwarding is not cosmetic. `node --test` pipes its reporter into this same
+// `process.stdout`, emitting each test's result line as that test completes —
+// which usually lands while the *next* test has stdout patched. Swallowing
+// writes therefore eats the runner's own output: the results vanish and the
+// final counts shrink to whatever happened to be emitted outside a capture
+// window. That silently dropped 32 of this file's tests once, with a green
+// "0 failed" summary, so the noise of echoing the CLI's own output is the
+// cheaper trade. Assertions are unaffected — they read `captured`.
 function captureStdout(t: { after: (fn: () => void) => void }): { read: () => string } {
   let captured = '';
   const original = process.stdout.write.bind(process.stdout);
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+  process.stdout.write = ((chunk: string | Uint8Array, ...rest: unknown[]): boolean => {
     captured += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
-    return true;
+    return (original as (...args: unknown[]) => boolean)(chunk, ...rest);
   }) as typeof process.stdout.write;
   t.after(() => {
     process.stdout.write = original;
@@ -715,6 +729,248 @@ test('agent callers {list,remove,issue-api-key} parse through the real parser wi
   // The top-level siblings must keep working after the reorder.
   expectOk(['agent', 'list'], { action: 'agent-list', connected: false });
   expectOk(['agent', 'remove', 'foo', '--yes'], { action: 'agent-delete', target: 'foo', yes: true });
+});
+
+// `agent x402 {show,clear}` are in the same tie-class as `callers {list,remove}`:
+// an AGENT_ID positional competing with the all-optional top-level `list` /
+// `remove`. They are registered before those siblings for the same reason, and
+// this asserts the ordering holds.
+test('agent x402 subcommands parse through the real parser with their AGENT_ID', () => {
+  const setDefaults = {
+    file: undefined,
+    scheme: undefined,
+    network: undefined,
+    asset: undefined,
+    payTo: undefined,
+    amount: undefined,
+    maxAmount: undefined,
+    minAmount: undefined,
+    rateInput: undefined,
+    rateOutput: undefined,
+    rateCachedInput: undefined,
+    facilitator: undefined,
+    description: undefined,
+  };
+  const expectOk = (argv: string[], expected: Record<string, unknown>) => {
+    const r = parse(agentCmd, argv);
+    assert.equal(r.success, true, `expected ${argv.join(' ')} to parse`);
+    if (r.success) assert.deepEqual(r.value, { ...SHARED, ...expected });
+  };
+
+  expectOk(['agent', 'x402', 'show', 'foo'], { action: 'agent-x402-show', agentId: 'foo' });
+  expectOk(['agent', 'x402', 'clear', 'foo'], { action: 'agent-x402-clear', agentId: 'foo' });
+  expectOk(['agent', 'x402', 'set', 'foo', '--amount', '10000'], {
+    action: 'agent-x402-set',
+    agentId: 'foo',
+    ...setDefaults,
+    amount: '10000',
+  });
+  expectOk(['agent', 'x402', 'set', 'foo', '--file', '-'], {
+    action: 'agent-x402-set',
+    agentId: 'foo',
+    ...setDefaults,
+    file: '-',
+  });
+});
+
+// ---- agent x402 (pricing) ---------------------------------------------------
+
+const x402ShowArgs = (agentId: string) =>
+  ({ action: 'agent-x402-show' as const, agentId, ...SHARED });
+const x402ClearArgs = (agentId: string) =>
+  ({ action: 'agent-x402-clear' as const, agentId, ...SHARED });
+const x402SetArgs = (agentId: string, p: Record<string, unknown> = {}) =>
+  ({
+    action: 'agent-x402-set' as const,
+    agentId,
+    ...SHARED,
+    file: undefined,
+    scheme: undefined,
+    network: undefined,
+    asset: undefined,
+    payTo: undefined,
+    amount: undefined,
+    maxAmount: undefined,
+    minAmount: undefined,
+    rateInput: undefined,
+    rateOutput: undefined,
+    rateCachedInput: undefined,
+    facilitator: undefined,
+    description: undefined,
+    ...p,
+  }) as unknown as AgentX402SetArgs;
+
+const PAY_TO = '0x1111111111111111111111111111111111111111';
+const ASSET = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+
+test('agent x402 show GETs the pricing endpoint', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, { body: { agent_id: 'foo', x402_pricing: null } });
+
+  assert.equal(await runAgentX402Show(x402ShowArgs('foo')), 0);
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/x402`);
+  assert.equal(calls[0].method, 'GET');
+  assert.equal(calls[0].headers.authorization, `Bearer ${TOKEN}`);
+});
+
+test('agent x402 show renders a free agent as free rather than as an empty table', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, { body: { agent_id: 'foo', x402_pricing: null } });
+
+  await runAgentX402Show(x402ShowArgs('foo'));
+  assert.match(stdout.read(), /free \(no x402 pricing configured\)/);
+});
+
+test('agent x402 show warns that an upto agent without a floor serves unmeterable calls free', async (t) => {
+  // The one operational footgun of metered pricing: a backend that reports no
+  // tokens is charged `minAmount`, which defaults to zero. Surfacing it in
+  // `show` is how an operator finds out before the invoices do.
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  const stdout = captureStdout(t);
+  installFetch(t, {
+    body: {
+      agent_id: 'foo',
+      x402_pricing: {
+        scheme: 'upto',
+        network: 'eip155:84532',
+        asset: ASSET,
+        payTo: PAY_TO,
+        maxAmount: '1000000',
+        rates: { input: '3000000', output: '15000000' },
+        facilitatorAddress: '0x3333333333333333333333333333333333333333',
+      },
+    },
+  });
+
+  await runAgentX402Show(x402ShowArgs('foo'));
+  const out = stdout.read();
+  assert.match(out, /calls the backend cannot meter are FREE/);
+  // The ceiling must not read as the price.
+  assert.match(out, /authorized maximum, not the charge/);
+  // An omitted cache rate is "same as input", not free — say so.
+  assert.match(out, /cached=same as in/);
+});
+
+test('agent x402 set PUTs the assembled pricing object', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, {
+    body: { agent_id: 'foo', x402_pricing: { scheme: 'exact' } },
+  });
+
+  const code = await runAgentX402Set(
+    x402SetArgs('foo', {
+      network: 'eip155:84532',
+      asset: ASSET,
+      payTo: PAY_TO,
+      amount: '10000',
+    }),
+  );
+  assert.equal(code, 0);
+  assert.equal(calls[0].method, 'PUT');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/x402`);
+  assert.deepEqual(JSON.parse(calls[0].body as string), {
+    network: 'eip155:84532',
+    asset: ASSET,
+    payTo: PAY_TO,
+    amount: '10000',
+  });
+});
+
+test('agent x402 set nests the --rate-* flags under rates', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, { body: { agent_id: 'foo', x402_pricing: {} } });
+
+  await runAgentX402Set(
+    x402SetArgs('foo', {
+      scheme: 'upto',
+      network: 'eip155:84532',
+      asset: ASSET,
+      payTo: PAY_TO,
+      maxAmount: '1000000',
+      minAmount: '1000',
+      rateInput: '3000000',
+      rateOutput: '15000000',
+      rateCachedInput: '300000',
+      facilitator: '0x3333333333333333333333333333333333333333',
+    }),
+  );
+  assert.deepEqual(JSON.parse(calls[0].body as string), {
+    scheme: 'upto',
+    network: 'eip155:84532',
+    asset: ASSET,
+    payTo: PAY_TO,
+    maxAmount: '1000000',
+    minAmount: '1000',
+    facilitatorAddress: '0x3333333333333333333333333333333333333333',
+    rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
+  });
+});
+
+test('agent x402 set refuses --file combined with field flags', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  const { calls } = installFetch(t, { body: {} });
+
+  const code = await runAgentX402Set(
+    x402SetArgs('foo', { file: 'pricing.json', amount: '10000' }),
+  );
+  assert.equal(code, 1);
+  assert.equal(calls.length, 0, 'must not reach the server with an ambiguous request');
+  assert.match(stderr.read(), /--file cannot be combined/);
+});
+
+test('agent x402 set with nothing to set explains itself instead of clearing pricing', async (t) => {
+  // An empty PUT would otherwise be indistinguishable from `clear`, which is
+  // a destructive difference for a money setting.
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  const { calls } = installFetch(t, { body: {} });
+
+  assert.equal(await runAgentX402Set(x402SetArgs('foo')), 1);
+  assert.equal(calls.length, 0);
+  assert.match(stderr.read(), /Nothing to set/);
+});
+
+test('agent x402 set reads a pricing object from a file', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, { body: { agent_id: 'foo', x402_pricing: {} } });
+
+  const dir = mkdtempSync(join(tmpdir(), 'x402-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'pricing.json');
+  const pricing = { network: 'eip155:84532', asset: ASSET, payTo: PAY_TO, amount: '10000' };
+  writeFileSync(path, JSON.stringify(pricing));
+
+  assert.equal(await runAgentX402Set(x402SetArgs('foo', { file: path })), 0);
+  assert.deepEqual(JSON.parse(calls[0].body as string), pricing);
+});
+
+test('agent x402 clear DELETEs the pricing endpoint', async (t) => {
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const { calls } = installFetch(t, { body: { agent_id: 'foo', x402_pricing: null } });
+
+  assert.equal(await runAgentX402Clear(x402ClearArgs('foo')), 0);
+  assert.equal(calls[0].method, 'DELETE');
+  assert.equal(calls[0].url, `${BRIDGE}/admin-api/agents/foo/x402`);
+});
+
+test('agent x402 surfaces a server rejection as a non-zero exit', async (t) => {
+  // The server owns validation; the CLI must not swallow its 400.
+  withEnv(t, { VICOOP_OWNER_TOKEN: TOKEN, VICOOP_BRIDGE: BRIDGE });
+  captureStdout(t);
+  const stderr = captureStderr(t);
+  installFetch(t, { status: 400, body: { error: 'Invalid x402 pricing: bad payTo' } });
+
+  assert.equal(await runAgentX402Set(x402SetArgs('foo', { amount: '10000' })), 1);
+  assert.match(stderr.read(), /error \(400\).*Invalid x402 pricing/);
 });
 
 // The new `agent` commands must not print a deprecation warning — that's

--- a/packages/client/src/admin-cli.ts
+++ b/packages/client/src/admin-cli.ts
@@ -14,6 +14,7 @@ import { argument, command, constant, flag, option } from '@optique/core/primiti
 import { message } from '@optique/core/message';
 import type { InferValue } from '@optique/core/parser';
 import { integer, string } from '@optique/core/valueparser';
+import { readFile } from 'node:fs/promises';
 import { resolveOwnerSession } from './owner-session.js';
 import { agentRegisterCmd } from './setup.js';
 
@@ -186,6 +187,100 @@ const agentCallersSubCmd = command(
   },
 );
 
+// ----- agent x402 (pricing) ---------------------------------------------------
+//
+// Pricing is server-side state, not client config: `payTo` names the wallet
+// that receives money, so it is stored on the agent's DB row and written only
+// with the owner-session bearer. A stolen agent token can therefore not
+// reprice an agent or redirect its payments. These commands are the operator's
+// interface to that state, mirroring `agent callers`.
+
+const agentX402ShowSubCmd = command(
+  'show',
+  object({
+    action: constant('agent-x402-show' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+  }),
+  {
+    brief: message`Show what this agent charges, or that it is free.`,
+    description: message`Calls GET /admin-api/agents/<AGENT_ID>/x402.`,
+  },
+);
+
+const agentX402SetSubCmd = command(
+  'set',
+  object({
+    action: constant('agent-x402-set' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+    file: optional(option('--file', string({ metavar: 'PATH' }), {
+      description: message`Read the pricing object as JSON from PATH, or from stdin when PATH is \`-\`. Mutually exclusive with the field flags below.`,
+    })),
+    scheme: optional(option('--scheme', string({ metavar: 'exact|upto' }), {
+      description: message`Pricing scheme. Defaults to \`exact\` (a flat fee per call).`,
+    })),
+    network: optional(option('--network', string({ metavar: 'CAIP2' }), {
+      description: message`Chain id, e.g. eip155:84532 for Base Sepolia.`,
+    })),
+    asset: optional(option('--asset', string({ metavar: 'ADDRESS' }), {
+      description: message`Token contract address.`,
+    })),
+    payTo: optional(option('--pay-to', string({ metavar: 'ADDRESS' }), {
+      description: message`Wallet that receives the payment.`,
+    })),
+    amount: optional(option('--amount', string({ metavar: 'ATOMIC' }), {
+      description: message`exact only: price per call, in the asset's smallest unit (USDC has 6 decimals, so 10000 = 0.01 USDC).`,
+    })),
+    maxAmount: optional(option('--max-amount', string({ metavar: 'ATOMIC' }), {
+      description: message`upto only: the ceiling the payer authorizes. The metered charge is clamped to it.`,
+    })),
+    minAmount: optional(option('--min-amount', string({ metavar: 'ATOMIC' }), {
+      description: message`upto only: floor for a completed call, and what is charged when the backend reported no token usage. Set this — without it such calls are free.`,
+    })),
+    rateInput: optional(option('--rate-input', string({ metavar: 'ATOMIC' }), {
+      description: message`upto only: price per MILLION input tokens, in atomic units.`,
+    })),
+    rateOutput: optional(option('--rate-output', string({ metavar: 'ATOMIC' }), {
+      description: message`upto only: price per MILLION output tokens, in atomic units.`,
+    })),
+    rateCachedInput: optional(option('--rate-cached-input', string({ metavar: 'ATOMIC' }), {
+      description: message`upto only: price per MILLION cache-read input tokens. Omitted means the same as --rate-input, NOT free.`,
+    })),
+    facilitator: optional(option('--facilitator', string({ metavar: 'ADDRESS' }), {
+      description: message`upto only: facilitator address the payer's Permit2 witness binds to. Read it from the facilitator's GET /supported.`,
+    })),
+    description: optional(option('--description', string({ metavar: 'TEXT' }), {
+      description: message`Shown in the payer's wallet consent prompt.`,
+    })),
+  }),
+  {
+    brief: message`Set what this agent charges.`,
+    description: message`Calls PUT /admin-api/agents/<AGENT_ID>/x402. Validated server-side against the same schema the payment gate uses, so a bad address or a non-atomic amount is rejected here rather than silently disabling payments at the agent's next connect. Hot-reloaded — no daemon restart needed. Amounts are always atomic units as decimal strings, never dollars.`,
+  },
+);
+
+const agentX402ClearSubCmd = command(
+  'clear',
+  object({
+    action: constant('agent-x402-clear' as const),
+    ...sharedFlags,
+    agentId: argument(string({ metavar: 'AGENT_ID' })),
+  }),
+  {
+    brief: message`Make this agent free again.`,
+    description: message`Calls DELETE /admin-api/agents/<AGENT_ID>/x402. The agent stops requesting payment on the next call.`,
+  },
+);
+
+const agentX402SubCmd = command(
+  'x402',
+  longestMatch(agentX402ShowSubCmd, agentX402SetSubCmd, agentX402ClearSubCmd),
+  {
+    brief: message`Manage the agent's x402 pricing.`,
+  },
+);
+
 export const agentCmd = command(
   'agent',
   // `agentCallersSubCmd` MUST come before `agentListSubCmd` / `agentRemoveSubCmd`.
@@ -198,12 +293,13 @@ export const agentCmd = command(
   longestMatch(
     agentRegisterCmd,
     agentCallersSubCmd,
+    agentX402SubCmd,
     agentListSubCmd,
     agentRemoveSubCmd,
   ),
   {
-    brief: message`Manage agent registrations and their callers.`,
-    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`remove\`, \`callers {list, add, remove, issue-api-key}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
+    brief: message`Manage agent registrations, their callers, and their pricing.`,
+    description: message`Operator-facing umbrella for agent state. Subcommands: \`register\`, \`list\`, \`remove\`, \`callers {list, add, remove, issue-api-key}\`, \`x402 {show, set, clear}\`. Replaces the older flat \`setup\` / \`list-agents\` / \`list-clients\` / \`revoke-client\` / \`{add,remove,list}-caller\` commands, which remain as deprecated aliases.`,
     hidden: 'usage',
   },
 );
@@ -215,6 +311,9 @@ export type AgentCallersListArgs = Extract<AgentCliArgs, { action: 'agent-caller
 export type AgentCallersAddArgs = Extract<AgentCliArgs, { action: 'agent-callers-add' }>;
 export type AgentCallersRemoveArgs = Extract<AgentCliArgs, { action: 'agent-callers-remove' }>;
 export type AgentCallersIssueArgs = Extract<AgentCliArgs, { action: 'agent-callers-issue' }>;
+export type AgentX402ShowArgs = Extract<AgentCliArgs, { action: 'agent-x402-show' }>;
+export type AgentX402SetArgs = Extract<AgentCliArgs, { action: 'agent-x402-set' }>;
+export type AgentX402ClearArgs = Extract<AgentCliArgs, { action: 'agent-x402-clear' }>;
 
 // ----- Legacy flat commands (deprecated, kept as aliases) --------------------
 //
@@ -349,7 +448,7 @@ function resolveSession(args: {
 
 interface RequestArgs {
   session: Session;
-  method: 'GET' | 'POST' | 'DELETE';
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
   path: string;
   body?: unknown;
 }
@@ -706,6 +805,155 @@ async function execRemoveCaller(args: CallerCommonArgs & { principal: string }):
     path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/callers?principal=${encodeURIComponent(args.principal)}`,
   });
   return emit(result, args.json, renderCallerMutation);
+}
+
+// ----- agent x402 (pricing) ---------------------------------------------------
+
+/**
+ * Assemble the pricing object from the field flags.
+ *
+ * Deliberately assembles rather than validates: the server checks the result
+ * against the same schema the payment gate uses, so validating here would
+ * mean two copies of the rules that could drift. The one thing done locally
+ * is rejecting a mix of `--file` and field flags, which is a CLI-shape error
+ * the server can't see.
+ */
+function buildPricingFromFlags(args: AgentX402SetArgs): Record<string, unknown> | null {
+  const out: Record<string, unknown> = {};
+  const put = (key: string, value: string | undefined): void => {
+    if (value !== undefined) out[key] = value;
+  };
+  put('scheme', args.scheme);
+  put('network', args.network);
+  put('asset', args.asset);
+  put('payTo', args.payTo);
+  put('amount', args.amount);
+  put('maxAmount', args.maxAmount);
+  put('minAmount', args.minAmount);
+  put('facilitatorAddress', args.facilitator);
+  put('description', args.description);
+
+  const rates: Record<string, unknown> = {};
+  if (args.rateInput !== undefined) rates.input = args.rateInput;
+  if (args.rateOutput !== undefined) rates.output = args.rateOutput;
+  if (args.rateCachedInput !== undefined) rates.cachedInput = args.rateCachedInput;
+  if (Object.keys(rates).length > 0) out.rates = rates;
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+async function readPricingFile(path: string): Promise<unknown> {
+  const raw =
+    path === '-'
+      ? await new Promise<string>((resolve, reject) => {
+          let buf = '';
+          process.stdin.setEncoding('utf-8');
+          process.stdin.on('data', (chunk) => {
+            buf += chunk;
+          });
+          process.stdin.on('end', () => resolve(buf));
+          process.stdin.on('error', reject);
+        })
+      : await readFile(path, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function renderPricing(body: unknown): string {
+  const b = body as { agent_id?: string; x402_pricing?: Record<string, unknown> | null };
+  if (!b.x402_pricing) {
+    return `agent:   ${b.agent_id ?? '?'}\npricing: free (no x402 pricing configured)`;
+  }
+  const p = b.x402_pricing;
+  const lines = [`agent:   ${b.agent_id ?? '?'}`, `scheme:  ${String(p.scheme ?? 'exact')}`];
+  lines.push(`network: ${String(p.network ?? '')}`);
+  lines.push(`asset:   ${String(p.asset ?? '')}`);
+  lines.push(`payTo:   ${String(p.payTo ?? '')}`);
+  if (p.scheme === 'upto') {
+    const rates = (p.rates ?? {}) as Record<string, unknown>;
+    lines.push(`ceiling: ${String(p.maxAmount ?? '')} (authorized maximum, not the charge)`);
+    lines.push(
+      `rates:   in=${String(rates.input ?? '')} out=${String(rates.output ?? '')}` +
+        ` cached=${rates.cachedInput === undefined ? 'same as in' : String(rates.cachedInput)}` +
+        ' (per million tokens)',
+    );
+    lines.push(
+      `floor:   ${p.minAmount === undefined ? '0 — calls the backend cannot meter are FREE' : String(p.minAmount)}`,
+    );
+    lines.push(`facilitator: ${String(p.facilitatorAddress ?? '')}`);
+  } else {
+    lines.push(`amount:  ${String(p.amount ?? '')} (per call)`);
+  }
+  if (p.description !== undefined) lines.push(`description: ${String(p.description)}`);
+  return lines.join('\n');
+}
+
+export async function runAgentX402Show(args: AgentX402ShowArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'GET',
+    path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/x402`,
+  });
+  return emit(result, args.json, renderPricing);
+}
+
+export async function runAgentX402Set(args: AgentX402SetArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+
+  const fromFlags = buildPricingFromFlags(args);
+  if (args.file !== undefined && fromFlags !== null) {
+    process.stderr.write(
+      '--file cannot be combined with the pricing field flags; pass the whole object one way or the other.\n',
+    );
+    return 1;
+  }
+
+  let pricing: unknown;
+  if (args.file !== undefined) {
+    try {
+      pricing = await readPricingFile(args.file);
+    } catch (err) {
+      process.stderr.write(`could not read pricing JSON: ${(err as Error).message}\n`);
+      return 1;
+    }
+  } else if (fromFlags !== null) {
+    pricing = fromFlags;
+  } else {
+    process.stderr.write(
+      'Nothing to set. Pass --file <path|-> or the pricing field flags (see `vicoop-client agent x402 set --help`).\n',
+    );
+    return 1;
+  }
+
+  const result = await callApi({
+    session,
+    method: 'PUT',
+    path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/x402`,
+    body: pricing,
+  });
+  return emit(result, args.json, renderPricing);
+}
+
+export async function runAgentX402Clear(args: AgentX402ClearArgs): Promise<number> {
+  const session = resolveSession(args);
+  if ('error' in session) {
+    process.stderr.write(`${session.error}\n`);
+    return 1;
+  }
+  const result = await callApi({
+    session,
+    method: 'DELETE',
+    path: `/admin-api/agents/${encodeURIComponent(args.agentId)}/x402`,
+  });
+  return emit(result, args.json, renderPricing);
 }
 
 export async function runAgentCallersList(args: AgentCallersListArgs): Promise<number> {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -15,6 +15,7 @@ import { normalizeTaskFailError } from '../failure-code.js';
 import { buildSelfIdentitySystemPrompt, type AgentIdentity } from '../identity.js';
 import {
   buildOpenAICompatResponseMetadata,
+  toProtocolTaskUsage,
   buildOpenAICompatUsage,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
@@ -3502,12 +3503,17 @@ export function createClaudeBackend(
       // A2A telemetry consumers see the response model whenever one was
       // resolved (#348).
       const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, envelopeUsage);
+      // Token counts also go out as the protocol's own `usage` field, which is
+      // what the bridge bills on. Same numbers, but owned by the transport
+      // rather than by the openai-compat extension's namespace.
+      const protocolUsage = toProtocolTaskUsage(envelopeUsage);
       // When parts is empty but we have envelope/usage to convey, still
       // emit the message frame so the metadata reaches the gateway.
       const hasMessage = parts.length > 0 || messageMetadata !== undefined;
       emit({
         type: 'task.complete',
         taskId: task.taskId,
+        ...(protocolUsage !== undefined ? { usage: protocolUsage } : {}),
         status: {
           state: 'completed',
           timestamp: new Date().toISOString(),

--- a/packages/client/src/backends/codex.ts
+++ b/packages/client/src/backends/codex.ts
@@ -21,6 +21,7 @@ import {
 } from './openai-compat.js';
 import {
   buildOpenAICompatResponseMetadata,
+  toProtocolTaskUsage,
   buildOpenAICompatUsage,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
@@ -1940,12 +1941,21 @@ export function createCodexBackend(
             : undefined;
 
           const messageMetadata = buildOpenAICompatResponseMetadata(responseEnvelope, finalUsage);
+          // Deliberately built from `finalUsage`, not `finalUsageSnapshot`.
+          // The snapshot substitutes {0,0,0} when codex reported nothing,
+          // because the openai-compat envelope contract requires the field.
+          // The protocol's `usage` has no such contract, so it stays absent —
+          // and absent is the truth here. The bridge bills on this field, and
+          // a fabricated zero would be indistinguishable from a genuinely
+          // free call.
+          const protocolUsage = toProtocolTaskUsage(finalUsage);
           // When parts is empty but we have envelope/usage to convey, still
           // emit the message frame so the metadata reaches the gateway.
           const hasMessage = parts.length > 0 || messageMetadata !== undefined;
           emit({
             type: 'task.complete',
             taskId: task.taskId,
+            ...(protocolUsage !== undefined ? { usage: protocolUsage } : {}),
             status: {
               state: 'completed',
               timestamp: new Date().toISOString(),

--- a/packages/client/src/backends/openai-compat-usage.test.ts
+++ b/packages/client/src/backends/openai-compat-usage.test.ts
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildOpenAICompatUsage, toProtocolTaskUsage } from './openai-compat-usage.js';
+
+test('toProtocolTaskUsage carries the counts onto the protocol shape', () => {
+  const usage = buildOpenAICompatUsage({
+    prompt_tokens: 1000,
+    completion_tokens: 200,
+    cached_tokens: 900,
+    reasoning_tokens: 50,
+    model: 'claude-sonnet-4',
+  });
+  assert.deepEqual(toProtocolTaskUsage(usage), {
+    promptTokens: 1000,
+    completionTokens: 200,
+    cachedInputTokens: 900,
+    model: 'claude-sonnet-4',
+  });
+});
+
+test('toProtocolTaskUsage does not carry a derived total', () => {
+  // `total_tokens` is recomputed by the consumer from prompt + completion, so
+  // shipping it would just be a second copy that could disagree.
+  const usage = buildOpenAICompatUsage({ prompt_tokens: 10, completion_tokens: 5 });
+  assert.deepEqual(toProtocolTaskUsage(usage), {
+    promptTokens: 10,
+    completionTokens: 5,
+  });
+});
+
+test('toProtocolTaskUsage omits cache and model when the runtime did not report them', () => {
+  const usage = buildOpenAICompatUsage({ prompt_tokens: 10, completion_tokens: 5 });
+  const converted = toProtocolTaskUsage(usage)!;
+  assert.equal('cachedInputTokens' in converted, false);
+  assert.equal('model' in converted, false);
+});
+
+test('toProtocolTaskUsage returns undefined for no usage', () => {
+  // Absent must stay absent all the way to the wire: the bridge bills on this
+  // field, and a fabricated zero would be indistinguishable from a genuinely
+  // free call.
+  assert.equal(toProtocolTaskUsage(null), undefined);
+});
+
+test('toProtocolTaskUsage passes a reported zero through as a real zero', () => {
+  // Distinct from the case above — here the runtime did answer, with zero.
+  const usage = buildOpenAICompatUsage({ prompt_tokens: 0, completion_tokens: 0 });
+  assert.deepEqual(toProtocolTaskUsage(usage), {
+    promptTokens: 0,
+    completionTokens: 0,
+  });
+});

--- a/packages/client/src/backends/openai-compat-usage.ts
+++ b/packages/client/src/backends/openai-compat-usage.ts
@@ -1,4 +1,4 @@
-import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { OPENAI_COMPAT_EXTENSION_URI, type TaskUsage } from '@vicoop-bridge/protocol';
 
 // Spec-compliant `usage` shape carried inside `chat_completion.usage`
 // (envelope contract, oai2a2a#80). Required: prompt_tokens,
@@ -79,6 +79,30 @@ export function buildOpenAICompatResponseMetadata(
     return { [OPENAI_COMPAT_EXTENSION_URI]: { usage } };
   }
   return undefined;
+}
+
+// Project the openai-compat usage onto the protocol's own `TaskUsage`, which
+// rides as a first-class field on `task.complete`.
+//
+// Both carry the same counts, but they answer to different owners: the
+// openai-compat payload exists for that extension's consumers, while the
+// frame field is what the bridge bills on (the x402 `upto` scheme settles the
+// metered charge from it). Deriving billing input from an unrelated
+// extension's namespace would tie revenue to that extension's URI staying
+// put — rename or version it and the counts silently read as "unreported",
+// which bills the floor. So both are emitted, from this one conversion.
+//
+// Returns `undefined` when there is nothing to report, which the server must
+// read as "the runtime did not report" rather than as zero.
+export function toProtocolTaskUsage(usage: OpenAICompatUsage | null): TaskUsage | undefined {
+  if (!usage) return undefined;
+  const cached = usage.prompt_tokens_details?.cached_tokens;
+  return {
+    promptTokens: usage.prompt_tokens,
+    completionTokens: usage.completion_tokens,
+    ...(isCount(cached) ? { cachedInputTokens: cached } : {}),
+    ...(usage.model !== undefined && usage.model.length > 0 ? { model: usage.model } : {}),
+  };
 }
 
 function isCount(n: unknown): n is number {

--- a/packages/client/src/backends/vicoop-codex.ts
+++ b/packages/client/src/backends/vicoop-codex.ts
@@ -28,6 +28,7 @@ import {
 } from './openai-compat.js';
 import {
   buildOpenAICompatResponseMetadata,
+  toProtocolTaskUsage,
   buildOpenAICompatUsage,
   type OpenAICompatUsage,
 } from './openai-compat-usage.js';
@@ -1650,6 +1651,12 @@ export function createVicoopCodexBackend(
       }
 
       let usage = parseChatCompletionUsage(response.usage, response.model);
+      // Captured before the zero-backfill below. The protocol's `usage` field
+      // is what the bridge bills on and has no "must be present" contract, so
+      // it stays absent when the runtime reported nothing — absent is the
+      // truth, and a fabricated zero would be indistinguishable from a
+      // genuinely free call.
+      const protocolUsage = toProtocolTaskUsage(usage);
       // We force `stream_options.include_usage` on the request, so a missing
       // usage block here means the runtime dropped it on this turn despite
       // being asked for it — the #317 failure mode, which still recurs
@@ -1691,6 +1698,7 @@ export function createVicoopCodexBackend(
       emit({
         type: 'task.complete',
         taskId: task.taskId,
+        ...(protocolUsage !== undefined ? { usage: protocolUsage } : {}),
         status: {
           state: 'completed',
           timestamp: new Date().toISOString(),

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -43,6 +43,7 @@ import {
   removeCallerCmd, revokeClientCmd,
   runAddCaller, runAgentCallersAdd, runAgentCallersList, runAgentCallersRemove,
   runAgentCallersIssue,
+  runAgentX402Clear, runAgentX402Set, runAgentX402Show,
   runAgentDelete, runAgentList, runListAgents, runListCallers, runListClients,
   runRemoveCaller, runRevokeClient,
 } from './admin-cli.js';
@@ -1045,6 +1046,15 @@ async function main(): Promise<void> {
       break;
     case 'agent-callers-issue':
       process.exit(await runAgentCallersIssue(parsed));
+      break;
+    case 'agent-x402-show':
+      process.exit(await runAgentX402Show(parsed));
+      break;
+    case 'agent-x402-set':
+      process.exit(await runAgentX402Set(parsed));
+      break;
+    case 'agent-x402-clear':
+      process.exit(await runAgentX402Clear(parsed));
       break;
     case 'add-caller':
       process.exit(await runAddCaller(parsed));

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -242,10 +242,41 @@ export const TaskArtifactFrame = z.object({
   lastChunk: z.boolean().optional(),
 });
 
+// Token consumption for one completed task, reported by the backend that ran
+// it. Backend-agnostic and deliberately minimal: this is a transport-level
+// fact about the task, not a marker owned by any extension.
+//
+// It is a first-class frame field rather than a `metadata` entry because the
+// bridge *bills* on it — the x402 `upto` scheme settles the metered charge
+// from these counts. Reading billing input out of another extension's
+// namespace (the counts also ride under the openai-compat URI, for that
+// extension's own consumers) would make revenue depend on an unrelated
+// extension's URI staying put: rename or version it and the numbers silently
+// become "unreported", which bills the floor instead of the charge. So the
+// protocol owns this one.
+//
+// Absent means "the runtime did not report", which is NOT the same as zero —
+// several runtimes drop their accounting for a turn, and openclaw has none at
+// all. Consumers must distinguish the two.
+export const TaskUsage = z.object({
+  // Total input tokens for the turn, INCLUDING any cached portion.
+  promptTokens: z.number().int().nonnegative(),
+  // Total output tokens, including any reasoning tokens.
+  completionTokens: z.number().int().nonnegative(),
+  // Portion of `promptTokens` served from cache. A breakdown, never additive.
+  cachedInputTokens: z.number().int().nonnegative().optional(),
+  // The model that answered, when the runtime names one. Advisory: on some
+  // backends the counts are summed across internal sub-model calls while the
+  // label names only the answering model.
+  model: z.string().min(1).optional(),
+});
+export type TaskUsage = z.infer<typeof TaskUsage>;
+
 export const TaskCompleteFrame = z.object({
   type: z.literal('task.complete'),
   taskId: z.string(),
   status: TaskStatus,
+  usage: TaskUsage.optional(),
 });
 
 export const TaskFailFrame = z.object({

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,6 +21,8 @@
     "@sentry/hono": "^10.57.0",
     "@sentry/node": "^10.57.0",
     "@vicoop-bridge/protocol": "workspace:*",
+    "@x402/core": "^2.21.0",
+    "@x402/evm": "^2.21.0",
     "ai": "^6.0.162",
     "express": "^5.2.1",
     "google-auth-library": "^10.6.2",
@@ -30,8 +32,8 @@
     "postgres": "^3.4.9",
     "siwe": "^3.0.0",
     "tsx": "^4.19.2",
+    "viem": "^2",
     "ws": "^8.18.0",
-    "x402": "^1.2.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -264,10 +264,21 @@ ALTER TABLE agents ADD COLUMN IF NOT EXISTS allowed_callers TEXT[] NOT NULL DEFA
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
 -- x402 pricing for this agent, or NULL for a free agent (the default).
 -- Shape is validated in the server by `X402PricingSchema`
--- (src/x402/pricing.ts): { network, amount, asset, payTo, description?, extra? }.
--- Kept JSONB rather than columns because the offering shape follows the x402
--- spec, which adds scheme-specific fields (`extra`, and the `upto` scheme's
--- facilitatorAddress) that would otherwise be a column migration each time.
+-- (src/x402/pricing.ts), a union discriminated on `scheme`:
+--
+--   exact (default when `scheme` is absent) — a flat fee per call:
+--     { network, amount, asset, payTo, description?, extra? }
+--
+--   upto — metered, billed on the tokens the call actually consumed:
+--     { scheme: 'upto', network, asset, payTo, maxAmount, facilitatorAddress,
+--       rates: { input, output, cachedInput? },   -- atomic units per MTok
+--       minAmount?, description?, extra? }
+--
+-- Every amount is a decimal string in the asset's smallest unit, never a
+-- number: 18-decimal assets exceed a double's exact integer range.
+--
+-- JSONB rather than columns because the offering follows the x402 spec, whose
+-- scheme-specific fields would otherwise be a column migration each time.
 --
 -- Writable only through the admin API, never through GraphQL: `payTo` decides
 -- who receives money, so it gets the same DB-owned trust boundary as

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -262,6 +262,17 @@ ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_email TEXT;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS client_id TEXT UNIQUE DEFAULT gen_random_uuid()::text;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS allowed_callers TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+-- x402 pricing for this agent, or NULL for a free agent (the default).
+-- Shape is validated in the server by `X402PricingSchema`
+-- (src/x402/pricing.ts): { network, amount, asset, payTo, description?, extra? }.
+-- Kept JSONB rather than columns because the offering shape follows the x402
+-- spec, which adds scheme-specific fields (`extra`, and the `upto` scheme's
+-- facilitatorAddress) that would otherwise be a column migration each time.
+--
+-- Writable only through the admin API, never through GraphQL: `payTo` decides
+-- who receives money, so it gets the same DB-owned trust boundary as
+-- allowed_callers.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS x402_pricing JSONB;
 -- See clients.revoked drop note above. Agents was the shadow column.
 ALTER TABLE agents DROP COLUMN IF EXISTS revoked;
 UPDATE agents SET client_id = gen_random_uuid()::text WHERE client_id IS NULL;
@@ -297,6 +308,10 @@ CREATE POLICY agents_postgraphile ON agents
   WITH CHECK (true);
 
 COMMENT ON COLUMN agents.token_hash IS E'@omit';
+-- Readable (an owner should see what their agent charges) but never writable
+-- through GraphQL — the admin API is the only write path, mirroring
+-- agent_policies.allowed_callers.
+COMMENT ON COLUMN agents.x402_pricing IS E'@omit create,update';
 -- Mirrors `clients`: token_hash is server-managed (no create), and the
 -- semantic delete path is `delete_client(TEXT)` which removes both the
 -- agents row and the legacy clients row in one transaction. Letting
@@ -866,6 +881,55 @@ CREATE POLICY used_siwe_nonces_postgraphile ON used_siwe_nonces
   FOR ALL TO app_postgraphile USING (true) WITH CHECK (true);
 
 COMMENT ON TABLE used_siwe_nonces IS E'@omit';
+
+-- ============================================================
+-- 6c. x402 payment offerings
+-- ============================================================
+-- One row per x402 payment round-trip, keyed by the A2A task it gates.
+-- Backs `PostgresX402Store` (src/x402/store.ts), which implements the SDK's
+-- `BaseX402Store`.
+--
+-- Why this must be in Postgres and not in process memory: the round-trip
+-- spans two HTTP requests — turn 1 advertises the offering and answers
+-- `input-required`, turn 2 carries the signed payload — and the bridge runs
+-- several Fly instances behind a load balancer. Turn 2 regularly lands on an
+-- instance that never saw turn 1. With an in-memory store that reads as "no
+-- offering for this task" and the payment is refused (the payer is not
+-- charged, but the call fails). Restarts do the same to a single instance.
+--
+-- `entry` is the SDK's `X402StoreEntry` verbatim — the advertised offering,
+-- lifecycle status, and, once settled, the receipt (tx hash, payer, amount).
+-- It is the audit record of what was charged, so rows outlive the task only
+-- until it terminates, at which point `clearOffering` deletes them.
+--
+-- `expires_at` is duplicated out of `entry` so expiry is a WHERE clause: the
+-- store contract requires `get` to return nothing past the deadline, and a
+-- filtered read satisfies it lazily, with no background reaper.
+CREATE TABLE IF NOT EXISTS x402_offerings (
+  task_id     TEXT PRIMARY KEY,
+  agent_id    TEXT NOT NULL,
+  entry       JSONB NOT NULL,
+  expires_at  TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Supports the expiry sweep and per-agent operational queries.
+CREATE INDEX IF NOT EXISTS x402_offerings_expires_idx
+  ON x402_offerings(expires_at);
+CREATE INDEX IF NOT EXISTS x402_offerings_agent_idx
+  ON x402_offerings(agent_id);
+
+ALTER TABLE x402_offerings ENABLE ROW LEVEL SECURITY;
+
+-- Server-only, like `callers` and `device_sessions`: the row holds in-flight
+-- payment state that no GraphQL consumer should read or write, so it gets the
+-- app_postgraphile bypass alone and no app_authenticated policies.
+DROP POLICY IF EXISTS x402_offerings_postgraphile ON x402_offerings;
+CREATE POLICY x402_offerings_postgraphile ON x402_offerings
+  FOR ALL TO app_postgraphile USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE x402_offerings IS E'@omit';
 
 -- ============================================================
 -- 7. Grants

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -916,14 +916,52 @@ COMMENT ON TABLE used_siwe_nonces IS E'@omit';
 -- `expires_at` is duplicated out of `entry` so expiry is a WHERE clause: the
 -- store contract requires `get` to return nothing past the deadline, and a
 -- filtered read satisfies it lazily, with no background reaper.
+-- The key is `(agent_id, task_id)`, not `task_id` alone. Tasks are resolved by
+-- id from a store shared across every agent (see #453), so a task created at
+-- agent A can be resumed at agent B's endpoint. Keyed on task_id alone, B's
+-- gate would find A's offering and accept A's cheap signature as payment for
+-- B's work.
+--
+-- `pricing` is the agent's pricing captured when the offering was published.
+-- Settlement must price from this, never from the agent's live pricing: the
+-- two turns of a payment are separate requests, and a reprice in between would
+-- otherwise meter turn 2 against a requirement turn 1 signed under different
+-- terms — which settles the wrong amount.
+--
+-- `claimed_at` is a one-shot concurrency guard. The SDK's `classify()` does not
+-- inspect the entry's status, so replaying one signed submission before
+-- settlement would classify valid twice and run the backend work twice for a
+-- single authorization. Claiming is a conditional UPDATE; the loser is refused.
 CREATE TABLE IF NOT EXISTS x402_offerings (
-  task_id     TEXT PRIMARY KEY,
+  task_id     TEXT NOT NULL,
   agent_id    TEXT NOT NULL,
   entry       JSONB NOT NULL,
+  pricing     JSONB,
+  claimed_at  TIMESTAMPTZ,
   expires_at  TIMESTAMPTZ,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (agent_id, task_id)
 );
+
+-- Converge a dev DB created from the first cut of this table, which keyed on
+-- task_id alone and had neither column. Never deployed, so this is only here
+-- so re-applying schema.sql on such a database doesn't fail.
+ALTER TABLE x402_offerings ADD COLUMN IF NOT EXISTS pricing JSONB;
+ALTER TABLE x402_offerings ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE i.indrelid = 'x402_offerings'::regclass
+      AND i.indisprimary
+      AND array_length(i.indkey::int2[], 1) = 1
+  ) THEN
+    ALTER TABLE x402_offerings DROP CONSTRAINT x402_offerings_pkey;
+    ALTER TABLE x402_offerings ADD PRIMARY KEY (agent_id, task_id);
+  END IF;
+END $$;
 
 -- Supports the expiry sweep and per-agent operational queries.
 CREATE INDEX IF NOT EXISTS x402_offerings_expires_idx

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -908,6 +908,10 @@ test(
         { ...EXACT_PRICING, amount: '0.01' },
         { ...EXACT_PRICING, amount: 10000 },
         { ...EXACT_PRICING, scheme: 'upto' }, // upto needs rates + facilitator
+        // A typo'd optional field must fail rather than be dropped: every
+        // optional field here changes what is charged, so silently ignoring
+        // one is a silently-wrong price.
+        { ...EXACT_PRICING, amout: '10000' },
       ]) {
         const res = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
           method: 'PUT',
@@ -921,6 +925,47 @@ test(
         SELECT x402_pricing FROM agents WHERE id = ${setup.agentId}
       `;
       assert.equal(rows[0]!.x402_pricing, null, 'no rejected value should have been persisted');
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'a typo in a metered pricing field is rejected by name, not silently dropped',
+  { skip: !hasDb },
+  async () => {
+    // `minamount` would leave the floor unset, which makes every call the
+    // backend cannot meter free. The operator is present at write time, so
+    // this is the one chance to tell them.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'3'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      const res = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'PUT',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify({
+          scheme: 'upto',
+          network: 'eip155:84532',
+          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          payTo: '0x1111111111111111111111111111111111111111',
+          facilitatorAddress: '0x3333333333333333333333333333333333333333',
+          maxAmount: '1000000',
+          minamount: '1000',
+          rates: { input: '3000000', output: '15000000' },
+        }),
+      });
+
+      assert.equal(res.status, 400);
+      const body = (await res.json()) as { error: string };
+      assert.match(body.error, /minamount/, 'the message must name the offending key');
+      assert.equal(body.error.includes('\n'), false, 'must stay one line for the CLI');
     } finally {
       if (setup) await teardown(sql, owner, setup.clientId);
       await sql.end();

--- a/packages/server/src/admin-api.test.ts
+++ b/packages/server/src/admin-api.test.ts
@@ -832,3 +832,221 @@ test(
     }
   },
 );
+
+// ---- x402 pricing ----------------------------------------------------------
+
+const EXACT_PRICING = {
+  network: 'eip155:84532',
+  amount: '10000',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: '0x1111111111111111111111111111111111111111',
+};
+
+test(
+  'PUT /admin-api/agents/:id/x402 stores pricing and GET reads it back',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'c'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      // A brand-new agent is free.
+      const before = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.equal(before.status, 200);
+      assert.equal(((await before.json()) as { x402_pricing: unknown }).x402_pricing, null);
+
+      const put = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'PUT',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify(EXACT_PRICING),
+      });
+      assert.equal(put.status, 200);
+      // The stored value is the parsed one, so the scheme discriminator is
+      // filled in even though the operator omitted it.
+      assert.deepEqual(((await put.json()) as { x402_pricing: unknown }).x402_pricing, {
+        ...EXACT_PRICING,
+        scheme: 'exact',
+      });
+
+      const after = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.deepEqual(((await after.json()) as { x402_pricing: unknown }).x402_pricing, {
+        ...EXACT_PRICING,
+        scheme: 'exact',
+      });
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'PUT /admin-api/agents/:id/x402 rejects malformed pricing before it reaches the DB',
+  { skip: !hasDb },
+  async () => {
+    // The whole point of routing pricing through the admin API is that a bad
+    // payTo or a dollars-instead-of-atomic amount fails here, loudly, rather
+    // than silently disabling payments at the agent's next connect.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'d'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      for (const bad of [
+        { ...EXACT_PRICING, payTo: '0xnope' },
+        { ...EXACT_PRICING, amount: '0.01' },
+        { ...EXACT_PRICING, amount: 10000 },
+        { ...EXACT_PRICING, scheme: 'upto' }, // upto needs rates + facilitator
+      ]) {
+        const res = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+          method: 'PUT',
+          headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+          body: JSON.stringify(bad),
+        });
+        assert.equal(res.status, 400, `expected 400 for ${JSON.stringify(bad)}`);
+      }
+
+      const rows = await sql<{ x402_pricing: unknown }[]>`
+        SELECT x402_pricing FROM agents WHERE id = ${setup.agentId}
+      `;
+      assert.equal(rows[0]!.x402_pricing, null, 'no rejected value should have been persisted');
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'x402 pricing routes require an owner session and are scoped by RLS',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const ownerA = `eth:0x${'e'.repeat(40)}`;
+    const ownerB = `eth:0x${'f'.repeat(40)}`;
+    let setupA: SetupResult | null = null;
+    let setupB: SetupResult | null = null;
+    try {
+      setupA = await setupOwner(sql, ownerA);
+      setupB = await setupOwner(sql, ownerB);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      const noAuth = await app.request(`/admin-api/agents/${setupA.agentId}/x402`);
+      assert.equal(noAuth.status, 401);
+
+      // B must not be able to reprice — or even confirm the existence of — A's
+      // agent. Both surface as 404 rather than 403 for that reason.
+      const cross = await app.request(`/admin-api/agents/${setupA.agentId}/x402`, {
+        method: 'PUT',
+        headers: { ...authHeaders(setupB.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify(EXACT_PRICING),
+      });
+      assert.equal(cross.status, 404);
+
+      const rows = await sql<{ x402_pricing: unknown }[]>`
+        SELECT x402_pricing FROM agents WHERE id = ${setupA.agentId}
+      `;
+      assert.equal(rows[0]!.x402_pricing, null, "another owner must not have repriced A's agent");
+    } finally {
+      if (setupA) await teardown(sql, ownerA, setupA.clientId);
+      if (setupB) await teardown(sql, ownerB, setupB.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'DELETE /admin-api/agents/:id/x402 makes the agent free again',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'1'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const app = createHttpApp({ db: sql, registry });
+
+      await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'PUT',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify(EXACT_PRICING),
+      });
+
+      const del = await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'DELETE',
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.equal(del.status, 200);
+      assert.equal(((await del.json()) as { x402_pricing: unknown }).x402_pricing, null);
+
+      const rows = await sql<{ x402_pricing: unknown }[]>`
+        SELECT x402_pricing FROM agents WHERE id = ${setup.agentId}
+      `;
+      assert.equal(rows[0]!.x402_pricing, null);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'repricing a connected agent takes effect without a reconnect',
+  { skip: !hasDb },
+  async () => {
+    // The executor reads pricing off the live connection every turn, and the
+    // AgentCard advertises it — so a write must both patch the connection and
+    // evict the cached card.
+    const sql = postgres(process.env.DATABASE_URL!);
+    const owner = `eth:0x${'2'.repeat(40)}`;
+    let setup: SetupResult | null = null;
+    try {
+      setup = await setupOwner(sql, owner);
+      const registry = new Registry();
+      const conn = fakeConnection({
+        agentId: setup.agentId,
+        clientId: setup.clientId,
+        ownerPrincipal: owner,
+      });
+      registry.registerAgent(conn);
+      let cardEvictions = 0;
+      registry.onAgentChange(() => {
+        cardEvictions += 1;
+      });
+      const app = createHttpApp({ db: sql, registry });
+
+      assert.equal(registry.getAgent(setup.agentId)?.x402Pricing, undefined);
+
+      await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'PUT',
+        headers: { ...authHeaders(setup.ownerToken), 'content-type': 'application/json' },
+        body: JSON.stringify(EXACT_PRICING),
+      });
+      assert.equal(registry.getAgent(setup.agentId)?.x402Pricing?.scheme, 'exact');
+      assert.equal(cardEvictions, 1, 'the cached AgentCard must be evicted so it re-advertises');
+
+      await app.request(`/admin-api/agents/${setup.agentId}/x402`, {
+        method: 'DELETE',
+        headers: authHeaders(setup.ownerToken),
+      });
+      assert.equal(registry.getAgent(setup.agentId)?.x402Pricing, undefined);
+      assert.equal(cardEvictions, 2);
+    } finally {
+      if (setup) await teardown(sql, owner, setup.clientId);
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -9,7 +9,12 @@ import type { Registry } from './registry.js';
 import { validatePrincipal } from './auth/principal.js';
 import { generateApiKeyId, issueSessionToken } from './auth/caller-token.js';
 import { isAdmin } from './admin-scope.js';
-import { X402PricingSchema, parseX402Pricing, type X402Pricing } from './x402/pricing.js';
+import {
+  X402PricingWriteSchema,
+  formatPricingError,
+  parseX402Pricing,
+  type X402Pricing,
+} from './x402/pricing.js';
 
 type Tx = postgres.TransactionSql;
 
@@ -268,11 +273,14 @@ export async function setX402Pricing(
   agentId: string,
   pricing: unknown,
 ): Promise<X402PricingResult> {
+  // The strict schema: an unrecognized key fails here rather than being
+  // dropped. Every optional field on a pricing object changes what is
+  // charged, so a silently-ignored typo is a silently-wrong price.
   let parsed: X402Pricing;
   try {
-    parsed = X402PricingSchema.parse(pricing);
+    parsed = X402PricingWriteSchema.parse(pricing);
   } catch (err) {
-    throw new AdminApiError(`Invalid x402 pricing: ${String(err)}`, 400);
+    throw new AdminApiError(`Invalid x402 pricing: ${formatPricingError(err)}`, 400);
   }
 
   const rows = await db.begin(async (tx) => {

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -15,6 +15,7 @@ import {
   parseX402Pricing,
   type X402Pricing,
 } from './x402/pricing.js';
+import { notifyX402PricingChanged } from './x402/pricing-watch.js';
 
 type Tx = postgres.TransactionSql;
 
@@ -298,7 +299,11 @@ export async function setX402Pricing(
   // distinguishing them would confirm the existence of someone else's agent.
   if (rows.length === 0) throw new AdminApiError('Agent not found or not authorized.', 404);
 
+  // Patch this instance, then tell the others. The agent's WebSocket usually
+  // lives on a different instance than the one that served this request, and
+  // that one is the one whose cached pricing decides what the agent charges.
   registry.updateX402Pricing(agentId, parsed);
+  await notifyX402PricingChanged(db, agentId);
   return { agent_id: agentId, x402_pricing: parsed };
 }
 
@@ -319,7 +324,10 @@ export async function clearX402Pricing(
   });
   if (rows.length === 0) throw new AdminApiError('Agent not found or not authorized.', 404);
 
+  // The direction that matters most: an agent made free here must stop being
+  // billed everywhere, not just on this instance.
   registry.updateX402Pricing(agentId, undefined);
+  await notifyX402PricingChanged(db, agentId);
   return { agent_id: agentId, x402_pricing: null };
 }
 

--- a/packages/server/src/admin-api.ts
+++ b/packages/server/src/admin-api.ts
@@ -9,6 +9,7 @@ import type { Registry } from './registry.js';
 import { validatePrincipal } from './auth/principal.js';
 import { generateApiKeyId, issueSessionToken } from './auth/caller-token.js';
 import { isAdmin } from './admin-scope.js';
+import { X402PricingSchema, parseX402Pricing, type X402Pricing } from './x402/pricing.js';
 
 type Tx = postgres.TransactionSql;
 
@@ -217,6 +218,101 @@ export async function listCallers(
     created_at: policy.created_at instanceof Date ? policy.created_at.toISOString() : policy.created_at as string | undefined,
     updated_at: policy.updated_at instanceof Date ? policy.updated_at.toISOString() : policy.updated_at as string | undefined,
   };
+}
+
+// ----- x402 pricing ---------------------------------------------------------
+//
+// `agents.x402_pricing` is DB-owned rather than declared in the WS hello
+// frame, because `payTo` names the wallet that receives money and the hello
+// frame is authored by the connecting agent. That makes this the only write
+// path, so it validates through the same `parseX402Pricing` the runtime uses:
+// a bad address or a dollars-instead-of-atomic-units amount is rejected here,
+// at write time, rather than silently disabling payments at the agent's next
+// connect.
+
+export interface X402PricingResult {
+  agent_id: string;
+  x402_pricing: X402Pricing | null;
+}
+
+export async function getX402Pricing(
+  db: Sql,
+  principalId: string,
+  agentId: string,
+): Promise<X402PricingResult> {
+  const rows = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`SELECT id AS agent_id, x402_pricing FROM agents WHERE id = ${agentId}`;
+  });
+  if (rows.length === 0) throw new AdminApiError('Agent not found.', 404);
+
+  // A row that fails to parse is reported rather than thrown: the operator
+  // asking "what does this agent charge?" is exactly who needs to be told it
+  // is currently unreadable (and therefore being served for free).
+  let pricing: X402Pricing | null = null;
+  try {
+    pricing = parseX402Pricing(rows[0].x402_pricing) ?? null;
+  } catch (err) {
+    throw new AdminApiError(
+      `Stored pricing for this agent is invalid and is being ignored at runtime: ${String(err)}`,
+      409,
+    );
+  }
+  return { agent_id: agentId, x402_pricing: pricing };
+}
+
+export async function setX402Pricing(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+  agentId: string,
+  pricing: unknown,
+): Promise<X402PricingResult> {
+  let parsed: X402Pricing;
+  try {
+    parsed = X402PricingSchema.parse(pricing);
+  } catch (err) {
+    throw new AdminApiError(`Invalid x402 pricing: ${String(err)}`, 400);
+  }
+
+  const rows = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      UPDATE agents
+      SET x402_pricing = ${tx.json(JSON.parse(JSON.stringify(parsed)))},
+          updated_at = now()
+      WHERE id = ${agentId}
+      RETURNING id AS agent_id
+    `;
+  });
+  // RLS hides agents the operator doesn't own, so zero rows is
+  // indistinguishable from "no such agent" — and deliberately so, since
+  // distinguishing them would confirm the existence of someone else's agent.
+  if (rows.length === 0) throw new AdminApiError('Agent not found or not authorized.', 404);
+
+  registry.updateX402Pricing(agentId, parsed);
+  return { agent_id: agentId, x402_pricing: parsed };
+}
+
+export async function clearX402Pricing(
+  db: Sql,
+  registry: Registry,
+  principalId: string,
+  agentId: string,
+): Promise<X402PricingResult> {
+  const rows = await db.begin(async (tx) => {
+    await setRlsContext(tx, principalId);
+    return tx`
+      UPDATE agents
+      SET x402_pricing = NULL, updated_at = now()
+      WHERE id = ${agentId}
+      RETURNING id AS agent_id
+    `;
+  });
+  if (rows.length === 0) throw new AdminApiError('Agent not found or not authorized.', 404);
+
+  registry.updateX402Pricing(agentId, undefined);
+  return { agent_id: agentId, x402_pricing: null };
 }
 
 // ----- Static API keys (issue #308) -----------------------------------------

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -6,8 +6,10 @@ import {
   TRACEABILITY_EXTENSION_URI,
   type AgentCard,
 } from '@vicoop-bridge/protocol';
+import { X402_FOUNDATION_EXTENSION_URI } from '@a2x/sdk/x402';
 import { buildAgentA2XServer } from './agent-card.js';
 import { Registry, type ClientConnection } from './registry.js';
+import { parseX402Pricing } from './x402/pricing.js';
 
 function fakeConn(card: AgentCard, overrides: Partial<ClientConnection> = {}): ClientConnection {
   return {
@@ -261,4 +263,92 @@ test('buildAgentA2XServer leaves a wire-declared SIWE extension alone when not r
   );
   assert.equal(siweEntries.length, 1);
   assert.equal(siweEntries[0]!.description, 'wire-declared');
+});
+
+// ---- x402 advertisement ------------------------------------------------
+
+const X402_PRICING = parseX402Pricing({
+  network: 'eip155:84532',
+  amount: '10000',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: '0x1111111111111111111111111111111111111111',
+})!;
+
+function cardWithX402Wire(): AgentCard {
+  return {
+    name: 'claude',
+    description: 'Claude Code',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: {
+      streaming: true,
+      extensions: [
+        { uri: TRACEABILITY_EXTENSION_URI, description: 'keep me' },
+        // A client declaring its own price. Must never reach the card.
+        {
+          uri: X402_FOUNDATION_EXTENSION_URI,
+          description: 'wire-declared x402',
+          params: { amount: '1', payTo: '0x9999999999999999999999999999999999999999' },
+        },
+      ],
+    },
+    skills: [],
+  };
+}
+
+function x402Entries(card: AgentCardV03) {
+  return (card.capabilities.extensions ?? []).filter(
+    (e) => e.uri === X402_FOUNDATION_EXTENSION_URI,
+  );
+}
+
+test('a wire-declared x402 advertisement is dropped from a free agent', () => {
+  // `addExtension` is append-only, so a passed-through entry would let an
+  // agent quote a price the bridge never asks for.
+  const agent = buildAgentA2XServer(
+    fakeConn(cardWithX402Wire()),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  assert.equal(x402Entries(card).length, 0, 'a free agent must advertise no price');
+  // Unrelated wire extensions still pass through.
+  assert.ok(
+    (card.capabilities.extensions ?? []).some((e) => e.uri === TRACEABILITY_EXTENSION_URI),
+  );
+});
+
+test('a paid agent advertises exactly one x402 entry, the DB-owned one', () => {
+  const agent = buildAgentA2XServer(
+    fakeConn(cardWithX402Wire(), { x402Pricing: X402_PRICING }),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: false, db: {} as never },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  const entries = x402Entries(card);
+  assert.equal(entries.length, 1, 'no duplicate URI at two different prices');
+  assert.equal(
+    (entries[0]!.params as { payTo: string }).payTo,
+    '0x1111111111111111111111111111111111111111',
+    'the DB price wins, not the wire-declared one',
+  );
+});
+
+test('a paid agent without PUBLIC_URL advertises no price', () => {
+  // x402 `resource` must be absolute; without one the offering could never
+  // verify or settle, so the gate is withheld and the card must not quote a
+  // price the gate is not installed to collect.
+  const agent = buildAgentA2XServer(
+    fakeConn(cardWithX402Wire(), { x402Pricing: X402_PRICING }),
+    new InMemoryTaskStore(),
+    new Registry(),
+    { publicUrl: undefined, deviceFlowEnabled: false, db: {} as never },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV03;
+  assert.equal(x402Entries(card).length, 0);
 });

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -7,7 +7,9 @@ import {
 import { SIWE_BEARER_AUTH_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { ClientConnection, Registry } from './registry.js';
 import { WSForwardingExecutor } from './executor.js';
+import { isX402ExtensionUri } from '@a2x/sdk/x402';
 import { X402_FOUNDATION_EXTENSION_URI } from './x402/gate.js';
+import { logEvent } from './log.js';
 import type { Sql } from './db.js';
 
 export interface AgentA2XOptions {
@@ -41,12 +43,26 @@ export function buildAgentA2XServer(
     ? `${opts.publicUrl}/agents/${conn.agentId}`
     : `/agents/${conn.agentId}`;
 
+  // x402 `resource` must be an absolute URL — strict facilitators reject
+  // anything else, so without `publicUrl` a paid agent would publish offerings
+  // that can never verify or settle. Withhold the gate instead: the agent
+  // serves for free and says so in the log, which is a working deployment with
+  // a visible misconfiguration rather than a broken payment loop. Same posture
+  // as an unparseable pricing row.
+  const paymentsWired = Boolean(opts.db) && Boolean(opts.publicUrl);
+  if (opts.db && !opts.publicUrl && conn.x402Pricing) {
+    logEvent('x402_config_invalid', {
+      agentId: conn.agentId,
+      reason: 'pricing is configured but PUBLIC_URL is not, so no absolute resource URL exists',
+    });
+  }
+
   const executor = new WSForwardingExecutor(
     conn.agentId,
     registry,
     taskStore,
     undefined,
-    opts.db ? { sql: opts.db, resource: url } : undefined,
+    paymentsWired ? { sql: opts.db!, resource: url } : undefined,
   );
 
   const a2xServer = new A2XServer({
@@ -105,6 +121,18 @@ export function buildAgentA2XServer(
       // publicUrl).
       continue;
     }
+    if (isX402ExtensionUri(extension.uri)) {
+      // Always dropped, paid or not. `addExtension` is append-only, so leaving
+      // a wire-declared x402 entry in would let a free agent advertise a price
+      // the bridge will never ask for, and would give a paid agent two entries
+      // for the same URI at different prices — with no rule saying which one a
+      // client reads. Pricing is DB-owned; so is saying so on the card.
+      logEvent('x402_wire_advertisement_dropped', {
+        agentId: conn.agentId,
+        uri: extension.uri,
+      });
+      continue;
+    }
     a2xServer.addExtension(extension);
   }
   if (bridgeWillEmitSiwe) {
@@ -139,7 +167,9 @@ export function buildAgentA2XServer(
   // `input-required` response naming the price, which is more useful than
   // being refused at extension activation. `params` mirrors the offering so a
   // client can decide whether it is willing to pay before spending a turn.
-  if (conn.x402Pricing) {
+  // Gated on `paymentsWired`, not just on pricing being set: the card must not
+  // quote a price the gate is not installed to collect.
+  if (conn.x402Pricing && paymentsWired) {
     const pricing = conn.x402Pricing;
     a2xServer.addExtension({
       uri: X402_FOUNDATION_EXTENSION_URI,

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -7,10 +7,15 @@ import {
 import { SIWE_BEARER_AUTH_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import type { ClientConnection, Registry } from './registry.js';
 import { WSForwardingExecutor } from './executor.js';
+import { X402_FOUNDATION_EXTENSION_URI } from './x402/gate.js';
+import type { Sql } from './db.js';
 
 export interface AgentA2XOptions {
   publicUrl: string | undefined;
   deviceFlowEnabled: boolean;
+  // DB handle for the x402 offering store. Absent on deployments assembled
+  // without a payment path; the executor then never installs the gate.
+  db?: Sql;
 }
 
 /**
@@ -36,7 +41,13 @@ export function buildAgentA2XServer(
     ? `${opts.publicUrl}/agents/${conn.agentId}`
     : `/agents/${conn.agentId}`;
 
-  const executor = new WSForwardingExecutor(conn.agentId, registry, taskStore);
+  const executor = new WSForwardingExecutor(
+    conn.agentId,
+    registry,
+    taskStore,
+    undefined,
+    opts.db ? { sql: opts.db, resource: url } : undefined,
+  );
 
   const a2xServer = new A2XServer({
     taskStore,
@@ -115,6 +126,32 @@ export function buildAgentA2XServer(
           mintToken: `a2a-wallet siwe auth --domain ${siweDomain} --uri ${opts.publicUrl} --ttl 1h --json | jq -r '.token'`,
           sendMessage: `a2a-wallet a2a send --bearer "$TOKEN" ${opts.publicUrl}/agents/${conn.agentId}/.well-known/agent-card.json "Hello"`,
         },
+      },
+    });
+  }
+
+  // Advertise x402 when this agent charges. The bridge owns this
+  // advertisement for the same reason it owns the SIWE one: it is the only
+  // side that knows whether a payment gate is actually installed, and pricing
+  // is DB-owned rather than declared by the connecting client.
+  //
+  // `required: false` — a caller that cannot pay still gets a well-formed
+  // `input-required` response naming the price, which is more useful than
+  // being refused at extension activation. `params` mirrors the offering so a
+  // client can decide whether it is willing to pay before spending a turn.
+  if (conn.x402Pricing) {
+    const pricing = conn.x402Pricing;
+    a2xServer.addExtension({
+      uri: X402_FOUNDATION_EXTENSION_URI,
+      description:
+        'x402 payments. Calls are answered with an input-required task carrying x402.payment.required; sign the payload and resubmit against the same taskId.',
+      required: false,
+      params: {
+        network: pricing.network,
+        amount: pricing.amount,
+        asset: pricing.asset,
+        payTo: pricing.payTo,
+        scheme: 'exact',
       },
     });
   }

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -144,15 +144,31 @@ export function buildAgentA2XServer(
     a2xServer.addExtension({
       uri: X402_FOUNDATION_EXTENSION_URI,
       description:
-        'x402 payments. Calls are answered with an input-required task carrying x402.payment.required; sign the payload and resubmit against the same taskId.',
+        pricing.scheme === 'upto'
+          ? 'x402 metered payments. Calls are answered with an input-required task carrying x402.payment.required; sign the payload (upto requires opting in on the client) and resubmit against the same taskId. You are charged for the tokens actually consumed, up to the authorized maximum.'
+          : 'x402 payments. Calls are answered with an input-required task carrying x402.payment.required; sign the payload and resubmit against the same taskId.',
       required: false,
-      params: {
-        network: pricing.network,
-        amount: pricing.amount,
-        asset: pricing.asset,
-        payTo: pricing.payTo,
-        scheme: 'exact',
-      },
+      params:
+        pricing.scheme === 'upto'
+          ? {
+              scheme: 'upto',
+              network: pricing.network,
+              asset: pricing.asset,
+              payTo: pricing.payTo,
+              // The ceiling, not the charge — named to match, because a
+              // client that read it as the price would refuse offers it can
+              // comfortably afford.
+              maxAmount: pricing.maxAmount,
+              ratesPerMTok: pricing.rates,
+              ...(pricing.minAmount !== undefined ? { minAmount: pricing.minAmount } : {}),
+            }
+          : {
+              scheme: 'exact',
+              network: pricing.network,
+              amount: pricing.amount,
+              asset: pricing.asset,
+              payTo: pricing.payTo,
+            },
     });
   }
 

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -573,3 +573,62 @@ test('executor omits terminal error metadata when openai-compat extension was no
   assert.equal(statuses[0]?.status.message?.metadata, undefined);
   assert.equal(statuses[0]?.status.message?.extensions, undefined);
 });
+
+test('an agent with no pricing is forwarded normally even when the payment path is configured', async () => {
+  // The gate is keyed off the connection's pricing, not off whether the
+  // deployment has a DB. A free agent must reach the backend on turn 1 with
+  // no payment round-trip and — importantly — without the store being
+  // touched, which the exploding `sql` stub here enforces.
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'free',
+    clientId: 'c-free',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const explodingSql = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('x402 store must not be reached for a free agent');
+      },
+    },
+  ) as never;
+
+  const executor = new WSForwardingExecutor('free', registry, noopTaskStore(), undefined, {
+    sql: explodingSql,
+    resource: 'https://bridge.test/agents/free',
+  });
+  const task = {
+    id: 't-free',
+    contextId: 'ctx-free',
+    status: { state: TaskState.SUBMITTED, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hi' }],
+    messageId: 'm-free',
+  } as unknown as Message;
+
+  const gen = executor.executeStream(task, message);
+  const first = gen.next();
+  const binding = registry.getBinding('t-free');
+  assert.ok(binding, 'task should be bound and forwarded, not gated');
+
+  binding.sink.pushStatus({
+    taskId: 't-free',
+    contextId: 'ctx-free',
+    final: true,
+    status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() },
+  });
+  binding.sink.finish();
+  await first;
+  for await (const _event of gen) void _event;
+
+  const assign = sent.map((raw) => parseDownFrame(raw)).find((f) => f.type === 'task.assign');
+  assert.ok(assign, 'the message should have been forwarded to the connected agent');
+});

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -19,7 +19,7 @@ import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { X402Gate, createPostgresX402Context } from './x402/gate.js';
-import { readTaskUsage } from './x402/usage.js';
+import { readTaskUsage, type TaskUsage } from './x402/usage.js';
 import type { Sql } from './db.js';
 
 /**
@@ -203,14 +203,14 @@ export class WSForwardingExecutor extends AgentExecutor {
    * success.
    *
    * For a metered (`upto`) agent the charge comes from the token counts the
-   * backend already stamped onto this very event — the connected agent
-   * reports per-turn usage on its `task.complete` frame and `ws.ts` carries
-   * the metadata through, so nothing has to be plumbed for this.
+   * connected agent reported on its `task.complete` frame, which `ws.ts`
+   * stashes on the binding.
    */
   private async settleTerminal(
     gate: X402Gate,
     classified: X402ValidClassification,
     event: TaskStatusUpdateEvent,
+    binding: TaskBinding,
     taskId: string,
     contextId: string,
   ): Promise<TaskStatusUpdateEvent> {
@@ -219,12 +219,19 @@ export class WSForwardingExecutor extends AgentExecutor {
       return event;
     }
 
-    const result = await gate.settle({
-      taskId,
-      contextId,
-      classified,
-      ...(gate.metered ? { usage: readTaskUsage(event.status.message?.metadata) } : {}),
-    });
+    let metered: { usage?: TaskUsage } = {};
+    if (gate.metered) {
+      const read = readTaskUsage(binding.usage, event.status.message?.metadata);
+      if (read.source === 'openai-compat') {
+        // The client is old enough not to send the protocol field. Billing
+        // still works off the legacy key, but this is the signal to chase the
+        // client upgrade — the fallback is meant to be retired.
+        logEvent('x402_usage_legacy_source', { agentId: this.agentId, taskId });
+      }
+      metered = { usage: read.usage };
+    }
+
+    const result = await gate.settle({ taskId, contextId, classified, ...metered });
     if (result.kind === 'failed') return result.event;
 
     // Attach the settlement receipt to the final status message, which is
@@ -473,7 +480,7 @@ export class WSForwardingExecutor extends AgentExecutor {
           // first would leave both in history.
           const terminal =
             gate && settlement
-              ? await this.settleTerminal(gate, settlement, event, taskId, contextId)
+              ? await this.settleTerminal(gate, settlement, event, binding, taskId, contextId)
               : event;
           // Terminal — mutate task in place so the request-handler's
           // post-stream read reflects the final state.

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -18,9 +18,8 @@ import type { Registry, TaskBinding, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
-import { X402Gate, createPostgresX402Context } from './x402/gate.js';
-import { readTaskUsage, type TaskUsage } from './x402/usage.js';
-import type { X402Pricing } from './x402/pricing.js';
+import { X402Gate, createPostgresX402Context, type X402Settlement } from './x402/gate.js';
+import { readTaskUsage } from './x402/usage.js';
 import type { Sql } from './db.js';
 
 /**
@@ -33,18 +32,6 @@ export interface X402ExecutorOptions {
   resource: string;
 }
 
-/**
- * A verified payment awaiting settlement, carried from the gate's `open` to
- * its `settle` within one turn.
- *
- * `pricing` travels with the classification on purpose: it is the offering's
- * frozen terms, and settling from the agent's live pricing instead would meter
- * against terms the payer never signed.
- */
-interface X402Settlement {
-  classified: X402ValidClassification;
-  pricing: X402Pricing;
-}
 
 // AgentExecutor's constructor requires a Runner+BaseAgent because Layer 2
 // (the in-process LLM model) is the default. Our WS-forwarding path
@@ -203,33 +190,28 @@ export class WSForwardingExecutor extends AgentExecutor {
   }
 
   /**
-   * Charge for a verified payment now that the agent has produced a terminal
-   * event, and fold the outcome into that event.
+   * Fold the payment outcome into the agent's terminal event, and release the
+   * offering.
    *
-   * Only a `completed` task is settled. Payment buys delivered work, so a
-   * task that failed or was cancelled leaves the payer's signed
-   * authorization unused — they are never charged for work they didn't get.
-   * A settlement that itself fails replaces the terminal event with a
-   * `failed` one: the merchant wasn't paid, so the call must not report
-   * success.
+   * Which half runs depends on when the scheme could settle:
    *
-   * For a metered (`upto`) agent the charge comes from the token counts the
-   * connected agent reported on its `task.complete` frame, which `ws.ts`
-   * stashes on the binding.
+   * - `settled` (`exact`) — already charged before the agent was contacted.
+   *   Only the receipt is attached here, on success *and* on failure: the
+   *   payer paid either way and the receipt is their proof. A task that fails
+   *   after payment is a real cost to them, which is what
+   *   `x402_paid_task_failed` counts.
+   * - `deferred` (`upto`) — the charge is metered from consumption, which does
+   *   not exist until now, so this is the first moment it can be computed. The
+   *   token counts come from the `task.complete` frame, which `ws.ts` stashes
+   *   on the binding.
    *
-   * **The output has already reached the caller by the time this runs.**
-   * Artifacts stream out as the agent produces them, and settlement cannot
-   * begin until the work is done — under `upto` there is nothing to meter
-   * before then. So a payer who invalidates their authorization between
-   * `verify` and here receives the full result and a `failed` status.
-   *
-   * That window is accepted rather than closed. The alternatives are worse:
-   * buffering output until settlement lands would remove streaming from
-   * exactly the agents people pay for, and settling before the work would
-   * charge for tasks that fail — which, on a bridge fronting coding agents
-   * that time out and error, is the far more common case. Undercharging on a
-   * rare adversarial payer beats overcharging on routine failure. The
-   * exposure is one task's work, and `x402_unpaid_delivery` measures it.
+   * Only a completed task is settled under `upto`: a failure leaves the
+   * payer's authorization unused rather than charging for work they did not
+   * get. The corollary is that the output has already streamed to the caller
+   * by the time this runs, so a payer who invalidates their authorization
+   * mid-task receives the result and a `failed` status. `upto` cannot avoid
+   * that — there is nothing to meter before the work — and
+   * `x402_unpaid_delivery` counts it.
    */
   private async settleTerminal(
     gate: X402Gate,
@@ -239,23 +221,33 @@ export class WSForwardingExecutor extends AgentExecutor {
     taskId: string,
     contextId: string,
   ): Promise<TaskStatusUpdateEvent> {
-    if (event.status.state !== TaskState.COMPLETED) {
+    // The offering row outlives the work — under `exact` it holds the claim
+    // that stops a resubmission being charged a second time — so releasing it
+    // is this function's job regardless of which branch runs.
+    const done = async <T>(value: T): Promise<T> => {
       await gate.clear(taskId);
-      return event;
+      return value;
+    };
+
+    if (settlement.mode === 'settled') {
+      if (event.status.state !== TaskState.COMPLETED) {
+        logEvent('x402_paid_task_failed', {
+          agentId: this.agentId,
+          taskId,
+          state: event.status.state,
+        });
+      }
+      return done(this.withReceipt(event, settlement.metadata, taskId, contextId));
     }
 
-    let metered: { usage?: TaskUsage } = {};
-    // Metered-ness comes from the offering's frozen terms, not from what the
-    // agent charges now — the same reason `settle` prices from them.
-    if (settlement.pricing.scheme === 'upto') {
-      const read = readTaskUsage(binding.usage, event.status.message?.metadata);
-      if (read.source === 'openai-compat') {
-        // The client is old enough not to send the protocol field. Billing
-        // still works off the legacy key, but this is the signal to chase the
-        // client upgrade — the fallback is meant to be retired.
-        logEvent('x402_usage_legacy_source', { agentId: this.agentId, taskId });
-      }
-      metered = { usage: read.usage };
+    if (event.status.state !== TaskState.COMPLETED) return done(event);
+
+    const read = readTaskUsage(binding.usage, event.status.message?.metadata);
+    if (read.source === 'openai-compat') {
+      // The client is old enough not to send the protocol field. Billing still
+      // works off the legacy key, but this is the signal to chase the client
+      // upgrade — the fallback is meant to be retired.
+      logEvent('x402_usage_legacy_source', { agentId: this.agentId, taskId });
     }
 
     const result = await gate.settle({
@@ -263,22 +255,28 @@ export class WSForwardingExecutor extends AgentExecutor {
       contextId,
       classified: settlement.classified,
       pricing: settlement.pricing,
-      ...metered,
+      usage: read.usage,
     });
     if (result.kind === 'failed') {
       // The caller already has the output — see the note above. This is the
-      // event that quantifies the accepted window, so it is emitted here
-      // rather than left implicit in the settlement failure.
-      logEvent('x402_unpaid_delivery', {
-        agentId: this.agentId,
-        taskId,
-        artifacts: event.status.message !== undefined ? 1 : 0,
-      });
-      return result.event;
+      // event that quantifies the window, so it is emitted here rather than
+      // left implicit in the settlement failure.
+      logEvent('x402_unpaid_delivery', { agentId: this.agentId, taskId });
+      return done(result.event);
     }
+    return done(this.withReceipt(event, result.metadata, taskId, contextId));
+  }
 
-    // Attach the settlement receipt to the final status message, which is
-    // where the x402 transport specifies clients read it from.
+  /**
+   * Attach settlement metadata to a terminal event's status message, which is
+   * where the x402 transport specifies clients read receipts from.
+   */
+  private withReceipt(
+    event: TaskStatusUpdateEvent,
+    metadata: Record<string, unknown>,
+    taskId: string,
+    contextId: string,
+  ): TaskStatusUpdateEvent {
     const existing = event.status.message;
     return {
       ...event,
@@ -292,7 +290,7 @@ export class WSForwardingExecutor extends AgentExecutor {
             taskId,
             contextId,
           }),
-          metadata: { ...(existing?.metadata ?? {}), ...result.metadata },
+          metadata: { ...(existing?.metadata ?? {}), ...metadata },
         },
       },
     };
@@ -340,10 +338,7 @@ export class WSForwardingExecutor extends AgentExecutor {
         }
         return;
       }
-      settlement =
-        outcome.classified && outcome.pricing
-          ? { classified: outcome.classified, pricing: outcome.pricing }
-          : undefined;
+      settlement = outcome.settlement;
     }
 
     const queue = new AsyncEventQueue<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>();

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -19,6 +19,7 @@ import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { X402Gate, createPostgresX402Context } from './x402/gate.js';
+import { readTaskUsage } from './x402/usage.js';
 import type { Sql } from './db.js';
 
 /**
@@ -194,12 +195,17 @@ export class WSForwardingExecutor extends AgentExecutor {
    * Charge for a verified payment now that the agent has produced a terminal
    * event, and fold the outcome into that event.
    *
-   * Only a `completed` task is settled. An `exact` payment buys delivered
-   * work, so a task that failed or was cancelled leaves the payer's signed
+   * Only a `completed` task is settled. Payment buys delivered work, so a
+   * task that failed or was cancelled leaves the payer's signed
    * authorization unused — they are never charged for work they didn't get.
    * A settlement that itself fails replaces the terminal event with a
    * `failed` one: the merchant wasn't paid, so the call must not report
    * success.
+   *
+   * For a metered (`upto`) agent the charge comes from the token counts the
+   * backend already stamped onto this very event — the connected agent
+   * reports per-turn usage on its `task.complete` frame and `ws.ts` carries
+   * the metadata through, so nothing has to be plumbed for this.
    */
   private async settleTerminal(
     gate: X402Gate,
@@ -213,7 +219,12 @@ export class WSForwardingExecutor extends AgentExecutor {
       return event;
     }
 
-    const result = await gate.settle({ taskId, contextId, classified });
+    const result = await gate.settle({
+      taskId,
+      contextId,
+      classified,
+      ...(gate.metered ? { usage: readTaskUsage(event.status.message?.metadata) } : {}),
+    });
     if (result.kind === 'failed') return result.event;
 
     // Attach the settlement receipt to the final status message, which is

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -422,12 +422,21 @@ export class WSForwardingExecutor extends AgentExecutor {
           },
         },
       };
-      task.status = failEvent.status;
-      history = appendHistoryMessage(history, failEvent.status.message);
+      // Route through the same terminal handling as any other failure. The
+      // agent can disconnect between verify and here, and under `exact` the
+      // payer has already been charged by that point — this is what attaches
+      // their receipt, records `x402_paid_task_failed`, and releases the
+      // offering. Skipping it also left `deferred` offerings uncleared.
+      const terminal =
+        gate && settlement
+          ? await this.settleTerminal(gate, settlement, failEvent, binding, taskId, contextId)
+          : failEvent;
+      task.status = terminal.status;
+      history = appendHistoryMessage(history, terminal.status.message);
       task.history = history;
       this.registry.unbindTask(taskId, binding);
       if (this.abortControllers.get(taskId) === ac) this.abortControllers.delete(taskId);
-      yield failEvent;
+      yield terminal;
       try {
         await this.taskStore.updateTask(taskId, {
           status: task.status,

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -13,10 +13,23 @@ import {
   type TaskStatusUpdateEvent,
   type TaskStore,
 } from '@a2x/sdk';
+import type { X402ValidClassification } from '@a2x/sdk/x402';
 import type { Registry, TaskBinding, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
+import { X402Gate, createPostgresX402Context } from './x402/gate.js';
+import type { Sql } from './db.js';
+
+/**
+ * What the executor needs to run the x402 payment gate: a DB handle for the
+ * offering store, and the public URL of this agent, which is what the payer
+ * is shown they are paying for.
+ */
+export interface X402ExecutorOptions {
+  sql: Sql;
+  resource: string;
+}
 
 // AgentExecutor's constructor requires a Runner+BaseAgent because Layer 2
 // (the in-process LLM model) is the default. Our WS-forwarding path
@@ -122,17 +135,49 @@ export function appendHistoryMessage(history: Message[], message: Message | unde
  */
 export class WSForwardingExecutor extends AgentExecutor {
   private readonly abortControllers = new Map<string, AbortController>();
+  // Gate for the agent's current pricing, rebuilt when the pricing changes.
+  // Pricing is read from the live `ClientConnection` on every turn rather
+  // than captured here, so an admin repricing an agent takes effect on the
+  // next call instead of on the next reconnect.
+  private gateCache: { key: string; gate: X402Gate } | undefined;
 
   constructor(
     private readonly agentId: string,
     private readonly registry: Registry,
     private readonly taskStore: TaskStore,
     private readonly inactivityTimeoutMs: number = DEFAULT_INACTIVITY_TIMEOUT_MS,
+    // Absent in tests and on deployments without a DB-backed payment path;
+    // the gate is then never installed and every agent is free.
+    private readonly x402: X402ExecutorOptions | undefined = undefined,
   ) {
     super({
       runner: NOOP_RUNNER,
       runConfig: { streamingMode: StreamingMode.SSE },
     });
+  }
+
+  /**
+   * The payment gate for this turn, or `undefined` when the agent is free.
+   */
+  private currentGate(): X402Gate | undefined {
+    if (this.x402 === undefined) return undefined;
+    const pricing = this.registry.getAgent(this.agentId)?.x402Pricing;
+    if (pricing === undefined) {
+      this.gateCache = undefined;
+      return undefined;
+    }
+    const key = JSON.stringify(pricing);
+    if (this.gateCache?.key !== key) {
+      this.gateCache = {
+        key,
+        gate: new X402Gate(
+          this.agentId,
+          pricing,
+          createPostgresX402Context(this.x402.sql, this.agentId),
+        ),
+      };
+    }
+    return this.gateCache.gate;
   }
 
   override async execute(task: Task, message: Message): Promise<Task> {
@@ -145,12 +190,98 @@ export class WSForwardingExecutor extends AgentExecutor {
     return task;
   }
 
+  /**
+   * Charge for a verified payment now that the agent has produced a terminal
+   * event, and fold the outcome into that event.
+   *
+   * Only a `completed` task is settled. An `exact` payment buys delivered
+   * work, so a task that failed or was cancelled leaves the payer's signed
+   * authorization unused — they are never charged for work they didn't get.
+   * A settlement that itself fails replaces the terminal event with a
+   * `failed` one: the merchant wasn't paid, so the call must not report
+   * success.
+   */
+  private async settleTerminal(
+    gate: X402Gate,
+    classified: X402ValidClassification,
+    event: TaskStatusUpdateEvent,
+    taskId: string,
+    contextId: string,
+  ): Promise<TaskStatusUpdateEvent> {
+    if (event.status.state !== TaskState.COMPLETED) {
+      await gate.clear(taskId);
+      return event;
+    }
+
+    const result = await gate.settle({ taskId, contextId, classified });
+    if (result.kind === 'failed') return result.event;
+
+    // Attach the settlement receipt to the final status message, which is
+    // where the x402 transport specifies clients read it from.
+    const existing = event.status.message;
+    return {
+      ...event,
+      status: {
+        ...event.status,
+        message: {
+          ...(existing ?? {
+            messageId: `${taskId}-x402-receipt`,
+            role: 'agent' as const,
+            parts: [],
+            taskId,
+            contextId,
+          }),
+          metadata: { ...(existing?.metadata ?? {}), ...result.metadata },
+        },
+      },
+    };
+  }
+
   override async *executeStream(
     task: Task,
     message: Message,
   ): AsyncGenerator<TaskStatusUpdateEvent | TaskArtifactUpdateEvent> {
     const taskId = task.id;
     const contextId = task.contextId ?? taskId;
+
+    // x402 payment gate. Runs before the task is bound or forwarded, so an
+    // unpaid call never reaches the connected agent and never consumes its
+    // capacity. `settlement` is set only when a payment was verified and is
+    // therefore owed once the work completes.
+    const gate = this.currentGate();
+    let settlement: X402ValidClassification | undefined;
+    if (gate) {
+      const outcome = await gate.open({
+        taskId,
+        contextId,
+        message,
+        resource: this.x402!.resource,
+      });
+      if (outcome.kind === 'halt') {
+        task.status = outcome.event.status;
+        task.history = appendHistoryMessage(
+          appendHistoryMessage(task.history ?? [], message),
+          outcome.event.status.message,
+        );
+        yield outcome.event;
+        // The SDK persists non-terminal statuses mid-stream on the streaming
+        // path but not on `message/send`, so write it here for both. The
+        // resume turn does not depend on this — it reads the offering from
+        // the x402 store — but `tasks/get` should report input-required
+        // rather than the state the task was loaded with.
+        try {
+          await this.taskStore.updateTask(taskId, {
+            status: task.status,
+            history: task.history,
+          });
+        } catch (err) {
+          logEvent('task_persist_error', { taskId, error: String(err) });
+        }
+        return;
+      }
+      settlement = outcome.classified;
+    }
+
     const queue = new AsyncEventQueue<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>();
     const ac = new AbortController();
     this.abortControllers.set(taskId, ac);
@@ -325,18 +456,27 @@ export class WSForwardingExecutor extends AgentExecutor {
         }
         // status event
         if (event.final) sawFinalEvent = true;
-        history = appendHistoryMessage(history, event.status.message);
-        task.history = history;
         if (TERMINAL_STATES.has(event.status.state)) {
+          // Settle before recording anything: a settlement failure replaces
+          // the agent's terminal event outright, and appending the original
+          // first would leave both in history.
+          const terminal =
+            gate && settlement
+              ? await this.settleTerminal(gate, settlement, event, taskId, contextId)
+              : event;
           // Terminal — mutate task in place so the request-handler's
           // post-stream read reflects the final state.
-          task.status = event.status;
+          history = appendHistoryMessage(history, terminal.status.message);
+          task.history = history;
+          task.status = terminal.status;
           if (accumulatedArtifacts.length > 0) {
             task.artifacts = accumulatedArtifacts;
           }
-          yield event;
+          yield terminal;
           break;
         }
+        history = appendHistoryMessage(history, event.status.message);
+        task.history = history;
         yield event;
       }
       // Stop the watchdog before the awaited persist below — the stream is done

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -216,6 +216,20 @@ export class WSForwardingExecutor extends AgentExecutor {
    * For a metered (`upto`) agent the charge comes from the token counts the
    * connected agent reported on its `task.complete` frame, which `ws.ts`
    * stashes on the binding.
+   *
+   * **The output has already reached the caller by the time this runs.**
+   * Artifacts stream out as the agent produces them, and settlement cannot
+   * begin until the work is done — under `upto` there is nothing to meter
+   * before then. So a payer who invalidates their authorization between
+   * `verify` and here receives the full result and a `failed` status.
+   *
+   * That window is accepted rather than closed. The alternatives are worse:
+   * buffering output until settlement lands would remove streaming from
+   * exactly the agents people pay for, and settling before the work would
+   * charge for tasks that fail — which, on a bridge fronting coding agents
+   * that time out and error, is the far more common case. Undercharging on a
+   * rare adversarial payer beats overcharging on routine failure. The
+   * exposure is one task's work, and `x402_unpaid_delivery` measures it.
    */
   private async settleTerminal(
     gate: X402Gate,
@@ -251,7 +265,17 @@ export class WSForwardingExecutor extends AgentExecutor {
       pricing: settlement.pricing,
       ...metered,
     });
-    if (result.kind === 'failed') return result.event;
+    if (result.kind === 'failed') {
+      // The caller already has the output — see the note above. This is the
+      // event that quantifies the accepted window, so it is emitted here
+      // rather than left implicit in the settlement failure.
+      logEvent('x402_unpaid_delivery', {
+        agentId: this.agentId,
+        taskId,
+        artifacts: event.status.message !== undefined ? 1 : 0,
+      });
+      return result.event;
+    }
 
     // Attach the settlement receipt to the final status message, which is
     // where the x402 transport specifies clients read it from.

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -20,6 +20,7 @@ import { logEvent } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { X402Gate, createPostgresX402Context } from './x402/gate.js';
 import { readTaskUsage, type TaskUsage } from './x402/usage.js';
+import type { X402Pricing } from './x402/pricing.js';
 import type { Sql } from './db.js';
 
 /**
@@ -30,6 +31,19 @@ import type { Sql } from './db.js';
 export interface X402ExecutorOptions {
   sql: Sql;
   resource: string;
+}
+
+/**
+ * A verified payment awaiting settlement, carried from the gate's `open` to
+ * its `settle` within one turn.
+ *
+ * `pricing` travels with the classification on purpose: it is the offering's
+ * frozen terms, and settling from the agent's live pricing instead would meter
+ * against terms the payer never signed.
+ */
+interface X402Settlement {
+  classified: X402ValidClassification;
+  pricing: X402Pricing;
 }
 
 // AgentExecutor's constructor requires a Runner+BaseAgent because Layer 2
@@ -169,13 +183,10 @@ export class WSForwardingExecutor extends AgentExecutor {
     }
     const key = JSON.stringify(pricing);
     if (this.gateCache?.key !== key) {
+      const { context, sidecar } = createPostgresX402Context(this.x402.sql, this.agentId);
       this.gateCache = {
         key,
-        gate: new X402Gate(
-          this.agentId,
-          pricing,
-          createPostgresX402Context(this.x402.sql, this.agentId),
-        ),
+        gate: new X402Gate(this.agentId, pricing, context, sidecar),
       };
     }
     return this.gateCache.gate;
@@ -208,7 +219,7 @@ export class WSForwardingExecutor extends AgentExecutor {
    */
   private async settleTerminal(
     gate: X402Gate,
-    classified: X402ValidClassification,
+    settlement: X402Settlement,
     event: TaskStatusUpdateEvent,
     binding: TaskBinding,
     taskId: string,
@@ -220,7 +231,9 @@ export class WSForwardingExecutor extends AgentExecutor {
     }
 
     let metered: { usage?: TaskUsage } = {};
-    if (gate.metered) {
+    // Metered-ness comes from the offering's frozen terms, not from what the
+    // agent charges now — the same reason `settle` prices from them.
+    if (settlement.pricing.scheme === 'upto') {
       const read = readTaskUsage(binding.usage, event.status.message?.metadata);
       if (read.source === 'openai-compat') {
         // The client is old enough not to send the protocol field. Billing
@@ -231,7 +244,13 @@ export class WSForwardingExecutor extends AgentExecutor {
       metered = { usage: read.usage };
     }
 
-    const result = await gate.settle({ taskId, contextId, classified, ...metered });
+    const result = await gate.settle({
+      taskId,
+      contextId,
+      classified: settlement.classified,
+      pricing: settlement.pricing,
+      ...metered,
+    });
     if (result.kind === 'failed') return result.event;
 
     // Attach the settlement receipt to the final status message, which is
@@ -267,7 +286,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     // capacity. `settlement` is set only when a payment was verified and is
     // therefore owed once the work completes.
     const gate = this.currentGate();
-    let settlement: X402ValidClassification | undefined;
+    let settlement: X402Settlement | undefined;
     if (gate) {
       const outcome = await gate.open({
         taskId,
@@ -297,7 +316,10 @@ export class WSForwardingExecutor extends AgentExecutor {
         }
         return;
       }
-      settlement = outcome.classified;
+      settlement =
+        outcome.classified && outcome.pricing
+          ? { classified: outcome.classified, pricing: outcome.pricing }
+          : undefined;
     }
 
     const queue = new AsyncEventQueue<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>();

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -122,7 +122,10 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
         A2A_EXTENSIONS_HEADER,
         A2A_EXTENSIONS_LEGACY_HEADER,
       ],
-      allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+      // PUT is here for /admin-api/agents/:id/x402. Without it a browser
+      // client (the Vite dev UI) fails preflight even though the CLI's Node
+      // fetch, which sends no preflight, gets through.
+      allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
       credentials: true,
       maxAge: 600,
     }),

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -150,6 +150,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   const agentCardOpts: AgentA2XOptions = {
     publicUrl: opts.publicUrl,
     deviceFlowEnabled,
+    db: opts.db,
   };
 
   function getAgentForConn(conn: ClientConnection): A2XServer {

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -19,12 +19,15 @@ import { requestUsage, UsageRpcError } from './usage-rpc.js';
 import {
   AdminApiError,
   addCaller,
+  clearX402Pricing,
   deleteClientForOwner,
+  getX402Pricing,
   issueAgentApiKey,
   listActiveAgents,
   listCallers,
   listClientsForOwner,
   removeCaller,
+  setX402Pricing,
 } from './admin-api.js';
 import {
   AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS,
@@ -420,6 +423,60 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     if (!auth.ok) return adminApiUnauthorized(c, auth);
     try {
       const result = await listCallers(opts.db, auth.principalId, c.req.param('id'));
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  // x402 pricing. The only write path for `agents.x402_pricing` — it is
+  // DB-owned rather than declared by the connecting agent because `payTo`
+  // names the wallet that gets paid. Unlike the agent's own token, these
+  // routes take the owner-session bearer, so a stolen agent token cannot
+  // reprice or redirect payments.
+  app.get('/admin-api/agents/:id/x402', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
+    try {
+      return c.json(await getX402Pricing(opts.db, auth.principalId, c.req.param('id')));
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  app.put('/admin-api/agents/:id/x402', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'Body must be a JSON x402 pricing object.' }, 400);
+    }
+    try {
+      const result = await setX402Pricing(
+        opts.db,
+        opts.registry,
+        auth.principalId,
+        c.req.param('id'),
+        body,
+      );
+      return c.json(result);
+    } catch (err) {
+      return adminApiErrorResponse(c, err);
+    }
+  });
+
+  app.delete('/admin-api/agents/:id/x402', async (c) => {
+    const auth = await authOwnerSession(c);
+    if (!auth.ok) return adminApiUnauthorized(c, auth);
+    try {
+      const result = await clearX402Pricing(
+        opts.db,
+        opts.registry,
+        auth.principalId,
+        c.req.param('id'),
+      );
       return c.json(result);
     } catch (err) {
       return adminApiErrorResponse(c, err);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -4,6 +4,8 @@ import { createHttpApp } from './http.js';
 import { attachWsServer } from './ws.js';
 import { PostgresTaskStore } from './postgres-task-store.js';
 import { logEvent } from './log.js';
+import { sweepExpiredX402Offerings } from './x402/store.js';
+import { watchX402PricingChanges } from './x402/pricing-watch.js';
 import type { Sql } from './db.js';
 import type { GoogleConfig } from './auth/google-oauth.js';
 
@@ -29,6 +31,16 @@ async function cleanupExpiredTransients(db: Sql): Promise<void> {
     await db`DELETE FROM used_siwe_nonces WHERE expires_at <= now()`;
   } catch (err) {
     console.error('[server] used_siwe_nonces cleanup failed:', err);
+  }
+  try {
+    // Lazy expiry hides a lapsed offering from `get` but never deletes it, so
+    // every caller that walks away at the `input-required` turn leaves a row
+    // behind. On a public paid agent that is an unauthenticated way to grow
+    // the table, which is why this runs rather than relying on task teardown.
+    const deleted = await sweepExpiredX402Offerings(db);
+    if (deleted > 0) logEvent('x402_offerings_swept', { deleted });
+  } catch (err) {
+    console.error('[server] x402_offerings cleanup failed:', err);
   }
 }
 
@@ -83,6 +95,13 @@ export async function startServer(opts: ServerOptions) {
   runCleanup();
   const cleanupTimer = setInterval(runCleanup, TRANSIENT_CLEANUP_INTERVAL_MS);
   cleanupTimer.unref();
+
+  // Pricing is cached on the live connection, and an admin write only patches
+  // the instance that served it. Without this, an agent repriced (or made
+  // free) on one instance keeps billing at the old price from another until it
+  // reconnects. Best-effort: a failed subscription degrades to that same
+  // reconnect-scoped behavior rather than blocking startup.
+  void watchX402PricingChanges(opts.db, registry);
 
   console.log(`[server] listening on :${opts.port}`);
   return { registry, server };

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -1,5 +1,5 @@
 import type { WebSocket } from 'ws';
-import type { AgentCard, DownFrame } from '@vicoop-bridge/protocol';
+import type { AgentCard, DownFrame, TaskUsage } from '@vicoop-bridge/protocol';
 import { encodeFrame } from '@vicoop-bridge/protocol';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { logEvent, truncate } from './log.js';
@@ -58,6 +58,13 @@ export interface TaskBinding {
   // router), a ~0 count points upstream (client never emitted). Lazily
   // initialized; incremented in ws.ts's `task.status` handler.
   heartbeats?: number;
+  // Token consumption reported on the client's `task.complete` frame, stashed
+  // here by ws.ts so the executor can price the task without re-deriving it
+  // from wire metadata. Server-internal: it is billing input and is never
+  // published back onto the A2A event. Set before the terminal status is
+  // pushed to the sink, so it is always visible by the time the executor
+  // reads the terminal event off the queue.
+  usage?: TaskUsage;
 }
 
 export type CallerChangeListener = (agentId: string, callers: string[]) => void;

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -4,6 +4,7 @@ import { encodeFrame } from '@vicoop-bridge/protocol';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { logEvent, truncate } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
+import type { X402Pricing } from './x402/pricing.js';
 
 export interface ClientConnection {
   agentId: string;
@@ -17,6 +18,11 @@ export interface ClientConnection {
   backendKind?: string;
   agentCard: AgentCard;
   allowedCallers: string[];
+  // x402 pricing from the agent's DB row, or undefined for a free agent (the
+  // default). DB-sourced, never read off the hello frame: `payTo` names the
+  // wallet that gets paid, so the same trust boundary applies as to
+  // `allowedCallers`.
+  x402Pricing?: X402Pricing;
   ws: WebSocket;
   connectedAt: number;
 }

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -301,6 +301,27 @@ export class Registry {
     }
   }
 
+  /**
+   * Apply a pricing change to the live connection.
+   *
+   * The executor re-reads `x402Pricing` off the connection on every turn, so
+   * this alone makes repricing take effect on the next call. It also fires
+   * the agent-change signal because the AgentCard advertises the price, and
+   * the card (plus the request handler built around it) is cached per agent —
+   * without the eviction a repriced agent would keep publishing the old
+   * figures until it reconnected.
+   *
+   * A no-op when the agent is not currently connected: the new pricing is
+   * already in the database and will be read at its next hello.
+   */
+  updateX402Pricing(agentId: string, pricing: X402Pricing | undefined): void {
+    const conn = this.agents.get(agentId);
+    if (!conn) return;
+    if (pricing === undefined) delete conn.x402Pricing;
+    else conn.x402Pricing = pricing;
+    this.notifyAgentChange(agentId);
+  }
+
   private notifyAgentChange(agentId: string): void {
     for (const listener of this.agentChangeListeners) {
       try {

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -326,6 +326,125 @@ test('task.complete log carries the forwarded heartbeat count, ignoring plain wo
   }
 });
 
+test('task.complete usage lands on the binding before the terminal status is delivered', async () => {
+  // This is the billing input for the x402 `upto` scheme. The executor reads
+  // it off the binding when it consumes the terminal event, so it has to be
+  // set by the time that event is pushed — asserting it from inside the sink
+  // is what pins that ordering.
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+
+    let usageAtTerminal: unknown;
+    const binding = {
+      agentId: 'agent-1',
+      taskId: 'task-usage',
+      contextId: 'ctx-usage',
+      sink: {
+        pushStatus: () => {
+          usageAtTerminal = binding.usage;
+        },
+        pushArtifact: () => {},
+        finish: () => {},
+      },
+    } as Parameters<Registry['bindTask']>[0];
+    registry.bindTask(binding);
+
+    ws.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-usage',
+      status: { state: 'completed', timestamp: '2026-06-18T00:00:00.000Z' },
+      usage: {
+        promptTokens: 1000,
+        completionTokens: 200,
+        cachedInputTokens: 900,
+        model: 'claude-sonnet-4',
+      },
+    }));
+
+    const deadline = Date.now() + 1_000;
+    while (usageAtTerminal === undefined) {
+      assert.ok(Date.now() < deadline, 'timed out waiting for the terminal status');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.deepEqual(usageAtTerminal, {
+      promptTokens: 1000,
+      completionTokens: 200,
+      cachedInputTokens: 900,
+      model: 'claude-sonnet-4',
+    });
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('a task.complete without usage leaves the binding unpriced rather than zeroed', async () => {
+  // Absent must not be normalized into a zero anywhere along the path: the
+  // two mean different things to the meter, and only one of them is free.
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+
+    let delivered = false;
+    const binding = {
+      agentId: 'agent-1',
+      taskId: 'task-nousage',
+      contextId: 'ctx-nousage',
+      sink: {
+        pushStatus: () => {
+          delivered = true;
+        },
+        pushArtifact: () => {},
+        finish: () => {},
+      },
+    } as Parameters<Registry['bindTask']>[0];
+    registry.bindTask(binding);
+
+    ws.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-nousage',
+      status: { state: 'completed', timestamp: '2026-06-18T00:00:00.000Z' },
+    }));
+
+    const deadline = Date.now() + 1_000;
+    while (!delivered) {
+      assert.ok(Date.now() < deadline, 'timed out waiting for the terminal status');
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(binding.usage, undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('task.status without metadata leaves TaskStatusUpdateEvent.metadata unset', async () => {
   const server = createServer();
   const registry = new Registry();

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -337,6 +337,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           });
           return;
         }
+        // Stash the reported token usage before the terminal status reaches
+        // the sink: the executor prices the task off the binding when it
+        // consumes that event, and pushStatus only enqueues, so setting it
+        // first makes the ordering unconditional.
+        if (frame.usage !== undefined) b.usage = frame.usage;
         b.sink.pushStatus({
           taskId: frame.taskId,
           contextId: b.contextId,

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -18,6 +18,7 @@ import { isReservedAgentId } from './reserved-agent-ids.js';
 import { resolveHelloAgentCard } from './card-resolver.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { resolveUsageResponse } from './usage-rpc.js';
+import { parseX402Pricing } from './x402/pricing.js';
 
 // Diagnostic (issue #414): is this `task.status` frame a tagged liveness
 // heartbeat (non-terminal working status carrying
@@ -35,6 +36,7 @@ interface ClientRow {
   owner_principal: string;
   owner_email: string | null;
   allowed_callers: string[];
+  x402_pricing: unknown;
 }
 
 async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | null> {
@@ -43,7 +45,7 @@ async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | nu
   // deleted simply matches nothing and the daemon sees the 4005 "bad token"
   // path.
   const rows = await sql<ClientRow[]>`
-    SELECT id, client_id, owner_principal, owner_email, allowed_callers
+    SELECT id, client_id, owner_principal, owner_email, allowed_callers, x402_pricing
     FROM agents
     WHERE token_hash = ${hash}
   `;
@@ -128,6 +130,21 @@ async function authenticateAndRegister(
     return { ok: false, code: resolvedCard.code, reason: resolvedCard.reason };
   }
 
+  // A malformed pricing row must not take the agent offline — it would turn
+  // an operator typo into an outage. Log it and connect the agent as free;
+  // the gate is then never installed, so nobody is charged against a config
+  // the server could not read.
+  let x402Pricing;
+  try {
+    x402Pricing = parseX402Pricing(client.x402_pricing);
+  } catch (err) {
+    logEvent('x402_pricing_invalid', {
+      agentId: frame.agentId,
+      clientId,
+      error: String(err),
+    });
+  }
+
   const result = opts.registry.registerAgent({
     agentId: frame.agentId,
     clientId,
@@ -136,6 +153,7 @@ async function authenticateAndRegister(
     backendKind: frame.backendKind,
     agentCard: resolvedCard.agentCard,
     allowedCallers: client.allowed_callers,
+    ...(x402Pricing !== undefined ? { x402Pricing } : {}),
     ws,
     connectedAt: Date.now(),
   });

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -1,0 +1,411 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { TaskState, type Message } from '@a2x/sdk';
+import {
+  X402Context,
+  InMemoryX402Store,
+  X402_METADATA_KEYS,
+  X402_PAYMENT_STATUS,
+  type X402Facilitator,
+  type X402PaymentPayload,
+  type X402VerifyResponse,
+  type X402FacilitatorSettleResponse,
+} from '@a2x/sdk/x402';
+import { X402Gate } from './gate.js';
+import { parseX402Pricing, type X402Pricing } from './pricing.js';
+
+const RESOURCE = 'https://bridge.test/agents/a1';
+const PAY_TO = '0x1111111111111111111111111111111111111111';
+
+const PRICING: X402Pricing = parseX402Pricing({
+  network: 'eip155:84532',
+  amount: '10000',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: PAY_TO,
+})!;
+
+// Stub facilitator: the on-chain half of x402. Recording the calls lets the
+// tests assert not just the outcome but whether settlement was attempted at
+// all — the difference between "charged for failed work" and "not charged".
+function stubFacilitator(
+  opts: {
+    verify?: X402VerifyResponse;
+    settle?: X402FacilitatorSettleResponse;
+    settleThrows?: boolean;
+  } = {},
+): X402Facilitator & { verifyCalls: number; settleCalls: number } {
+  const state = {
+    verifyCalls: 0,
+    settleCalls: 0,
+    async verify(): Promise<X402VerifyResponse> {
+      state.verifyCalls += 1;
+      return opts.verify ?? { isValid: true };
+    },
+    async settle(): Promise<X402FacilitatorSettleResponse> {
+      state.settleCalls += 1;
+      if (opts.settleThrows) throw new Error('facilitator unreachable');
+      return (
+        opts.settle ?? {
+          success: true,
+          transaction: '0xdeadbeef',
+          network: 'eip155:84532',
+          payer: '0x2222222222222222222222222222222222222222',
+        }
+      );
+    },
+  };
+  return state;
+}
+
+function makeGate(facilitator: X402Facilitator): X402Gate {
+  return new X402Gate(
+    'a1',
+    PRICING,
+    new X402Context({ store: new InMemoryX402Store(), facilitator, x402Version: 2 }),
+  );
+}
+
+function userMessage(metadata?: Record<string, unknown>): Message {
+  return {
+    messageId: `m-${Math.random().toString(16).slice(2)}`,
+    role: 'user',
+    parts: [{ text: 'do the thing' }],
+    ...(metadata !== undefined ? { metadata } : {}),
+  } as unknown as Message;
+}
+
+/** The `accepts[0]` requirement the merchant published on turn 1. */
+function offeredRequirement(event: {
+  status: { message?: { metadata?: Record<string, unknown> } };
+}): Record<string, unknown> {
+  const required = event.status.message?.metadata?.[X402_METADATA_KEYS.REQUIRED] as {
+    accepts: Record<string, unknown>[];
+  };
+  return required.accepts[0]!;
+}
+
+/**
+ * A turn-2 message carrying a signed `exact` payload that echoes the offered
+ * requirement — the shape `@x402/evm` produces for an EIP-3009 signature.
+ */
+function submissionMessage(
+  requirement: Record<string, unknown>,
+  overrides: { to?: string; value?: string } = {},
+): Message {
+  const payload: X402PaymentPayload = {
+    x402Version: 2,
+    accepted: requirement as never,
+    payload: {
+      signature: `0x${'ab'.repeat(65)}`,
+      authorization: {
+        from: '0x2222222222222222222222222222222222222222',
+        to: overrides.to ?? PAY_TO,
+        value: overrides.value ?? '10000',
+        validAfter: '0',
+        validBefore: String(Math.floor(Date.now() / 1000) + 3600),
+        nonce: `0x${'11'.repeat(32)}`,
+      },
+    },
+  } as X402PaymentPayload;
+
+  return userMessage({
+    [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.SUBMITTED,
+    [X402_METADATA_KEYS.PAYLOAD]: payload,
+  });
+}
+
+test('turn 1 halts with input-required carrying the payment-required offering', async () => {
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const outcome = await gate.open({
+    taskId: 't-1',
+    contextId: 'ctx-1',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.INPUT_REQUIRED);
+  // `final` ends the SSE stream without terminating the task, which is what
+  // lets the client resume the same taskId on turn 2.
+  assert.equal(outcome.event.final, true);
+
+  const metadata = outcome.event.status.message?.metadata ?? {};
+  assert.equal(metadata[X402_METADATA_KEYS.STATUS], X402_PAYMENT_STATUS.REQUIRED);
+
+  const requirement = offeredRequirement(outcome.event);
+  assert.equal(requirement.payTo, PAY_TO);
+  assert.equal(requirement.amount, '10000');
+  assert.equal(requirement.scheme, 'exact');
+  assert.equal(requirement.network, 'eip155:84532');
+
+  // V2 hoists the resource out of each requirement to the envelope's top
+  // level, so that is where the payer's wallet reads what it is paying for.
+  const required = outcome.event.status.message?.metadata?.[X402_METADATA_KEYS.REQUIRED] as {
+    x402Version: number;
+    resource: { url: string };
+  };
+  assert.equal(required.x402Version, 2);
+  assert.equal(required.resource.url, RESOURCE);
+
+  // Nothing was charged just by asking.
+  assert.equal(facilitator.verifyCalls, 0);
+  assert.equal(facilitator.settleCalls, 0);
+});
+
+test('turn 2 with a valid signed payload verifies and proceeds', async () => {
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-2',
+    contextId: 'ctx-2',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 't-2',
+    contextId: 'ctx-2',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+
+  assert.equal(second.kind, 'proceed');
+  assert.equal(facilitator.verifyCalls, 1);
+  // Verification alone must not move money — settlement waits for the work.
+  assert.equal(facilitator.settleCalls, 0);
+});
+
+test('a submission whose taskId was never offered is refused', async () => {
+  // The horizontally-scaled failure mode this store exists to prevent: if the
+  // offering is missing, the payload must be refused rather than trusted.
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const offering = await gate.open({
+    taskId: 't-known',
+    contextId: 'ctx',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(offering.kind, 'halt');
+  if (offering.kind !== 'halt') return;
+
+  const outcome = await gate.open({
+    taskId: 't-unknown',
+    contextId: 'ctx',
+    message: submissionMessage(offeredRequirement(offering.event)),
+    resource: RESOURCE,
+  });
+
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.FAILED);
+  assert.equal(facilitator.verifyCalls, 0);
+});
+
+test('a payload paying the wrong recipient is refused before the facilitator', async () => {
+  // The signature is bound to `to`; a payload redirecting funds elsewhere is
+  // caught locally, so a malicious client cannot even spend facilitator quota.
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-3',
+    contextId: 'ctx-3',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const outcome = await gate.open({
+    taskId: 't-3',
+    contextId: 'ctx-3',
+    message: submissionMessage(offeredRequirement(first.event), {
+      to: '0x9999999999999999999999999999999999999999',
+    }),
+    resource: RESOURCE,
+  });
+
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.FAILED);
+  assert.equal(facilitator.verifyCalls, 0);
+});
+
+test('a failed facilitator verification halts without settling', async () => {
+  const facilitator = stubFacilitator({
+    verify: { isValid: false, invalidReason: 'insufficient_funds' },
+  });
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-4',
+    contextId: 'ctx-4',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const outcome = await gate.open({
+    taskId: 't-4',
+    contextId: 'ctx-4',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.FAILED);
+  assert.equal(
+    outcome.event.status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
+    X402_PAYMENT_STATUS.FAILED,
+  );
+  assert.equal(facilitator.settleCalls, 0);
+});
+
+test('a store or facilitator error fails closed instead of serving the call free', async () => {
+  const facilitator: X402Facilitator = {
+    async verify() {
+      throw new Error('facilitator down');
+    },
+    async settle() {
+      throw new Error('facilitator down');
+    },
+  };
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-5',
+    contextId: 'ctx-5',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const outcome = await gate.open({
+    taskId: 't-5',
+    contextId: 'ctx-5',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+
+  // The important part is that it is NOT 'proceed' — an unpaid call must
+  // never reach the agent because the payment rail was unavailable.
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.FAILED);
+});
+
+test('settle attaches the receipt metadata on success', async () => {
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-6',
+    contextId: 'ctx-6',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 't-6',
+    contextId: 'ctx-6',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed' || !second.classified) return;
+
+  const result = await gate.settle({
+    taskId: 't-6',
+    contextId: 'ctx-6',
+    classified: second.classified,
+  });
+
+  assert.equal(result.kind, 'settled');
+  if (result.kind !== 'settled') return;
+  assert.equal(result.metadata[X402_METADATA_KEYS.STATUS], X402_PAYMENT_STATUS.COMPLETED);
+  const receipts = result.metadata[X402_METADATA_KEYS.RECEIPTS] as { transaction: string }[];
+  assert.equal(receipts[0]!.transaction, '0xdeadbeef');
+  assert.equal(facilitator.settleCalls, 1);
+});
+
+test('a failed settlement replaces the terminal event so the task cannot report success', async () => {
+  const facilitator = stubFacilitator({
+    settle: { success: false, errorReason: 'INSUFFICIENT_FUNDS' },
+  });
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-7',
+    contextId: 'ctx-7',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 't-7',
+    contextId: 'ctx-7',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed' || !second.classified) return;
+
+  const result = await gate.settle({
+    taskId: 't-7',
+    contextId: 'ctx-7',
+    classified: second.classified,
+  });
+
+  assert.equal(result.kind, 'failed');
+  if (result.kind !== 'failed') return;
+  assert.equal(result.event.status.state, TaskState.FAILED);
+  assert.equal(
+    result.event.status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
+    X402_PAYMENT_STATUS.FAILED,
+  );
+});
+
+test('a throwing settlement is reported as a failure, not propagated', async () => {
+  const facilitator = stubFacilitator({ settleThrows: true });
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 't-8',
+    contextId: 'ctx-8',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 't-8',
+    contextId: 'ctx-8',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed' || !second.classified) return;
+
+  const result = await gate.settle({
+    taskId: 't-8',
+    contextId: 'ctx-8',
+    classified: second.classified,
+  });
+  assert.equal(result.kind, 'failed');
+});

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -12,7 +12,7 @@ import {
   type X402VerifyResponse,
   type X402FacilitatorSettleResponse,
 } from '@a2x/sdk/x402';
-import { X402Gate } from './gate.js';
+import { X402Gate, type X402OfferingSidecar } from './gate.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
 import type { TaskUsage } from './usage.js';
 
@@ -72,11 +72,42 @@ function stubFacilitator(
   return state as X402Facilitator & typeof state;
 }
 
-function makeGate(facilitator: X402Facilitator, pricing: X402Pricing = PRICING): X402Gate {
+/**
+ * In-memory stand-in for the Postgres sidecar: the pricing snapshot taken when
+ * an offering is published, and the one-shot claim that stops a replayed
+ * submission from running the work twice.
+ */
+function memorySidecar(): X402OfferingSidecar & { claims: number } {
+  const pricingByTask = new Map<string, X402Pricing>();
+  const claimed = new Set<string>();
+  return {
+    claims: 0,
+    async putPricing(taskId, pricing) {
+      pricingByTask.set(taskId, pricing);
+    },
+    async getPricing(taskId) {
+      return pricingByTask.get(taskId);
+    },
+    async claim(taskId) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      (this as { claims: number }).claims += 1;
+      if (claimed.has(taskId)) return false;
+      claimed.add(taskId);
+      return true;
+    },
+  } as X402OfferingSidecar & { claims: number };
+}
+
+function makeGate(
+  facilitator: X402Facilitator,
+  pricing: X402Pricing = PRICING,
+  sidecar: X402OfferingSidecar = memorySidecar(),
+): X402Gate {
   return new X402Gate(
     'a1',
     pricing,
     new X402Context({ store: new InMemoryX402Store(), facilitator, x402Version: 2 }),
+    sidecar,
   );
 }
 
@@ -346,6 +377,7 @@ test('settle attaches the receipt metadata on success', async () => {
     taskId: 't-6',
     contextId: 'ctx-6',
     classified: second.classified,
+    pricing: second.pricing!,
   });
 
   assert.equal(result.kind, 'settled');
@@ -384,6 +416,7 @@ test('a failed settlement replaces the terminal event so the task cannot report 
     taskId: 't-7',
     contextId: 'ctx-7',
     classified: second.classified,
+    pricing: second.pricing!,
   });
 
   assert.equal(result.kind, 'failed');
@@ -421,6 +454,7 @@ test('a throwing settlement is reported as a failure, not propagated', async () 
     taskId: 't-8',
     contextId: 'ctx-8',
     classified: second.classified,
+    pricing: second.pricing!,
   });
   assert.equal(result.kind, 'failed');
 });
@@ -476,7 +510,7 @@ async function uptoVerified(
   facilitator: X402Facilitator,
   taskId: string,
   pricing: X402Pricing = UPTO_PRICING,
-): Promise<{ gate: X402Gate; classified: X402ValidClassification }> {
+): Promise<{ gate: X402Gate; classified: X402ValidClassification; pricing: X402Pricing }> {
   const gate = makeGate(facilitator, pricing);
   const first = await gate.open({
     taskId,
@@ -495,7 +529,8 @@ async function uptoVerified(
   });
   assert.equal(second.kind, 'proceed', 'upto submission should verify');
   if (second.kind !== 'proceed' || !second.classified) throw new Error('unreachable');
-  return { gate, classified: second.classified };
+  assert.ok(second.pricing, 'open must hand back the offering pricing snapshot');
+  return { gate, classified: second.classified, pricing: second.pricing };
 }
 
 test('an upto offering advertises the ceiling and the facilitator address', async () => {
@@ -519,7 +554,7 @@ test('an upto offering advertises the ceiling and the facilitator address', asyn
 
 test('upto settles the metered charge, not the authorized ceiling', async () => {
   const facilitator = stubFacilitator();
-  const { gate, classified } = await uptoVerified(facilitator, 'u-2');
+  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-2');
 
   // 100k in @ $3/MTok + 10k out @ $15/MTok = 450000 atomic, well under the
   // 1000000 ceiling the payer authorized.
@@ -532,6 +567,7 @@ test('upto settles the metered charge, not the authorized ceiling', async () => 
     taskId: 'u-2',
     contextId: 'ctx-u-2',
     classified,
+    pricing,
     usage,
   });
 
@@ -541,7 +577,7 @@ test('upto settles the metered charge, not the authorized ceiling', async () => 
 
 test('a metered charge above the ceiling is clamped down to it', async () => {
   const facilitator = stubFacilitator();
-  const { gate, classified } = await uptoVerified(facilitator, 'u-3');
+  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-3');
 
   // 10M input tokens prices to 30000000 — 30x the authorized ceiling. The
   // SDK clamps, which is what makes a pricing mistake unable to overcharge.
@@ -549,6 +585,7 @@ test('a metered charge above the ceiling is clamped down to it', async () => {
     taskId: 'u-3',
     contextId: 'ctx-u-3',
     classified,
+    pricing,
     usage: { prompt_tokens: 10_000_000, completion_tokens: 0, total_tokens: 10_000_000 },
   });
 
@@ -571,12 +608,13 @@ test('upto settles the floor when the backend reported no usage', async () => {
     minAmount: '25000',
     facilitatorAddress: FACILITATOR,
   })!;
-  const { gate, classified } = await uptoVerified(facilitator, 'u-4', priced);
+  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-4', priced);
 
   const result = await gate.settle({
     taskId: 'u-4',
     contextId: 'ctx-u-4',
     classified,
+    pricing,
     usage: undefined,
   });
 
@@ -589,12 +627,13 @@ test('upto with no usage and no floor settles zero rather than the ceiling', asy
   // maximum because *our* instrumentation lost the token count would be a
   // user-visible wrong, where undercharging is our own loss to fix.
   const facilitator = stubFacilitator();
-  const { gate, classified } = await uptoVerified(facilitator, 'u-5');
+  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-5');
 
   const result = await gate.settle({
     taskId: 'u-5',
     contextId: 'ctx-u-5',
     classified,
+    pricing,
     usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
   });
 
@@ -630,6 +669,7 @@ test('an exact agent ignores usage and settles the signed amount', async () => {
     taskId: 'u-6',
     contextId: 'ctx-u-6',
     classified: second.classified,
+    pricing: second.pricing!,
     usage: { prompt_tokens: 999, completion_tokens: 999, total_tokens: 1998 },
   });
 
@@ -637,7 +677,124 @@ test('an exact agent ignores usage and settles the signed amount', async () => {
   assert.equal(facilitator.settledAmount, '10000');
 });
 
-test('the gate reports whether it meters, so the executor knows to read usage', () => {
-  assert.equal(makeGate(stubFacilitator(), UPTO_PRICING).metered, true);
-  assert.equal(makeGate(stubFacilitator()).metered, false);
+// ── the offering's terms are frozen, and usable once ──────────────────────
+
+test('settlement prices from the offering, not from a reprice that landed between turns', async () => {
+  // The two turns are separate requests, so the agent can be repriced in
+  // between. Settling from live pricing would meter turn 2 against terms turn
+  // 1 never signed — and when an `upto` offering met `exact` pricing, the
+  // metering branch was skipped and the SDK settled the full authorized
+  // ceiling instead of the metered charge.
+  const facilitator = stubFacilitator();
+  const store = new InMemoryX402Store();
+  const sidecar = memorySidecar();
+  const context = () =>
+    new X402Context({ store, facilitator, x402Version: 2 });
+
+  const atOfferTime = new X402Gate('a1', UPTO_PRICING, context(), sidecar);
+  const first = await atOfferTime.open({
+    taskId: 'reprice',
+    contextId: 'ctx-reprice',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  // Admin reprices to a flat fee. The executor rebuilds the gate on the next
+  // turn, so turn 2 runs with entirely different live pricing.
+  const afterReprice = new X402Gate('a1', PRICING, context(), sidecar);
+  const second = await afterReprice.open({
+    taskId: 'reprice',
+    contextId: 'ctx-reprice',
+    message: uptoSubmissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed' || !second.classified || !second.pricing) return;
+
+  // `open` hands back the frozen terms, not what the agent charges now.
+  assert.equal(second.pricing.scheme, 'upto');
+
+  await afterReprice.settle({
+    taskId: 'reprice',
+    contextId: 'ctx-reprice',
+    classified: second.classified,
+    pricing: second.pricing,
+    usage: { prompt_tokens: 100_000, completion_tokens: 10_000, total_tokens: 110_000 },
+  });
+
+  // Metered, not the 1000000 ceiling the old code would have settled.
+  assert.equal(facilitator.settledAmount, '450000');
+});
+
+test('a replayed submission is refused instead of running the work twice', async () => {
+  // `classify()` does not inspect the entry's status, so the same signed
+  // payload classifies valid every time it is sent. Without the claim the
+  // backend would run again for one authorization.
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 'replay',
+    contextId: 'ctx-replay',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const submission = submissionMessage(offeredRequirement(first.event));
+  const attempt = () =>
+    gate.open({
+      taskId: 'replay',
+      contextId: 'ctx-replay',
+      message: submission,
+      resource: RESOURCE,
+    });
+
+  assert.equal((await attempt()).kind, 'proceed');
+
+  const replay = await attempt();
+  assert.equal(replay.kind, 'halt');
+  if (replay.kind !== 'halt') return;
+  assert.equal(replay.event.status.state, TaskState.FAILED);
+  // The claim is taken before verify, so the replay costs no facilitator call.
+  assert.equal(facilitator.verifyCalls, 1);
+});
+
+test('a missing pricing snapshot refuses the call rather than guessing a price', async () => {
+  // Written in the same breath as the offering, so absence means corruption.
+  // Falling back to live pricing here is exactly the bug the snapshot exists
+  // to prevent, so the safe direction is to refuse.
+  const facilitator = stubFacilitator();
+  const sidecar = memorySidecar();
+  const forgetful: X402OfferingSidecar = {
+    putPricing: async () => {},
+    getPricing: async () => undefined,
+    claim: (taskId) => sidecar.claim(taskId),
+  };
+  const gate = makeGate(facilitator, PRICING, forgetful);
+
+  const first = await gate.open({
+    taskId: 'no-snapshot',
+    contextId: 'ctx-no-snapshot',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 'no-snapshot',
+    contextId: 'ctx-no-snapshot',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+
+  assert.equal(second.kind, 'halt');
+  if (second.kind !== 'halt') return;
+  assert.equal(second.event.status.state, TaskState.FAILED);
+  assert.equal(facilitator.verifyCalls, 0);
+  assert.equal(facilitator.settleCalls, 0);
 });

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -8,14 +8,17 @@ import {
   X402_PAYMENT_STATUS,
   type X402Facilitator,
   type X402PaymentPayload,
+  type X402ValidClassification,
   type X402VerifyResponse,
   type X402FacilitatorSettleResponse,
 } from '@a2x/sdk/x402';
 import { X402Gate } from './gate.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
+import type { TaskUsage } from './usage.js';
 
 const RESOURCE = 'https://bridge.test/agents/a1';
 const PAY_TO = '0x1111111111111111111111111111111111111111';
+const FACILITATOR = '0x3333333333333333333333333333333333333333';
 
 const PRICING: X402Pricing = parseX402Pricing({
   network: 'eip155:84532',
@@ -33,16 +36,28 @@ function stubFacilitator(
     settle?: X402FacilitatorSettleResponse;
     settleThrows?: boolean;
   } = {},
-): X402Facilitator & { verifyCalls: number; settleCalls: number } {
+): X402Facilitator & {
+  verifyCalls: number;
+  settleCalls: number;
+  // The amount on the requirement handed to `settle` — under `upto` this is
+  // the metered charge after the SDK's clamp, i.e. what the payer is billed.
+  settledAmount?: string;
+} {
   const state = {
     verifyCalls: 0,
     settleCalls: 0,
+    settledAmount: undefined as string | undefined,
     async verify(): Promise<X402VerifyResponse> {
       state.verifyCalls += 1;
       return opts.verify ?? { isValid: true };
     },
-    async settle(): Promise<X402FacilitatorSettleResponse> {
+    async settle(
+      _payload: unknown,
+      requirements: unknown,
+    ): Promise<X402FacilitatorSettleResponse> {
       state.settleCalls += 1;
+      const r = requirements as { amount?: string; maxAmountRequired?: string };
+      state.settledAmount = r.amount ?? r.maxAmountRequired;
       if (opts.settleThrows) throw new Error('facilitator unreachable');
       return (
         opts.settle ?? {
@@ -54,13 +69,13 @@ function stubFacilitator(
       );
     },
   };
-  return state;
+  return state as X402Facilitator & typeof state;
 }
 
-function makeGate(facilitator: X402Facilitator): X402Gate {
+function makeGate(facilitator: X402Facilitator, pricing: X402Pricing = PRICING): X402Gate {
   return new X402Gate(
     'a1',
-    PRICING,
+    pricing,
     new X402Context({ store: new InMemoryX402Store(), facilitator, x402Version: 2 }),
   );
 }
@@ -408,4 +423,221 @@ test('a throwing settlement is reported as a failure, not propagated', async () 
     classified: second.classified,
   });
   assert.equal(result.kind, 'failed');
+});
+
+// ── upto: metered settlement ──────────────────────────────────────────────
+
+const UPTO_PRICING: X402Pricing = parseX402Pricing({
+  scheme: 'upto',
+  network: 'eip155:84532',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: PAY_TO,
+  maxAmount: '1000000', // 1 USDC ceiling
+  rates: { input: '3000000', output: '15000000' }, // $3 / $15 per MTok
+  facilitatorAddress: FACILITATOR,
+})!;
+
+/** A turn-2 message carrying a Permit2 witness — the `upto` signed shape. */
+function uptoSubmissionMessage(
+  requirement: Record<string, unknown>,
+  overrides: { authorized?: string } = {},
+): Message {
+  const payload: X402PaymentPayload = {
+    x402Version: 2,
+    accepted: requirement as never,
+    payload: {
+      signature: `0x${'cd'.repeat(65)}`,
+      permit2Authorization: {
+        from: '0x2222222222222222222222222222222222222222',
+        permitted: {
+          token: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          amount: overrides.authorized ?? '1000000',
+        },
+        spender: '0x4444444444444444444444444444444444444444',
+        nonce: `0x${'22'.repeat(32)}`,
+        deadline: String(Math.floor(Date.now() / 1000) + 3600),
+        witness: {
+          to: PAY_TO,
+          facilitator: FACILITATOR,
+          validAfter: '0',
+        },
+      },
+    },
+  } as X402PaymentPayload;
+
+  return userMessage({
+    [X402_METADATA_KEYS.STATUS]: X402_PAYMENT_STATUS.SUBMITTED,
+    [X402_METADATA_KEYS.PAYLOAD]: payload,
+  });
+}
+
+/** Run an upto round-trip to a verified payment, ready to settle. */
+async function uptoVerified(
+  facilitator: X402Facilitator,
+  taskId: string,
+  pricing: X402Pricing = UPTO_PRICING,
+): Promise<{ gate: X402Gate; classified: X402ValidClassification }> {
+  const gate = makeGate(facilitator, pricing);
+  const first = await gate.open({
+    taskId,
+    contextId: `ctx-${taskId}`,
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') throw new Error('unreachable');
+
+  const second = await gate.open({
+    taskId,
+    contextId: `ctx-${taskId}`,
+    message: uptoSubmissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed', 'upto submission should verify');
+  if (second.kind !== 'proceed' || !second.classified) throw new Error('unreachable');
+  return { gate, classified: second.classified };
+}
+
+test('an upto offering advertises the ceiling and the facilitator address', async () => {
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator, UPTO_PRICING);
+
+  const outcome = await gate.open({
+    taskId: 'u-1',
+    contextId: 'ctx-u1',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(outcome.kind, 'halt');
+  if (outcome.kind !== 'halt') return;
+
+  const requirement = offeredRequirement(outcome.event);
+  assert.equal(requirement.scheme, 'upto');
+  assert.equal(requirement.amount, '1000000');
+  assert.deepEqual(requirement.extra, { facilitatorAddress: FACILITATOR });
+});
+
+test('upto settles the metered charge, not the authorized ceiling', async () => {
+  const facilitator = stubFacilitator();
+  const { gate, classified } = await uptoVerified(facilitator, 'u-2');
+
+  // 100k in @ $3/MTok + 10k out @ $15/MTok = 450000 atomic, well under the
+  // 1000000 ceiling the payer authorized.
+  const usage: TaskUsage = {
+    prompt_tokens: 100_000,
+    completion_tokens: 10_000,
+    total_tokens: 110_000,
+  };
+  const result = await gate.settle({
+    taskId: 'u-2',
+    contextId: 'ctx-u-2',
+    classified,
+    usage,
+  });
+
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '450000');
+});
+
+test('a metered charge above the ceiling is clamped down to it', async () => {
+  const facilitator = stubFacilitator();
+  const { gate, classified } = await uptoVerified(facilitator, 'u-3');
+
+  // 10M input tokens prices to 30000000 — 30x the authorized ceiling. The
+  // SDK clamps, which is what makes a pricing mistake unable to overcharge.
+  const result = await gate.settle({
+    taskId: 'u-3',
+    contextId: 'ctx-u-3',
+    classified,
+    usage: { prompt_tokens: 10_000_000, completion_tokens: 0, total_tokens: 10_000_000 },
+  });
+
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '1000000');
+});
+
+test('upto settles the floor when the backend reported no usage', async () => {
+  // openclaw reports nothing; codex can emit {0,0,0} when its runtime drops
+  // accounting. Charging zero for delivered work is a real loss, so an
+  // operator who sets minAmount gets that instead.
+  const facilitator = stubFacilitator();
+  const priced = parseX402Pricing({
+    scheme: 'upto',
+    network: 'eip155:84532',
+    asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    payTo: PAY_TO,
+    maxAmount: '1000000',
+    rates: { input: '3000000', output: '15000000' },
+    minAmount: '25000',
+    facilitatorAddress: FACILITATOR,
+  })!;
+  const { gate, classified } = await uptoVerified(facilitator, 'u-4', priced);
+
+  const result = await gate.settle({
+    taskId: 'u-4',
+    contextId: 'ctx-u-4',
+    classified,
+    usage: undefined,
+  });
+
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '25000');
+});
+
+test('upto with no usage and no floor settles zero rather than the ceiling', async () => {
+  // The default direction is payer-favourable on purpose: billing the
+  // maximum because *our* instrumentation lost the token count would be a
+  // user-visible wrong, where undercharging is our own loss to fix.
+  const facilitator = stubFacilitator();
+  const { gate, classified } = await uptoVerified(facilitator, 'u-5');
+
+  const result = await gate.settle({
+    taskId: 'u-5',
+    contextId: 'ctx-u-5',
+    classified,
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  });
+
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '0');
+});
+
+test('an exact agent ignores usage and settles the signed amount', async () => {
+  // Metering an `exact` requirement throws in the SDK, so the gate must not
+  // pass an amount through for a flat-fee agent even when usage is present.
+  const facilitator = stubFacilitator();
+  const gate = makeGate(facilitator);
+
+  const first = await gate.open({
+    taskId: 'u-6',
+    contextId: 'ctx-u-6',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+
+  const second = await gate.open({
+    taskId: 'u-6',
+    contextId: 'ctx-u-6',
+    message: submissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed' || !second.classified) return;
+
+  const result = await gate.settle({
+    taskId: 'u-6',
+    contextId: 'ctx-u-6',
+    classified: second.classified,
+    usage: { prompt_tokens: 999, completion_tokens: 999, total_tokens: 1998 },
+  });
+
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '10000');
+});
+
+test('the gate reports whether it meters, so the executor knows to read usage', () => {
+  assert.equal(makeGate(stubFacilitator(), UPTO_PRICING).metered, true);
+  assert.equal(makeGate(stubFacilitator()).metered, false);
 });

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -77,25 +77,33 @@ function stubFacilitator(
  * an offering is published, and the one-shot claim that stops a replayed
  * submission from running the work twice.
  */
-function memorySidecar(): X402OfferingSidecar & { claims: number } {
+interface MemorySidecar extends X402OfferingSidecar {
+  /** Test hook: force the stored terms out of step with the offering. */
+  overwritePricing(taskId: string, pricing: X402Pricing): void;
+}
+
+function memorySidecar(): MemorySidecar {
   const pricingByTask = new Map<string, X402Pricing>();
   const claimed = new Set<string>();
   return {
-    claims: 0,
-    async putPricing(taskId, pricing) {
+    // The real store records the terms in the same statement as the offering;
+    // recording them here on entry is the equivalent for a double.
+    async publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T> {
       pricingByTask.set(taskId, pricing);
+      return fn();
     },
     async getPricing(taskId) {
       return pricingByTask.get(taskId);
     },
     async claim(taskId) {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      (this as { claims: number }).claims += 1;
       if (claimed.has(taskId)) return false;
       claimed.add(taskId);
       return true;
     },
-  } as X402OfferingSidecar & { claims: number };
+    overwritePricing(taskId, pricing) {
+      pricingByTask.set(taskId, pricing);
+    },
+  };
 }
 
 function makeGate(
@@ -754,7 +762,7 @@ test('a snapshot that disagrees with the signed requirement is refused, not sile
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
-  await sidecar.putPricing('mismatch', PRICING);
+  sidecar.overwritePricing('mismatch', PRICING);
 
   const second = await gate.open({
     taskId: 'mismatch',
@@ -777,7 +785,7 @@ test('a missing pricing snapshot refuses the call rather than guessing a price',
   const facilitator = stubFacilitator();
   const sidecar = memorySidecar();
   const forgetful: X402OfferingSidecar = {
-    putPricing: async () => {},
+    publishing: (_t, _p, fn) => fn(),
     getPricing: async () => undefined,
     claim: (taskId) => sidecar.claim(taskId),
   };

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -12,7 +12,7 @@ import {
   type X402VerifyResponse,
   type X402FacilitatorSettleResponse,
 } from '@a2x/sdk/x402';
-import { X402Gate, type X402OfferingSidecar } from './gate.js';
+import { X402Gate, type X402GateOutcome, type X402OfferingSidecar } from './gate.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
 import type { TaskUsage } from './usage.js';
 
@@ -222,9 +222,18 @@ test('turn 2 with a valid signed payload verifies and proceeds', async () => {
   });
 
   assert.equal(second.kind, 'proceed');
+  if (second.kind !== 'proceed') return;
   assert.equal(facilitator.verifyCalls, 1);
-  // Verification alone must not move money — settlement waits for the work.
-  assert.equal(facilitator.settleCalls, 0);
+  // Flat-fee agents charge here, before the caller's work is forwarded — the
+  // amount was fixed at offer time, so there is nothing to learn by doing the
+  // work first.
+  assert.equal(facilitator.settleCalls, 1);
+  assert.equal(second.settlement?.mode, 'settled');
+  if (second.settlement?.mode !== 'settled') return;
+  const receipts = second.settlement.metadata[X402_METADATA_KEYS.RECEIPTS] as {
+    transaction: string;
+  }[];
+  assert.equal(receipts[0]!.transaction, '0xdeadbeef');
 });
 
 test('a submission whose taskId was never offered is refused', async () => {
@@ -351,112 +360,67 @@ test('a store or facilitator error fails closed instead of serving the call free
   assert.equal(outcome.event.status.state, TaskState.FAILED);
 });
 
-test('settle attaches the receipt metadata on success', async () => {
-  const facilitator = stubFacilitator();
+/** Turn 1 then turn 2 for a flat-fee agent, returning turn 2's outcome. */
+async function exactTurnTwo(
+  facilitator: X402Facilitator,
+  taskId: string,
+): Promise<X402GateOutcome> {
   const gate = makeGate(facilitator);
-
   const first = await gate.open({
-    taskId: 't-6',
-    contextId: 'ctx-6',
+    taskId,
+    contextId: `ctx-${taskId}`,
     message: userMessage(),
     resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-
-  const second = await gate.open({
-    taskId: 't-6',
-    contextId: 'ctx-6',
+  if (first.kind !== 'halt') throw new Error('unreachable');
+  return gate.open({
+    taskId,
+    contextId: `ctx-${taskId}`,
     message: submissionMessage(offeredRequirement(first.event)),
     resource: RESOURCE,
   });
-  assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed' || !second.classified) return;
+}
 
-  const result = await gate.settle({
-    taskId: 't-6',
-    contextId: 'ctx-6',
-    classified: second.classified,
-    pricing: second.pricing!,
-  });
+test('a flat fee settles before the work and hands back the receipt', async () => {
+  const facilitator = stubFacilitator();
+  const outcome = await exactTurnTwo(facilitator, 't-6');
 
-  assert.equal(result.kind, 'settled');
-  if (result.kind !== 'settled') return;
-  assert.equal(result.metadata[X402_METADATA_KEYS.STATUS], X402_PAYMENT_STATUS.COMPLETED);
-  const receipts = result.metadata[X402_METADATA_KEYS.RECEIPTS] as { transaction: string }[];
+  assert.equal(outcome.kind, 'proceed');
+  if (outcome.kind !== 'proceed' || outcome.settlement?.mode !== 'settled') return;
+  assert.equal(
+    outcome.settlement.metadata[X402_METADATA_KEYS.STATUS],
+    X402_PAYMENT_STATUS.COMPLETED,
+  );
+  const receipts = outcome.settlement.metadata[X402_METADATA_KEYS.RECEIPTS] as {
+    transaction: string;
+  }[];
   assert.equal(receipts[0]!.transaction, '0xdeadbeef');
   assert.equal(facilitator.settleCalls, 1);
 });
 
-test('a failed settlement replaces the terminal event so the task cannot report success', async () => {
+test('a flat fee that cannot be collected never reaches the agent', async () => {
+  // The point of settling first: a drained authorization costs the merchant
+  // nothing, because the work has not been done yet. Under the previous
+  // settle-after-work order this same failure meant the caller kept the output.
   const facilitator = stubFacilitator({
     settle: { success: false, errorReason: 'INSUFFICIENT_FUNDS' },
   });
-  const gate = makeGate(facilitator);
+  const outcome = await exactTurnTwo(facilitator, 't-7');
 
-  const first = await gate.open({
-    taskId: 't-7',
-    contextId: 'ctx-7',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-
-  const second = await gate.open({
-    taskId: 't-7',
-    contextId: 'ctx-7',
-    message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
-  });
-  assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed' || !second.classified) return;
-
-  const result = await gate.settle({
-    taskId: 't-7',
-    contextId: 'ctx-7',
-    classified: second.classified,
-    pricing: second.pricing!,
-  });
-
-  assert.equal(result.kind, 'failed');
-  if (result.kind !== 'failed') return;
-  assert.equal(result.event.status.state, TaskState.FAILED);
+  assert.equal(outcome.kind, 'halt', 'the turn must not proceed to the backend');
+  if (outcome.kind !== 'halt') return;
+  assert.equal(outcome.event.status.state, TaskState.FAILED);
   assert.equal(
-    result.event.status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
+    outcome.event.status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
     X402_PAYMENT_STATUS.FAILED,
   );
 });
 
-test('a throwing settlement is reported as a failure, not propagated', async () => {
+test('a throwing settlement halts the turn rather than propagating', async () => {
   const facilitator = stubFacilitator({ settleThrows: true });
-  const gate = makeGate(facilitator);
-
-  const first = await gate.open({
-    taskId: 't-8',
-    contextId: 'ctx-8',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-
-  const second = await gate.open({
-    taskId: 't-8',
-    contextId: 'ctx-8',
-    message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
-  });
-  assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed' || !second.classified) return;
-
-  const result = await gate.settle({
-    taskId: 't-8',
-    contextId: 'ctx-8',
-    classified: second.classified,
-    pricing: second.pricing!,
-  });
-  assert.equal(result.kind, 'failed');
+  const outcome = await exactTurnTwo(facilitator, 't-8');
+  assert.equal(outcome.kind, 'halt');
 });
 
 // ── upto: metered settlement ──────────────────────────────────────────────
@@ -528,9 +492,17 @@ async function uptoVerified(
     resource: RESOURCE,
   });
   assert.equal(second.kind, 'proceed', 'upto submission should verify');
-  if (second.kind !== 'proceed' || !second.classified) throw new Error('unreachable');
-  assert.ok(second.pricing, 'open must hand back the offering pricing snapshot');
-  return { gate, classified: second.classified, pricing: second.pricing };
+  if (second.kind !== 'proceed' || second.settlement?.mode !== 'deferred') {
+    throw new Error('a metered offering must defer settlement until after the work');
+  }
+  // Metered agents must not have moved money yet — the charge does not exist
+  // until the work has been done.
+  assert.equal((facilitator as { settleCalls?: number }).settleCalls, 0);
+  return {
+    gate,
+    classified: second.settlement.classified,
+    pricing: second.settlement.pricing,
+  };
 }
 
 test('an upto offering advertises the ceiling and the facilitator address', async () => {
@@ -662,18 +634,11 @@ test('an exact agent ignores usage and settles the signed amount', async () => {
     message: submissionMessage(offeredRequirement(first.event)),
     resource: RESOURCE,
   });
+  // Settled inside `open`, at the signed amount, with usage nowhere in play —
+  // metering an `exact` requirement throws in the SDK.
   assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed' || !second.classified) return;
-
-  const result = await gate.settle({
-    taskId: 'u-6',
-    contextId: 'ctx-u-6',
-    classified: second.classified,
-    pricing: second.pricing!,
-    usage: { prompt_tokens: 999, completion_tokens: 999, total_tokens: 1998 },
-  });
-
-  assert.equal(result.kind, 'settled');
+  if (second.kind !== 'proceed') return;
+  assert.equal(second.settlement?.mode, 'settled');
   assert.equal(facilitator.settledAmount, '10000');
 });
 
@@ -711,16 +676,18 @@ test('settlement prices from the offering, not from a reprice that landed betwee
     resource: RESOURCE,
   });
   assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed' || !second.classified || !second.pricing) return;
+  if (second.kind !== 'proceed' || second.settlement?.mode !== 'deferred') return;
 
-  // `open` hands back the frozen terms, not what the agent charges now.
-  assert.equal(second.pricing.scheme, 'upto');
+  // `open` hands back the frozen terms, not what the agent charges now — and
+  // defers, because the offering was metered even though the agent is now
+  // flat-fee. Settling here as `exact` would have charged the ceiling.
+  assert.equal(second.settlement.pricing.scheme, 'upto');
 
   await afterReprice.settle({
     taskId: 'reprice',
     contextId: 'ctx-reprice',
-    classified: second.classified,
-    pricing: second.pricing,
+    classified: second.settlement.classified,
+    pricing: second.settlement.pricing,
     usage: { prompt_tokens: 100_000, completion_tokens: 10_000, total_tokens: 110_000 },
   });
 

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -763,6 +763,46 @@ test('a replayed submission is refused instead of running the work twice', async
   assert.equal(facilitator.verifyCalls, 1);
 });
 
+test('a snapshot that disagrees with the signed requirement is refused, not silently unmetered', async () => {
+  // Concurrent turn-1s racing a reprice can leave the offering and the
+  // snapshot describing different schemes. Merely skipping the metering
+  // branch is the expensive failure: an `upto` requirement with no amount
+  // settles the full authorized ceiling.
+  const facilitator = stubFacilitator();
+  const store = new InMemoryX402Store();
+  const sidecar = memorySidecar();
+
+  // Publish an `upto` offering, then corrupt the snapshot to `exact`.
+  const gate = new X402Gate(
+    'a1',
+    UPTO_PRICING,
+    new X402Context({ store, facilitator, x402Version: 2 }),
+    sidecar,
+  );
+  const first = await gate.open({
+    taskId: 'mismatch',
+    contextId: 'ctx-mismatch',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+  if (first.kind !== 'halt') return;
+  await sidecar.putPricing('mismatch', PRICING);
+
+  const second = await gate.open({
+    taskId: 'mismatch',
+    contextId: 'ctx-mismatch',
+    message: uptoSubmissionMessage(offeredRequirement(first.event)),
+    resource: RESOURCE,
+  });
+
+  assert.equal(second.kind, 'halt');
+  if (second.kind !== 'halt') return;
+  assert.equal(second.event.status.state, TaskState.FAILED);
+  assert.equal(facilitator.verifyCalls, 0, 'refused before the facilitator is involved');
+  assert.equal(facilitator.settleCalls, 0);
+});
+
 test('a missing pricing snapshot refuses the call rather than guessing a price', async () => {
   // Written in the same breath as the offering, so absence means corruption.
   // Falling back to live pricing here is exactly the bug the snapshot exists

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -86,11 +86,16 @@ function memorySidecar(): MemorySidecar {
   const pricingByTask = new Map<string, X402Pricing>();
   const claimed = new Set<string>();
   return {
-    // The real store records the terms in the same statement as the offering;
-    // recording them here on entry is the equivalent for a double.
-    async publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T> {
-      pricingByTask.set(taskId, pricing);
-      return fn();
+    // The real store serializes publishers and keeps the first live terms.
+    // This double has no expiry, so an existing entry is always live.
+    async publishing<T>(
+      taskId: string,
+      pricing: X402Pricing,
+      fn: (frozenPricing: X402Pricing) => Promise<T>,
+    ): Promise<T> {
+      const frozenPricing = pricingByTask.get(taskId) ?? pricing;
+      pricingByTask.set(taskId, frozenPricing);
+      return fn(frozenPricing);
     },
     async getPricing(taskId) {
       return pricingByTask.get(taskId);
@@ -703,6 +708,50 @@ test('settlement prices from the offering, not from a reprice that landed betwee
   assert.equal(facilitator.settledAmount, '450000');
 });
 
+test('a repeated unpaid turn reuses the live offering terms after a reprice', async () => {
+  // A continuation without payment metadata is classified as `no-submission`
+  // without consulting the store. It must not replace the snapshot that a
+  // concurrent signed continuation may already have classified.
+  const facilitator = stubFacilitator();
+  const store = new InMemoryX402Store();
+  const sidecar = memorySidecar();
+  const context = () => new X402Context({ store, facilitator, x402Version: 2 });
+
+  const original = new X402Gate('a1', UPTO_PRICING, context(), sidecar);
+  const first = await original.open({
+    taskId: 'unpaid-retry',
+    contextId: 'ctx-unpaid-retry',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(first.kind, 'halt');
+
+  const repriced = parseX402Pricing({
+    ...UPTO_PRICING,
+    rates: { input: '9000000', output: '45000000', cachedInput: '900000' },
+  })!;
+  const afterReprice = new X402Gate('a1', repriced, context(), sidecar);
+
+  const repeated = await afterReprice.open({
+    taskId: 'unpaid-retry',
+    contextId: 'ctx-unpaid-retry',
+    message: userMessage(),
+    resource: RESOURCE,
+  });
+  assert.equal(repeated.kind, 'halt');
+  if (repeated.kind !== 'halt') return;
+
+  const submitted = await afterReprice.open({
+    taskId: 'unpaid-retry',
+    contextId: 'ctx-unpaid-retry',
+    message: uptoSubmissionMessage(offeredRequirement(repeated.event)),
+    resource: RESOURCE,
+  });
+  assert.equal(submitted.kind, 'proceed');
+  if (submitted.kind !== 'proceed' || submitted.settlement?.mode !== 'deferred') return;
+  assert.deepEqual(submitted.settlement.pricing, UPTO_PRICING);
+});
+
 test('a replayed submission is refused instead of running the work twice', async () => {
   // `classify()` does not inspect the entry's status, so the same signed
   // payload classifies valid every time it is sent. Without the claim the
@@ -785,7 +834,7 @@ test('a missing pricing snapshot refuses the call rather than guessing a price',
   const facilitator = stubFacilitator();
   const sidecar = memorySidecar();
   const forgetful: X402OfferingSidecar = {
-    publishing: (_t, _p, fn) => fn(),
+    publishing: (_t, pricing, fn) => fn(pricing),
     getPricing: async () => undefined,
     claim: (taskId) => sidecar.claim(taskId),
   };

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -137,7 +137,12 @@ export interface X402GateParams {
  * without a database.
  */
 export interface X402OfferingSidecar {
-  putPricing(taskId: string, pricing: X402Pricing): Promise<void>;
+  /**
+   * Run `fn` with `pricing` bound to whatever offering it publishes, so the
+   * two are written together. Anything less leaves a window where concurrent
+   * turn-1s racing a reprice pair one offering with the other's terms.
+   */
+  publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T>;
   getPricing(taskId: string): Promise<X402Pricing | undefined>;
   /** `true` for the one caller that wins the right to act on a submission. */
   claim(taskId: string): Promise<boolean>;
@@ -211,24 +216,24 @@ export class X402Gate {
         // Turn 1. `requestPayment` persists the offering (status `offered`,
         // with the TTL) and yields the `request-input` event we translate.
         const accepts = pricingToAccepts(this.pricing, resource);
-        // Freeze the terms *before* the offering exists. The SDK owns the
-        // entry write, so the two cannot share one statement; ordering it this
-        // way means an entry never exists without a snapshot, and the failure
-        // mode of a crash in between is a snapshot with no offering — which
-        // reads as "no offering" and is refused, rather than an offering with
-        // no terms.
-        await this.sidecar.putPricing(taskId, this.pricing);
         let metadata: Record<string, unknown> | undefined;
         let text: string | undefined;
-        for await (const event of this.x402.requestPayment(ctx, {
-          accepts,
-          expiresInSeconds: OFFERING_TTL_SECONDS,
-        })) {
-          if (event.type === 'request-input') {
-            metadata = event.metadata;
-            text = event.message;
+        // The terms ride along with the offering write the SDK performs inside
+        // here, in one statement. Writing them separately — in either order —
+        // leaves a window where two concurrent turn-1s racing a reprice
+        // interleave into one agent's offering paired with the other's rates.
+        // Both would be the same scheme, so no shape check downstream can tell.
+        await this.sidecar.publishing(taskId, this.pricing, async () => {
+          for await (const event of this.x402.requestPayment(ctx, {
+            accepts,
+            expiresInSeconds: OFFERING_TTL_SECONDS,
+          })) {
+            if (event.type === 'request-input') {
+              metadata = event.metadata;
+              text = event.message;
+            }
           }
-        }
+        });
         if (metadata === undefined) {
           // `requestPayment` always yields a `request-input`; reaching here
           // means the SDK contract changed under us. Refuse rather than

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -138,11 +138,17 @@ export interface X402GateParams {
  */
 export interface X402OfferingSidecar {
   /**
-   * Run `fn` with `pricing` bound to whatever offering it publishes, so the
-   * two are written together. Anything less leaves a window where concurrent
-   * turn-1s racing a reprice pair one offering with the other's terms.
+   * Serialize publishers for this task and run `fn` with the terms frozen for
+   * its live offering. The first live offering wins; later unpaid turns reuse
+   * it instead of replacing terms underneath an in-flight signed submission.
+   * The implementation also binds the returned pricing to the SDK's offering
+   * write so the two land in one statement.
    */
-  publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T>;
+  publishing<T>(
+    taskId: string,
+    pricing: X402Pricing,
+    fn: (frozenPricing: X402Pricing) => Promise<T>,
+  ): Promise<T>;
   getPricing(taskId: string): Promise<X402Pricing | undefined>;
   /** `true` for the one caller that wins the right to act on a submission. */
   claim(taskId: string): Promise<boolean>;
@@ -215,15 +221,16 @@ export class X402Gate {
       if (classified.kind === 'no-submission') {
         // Turn 1. `requestPayment` persists the offering (status `offered`,
         // with the TTL) and yields the `request-input` event we translate.
-        const accepts = pricingToAccepts(this.pricing, resource);
         let metadata: Record<string, unknown> | undefined;
         let text: string | undefined;
+        let offeredPricing = this.pricing;
         // The terms ride along with the offering write the SDK performs inside
-        // here, in one statement. Writing them separately — in either order —
-        // leaves a window where two concurrent turn-1s racing a reprice
-        // interleave into one agent's offering paired with the other's rates.
-        // Both would be the same scheme, so no shape check downstream can tell.
-        await this.sidecar.publishing(taskId, this.pricing, async () => {
+        // here, in one statement. Publishers for one task are serialized and
+        // reuse a still-live snapshot, so a new unpaid turn cannot replace the
+        // rates after a signed turn has classified but before it claims.
+        await this.sidecar.publishing(taskId, this.pricing, async (frozenPricing) => {
+          offeredPricing = frozenPricing;
+          const accepts = pricingToAccepts(frozenPricing, resource);
           for await (const event of this.x402.requestPayment(ctx, {
             accepts,
             expiresInSeconds: OFFERING_TTL_SECONDS,
@@ -243,7 +250,7 @@ export class X402Gate {
         logEvent('x402_payment_required', {
           agentId: this.agentId,
           taskId,
-          ...this.offeringFields(this.pricing),
+          ...this.offeringFields(offeredPricing),
         });
         return {
           kind: 'halt',

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -67,18 +67,35 @@ export function createPostgresX402Context(
  *   (`input-required`, awaiting the client's signed resubmission) or it was
  *   refused (`failed`).
  */
-export type X402GateOutcome =
+/**
+ * What the caller still owes, once the gate has cleared a turn to run.
+ *
+ * The two schemes settle at opposite ends of the work, and the difference is
+ * not an implementation detail — it decides who carries the risk when things
+ * go wrong.
+ *
+ * - `settled` (`exact`): already charged, before the agent was contacted. The
+ *   amount is fixed and known up front, so there is no reason to hand over the
+ *   work first and hope the authorization is still good afterwards.
+ * - `deferred` (`upto`): the charge comes from consumption, which does not
+ *   exist until the work is done, so settlement can only follow it.
+ */
+export type X402Settlement =
+  | { mode: 'settled'; metadata: Record<string, unknown> }
   | {
-      kind: 'proceed';
-      classified?: X402ValidClassification;
+      mode: 'deferred';
+      classified: X402ValidClassification;
       /**
        * The pricing the offering was published under, read back from the
        * store. Settlement uses this, never the agent's live pricing — the two
        * turns are separate requests and a reprice in between would otherwise
        * meter against terms the payer never signed.
        */
-      pricing?: X402Pricing;
-    }
+      pricing: X402Pricing;
+    };
+
+export type X402GateOutcome =
+  | { kind: 'proceed'; settlement?: X402Settlement }
   | { kind: 'halt'; event: TaskStatusUpdateEvent };
 
 export interface X402GateParams {
@@ -336,7 +353,32 @@ export class X402Gate {
         taskId,
         ...this.offeringFields(settlementPricing),
       });
-      return { kind: 'proceed', classified, pricing: settlementPricing };
+
+      if (settlementPricing.scheme === 'upto') {
+        // Metered: the charge does not exist until the work has been done, so
+        // settlement has to follow it. See the note on `settleTerminal`.
+        return {
+          kind: 'proceed',
+          settlement: { mode: 'deferred', classified, pricing: settlementPricing },
+        };
+      }
+
+      // Flat fee: charge now, before the agent is contacted. The amount was
+      // fixed at offer time and the payer has signed for exactly it, so there
+      // is nothing to learn by doing the work first — and doing it first means
+      // handing over the result and only then discovering the authorization
+      // has been drained. A failure here costs nobody: no charge, no work.
+      //
+      // Safe to do here only because `claim` above is a one-shot: without it a
+      // replayed submission would settle a second time.
+      const settled = await this.settle({
+        taskId,
+        contextId,
+        classified,
+        pricing: settlementPricing,
+      });
+      if (settled.kind === 'failed') return { kind: 'halt', event: settled.event };
+      return { kind: 'proceed', settlement: { mode: 'settled', metadata: settled.metadata } };
     } catch (err) {
       // Facilitator unreachable, DB down, malformed offering — fail closed.
       logEvent('x402_gate_error', {
@@ -475,7 +517,10 @@ export class X402Gate {
 
     const done = this.x402.completedEvent({ receipt });
     const metadata = done.type === 'done' ? (done.metadata ?? {}) : {};
-    await this.clear(taskId);
+    // Deliberately does not clear the offering. Under `exact` this runs before
+    // the work, and dropping the row would release the claim mid-task — a
+    // resubmission would then be treated as a fresh payment and charged again.
+    // The executor clears once the task reaches a terminal state.
     return { kind: 'settled', metadata };
   }
 

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -194,6 +194,13 @@ export class X402Gate {
         // Turn 1. `requestPayment` persists the offering (status `offered`,
         // with the TTL) and yields the `request-input` event we translate.
         const accepts = pricingToAccepts(this.pricing, resource);
+        // Freeze the terms *before* the offering exists. The SDK owns the
+        // entry write, so the two cannot share one statement; ordering it this
+        // way means an entry never exists without a snapshot, and the failure
+        // mode of a crash in between is a snapshot with no offering — which
+        // reads as "no offering" and is refused, rather than an offering with
+        // no terms.
+        await this.sidecar.putPricing(taskId, this.pricing);
         let metadata: Record<string, unknown> | undefined;
         let text: string | undefined;
         for await (const event of this.x402.requestPayment(ctx, {
@@ -211,10 +218,6 @@ export class X402Gate {
           // silently serve the call for free.
           throw new Error('x402 requestPayment yielded no request-input event');
         }
-        // Freeze the terms alongside the offering. Turn 2 settles from this,
-        // so a reprice between the turns cannot change what the payer is
-        // charged for a requirement they already signed.
-        await this.sidecar.putPricing(taskId, this.pricing);
         logEvent('x402_payment_required', {
           agentId: this.agentId,
           taskId,
@@ -272,8 +275,9 @@ export class X402Gate {
       // agent charges right now.
       const settlementPricing = await this.sidecar.getPricing(taskId);
       if (settlementPricing === undefined) {
-        // Written in the same breath as the offering, so this is corruption
-        // rather than a normal state. Refuse instead of guessing a price.
+        // Written before the offering row carries an entry, so absence here
+        // is corruption rather than a normal state. Refuse instead of
+        // guessing a price.
         logEvent('x402_pricing_snapshot_missing', { agentId: this.agentId, taskId });
         return {
           kind: 'halt',
@@ -282,6 +286,32 @@ export class X402Gate {
             contextId,
             code: 'SETTLEMENT_FAILED',
             reason: 'The terms this payment was offered under are no longer available.',
+          }),
+        };
+      }
+
+      // The snapshot and the requirement the payer actually signed must name
+      // the same scheme. Concurrent turn-1s racing a reprice can leave the two
+      // disagreeing, and the disagreement is expensive in one specific
+      // direction: an `upto` requirement paired with an `exact` snapshot skips
+      // the metering branch, which hands the SDK no amount and settles the
+      // full authorized ceiling. Refuse rather than let a mismatch pick a
+      // price — merely skipping the metering is not a safe default here.
+      const signedScheme = requirementScheme(classified.requirement);
+      if (signedScheme !== settlementPricing.scheme) {
+        logEvent('x402_scheme_mismatch', {
+          agentId: this.agentId,
+          taskId,
+          signed: signedScheme,
+          snapshot: settlementPricing.scheme,
+        });
+        return {
+          kind: 'halt',
+          event: this.failedEvent({
+            taskId,
+            contextId,
+            code: 'SETTLEMENT_FAILED',
+            reason: 'The offered terms and the signed payment disagree; start a new task.',
           }),
         };
       }

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -1,0 +1,345 @@
+import {
+  X402Context,
+  X402_FOUNDATION_EXTENSION_URI,
+  type BaseX402Context,
+  type X402ValidClassification,
+  type X402SettleResponse,
+} from '@a2x/sdk/x402';
+import { TaskState, type Message, type TaskStatusUpdateEvent } from '@a2x/sdk';
+import type { Sql } from '../db.js';
+import { logEvent } from '../log.js';
+import { PostgresX402Store } from './store.js';
+import { pricingToAccepts, type X402Pricing } from './pricing.js';
+
+export { X402_FOUNDATION_EXTENSION_URI };
+
+// The x402 wire version this deployment emits. V2 is the x402 Foundation
+// A2A transport — CAIP-2 networks, top-level `resource`, and the only version
+// with a path to the usage-based `upto` scheme, which is where metered
+// per-token billing eventually goes. The SDK still defaults to V1 for
+// compatibility with the older reference lineage, so we opt in explicitly and
+// leave an escape hatch for a deployment that has to serve V1-only clients.
+const X402_VERSION: 1 | 2 = process.env.BRIDGE_X402_VERSION === '1' ? 1 : 2;
+
+// How long a payer has to sign and resubmit before the offering lapses. Past
+// it the store reports no offering and the submission is refused — the payer
+// is never charged for a lapsed offer, they just have to start over.
+const OFFERING_TTL_SECONDS = (() => {
+  const raw = process.env.BRIDGE_X402_OFFER_TTL_SECONDS;
+  const n = raw ? Number(raw) : Number.NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 600;
+})();
+
+/**
+ * Build the payment context this deployment runs on: offerings in Postgres,
+ * settlement through the configured facilitator (the SDK's hosted default
+ * when `BRIDGE_X402_FACILITATOR_URL` is unset).
+ *
+ * Separate from `X402Gate` so tests can drive the gate with an in-memory
+ * store and a stub facilitator instead of a database and a live chain.
+ */
+export function createPostgresX402Context(sql: Sql, agentId: string): X402Context {
+  const url = process.env.BRIDGE_X402_FACILITATOR_URL;
+  return new X402Context({
+    store: new PostgresX402Store(sql, agentId),
+    x402Version: X402_VERSION,
+    ...(url ? { facilitator: { url } } : {}),
+  });
+}
+
+/**
+ * Outcome of running the payment gate on an inbound turn.
+ *
+ * - `proceed` — nothing to charge for, or the payment verified. Run the work.
+ *   `classified` is present exactly when a settlement is owed afterwards.
+ * - `halt` — emit `event` and end the turn. Either the payment was requested
+ *   (`input-required`, awaiting the client's signed resubmission) or it was
+ *   refused (`failed`).
+ */
+export type X402GateOutcome =
+  | { kind: 'proceed'; classified?: X402ValidClassification }
+  | { kind: 'halt'; event: TaskStatusUpdateEvent };
+
+export interface X402GateParams {
+  taskId: string;
+  contextId: string;
+  message: Message;
+  /** Public URL of the agent being paid for — shown in the payer's wallet. */
+  resource: string;
+}
+
+/**
+ * Server-side x402 payment gate for one agent.
+ *
+ * Sits in front of `WSForwardingExecutor`'s forwarding path and implements
+ * the merchant half of the x402 A2A round-trip:
+ *
+ *   turn 1  unpaid request      → `input-required` + `x402.payment.required`
+ *   turn 2  signed resubmission → verify → forward to the agent → settle
+ *
+ * The bridge drives this through the SDK's `X402Context` rather than the
+ * `BaseAgent.run()` path the SDK documents, because `WSForwardingExecutor`
+ * overrides `execute`/`executeStream` outright — there is no in-process agent
+ * to host the flow. `X402Context`'s methods take a structural
+ * `{ taskId, message }`, so they compose with a custom executor unchanged;
+ * only the events need translating, which `haltEvent` does.
+ *
+ * Settlement is deliberately deferred until the agent has finished
+ * successfully: an `exact` payment is a charge for delivered work, so a task
+ * that fails or is cancelled is never settled and the payer's signed
+ * authorization simply goes unused.
+ */
+export class X402Gate {
+  constructor(
+    private readonly agentId: string,
+    private readonly pricing: X402Pricing,
+    private readonly x402: BaseX402Context,
+  ) {}
+
+  /**
+   * Classify the inbound turn and either request payment, refuse it, or clear
+   * the request to run.
+   *
+   * Facilitator or store failures resolve to a `halt` rather than throwing:
+   * an unpaid request must never fall through to the agent, so the safe
+   * direction on an unexpected error is to refuse the call.
+   */
+  async open(params: X402GateParams): Promise<X402GateOutcome> {
+    const { taskId, contextId, message, resource } = params;
+    const ctx = { taskId, message };
+
+    try {
+      const classified = await this.x402.classify(ctx);
+
+      if (classified.kind === 'no-submission') {
+        // Turn 1. `requestPayment` persists the offering (status `offered`,
+        // with the TTL) and yields the `request-input` event we translate.
+        const accepts = pricingToAccepts(this.pricing, resource);
+        let metadata: Record<string, unknown> | undefined;
+        let text: string | undefined;
+        for await (const event of this.x402.requestPayment(ctx, {
+          accepts,
+          expiresInSeconds: OFFERING_TTL_SECONDS,
+        })) {
+          if (event.type === 'request-input') {
+            metadata = event.metadata;
+            text = event.message;
+          }
+        }
+        if (metadata === undefined) {
+          // `requestPayment` always yields a `request-input`; reaching here
+          // means the SDK contract changed under us. Refuse rather than
+          // silently serve the call for free.
+          throw new Error('x402 requestPayment yielded no request-input event');
+        }
+        logEvent('x402_payment_required', {
+          agentId: this.agentId,
+          taskId,
+          amount: this.pricing.amount,
+          asset: this.pricing.asset,
+          network: this.pricing.network,
+        });
+        return {
+          kind: 'halt',
+          event: this.statusEvent({
+            taskId,
+            contextId,
+            state: TaskState.INPUT_REQUIRED,
+            text: text ?? 'Payment required to invoke this agent.',
+            metadata,
+          }),
+        };
+      }
+
+      if (classified.kind !== 'valid') {
+        // `classify` has already recorded the failure on the store entry.
+        logEvent('x402_payment_refused', {
+          agentId: this.agentId,
+          taskId,
+          reason: classified.kind,
+          code: classified.code,
+        });
+        return {
+          kind: 'halt',
+          event: this.failedEvent({
+            taskId,
+            contextId,
+            code: classified.code,
+            reason: classified.reason,
+          }),
+        };
+      }
+
+      const verify = await this.x402.verify(ctx, classified);
+      if (!verify.isValid) {
+        const reason = verify.invalidReason ?? 'Payment verification failed.';
+        logEvent('x402_verify_failed', { agentId: this.agentId, taskId, reason });
+        return {
+          kind: 'halt',
+          event: this.failedEvent({
+            taskId,
+            contextId,
+            code: 'VERIFY_FAILED',
+            reason,
+          }),
+        };
+      }
+
+      logEvent('x402_payment_verified', {
+        agentId: this.agentId,
+        taskId,
+        amount: this.pricing.amount,
+        network: this.pricing.network,
+      });
+      return { kind: 'proceed', classified };
+    } catch (err) {
+      // Facilitator unreachable, DB down, malformed offering — fail closed.
+      logEvent('x402_gate_error', {
+        agentId: this.agentId,
+        taskId,
+        error: String(err),
+      });
+      return {
+        kind: 'halt',
+        event: this.failedEvent({
+          taskId,
+          contextId,
+          code: 'SETTLEMENT_FAILED',
+          reason: 'Payment processing is temporarily unavailable.',
+        }),
+      };
+    }
+  }
+
+  /**
+   * Settle a verified payment after the agent completed the work.
+   *
+   * Returns metadata to merge onto the task's final status message on
+   * success, or a replacement terminal event when settlement failed — the
+   * merchant was not paid, so the task must not report success.
+   */
+  async settle(params: {
+    taskId: string;
+    contextId: string;
+    classified: X402ValidClassification;
+  }): Promise<
+    | { kind: 'settled'; metadata: Record<string, unknown> }
+    | { kind: 'failed'; event: TaskStatusUpdateEvent }
+  > {
+    const { taskId, contextId, classified } = params;
+    const ctx = { taskId };
+    let receipt: X402SettleResponse;
+    try {
+      receipt = await this.x402.settle(ctx, classified);
+    } catch (err) {
+      logEvent('x402_settle_error', {
+        agentId: this.agentId,
+        taskId,
+        error: String(err),
+      });
+      return {
+        kind: 'failed',
+        event: this.failedEvent({
+          taskId,
+          contextId,
+          code: 'SETTLEMENT_FAILED',
+          reason: 'Payment settlement failed.',
+        }),
+      };
+    }
+
+    if (!receipt.success) {
+      logEvent('x402_settle_failed', {
+        agentId: this.agentId,
+        taskId,
+        reason: receipt.errorReason ?? 'unknown',
+      });
+      return {
+        kind: 'failed',
+        event: this.failedEvent({
+          taskId,
+          contextId,
+          code: 'SETTLEMENT_FAILED',
+          reason: receipt.errorReason ?? 'Payment settlement failed.',
+          failureReceipt: receipt,
+        }),
+      };
+    }
+
+    logEvent('x402_settled', {
+      agentId: this.agentId,
+      taskId,
+      transaction: receipt.transaction,
+      network: receipt.network,
+      ...(receipt.payer !== undefined ? { payer: receipt.payer } : {}),
+    });
+
+    const done = this.x402.completedEvent({ receipt });
+    const metadata = done.type === 'done' ? (done.metadata ?? {}) : {};
+    await this.clear(taskId);
+    return { kind: 'settled', metadata };
+  }
+
+  /** Drop the lifecycle record once the task has terminated. Best-effort. */
+  async clear(taskId: string): Promise<void> {
+    try {
+      await this.x402.clearOffering({ taskId });
+    } catch (err) {
+      logEvent('x402_clear_error', { agentId: this.agentId, taskId, error: String(err) });
+    }
+  }
+
+  private failedEvent(input: {
+    taskId: string;
+    contextId: string;
+    code: Parameters<X402Context['failedEvent']>[0]['code'];
+    reason: string;
+    failureReceipt?: X402SettleResponse;
+  }): TaskStatusUpdateEvent {
+    const event = this.x402.failedEvent({
+      code: input.code,
+      reason: input.reason,
+      ...(input.failureReceipt !== undefined
+        ? { failureReceipt: input.failureReceipt }
+        : {}),
+    });
+    return this.statusEvent({
+      taskId: input.taskId,
+      contextId: input.contextId,
+      state: TaskState.FAILED,
+      text: input.reason,
+      metadata: event.type === 'error' ? (event.metadata ?? {}) : {},
+    });
+  }
+
+  /**
+   * Translate an x402 `AgentEvent` into the wire event this executor emits.
+   * `final: true` on both states: an `input-required` turn ends the stream
+   * without terminating the task, which is exactly what the flag means here.
+   */
+  private statusEvent(input: {
+    taskId: string;
+    contextId: string;
+    state: TaskState;
+    text: string;
+    metadata: Record<string, unknown>;
+  }): TaskStatusUpdateEvent {
+    return {
+      taskId: input.taskId,
+      contextId: input.contextId,
+      final: true,
+      status: {
+        state: input.state,
+        timestamp: new Date().toISOString(),
+        message: {
+          messageId: `${input.taskId}-x402-${input.state}`,
+          role: 'agent',
+          parts: [{ text: input.text }],
+          metadata: input.metadata,
+          taskId: input.taskId,
+          contextId: input.contextId,
+        },
+      },
+    };
+  }
+}

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -9,16 +9,17 @@ import { TaskState, type Message, type TaskStatusUpdateEvent } from '@a2x/sdk';
 import type { Sql } from '../db.js';
 import { logEvent } from '../log.js';
 import { PostgresX402Store } from './store.js';
-import { pricingToAccepts, type X402Pricing } from './pricing.js';
+import { meterUsage, pricingToAccepts, type X402Pricing } from './pricing.js';
+import type { TaskUsage } from './usage.js';
 
 export { X402_FOUNDATION_EXTENSION_URI };
 
 // The x402 wire version this deployment emits. V2 is the x402 Foundation
 // A2A transport — CAIP-2 networks, top-level `resource`, and the only version
-// with a path to the usage-based `upto` scheme, which is where metered
-// per-token billing eventually goes. The SDK still defaults to V1 for
-// compatibility with the older reference lineage, so we opt in explicitly and
-// leave an escape hatch for a deployment that has to serve V1-only clients.
+// that has the usage-based `upto` scheme at all. The SDK still defaults to V1
+// for compatibility with the older reference lineage, so we opt in explicitly
+// and leave an escape hatch for a deployment that has to serve V1-only
+// clients — one that an `upto` agent cannot use.
 const X402_VERSION: 1 | 2 = process.env.BRIDGE_X402_VERSION === '1' ? 1 : 2;
 
 // How long a payer has to sign and resubmit before the offering lapses. Past
@@ -85,9 +86,10 @@ export interface X402GateParams {
  * only the events need translating, which `haltEvent` does.
  *
  * Settlement is deliberately deferred until the agent has finished
- * successfully: an `exact` payment is a charge for delivered work, so a task
- * that fails or is cancelled is never settled and the payer's signed
- * authorization simply goes unused.
+ * successfully: payment buys delivered work, so a task that fails or is
+ * cancelled is never settled and the payer's signed authorization simply goes
+ * unused. Under `upto` that deferral is also what makes metering possible —
+ * the token counts only exist once the work is done.
  */
 export class X402Gate {
   constructor(
@@ -95,6 +97,32 @@ export class X402Gate {
     private readonly pricing: X402Pricing,
     private readonly x402: BaseX402Context,
   ) {}
+
+  /** True when this agent bills by consumption rather than a flat fee. */
+  get metered(): boolean {
+    return this.pricing.scheme === 'upto';
+  }
+
+  /**
+   * Scheme-independent description of what was offered, for logs. Under
+   * `upto` the amount is the authorized ceiling, so it is labelled as such
+   * rather than reported as a price that will be charged.
+   */
+  private offeringFields(): Record<string, string> {
+    return this.pricing.scheme === 'upto'
+      ? {
+          scheme: 'upto',
+          ceiling: this.pricing.maxAmount,
+          network: this.pricing.network,
+          asset: this.pricing.asset,
+        }
+      : {
+          scheme: 'exact',
+          amount: this.pricing.amount,
+          network: this.pricing.network,
+          asset: this.pricing.asset,
+        };
+  }
 
   /**
    * Classify the inbound turn and either request payment, refuse it, or clear
@@ -107,6 +135,26 @@ export class X402Gate {
   async open(params: X402GateParams): Promise<X402GateOutcome> {
     const { taskId, contextId, message, resource } = params;
     const ctx = { taskId, message };
+
+    // `upto` exists only in x402 V2. The SDK would throw from
+    // `requestPayment`, which the catch below would report as a transient
+    // outage — misleading for what is a permanent misconfiguration.
+    if (this.pricing.scheme === 'upto' && X402_VERSION === 1) {
+      logEvent('x402_config_invalid', {
+        agentId: this.agentId,
+        taskId,
+        reason: 'upto pricing requires x402 V2, but BRIDGE_X402_VERSION is 1',
+      });
+      return {
+        kind: 'halt',
+        event: this.failedEvent({
+          taskId,
+          contextId,
+          code: 'invalid_x402_version',
+          reason: 'Metered pricing requires x402 V2, which this deployment does not serve.',
+        }),
+      };
+    }
 
     try {
       const classified = await this.x402.classify(ctx);
@@ -135,9 +183,7 @@ export class X402Gate {
         logEvent('x402_payment_required', {
           agentId: this.agentId,
           taskId,
-          amount: this.pricing.amount,
-          asset: this.pricing.asset,
-          network: this.pricing.network,
+          ...this.offeringFields(),
         });
         return {
           kind: 'halt',
@@ -188,8 +234,7 @@ export class X402Gate {
       logEvent('x402_payment_verified', {
         agentId: this.agentId,
         taskId,
-        amount: this.pricing.amount,
-        network: this.pricing.network,
+        ...this.offeringFields(),
       });
       return { kind: 'proceed', classified };
     } catch (err) {
@@ -214,6 +259,12 @@ export class X402Gate {
   /**
    * Settle a verified payment after the agent completed the work.
    *
+   * Under `exact` the charge is the amount the payer already signed for and
+   * `usage` is ignored. Under `upto` the charge is metered from `usage` and
+   * the SDK clamps it down to the minimum of the metered value, the offered
+   * ceiling, and the payer's signed cap — so a pricing or metering mistake
+   * here can only ever undercharge.
+   *
    * Returns metadata to merge onto the task's final status message on
    * success, or a replacement terminal event when settlement failed — the
    * merchant was not paid, so the task must not report success.
@@ -222,15 +273,51 @@ export class X402Gate {
     taskId: string;
     contextId: string;
     classified: X402ValidClassification;
+    usage?: TaskUsage | undefined;
   }): Promise<
     | { kind: 'settled'; metadata: Record<string, unknown> }
     | { kind: 'failed'; event: TaskStatusUpdateEvent }
   > {
-    const { taskId, contextId, classified } = params;
+    const { taskId, contextId, classified, usage } = params;
     const ctx = { taskId };
+
+    // Metering an `exact` requirement throws in the SDK — the signature binds
+    // it to one value — so the option is only ever passed for `upto`.
+    let settleOpts: { amountAtomic?: string } | undefined;
+    if (this.pricing.scheme === 'upto') {
+      const charge = meterUsage(this.pricing, usage);
+      settleOpts = { amountAtomic: charge.amountAtomic };
+      logEvent('x402_metered', {
+        agentId: this.agentId,
+        taskId,
+        basis: charge.basis,
+        amount: charge.amountAtomic,
+        ceiling: this.pricing.maxAmount,
+        ...(usage !== undefined
+          ? {
+              promptTokens: usage.prompt_tokens,
+              completionTokens: usage.completion_tokens,
+              ...(usage.cached_tokens !== undefined ? { cachedTokens: usage.cached_tokens } : {}),
+              ...(usage.model !== undefined ? { model: usage.model } : {}),
+            }
+          : {}),
+      });
+      if (charge.basis === 'no-usage') {
+        // Loud on purpose: the backend delivered work the bridge could not
+        // price. Either the runtime dropped its accounting (codex #351) or
+        // the backend has none at all (openclaw), and both mean this agent
+        // is being given away at `minAmount` on every such call.
+        logEvent('x402_usage_unavailable', {
+          agentId: this.agentId,
+          taskId,
+          charged: charge.amountAtomic,
+        });
+      }
+    }
+
     let receipt: X402SettleResponse;
     try {
-      receipt = await this.x402.settle(ctx, classified);
+      receipt = await this.x402.settle(ctx, classified, settleOpts);
     } catch (err) {
       logEvent('x402_settle_error', {
         agentId: this.agentId,
@@ -272,6 +359,11 @@ export class X402Gate {
       transaction: receipt.transaction,
       network: receipt.network,
       ...(receipt.payer !== undefined ? { payer: receipt.payer } : {}),
+      // What the facilitator confirmed charging, which under `upto` is the
+      // reconciliation datum and is not recoverable from the offering. Absent
+      // whenever the facilitator reported no amount — the SDK does not
+      // backfill it from what was requested.
+      ...(receipt.amount !== undefined ? { amount: receipt.amount } : {}),
     });
 
     const done = this.x402.completedEvent({ receipt });

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -1,6 +1,7 @@
 import {
   X402Context,
   X402_FOUNDATION_EXTENSION_URI,
+  requirementScheme,
   type BaseX402Context,
   type X402ValidClassification,
   type X402SettleResponse,
@@ -39,13 +40,22 @@ const OFFERING_TTL_SECONDS = (() => {
  * Separate from `X402Gate` so tests can drive the gate with an in-memory
  * store and a stub facilitator instead of a database and a live chain.
  */
-export function createPostgresX402Context(sql: Sql, agentId: string): X402Context {
+export function createPostgresX402Context(
+  sql: Sql,
+  agentId: string,
+): { context: X402Context; sidecar: X402OfferingSidecar } {
   const url = process.env.BRIDGE_X402_FACILITATOR_URL;
-  return new X402Context({
-    store: new PostgresX402Store(sql, agentId),
-    x402Version: X402_VERSION,
-    ...(url ? { facilitator: { url } } : {}),
-  });
+  const store = new PostgresX402Store(sql, agentId);
+  return {
+    context: new X402Context({
+      store,
+      x402Version: X402_VERSION,
+      ...(url ? { facilitator: { url } } : {}),
+    }),
+    // Same instance: the sidecar rows live on the offering row, so they share
+    // the store's agent scoping rather than re-deriving it.
+    sidecar: store,
+  };
 }
 
 /**
@@ -58,7 +68,17 @@ export function createPostgresX402Context(sql: Sql, agentId: string): X402Contex
  *   refused (`failed`).
  */
 export type X402GateOutcome =
-  | { kind: 'proceed'; classified?: X402ValidClassification }
+  | {
+      kind: 'proceed';
+      classified?: X402ValidClassification;
+      /**
+       * The pricing the offering was published under, read back from the
+       * store. Settlement uses this, never the agent's live pricing — the two
+       * turns are separate requests and a reprice in between would otherwise
+       * meter against terms the payer never signed.
+       */
+      pricing?: X402Pricing;
+    }
   | { kind: 'halt'; event: TaskStatusUpdateEvent };
 
 export interface X402GateParams {
@@ -91,36 +111,47 @@ export interface X402GateParams {
  * unused. Under `upto` that deferral is also what makes metering possible —
  * the token counts only exist once the work is done.
  */
+/**
+ * The per-offering state the bridge keeps alongside the SDK's entry: the
+ * pricing an offering was published under, and a one-shot claim.
+ *
+ * Separate from `BaseX402Store` because the SDK owns that shape, and separate
+ * from the gate's constructor argument so tests can drive the round-trip
+ * without a database.
+ */
+export interface X402OfferingSidecar {
+  putPricing(taskId: string, pricing: X402Pricing): Promise<void>;
+  getPricing(taskId: string): Promise<X402Pricing | undefined>;
+  /** `true` for the one caller that wins the right to act on a submission. */
+  claim(taskId: string): Promise<boolean>;
+}
+
 export class X402Gate {
   constructor(
     private readonly agentId: string,
     private readonly pricing: X402Pricing,
     private readonly x402: BaseX402Context,
+    private readonly sidecar: X402OfferingSidecar,
   ) {}
 
-  /** True when this agent bills by consumption rather than a flat fee. */
-  get metered(): boolean {
-    return this.pricing.scheme === 'upto';
-  }
-
   /**
-   * Scheme-independent description of what was offered, for logs. Under
-   * `upto` the amount is the authorized ceiling, so it is labelled as such
-   * rather than reported as a price that will be charged.
+   * Scheme-independent description of an offering, for logs. Under `upto` the
+   * amount is the authorized ceiling, so it is labelled as such rather than
+   * reported as a price that will be charged.
    */
-  private offeringFields(): Record<string, string> {
-    return this.pricing.scheme === 'upto'
+  private offeringFields(pricing: X402Pricing): Record<string, string> {
+    return pricing.scheme === 'upto'
       ? {
           scheme: 'upto',
-          ceiling: this.pricing.maxAmount,
-          network: this.pricing.network,
-          asset: this.pricing.asset,
+          ceiling: pricing.maxAmount,
+          network: pricing.network,
+          asset: pricing.asset,
         }
       : {
           scheme: 'exact',
-          amount: this.pricing.amount,
-          network: this.pricing.network,
-          asset: this.pricing.asset,
+          amount: pricing.amount,
+          network: pricing.network,
+          asset: pricing.asset,
         };
   }
 
@@ -180,10 +211,14 @@ export class X402Gate {
           // silently serve the call for free.
           throw new Error('x402 requestPayment yielded no request-input event');
         }
+        // Freeze the terms alongside the offering. Turn 2 settles from this,
+        // so a reprice between the turns cannot change what the payer is
+        // charged for a requirement they already signed.
+        await this.sidecar.putPricing(taskId, this.pricing);
         logEvent('x402_payment_required', {
           agentId: this.agentId,
           taskId,
-          ...this.offeringFields(),
+          ...this.offeringFields(this.pricing),
         });
         return {
           kind: 'halt',
@@ -216,6 +251,41 @@ export class X402Gate {
         };
       }
 
+      // One submission, one execution. `classify` above does not inspect the
+      // entry's status, so a replayed `payment-submitted` classifies valid
+      // every time; without this the backend would run the work again for the
+      // same authorization. The claim is never released — see `claim`.
+      if (!(await this.sidecar.claim(taskId))) {
+        logEvent('x402_submission_replayed', { agentId: this.agentId, taskId });
+        return {
+          kind: 'halt',
+          event: this.failedEvent({
+            taskId,
+            contextId,
+            code: 'DUPLICATE_NONCE',
+            reason: 'This payment has already been submitted for this task.',
+          }),
+        };
+      }
+
+      // Terms are the ones the offering was published under, not whatever the
+      // agent charges right now.
+      const settlementPricing = await this.sidecar.getPricing(taskId);
+      if (settlementPricing === undefined) {
+        // Written in the same breath as the offering, so this is corruption
+        // rather than a normal state. Refuse instead of guessing a price.
+        logEvent('x402_pricing_snapshot_missing', { agentId: this.agentId, taskId });
+        return {
+          kind: 'halt',
+          event: this.failedEvent({
+            taskId,
+            contextId,
+            code: 'SETTLEMENT_FAILED',
+            reason: 'The terms this payment was offered under are no longer available.',
+          }),
+        };
+      }
+
       const verify = await this.x402.verify(ctx, classified);
       if (!verify.isValid) {
         const reason = verify.invalidReason ?? 'Payment verification failed.';
@@ -234,9 +304,9 @@ export class X402Gate {
       logEvent('x402_payment_verified', {
         agentId: this.agentId,
         taskId,
-        ...this.offeringFields(),
+        ...this.offeringFields(settlementPricing),
       });
-      return { kind: 'proceed', classified };
+      return { kind: 'proceed', classified, pricing: settlementPricing };
     } catch (err) {
       // Facilitator unreachable, DB down, malformed offering — fail closed.
       logEvent('x402_gate_error', {
@@ -273,26 +343,33 @@ export class X402Gate {
     taskId: string;
     contextId: string;
     classified: X402ValidClassification;
+    /** The offering's frozen terms, from `open`. Never the live pricing. */
+    pricing: X402Pricing;
     usage?: TaskUsage | undefined;
   }): Promise<
     | { kind: 'settled'; metadata: Record<string, unknown> }
     | { kind: 'failed'; event: TaskStatusUpdateEvent }
   > {
-    const { taskId, contextId, classified, usage } = params;
+    const { taskId, contextId, classified, pricing, usage } = params;
     const ctx = { taskId };
 
     // Metering an `exact` requirement throws in the SDK — the signature binds
     // it to one value — so the option is only ever passed for `upto`.
+    //
+    // Gated on the *requirement* the payer actually signed as well as on the
+    // snapshot: the two agree by construction, and requiring both means no
+    // single stale value can send a metered amount at an exact signature or
+    // vice versa.
     let settleOpts: { amountAtomic?: string } | undefined;
-    if (this.pricing.scheme === 'upto') {
-      const charge = meterUsage(this.pricing, usage);
+    if (pricing.scheme === 'upto' && requirementScheme(classified.requirement) === 'upto') {
+      const charge = meterUsage(pricing, usage);
       settleOpts = { amountAtomic: charge.amountAtomic };
       logEvent('x402_metered', {
         agentId: this.agentId,
         taskId,
         basis: charge.basis,
         amount: charge.amountAtomic,
-        ceiling: this.pricing.maxAmount,
+        ceiling: pricing.maxAmount,
         ...(usage !== undefined
           ? {
               promptTokens: usage.prompt_tokens,

--- a/packages/server/src/x402/pricing-watch.ts
+++ b/packages/server/src/x402/pricing-watch.ts
@@ -1,0 +1,98 @@
+import type { Sql } from '../db.js';
+import type { Registry } from '../registry.js';
+import { logEvent, truncate } from '../log.js';
+import { parseX402Pricing } from './pricing.js';
+
+// Cross-instance pricing invalidation.
+//
+// Pricing is read once per connection and cached on the live
+// `ClientConnection`, which the executor consults every turn. An admin write
+// patches that copy — but only on the instance that served the HTTP request.
+// The bridge runs several Fly instances and the agent's WebSocket lives on
+// exactly one of them, which is usually not the one that handled the write, so
+// without this the agent keeps charging the old price until it reconnects.
+//
+// The dangerous direction is `clear`: an agent made free on one instance goes
+// on billing from another. That is money taken after the operator believes
+// they turned it off, which is why this is a NOTIFY rather than a TTL.
+
+export const X402_PRICING_CHANNEL = 'x402_pricing_changed';
+
+/** Announce that an agent's pricing row changed. Best-effort. */
+export async function notifyX402PricingChanged(sql: Sql, agentId: string): Promise<void> {
+  try {
+    await sql.notify(X402_PRICING_CHANNEL, agentId);
+  } catch (err) {
+    // A failed notification degrades to the pre-existing behavior — other
+    // instances stay stale until the agent reconnects — so it must not fail
+    // the admin write that already committed.
+    logEvent('x402_pricing_notify_failed', {
+      agentId: truncate(String(agentId), 128),
+      error: String(err),
+    });
+  }
+}
+
+/**
+ * Re-read an agent's pricing from the database and push it into the registry.
+ *
+ * Re-reads rather than trusting the payload: the notification carries only an
+ * agent id, so two writes racing cannot leave an instance holding whichever
+ * message happened to arrive last.
+ */
+async function refresh(sql: Sql, registry: Registry, agentId: string): Promise<void> {
+  // Only instances actually holding this agent's socket have anything to
+  // update; everyone else can drop the notification without a query.
+  if (!registry.getAgent(agentId)) return;
+
+  const rows = await sql<{ x402_pricing: unknown }[]>`
+    SELECT x402_pricing FROM agents WHERE id = ${agentId}
+  `;
+  if (rows.length === 0) return;
+
+  let pricing;
+  try {
+    pricing = parseX402Pricing(rows[0]!.x402_pricing);
+  } catch (err) {
+    // Same posture as the connect-time read: an unreadable row makes the agent
+    // free rather than taking it offline, and nobody is charged against
+    // configuration the server could not parse.
+    logEvent('x402_pricing_invalid', {
+      agentId: truncate(String(agentId), 128),
+      error: String(err),
+    });
+    pricing = undefined;
+  }
+  registry.updateX402Pricing(agentId, pricing);
+  logEvent('x402_pricing_refreshed', {
+    agentId: truncate(String(agentId), 128),
+    paid: pricing !== undefined,
+  });
+}
+
+/**
+ * Subscribe to pricing changes for the lifetime of the process.
+ *
+ * Resolves once the subscription is live. Returns `undefined` if it could not
+ * be established — the deployment still works, it just falls back to
+ * pricing being refreshed when an agent reconnects.
+ */
+export async function watchX402PricingChanges(
+  sql: Sql,
+  registry: Registry,
+): Promise<{ unlisten: () => Promise<void> } | undefined> {
+  try {
+    const subscription = await sql.listen(X402_PRICING_CHANNEL, (payload) => {
+      void refresh(sql, registry, payload).catch((err) => {
+        logEvent('x402_pricing_refresh_failed', {
+          agentId: truncate(String(payload), 128),
+          error: String(err),
+        });
+      });
+    });
+    return { unlisten: () => subscription.unlisten() };
+  } catch (err) {
+    logEvent('x402_pricing_watch_failed', { error: String(err) });
+    return undefined;
+  }
+}

--- a/packages/server/src/x402/pricing.test.ts
+++ b/packages/server/src/x402/pricing.test.ts
@@ -1,6 +1,11 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseX402Pricing, pricingToAccepts } from './pricing.js';
+import {
+  meterUsage,
+  parseX402Pricing,
+  pricingToAccepts,
+  type X402UptoPricing,
+} from './pricing.js';
 
 const VALID = {
   network: 'eip155:84532',
@@ -14,8 +19,14 @@ test('parseX402Pricing treats NULL and undefined as "free agent"', () => {
   assert.equal(parseX402Pricing(undefined), undefined);
 });
 
-test('parseX402Pricing accepts a minimal offering', () => {
-  assert.deepEqual(parseX402Pricing(VALID), VALID);
+test('parseX402Pricing defaults a scheme-less row to exact', () => {
+  // Flat-fee pricing is the common case and stays a four-field object; the
+  // discriminator is filled in so downstream code can switch on it.
+  assert.deepEqual(parseX402Pricing(VALID), { ...VALID, scheme: 'exact' });
+  assert.deepEqual(parseX402Pricing({ ...VALID, scheme: 'exact' }), {
+    ...VALID,
+    scheme: 'exact',
+  });
 });
 
 test('parseX402Pricing rejects a non-address payTo', () => {
@@ -46,7 +57,8 @@ test('parseX402Pricing keeps a large atomic amount exact', () => {
   // 18-decimal assets exceed the exact integer range of a double, which is
   // why the wire format (and this column) uses strings throughout.
   const big = '1234567890123456789';
-  assert.equal(parseX402Pricing({ ...VALID, amount: big })?.amount, big);
+  const parsed = parseX402Pricing({ ...VALID, amount: big });
+  assert.equal(parsed?.scheme === 'exact' ? parsed.amount : undefined, big);
 });
 
 test('pricingToAccepts builds a single exact offering bound to the resource URL', () => {
@@ -71,4 +83,133 @@ test('pricingToAccepts forwards a custom description and EIP-712 extra', () => {
   );
   assert.equal(accepts[0]!.description, 'Premium research');
   assert.deepEqual(accepts[0]!.extra, extra);
+});
+
+// ── upto (metered) pricing ────────────────────────────────────────────────
+
+const UPTO = {
+  scheme: 'upto' as const,
+  network: 'eip155:84532',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: '0x1111111111111111111111111111111111111111',
+  maxAmount: '1000000',
+  // $3.00 / MTok in, $15.00 / MTok out, at 6 decimals.
+  rates: { input: '3000000', output: '15000000' },
+  facilitatorAddress: '0x3333333333333333333333333333333333333333',
+};
+
+function upto(overrides: Record<string, unknown> = {}): X402UptoPricing {
+  const parsed = parseX402Pricing({ ...UPTO, ...overrides });
+  assert.equal(parsed?.scheme, 'upto');
+  return parsed as X402UptoPricing;
+}
+
+test('parseX402Pricing accepts an upto offering', () => {
+  assert.deepEqual(parseX402Pricing(UPTO), UPTO);
+});
+
+test('parseX402Pricing requires a facilitator address for upto', () => {
+  // The payer's Permit2 witness binds to it and the SDK substitutes no
+  // default, so an offering without it could only dead-end at signing.
+  const { facilitatorAddress: _omitted, ...withoutFacilitator } = UPTO;
+  assert.throws(() => parseX402Pricing(withoutFacilitator));
+});
+
+test('parseX402Pricing requires atomic-unit rates for upto', () => {
+  const { rates: _omitted, ...withoutRates } = UPTO;
+  assert.throws(() => parseX402Pricing(withoutRates));
+  assert.throws(() => parseX402Pricing({ ...UPTO, rates: { input: '3.00', output: '15' } }));
+  assert.throws(() => parseX402Pricing({ ...UPTO, rates: { input: 3000000, output: '15' } }));
+});
+
+test('pricingToAccepts offers the ceiling and the facilitator address for upto', () => {
+  const accepts = pricingToAccepts(upto(), 'https://bridge.test/agents/a1');
+  assert.equal(accepts.length, 1);
+  assert.equal(accepts[0]!.scheme, 'upto');
+  // `amount` on the wire is what the payer authorizes, not what is charged.
+  assert.equal(accepts[0]!.amount, '1000000');
+  assert.deepEqual(accepts[0]!.extra, { facilitatorAddress: UPTO.facilitatorAddress });
+});
+
+test('meterUsage prices input and output at their separate rates', () => {
+  // 100k in @ $3/MTok = 300000 atomic; 10k out @ $15/MTok = 150000 atomic.
+  const charge = meterUsage(upto(), {
+    prompt_tokens: 100_000,
+    completion_tokens: 10_000,
+    total_tokens: 110_000,
+  });
+  assert.equal(charge.basis, 'metered');
+  assert.equal(charge.amountAtomic, '450000');
+});
+
+test('meterUsage discounts cached input without double-counting it', () => {
+  // cached_tokens is a breakdown of prompt_tokens, never additive: 100k
+  // prompt of which 90k cached = 10k fresh @ $3 + 90k cached @ $0.30.
+  const charge = meterUsage(upto({ rates: { ...UPTO.rates, cachedInput: '300000' } }), {
+    prompt_tokens: 100_000,
+    completion_tokens: 0,
+    total_tokens: 100_000,
+    cached_tokens: 90_000,
+  });
+  assert.equal(charge.amountAtomic, '57000');
+});
+
+test('meterUsage charges cached input at the full rate when no discount is set', () => {
+  // Absent cachedInput means "same as input", not "free" — treating an
+  // unstated discount as 100% would give away most of a cache-heavy call.
+  const charge = meterUsage(upto(), {
+    prompt_tokens: 100_000,
+    completion_tokens: 0,
+    total_tokens: 100_000,
+    cached_tokens: 90_000,
+  });
+  assert.equal(charge.amountAtomic, '300000');
+});
+
+test('meterUsage rounds a sub-unit charge up rather than down to zero', () => {
+  // A fractional result must not floor to 0, which downstream is
+  // indistinguishable from "nothing was reported".
+  const charge = meterUsage(upto({ rates: { input: '1', output: '1' } }), {
+    prompt_tokens: 1,
+    completion_tokens: 0,
+    total_tokens: 1,
+  });
+  assert.equal(charge.amountAtomic, '1');
+  assert.equal(charge.basis, 'metered');
+});
+
+test('meterUsage applies the floor when the metered charge is below it', () => {
+  const charge = meterUsage(upto({ minAmount: '50000' }), {
+    prompt_tokens: 100,
+    completion_tokens: 0,
+    total_tokens: 100,
+  });
+  assert.equal(charge.basis, 'floor');
+  assert.equal(charge.amountAtomic, '50000');
+});
+
+test('meterUsage treats missing or zero usage as unpriceable, not free', () => {
+  // The distinction that matters for revenue: openclaw reports no usage at
+  // all, and codex/vicoop-codex emit {0,0,0} when their runtime dropped
+  // accounting. Neither means the call was free.
+  for (const usage of [undefined, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }]) {
+    const withoutFloor = meterUsage(upto(), usage);
+    assert.equal(withoutFloor.basis, 'no-usage');
+    assert.equal(withoutFloor.amountAtomic, '0');
+
+    const withFloor = meterUsage(upto({ minAmount: '25000' }), usage);
+    assert.equal(withFloor.basis, 'no-usage');
+    assert.equal(withFloor.amountAtomic, '25000');
+  }
+});
+
+test('meterUsage stays exact on values that would break a double', () => {
+  // 1e9 tokens * 3e12 rate = 3e21 before division — far past 2^53, which is
+  // why the arithmetic is BigInt end to end.
+  const charge = meterUsage(upto({ rates: { input: '3000000000000', output: '0' } }), {
+    prompt_tokens: 1_000_000_000,
+    completion_tokens: 0,
+    total_tokens: 1_000_000_000,
+  });
+  assert.equal(charge.amountAtomic, '3000000000000000');
 });

--- a/packages/server/src/x402/pricing.test.ts
+++ b/packages/server/src/x402/pricing.test.ts
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseX402Pricing, pricingToAccepts } from './pricing.js';
+
+const VALID = {
+  network: 'eip155:84532',
+  amount: '10000',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: '0x1111111111111111111111111111111111111111',
+};
+
+test('parseX402Pricing treats NULL and undefined as "free agent"', () => {
+  assert.equal(parseX402Pricing(null), undefined);
+  assert.equal(parseX402Pricing(undefined), undefined);
+});
+
+test('parseX402Pricing accepts a minimal offering', () => {
+  assert.deepEqual(parseX402Pricing(VALID), VALID);
+});
+
+test('parseX402Pricing rejects a non-address payTo', () => {
+  // The whole point of DB-owned pricing is that payTo names who gets paid;
+  // a typo that silently became a valid-looking address would send money to
+  // an unrecoverable hole.
+  assert.throws(() => parseX402Pricing({ ...VALID, payTo: '0xnope' }));
+  assert.throws(() => parseX402Pricing({ ...VALID, asset: 'USDC' }));
+});
+
+test('parseX402Pricing rejects amounts that are not atomic integer strings', () => {
+  // `0.01` is the classic mistake: x402 amounts are atomic units, so a
+  // decimal here means the operator thought in dollars and would undercharge
+  // by six orders of magnitude if it were coerced.
+  assert.throws(() => parseX402Pricing({ ...VALID, amount: '0.01' }));
+  assert.throws(() => parseX402Pricing({ ...VALID, amount: 10000 }));
+  assert.throws(() => parseX402Pricing({ ...VALID, amount: '1e4' }));
+  assert.throws(() => parseX402Pricing({ ...VALID, amount: '-1' }));
+});
+
+test('parseX402Pricing rejects a zero charge', () => {
+  // A zero-amount offering would make every caller sign a payment that
+  // transfers nothing — a free agent is expressed by NULL pricing instead.
+  assert.throws(() => parseX402Pricing({ ...VALID, amount: '0' }));
+});
+
+test('parseX402Pricing keeps a large atomic amount exact', () => {
+  // 18-decimal assets exceed the exact integer range of a double, which is
+  // why the wire format (and this column) uses strings throughout.
+  const big = '1234567890123456789';
+  assert.equal(parseX402Pricing({ ...VALID, amount: big })?.amount, big);
+});
+
+test('pricingToAccepts builds a single exact offering bound to the resource URL', () => {
+  const accepts = pricingToAccepts(parseX402Pricing(VALID)!, 'https://bridge.test/agents/a1');
+  assert.equal(accepts.length, 1);
+  assert.deepEqual(accepts[0], {
+    scheme: 'exact',
+    network: 'eip155:84532',
+    amount: '10000',
+    asset: VALID.asset,
+    payTo: VALID.payTo,
+    resource: 'https://bridge.test/agents/a1',
+    description: 'Agent invocation',
+  });
+});
+
+test('pricingToAccepts forwards a custom description and EIP-712 extra', () => {
+  const extra = { name: 'USD Coin', version: '2' };
+  const accepts = pricingToAccepts(
+    parseX402Pricing({ ...VALID, description: 'Premium research', extra })!,
+    'https://bridge.test/agents/a1',
+  );
+  assert.equal(accepts[0]!.description, 'Premium research');
+  assert.deepEqual(accepts[0]!.extra, extra);
+});

--- a/packages/server/src/x402/pricing.test.ts
+++ b/packages/server/src/x402/pricing.test.ts
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  X402PricingSchema,
+  X402PricingWriteSchema,
+  formatPricingError,
   meterUsage,
   parseX402Pricing,
   pricingToAccepts,
@@ -200,6 +203,85 @@ test('meterUsage treats missing or zero usage as unpriceable, not free', () => {
     const withFloor = meterUsage(upto({ minAmount: '25000' }), usage);
     assert.equal(withFloor.basis, 'no-usage');
     assert.equal(withFloor.amountAtomic, '25000');
+  }
+});
+
+// ── write-time strictness ─────────────────────────────────────────────────
+//
+// Every optional field on a pricing object changes what is charged, so a
+// dropped typo is a wrong price rather than a no-op. The write path rejects
+// unknown keys; the read path still drops them, so a row written by a newer
+// server keeps pricing correctly after a rollback instead of silently
+// downgrading the agent to free.
+
+test('the write schema rejects a typo in the floor instead of dropping it', () => {
+  // `minamount` would leave minAmount unset, making every call the backend
+  // cannot meter free — the exact footgun the docs warn about.
+  const typo = { ...UPTO, minamount: '1000' };
+  assert.throws(() => X402PricingWriteSchema.parse(typo), /minamount/);
+
+  // The read path still tolerates it, and drops it.
+  const read = X402PricingSchema.parse(typo) as X402UptoPricing;
+  assert.equal(read.minAmount, undefined);
+});
+
+test('the write schema rejects a typo in the nested rate table', () => {
+  // `.strict()` guards one level, so the nested rates object needs its own —
+  // `cachedinput` would charge cache reads at the full input rate.
+  assert.throws(
+    () =>
+      X402PricingWriteSchema.parse({
+        ...UPTO,
+        rates: { input: '3000000', output: '15000000', cachedinput: '300000' },
+      }),
+    /cachedinput/,
+  );
+});
+
+test('the write schema rejects an unknown key on exact pricing too', () => {
+  assert.throws(() => X402PricingWriteSchema.parse({ ...VALID, amout: '10000' }), /amout/);
+});
+
+test('the write schema still accepts every documented field', () => {
+  assert.doesNotThrow(() =>
+    X402PricingWriteSchema.parse({
+      ...UPTO,
+      minAmount: '1000',
+      description: 'Metered research',
+      rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
+    }),
+  );
+  assert.doesNotThrow(() => X402PricingWriteSchema.parse(VALID));
+  assert.doesNotThrow(() => X402PricingWriteSchema.parse({ ...VALID, scheme: 'exact' }));
+});
+
+test('the write schema leaves `extra` free-form', () => {
+  // It is a passthrough for scheme-specific fields the SDK owns (the EIP-712
+  // domain), so strictness must not reach inside it.
+  assert.doesNotThrow(() =>
+    X402PricingWriteSchema.parse({
+      ...VALID,
+      extra: { name: 'USD Coin', version: '2', somethingNew: true },
+    }),
+  );
+});
+
+test('the read schema tolerates a field a newer server wrote', () => {
+  // Rejecting would make parseX402Pricing throw, which connects the agent as
+  // free — a rollback would quietly stop charging for every paid agent.
+  const fromFuture = { ...UPTO, chargeSource: 'client' };
+  assert.doesNotThrow(() => X402PricingSchema.parse(fromFuture));
+  assert.equal((X402PricingSchema.parse(fromFuture) as X402UptoPricing).maxAmount, '1000000');
+});
+
+test('formatPricingError names the offending field on one line', () => {
+  try {
+    X402PricingWriteSchema.parse({ ...UPTO, minamount: '1000' });
+    assert.fail('expected a validation error');
+  } catch (err) {
+    const message = formatPricingError(err);
+    assert.match(message, /minamount/);
+    assert.equal(message.includes('\n'), false, 'must stay a single line for the CLI');
   }
 });
 

--- a/packages/server/src/x402/pricing.ts
+++ b/packages/server/src/x402/pricing.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { X402Accept } from '@a2x/sdk/x402';
+import type { TaskUsage } from './usage.js';
 
 // Per-agent x402 pricing, persisted on `agents.x402_pricing` and carried on
 // the live `ClientConnection`. Deliberately DB-owned rather than declared in
@@ -7,9 +8,11 @@ import type { X402Accept } from '@a2x/sdk/x402';
 // is authored by the connecting client. Same trust boundary as
 // `allowed_callers` — the bridge, not the agent, is authoritative.
 //
-// One offering, `exact` scheme only. Multi-offer (several networks) and the
-// usage-based `upto` scheme both fit this shape later: `upto` needs a metered
-// amount at settle time, which needs per-task usage on the WS protocol first.
+// Two schemes:
+//
+//   exact — a fixed charge per call, agreed before the work happens.
+//   upto  — the payer authorizes up to a ceiling and the bridge settles the
+//           metered token consumption. x402 V2 only.
 
 // An EVM address. Stored as given (checksummed or not) — the x402 payload
 // checks compare case-insensitively.
@@ -22,15 +25,15 @@ const EvmAddress = z
 // range of a double — the same reason the x402 wire format uses strings.
 const AtomicAmount = z
   .string()
-  .regex(/^(0|[1-9][0-9]*)$/, 'must be a decimal integer string in atomic units')
-  .refine((v) => v !== '0', 'must be greater than zero');
+  .regex(/^(0|[1-9][0-9]*)$/, 'must be a decimal integer string in atomic units');
 
-export const X402PricingSchema = z.object({
+const PositiveAtomicAmount = AtomicAmount.refine((v) => v !== '0', 'must be greater than zero');
+
+const BasePricing = {
   // Bare name (`base-sepolia`) under x402 V1, CAIP-2 (`eip155:84532`) under V2.
   // Not constrained here: the SDK owns per-version network encoding, and
   // pinning a list would reject a chain the facilitator already supports.
   network: z.string().min(1),
-  amount: AtomicAmount,
   asset: EvmAddress,
   payTo: EvmAddress,
   description: z.string().min(1).optional(),
@@ -38,9 +41,58 @@ export const X402PricingSchema = z.object({
   // outside the well-known USDC deployments the SDK special-cases; a wrong
   // domain produces signatures the facilitator can never verify.
   extra: z.record(z.string(), z.unknown()).optional(),
+};
+
+const ExactPricingSchema = z.object({
+  ...BasePricing,
+  scheme: z.literal('exact'),
+  amount: PositiveAtomicAmount,
 });
 
+// Price per *million* tokens, in atomic units — the unit model providers
+// quote in, kept as-is so an operator transcribes a price list without
+// converting. Atomic strings again: at 6 decimals `$3.00 / MTok` is
+// `"3000000"`.
+const RatesSchema = z.object({
+  input: AtomicAmount,
+  output: AtomicAmount,
+  // Cache reads are normally discounted heavily. Absent means "same as
+  // input" rather than "free" — treating an unstated discount as 100% would
+  // give away the bulk of a cache-heavy call.
+  cachedInput: AtomicAmount.optional(),
+});
+
+const UptoPricingSchema = z.object({
+  ...BasePricing,
+  scheme: z.literal('upto'),
+  // The ceiling the payer authorizes. The metered charge is clamped to it by
+  // the SDK, so it doubles as the blast radius of a metering bug.
+  maxAmount: PositiveAtomicAmount,
+  rates: RatesSchema,
+  // Floor for a completed call. Also what is charged when the backend
+  // reported no usage at all — see `meterUsage`. Absent means zero.
+  minAmount: AtomicAmount.optional(),
+  // The payer's Permit2 witness binds to this address, so it must match the
+  // facilitator that will settle. Read it from the facilitator's
+  // `GET /supported` (`extra.facilitatorAddress`). The SDK never substitutes
+  // a default here, unlike the `exact` scheme's EIP-712 domain.
+  facilitatorAddress: EvmAddress,
+});
+
+/**
+ * Pricing as stored. `scheme` defaults to `exact` so the common flat-fee row
+ * stays a four-field object.
+ */
+export const X402PricingSchema = z.preprocess((raw) => {
+  if (typeof raw === 'object' && raw !== null && !Array.isArray(raw) && !('scheme' in raw)) {
+    return { ...(raw as Record<string, unknown>), scheme: 'exact' };
+  }
+  return raw;
+}, z.discriminatedUnion('scheme', [ExactPricingSchema, UptoPricingSchema]));
+
 export type X402Pricing = z.infer<typeof X402PricingSchema>;
+export type X402ExactPricing = z.infer<typeof ExactPricingSchema>;
+export type X402UptoPricing = z.infer<typeof UptoPricingSchema>;
 
 /**
  * Parse a `agents.x402_pricing` JSONB value. Returns `undefined` for NULL —
@@ -59,16 +111,88 @@ export function parseX402Pricing(raw: unknown): X402Pricing | undefined {
  * endpoint rather than an opaque id.
  */
 export function pricingToAccepts(pricing: X402Pricing, resource: string): X402Accept[] {
+  const common = {
+    network: pricing.network,
+    asset: pricing.asset,
+    payTo: pricing.payTo,
+    resource,
+  };
+
+  if (pricing.scheme === 'upto') {
+    return [
+      {
+        ...common,
+        scheme: 'upto',
+        // What the payer authorizes, not what they will be charged.
+        amount: pricing.maxAmount,
+        description: pricing.description ?? 'Metered agent invocation — billed per token',
+        extra: { ...(pricing.extra ?? {}), facilitatorAddress: pricing.facilitatorAddress },
+      },
+    ];
+  }
+
   return [
     {
+      ...common,
       scheme: 'exact',
-      network: pricing.network,
       amount: pricing.amount,
-      asset: pricing.asset,
-      payTo: pricing.payTo,
-      resource,
       description: pricing.description ?? 'Agent invocation',
       ...(pricing.extra !== undefined ? { extra: pricing.extra } : {}),
     },
   ];
+}
+
+/** What `meterUsage` decided to charge, and why — the `why` is logged. */
+export interface MeteredCharge {
+  amountAtomic: string;
+  /**
+   * - `metered`  — priced from reported token counts.
+   * - `floor`    — the metered value was below `minAmount`.
+   * - `no-usage` — the backend reported nothing; `minAmount` (or zero) applied.
+   */
+  basis: 'metered' | 'floor' | 'no-usage';
+}
+
+/**
+ * Price a completed call from its reported token usage.
+ *
+ * Arithmetic is BigInt throughout: rates are per million tokens, so the
+ * intermediate product overflows a double's exact range long before the
+ * amounts do. The division rounds **up** — standard for billing, and it keeps
+ * a genuinely tiny call from pricing to zero, which would be
+ * indistinguishable from "the runtime told us nothing".
+ *
+ * That distinction is the reason `basis` exists. `total_tokens: 0` does not
+ * mean the call was free: codex and vicoop-codex emit `{0,0,0}` as an honest
+ * "the runtime did not report" placeholder, and openclaw reports no usage at
+ * all. Charging zero for delivered work is a real loss, so an operator who
+ * cares sets `minAmount` and gets that floor instead. Charging the authorized
+ * ceiling in this case would be worse: it bills the payer the maximum for a
+ * gap in *our* instrumentation.
+ */
+export function meterUsage(pricing: X402UptoPricing, usage: TaskUsage | undefined): MeteredCharge {
+  const floor = BigInt(pricing.minAmount ?? '0');
+
+  if (usage === undefined || usage.total_tokens === 0) {
+    return { amountAtomic: floor.toString(), basis: 'no-usage' };
+  }
+
+  const cached = BigInt(usage.cached_tokens ?? 0);
+  // `cached_tokens` is a breakdown of `prompt_tokens`, never additive, so the
+  // full-price share is what remains after taking the cached part out.
+  const freshInput = BigInt(usage.prompt_tokens) - cached;
+  const cachedRate = BigInt(pricing.rates.cachedInput ?? pricing.rates.input);
+
+  const micros =
+    (freshInput > 0n ? freshInput : 0n) * BigInt(pricing.rates.input) +
+    cached * cachedRate +
+    // `reasoning_tokens` is likewise a breakdown of `completion_tokens`, so
+    // completion alone already covers it.
+    BigInt(usage.completion_tokens) * BigInt(pricing.rates.output);
+
+  const PER = 1_000_000n;
+  const metered = micros === 0n ? 0n : (micros + PER - 1n) / PER;
+
+  if (metered < floor) return { amountAtomic: floor.toString(), basis: 'floor' };
+  return { amountAtomic: metered.toString(), basis: 'metered' };
 }

--- a/packages/server/src/x402/pricing.ts
+++ b/packages/server/src/x402/pricing.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import type { X402Accept } from '@a2x/sdk/x402';
+
+// Per-agent x402 pricing, persisted on `agents.x402_pricing` and carried on
+// the live `ClientConnection`. Deliberately DB-owned rather than declared in
+// the WS hello frame: `payTo` decides who receives money, and the hello frame
+// is authored by the connecting client. Same trust boundary as
+// `allowed_callers` — the bridge, not the agent, is authoritative.
+//
+// One offering, `exact` scheme only. Multi-offer (several networks) and the
+// usage-based `upto` scheme both fit this shape later: `upto` needs a metered
+// amount at settle time, which needs per-task usage on the WS protocol first.
+
+// An EVM address. Stored as given (checksummed or not) — the x402 payload
+// checks compare case-insensitively.
+const EvmAddress = z
+  .string()
+  .regex(/^0x[0-9a-fA-F]{40}$/, 'must be a 0x-prefixed 20-byte hex address');
+
+// Atomic units of the asset, as a decimal integer string. Never a number:
+// USDC has 6 decimals but other assets have 18, and 1e18 exceeds the exact
+// range of a double — the same reason the x402 wire format uses strings.
+const AtomicAmount = z
+  .string()
+  .regex(/^(0|[1-9][0-9]*)$/, 'must be a decimal integer string in atomic units')
+  .refine((v) => v !== '0', 'must be greater than zero');
+
+export const X402PricingSchema = z.object({
+  // Bare name (`base-sepolia`) under x402 V1, CAIP-2 (`eip155:84532`) under V2.
+  // Not constrained here: the SDK owns per-version network encoding, and
+  // pinning a list would reject a chain the facilitator already supports.
+  network: z.string().min(1),
+  amount: AtomicAmount,
+  asset: EvmAddress,
+  payTo: EvmAddress,
+  description: z.string().min(1).optional(),
+  // Overrides the SDK's per-asset EIP-712 domain default. Needed for tokens
+  // outside the well-known USDC deployments the SDK special-cases; a wrong
+  // domain produces signatures the facilitator can never verify.
+  extra: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type X402Pricing = z.infer<typeof X402PricingSchema>;
+
+/**
+ * Parse a `agents.x402_pricing` JSONB value. Returns `undefined` for NULL —
+ * the overwhelmingly common case (a free agent) — and throws only on a value
+ * that is present but malformed, which is an operator error worth surfacing.
+ */
+export function parseX402Pricing(raw: unknown): X402Pricing | undefined {
+  if (raw === null || raw === undefined) return undefined;
+  return X402PricingSchema.parse(raw);
+}
+
+/**
+ * Build the offering advertised to the payer. `resource` must be the public
+ * URL of what is being paid for — strict facilitators reject non-URL values,
+ * and wallets show it in the consent prompt, so it is the agent's own
+ * endpoint rather than an opaque id.
+ */
+export function pricingToAccepts(pricing: X402Pricing, resource: string): X402Accept[] {
+  return [
+    {
+      scheme: 'exact',
+      network: pricing.network,
+      amount: pricing.amount,
+      asset: pricing.asset,
+      payTo: pricing.payTo,
+      resource,
+      description: pricing.description ?? 'Agent invocation',
+      ...(pricing.extra !== undefined ? { extra: pricing.extra } : {}),
+    },
+  ];
+}

--- a/packages/server/src/x402/pricing.ts
+++ b/packages/server/src/x402/pricing.ts
@@ -79,16 +79,51 @@ const UptoPricingSchema = z.object({
   facilitatorAddress: EvmAddress,
 });
 
-/**
- * Pricing as stored. `scheme` defaults to `exact` so the common flat-fee row
- * stays a four-field object.
- */
-export const X402PricingSchema = z.preprocess((raw) => {
+// `scheme` defaults to `exact` so the common flat-fee row stays a four-field
+// object.
+function withSchemeDefault(raw: unknown): unknown {
   if (typeof raw === 'object' && raw !== null && !Array.isArray(raw) && !('scheme' in raw)) {
     return { ...(raw as Record<string, unknown>), scheme: 'exact' };
   }
   return raw;
-}, z.discriminatedUnion('scheme', [ExactPricingSchema, UptoPricingSchema]));
+}
+
+/**
+ * Pricing as **read** from storage. Unknown keys are dropped rather than
+ * rejected, on purpose: a row written by a newer server (a field this build
+ * doesn't know yet) must still price correctly here. Rejecting it would make
+ * `parseX402Pricing` throw, which downgrades the agent to free — a rollback
+ * would quietly stop charging for every paid agent.
+ */
+export const X402PricingSchema = z.preprocess(
+  withSchemeDefault,
+  z.discriminatedUnion('scheme', [ExactPricingSchema, UptoPricingSchema]),
+);
+
+/**
+ * Pricing as **written** through the admin API. Strict: an unrecognized key
+ * is an error, not something to drop silently.
+ *
+ * The asymmetry with the read schema is deliberate. Every field here is
+ * optional-with-a-consequential-default, so a typo does not fail — it changes
+ * the price. `minamount` instead of `minAmount` leaves the floor unset, which
+ * makes every call the backend cannot meter free. `cachedinput` instead of
+ * `cachedInput` charges cache reads at the full input rate, overcharging the
+ * payer. Both would return 200 under the lenient schema, and the operator
+ * would find out from an invoice. Writes are the one place where the caller
+ * is present to be told, so they are told.
+ */
+export const X402PricingWriteSchema = z.preprocess(
+  withSchemeDefault,
+  z.discriminatedUnion('scheme', [
+    ExactPricingSchema.strict(),
+    // `.strict()` only guards the level it is applied to, so the nested rate
+    // table needs its own — that is where two of the three typo-able optional
+    // fields live. `extra` stays a free-form record by design: it is a
+    // passthrough for scheme-specific fields the SDK owns.
+    UptoPricingSchema.extend({ rates: RatesSchema.strict() }).strict(),
+  ]),
+);
 
 export type X402Pricing = z.infer<typeof X402PricingSchema>;
 export type X402ExactPricing = z.infer<typeof ExactPricingSchema>;
@@ -102,6 +137,22 @@ export type X402UptoPricing = z.infer<typeof UptoPricingSchema>;
 export function parseX402Pricing(raw: unknown): X402Pricing | undefined {
   if (raw === null || raw === undefined) return undefined;
   return X402PricingSchema.parse(raw);
+}
+
+/**
+ * Render a validation failure as one line an operator can act on.
+ *
+ * `String(zodError)` is a multi-line JSON dump that reaches the CLI as a wall
+ * of text; the field path and the reason are the only parts that matter.
+ */
+export function formatPricingError(err: unknown): string {
+  if (!(err instanceof z.ZodError)) return String(err);
+  return err.issues
+    .map((issue) => {
+      const path = issue.path.join('.');
+      return path ? `${path}: ${issue.message}` : issue.message;
+    })
+    .join('; ');
 }
 
 /**

--- a/packages/server/src/x402/store.test.ts
+++ b/packages/server/src/x402/store.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict';
 import postgres from 'postgres';
 import type { X402StoreEntry } from '@a2x/sdk/x402';
 import { PostgresX402Store, sweepExpiredX402Offerings } from './store.js';
-import { parseX402Pricing } from './pricing.js';
+import { parseX402Pricing, type X402Pricing } from './pricing.js';
 
 const hasDb = !!process.env.DATABASE_URL;
 
@@ -202,7 +202,7 @@ test(
 );
 
 test(
-  'concurrent publishes never pair one offering with the other terms',
+  'concurrent publishes freeze one live offering and its terms',
   { skip: !hasDb },
   async () => {
     // The race this design exists for. Two turn-1s for the same task, racing a
@@ -221,14 +221,26 @@ test(
           accepts: [{ ...entry(taskId).accepts[0]!, amount }],
         });
 
-      await Promise.all([
-        store.publishing(taskId, cheap, () => store.put(offering('10000'))),
-        store.publishing(taskId, dear, () => store.put(offering('990000'))),
-      ]);
+      const publishedAmounts: string[] = [];
+      const publish = (requested: X402Pricing) =>
+        store.publishing(taskId, requested, async (frozen) => {
+          assert.equal(frozen.scheme, 'exact');
+          const amount = frozen.scheme === 'exact' ? frozen.amount : '';
+          publishedAmounts.push(amount);
+          await store.put(offering(amount));
+        });
+
+      await Promise.all([publish(cheap), publish(dear)]);
 
       const stored = await store.get(taskId);
       const terms = await store.getPricing(taskId);
       assert.ok(stored && terms);
+      assert.equal(publishedAmounts.length, 2);
+      assert.equal(
+        publishedAmounts[0],
+        publishedAmounts[1],
+        'the later publisher must reuse the first live terms',
+      );
       assert.equal(
         terms.scheme === 'exact' ? terms.amount : undefined,
         stored.accepts[0]!.amount,

--- a/packages/server/src/x402/store.test.ts
+++ b/packages/server/src/x402/store.test.ts
@@ -64,8 +64,7 @@ test(
       const a = new PostgresX402Store(sql, `${tag}-agent-a`);
       const b = new PostgresX402Store(sql, `${tag}-agent-b`);
 
-      await a.put(entry(taskId));
-      await a.putPricing(taskId, PRICING);
+      await a.publishing(taskId, PRICING, () => a.put(entry(taskId)));
 
       assert.ok(await a.get(taskId), 'the owning agent sees its own offering');
       assert.equal(await b.get(taskId), undefined, 'another agent must not');
@@ -134,8 +133,7 @@ test(
     await withDb(async (sql, tag) => {
       const taskId = `${tag}-patch`;
       const store = new PostgresX402Store(sql, `${tag}-agent`);
-      await store.put(entry(taskId));
-      await store.putPricing(taskId, PRICING);
+      await store.publishing(taskId, PRICING, () => store.put(entry(taskId)));
       assert.equal(await store.claim(taskId), true);
 
       await store.update(taskId, { status: 'verified', verifiedAt: new Date() });
@@ -197,9 +195,45 @@ test(
         rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
       })!;
 
-      await store.put(entry(taskId));
-      await store.putPricing(taskId, upto);
+      await store.publishing(taskId, upto, () => store.put(entry(taskId)));
       assert.deepEqual(await store.getPricing(taskId), upto);
+    });
+  },
+);
+
+test(
+  'concurrent publishes never pair one offering with the other terms',
+  { skip: !hasDb },
+  async () => {
+    // The race this design exists for. Two turn-1s for the same task, racing a
+    // reprice: whichever offering ends up stored, the terms beside it must be
+    // the ones that produced it. Writing the two separately — in either order —
+    // can interleave into A's offering with B's rates, and since both are the
+    // same scheme no downstream shape check would notice.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-race`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+
+      const cheap = parseX402Pricing({ ...PRICING, amount: '10000' })!;
+      const dear = parseX402Pricing({ ...PRICING, amount: '990000' })!;
+      const offering = (amount: string) =>
+        entry(taskId, {
+          accepts: [{ ...entry(taskId).accepts[0]!, amount }],
+        });
+
+      await Promise.all([
+        store.publishing(taskId, cheap, () => store.put(offering('10000'))),
+        store.publishing(taskId, dear, () => store.put(offering('990000'))),
+      ]);
+
+      const stored = await store.get(taskId);
+      const terms = await store.getPricing(taskId);
+      assert.ok(stored && terms);
+      assert.equal(
+        terms.scheme === 'exact' ? terms.amount : undefined,
+        stored.accepts[0]!.amount,
+        'the stored terms must be the ones that produced the stored offering',
+      );
     });
   },
 );

--- a/packages/server/src/x402/store.test.ts
+++ b/packages/server/src/x402/store.test.ts
@@ -1,0 +1,205 @@
+// Integration tests for the x402 offering store against a real Postgres.
+// The three properties here are the ones a unit test with an in-memory stub
+// cannot establish: agent scoping is a WHERE clause, the claim is a conditional
+// UPDATE, and the sweep is a DELETE.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+import type { X402StoreEntry } from '@a2x/sdk/x402';
+import { PostgresX402Store, sweepExpiredX402Offerings } from './store.js';
+import { parseX402Pricing } from './pricing.js';
+
+const hasDb = !!process.env.DATABASE_URL;
+
+const PRICING = parseX402Pricing({
+  network: 'eip155:84532',
+  amount: '10000',
+  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  payTo: '0x1111111111111111111111111111111111111111',
+})!;
+
+function entry(taskId: string, overrides: Partial<X402StoreEntry> = {}): X402StoreEntry {
+  return {
+    taskId,
+    accepts: [
+      {
+        scheme: 'exact',
+        network: 'eip155:84532',
+        amount: '10000',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0x1111111111111111111111111111111111111111',
+        resource: 'https://bridge.test/agents/a',
+        description: 'test',
+      },
+    ],
+    status: 'offered',
+    storedAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+async function withDb(fn: (sql: postgres.Sql, tag: string) => Promise<void>): Promise<void> {
+  const sql = postgres(process.env.DATABASE_URL!);
+  const tag = `x402-store-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    await fn(sql, tag);
+  } finally {
+    await sql`DELETE FROM x402_offerings WHERE task_id LIKE ${`${tag}%`}`;
+    await sql.end();
+  }
+}
+
+test(
+  'an offering is invisible to a different agent',
+  { skip: !hasDb },
+  async () => {
+    // The reason this matters: tasks resolve by id from a store shared across
+    // agents (#453), so agent B can be handed a task created at agent A.
+    // Keyed on task_id alone, B's gate would load A's cheap offering and
+    // accept A's signature as payment for B's work.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-shared`;
+      const a = new PostgresX402Store(sql, `${tag}-agent-a`);
+      const b = new PostgresX402Store(sql, `${tag}-agent-b`);
+
+      await a.put(entry(taskId));
+      await a.putPricing(taskId, PRICING);
+
+      assert.ok(await a.get(taskId), 'the owning agent sees its own offering');
+      assert.equal(await b.get(taskId), undefined, 'another agent must not');
+      assert.equal(await b.getPricing(taskId), undefined);
+      assert.equal(await b.claim(taskId), false, 'and must not be able to claim it');
+
+      // B's delete must not reach A's row either.
+      await b.delete(taskId);
+      assert.ok(await a.get(taskId), "another agent's delete must not remove it");
+    });
+  },
+);
+
+test(
+  'the same taskId can hold an independent offering per agent',
+  { skip: !hasDb },
+  async () => {
+    // Follows from the composite key. Worth pinning because the previous
+    // single-column PK made the second put silently overwrite the first.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-collide`;
+      const a = new PostgresX402Store(sql, `${tag}-agent-a`);
+      const b = new PostgresX402Store(sql, `${tag}-agent-b`);
+
+      await a.put(entry(taskId, { status: 'offered' }));
+      await b.put(entry(taskId, { status: 'verified' }));
+
+      assert.equal((await a.get(taskId))?.status, 'offered');
+      assert.equal((await b.get(taskId))?.status, 'verified');
+    });
+  },
+);
+
+test(
+  'claim succeeds exactly once, including under concurrency',
+  { skip: !hasDb },
+  async () => {
+    // The SDK's classify() does not inspect the entry's status, so a replayed
+    // submission classifies valid every time. This conditional UPDATE is what
+    // stops the backend running the work twice for one authorization.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-claim`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+      await store.put(entry(taskId));
+
+      assert.equal(await store.claim(taskId), true);
+      assert.equal(await store.claim(taskId), false, 'a sequential replay loses');
+
+      // And when both arrive at once, exactly one wins.
+      const raced = `${tag}-claim-race`;
+      await store.put(entry(raced));
+      const results = await Promise.all(
+        Array.from({ length: 8 }, () => store.claim(raced)),
+      );
+      assert.equal(results.filter(Boolean).length, 1, 'exactly one concurrent claim wins');
+    });
+  },
+);
+
+test(
+  'a lifecycle update does not reset the claim or the pricing snapshot',
+  { skip: !hasDb },
+  async () => {
+    // `put` runs repeatedly as the SDK patches the entry through verify and
+    // settle. Neither the claim nor the frozen terms may be clobbered by it.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-patch`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+      await store.put(entry(taskId));
+      await store.putPricing(taskId, PRICING);
+      assert.equal(await store.claim(taskId), true);
+
+      await store.update(taskId, { status: 'verified', verifiedAt: new Date() });
+
+      assert.equal((await store.get(taskId))?.status, 'verified');
+      assert.equal(await store.claim(taskId), false, 'the claim survives the patch');
+      assert.deepEqual(await store.getPricing(taskId), PRICING);
+    });
+  },
+);
+
+test(
+  'an expired offering reads as absent and is swept',
+  { skip: !hasDb },
+  async () => {
+    await withDb(async (sql, tag) => {
+      const live = `${tag}-live`;
+      const lapsed = `${tag}-lapsed`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+
+      await store.put(entry(live, { expiresAt: new Date(Date.now() + 600_000) }));
+      await store.put(entry(lapsed, { expiresAt: new Date(Date.now() - 1_000) }));
+
+      // Lazy expiry: hidden from reads before anything deletes it.
+      assert.ok(await store.get(live));
+      assert.equal(await store.get(lapsed), undefined);
+      assert.equal(await store.claim(lapsed), false, 'an expired offering cannot be claimed');
+
+      const deleted = await sweepExpiredX402Offerings(sql);
+      assert.ok(deleted >= 1, 'the sweep reclaims the lapsed row');
+
+      const remaining = await sql<{ task_id: string }[]>`
+        SELECT task_id FROM x402_offerings WHERE task_id IN (${live}, ${lapsed})
+      `;
+      assert.deepEqual(
+        remaining.map((r) => r.task_id),
+        [live],
+        'the sweep leaves live offerings alone',
+      );
+    });
+  },
+);
+
+test(
+  'the pricing snapshot round-trips through JSONB',
+  { skip: !hasDb },
+  async () => {
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-pricing`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+      const upto = parseX402Pricing({
+        scheme: 'upto',
+        network: 'eip155:84532',
+        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+        payTo: '0x1111111111111111111111111111111111111111',
+        facilitatorAddress: '0x3333333333333333333333333333333333333333',
+        maxAmount: '1000000',
+        minAmount: '1000',
+        rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
+      })!;
+
+      await store.put(entry(taskId));
+      await store.putPricing(taskId, upto);
+      assert.deepEqual(await store.getPricing(taskId), upto);
+    });
+  },
+);

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -1,0 +1,144 @@
+import {
+  BaseX402Store,
+  type X402StoreEntry,
+  type X402StoreEntryPatch,
+} from '@a2x/sdk/x402';
+import type { Sql } from '../db.js';
+
+// Postgres-backed x402 offering store.
+//
+// The SDK's default `InMemoryX402Store` cannot back this deployment: the
+// payment round-trip spans two HTTP requests (turn 1 advertises the offering,
+// turn 2 submits the signed payload), and the bridge runs multiple Fly
+// instances behind a load balancer. Turn 2 routinely lands on an instance
+// that never saw turn 1, and an in-memory offering would classify it as
+// `no-stored-offering` — the payer signs, gets rejected, and is not charged,
+// but the call fails. Restarts have the same effect on a single instance.
+//
+// Expiry is lazy per the store contract: `get` filters on `expires_at`, so a
+// lapsed offering reads as absent without a background reaper. Rows are
+// deleted by `clearOffering` after a task terminates; `sweepExpired` exists
+// for the rows whose task never terminated at all.
+
+interface OfferingRow {
+  task_id: string;
+  entry: unknown;
+}
+
+// The entry round-trips through JSONB, which has no Date type. Every Date
+// field is written as an ISO string by `JSON.stringify` and must be revived
+// on read — a string where the SDK expects a Date silently breaks the
+// `expiresAt` comparison and `receipt.settledAt` arithmetic.
+function reviveEntry(raw: unknown): X402StoreEntry {
+  const e = raw as Record<string, unknown>;
+  const date = (v: unknown): Date | undefined =>
+    typeof v === 'string' ? new Date(v) : undefined;
+
+  const storedAt = date(e.storedAt);
+  const updatedAt = date(e.updatedAt);
+  const expiresAt = date(e.expiresAt);
+  const verifiedAt = date(e.verifiedAt);
+  const receipt = e.receipt as Record<string, unknown> | undefined;
+  const failure = e.failure as Record<string, unknown> | undefined;
+
+  return {
+    ...(e as unknown as X402StoreEntry),
+    // storedAt/updatedAt are non-optional on the entry; a row that somehow
+    // lacks them is more useful with a placeholder than as a crash on an
+    // audit read.
+    storedAt: storedAt ?? new Date(0),
+    updatedAt: updatedAt ?? new Date(0),
+    ...(expiresAt !== undefined ? { expiresAt } : {}),
+    ...(verifiedAt !== undefined ? { verifiedAt } : {}),
+    ...(receipt !== undefined
+      ? {
+          receipt: {
+            ...(receipt as unknown as NonNullable<X402StoreEntry['receipt']>),
+            settledAt: date(receipt.settledAt) ?? new Date(0),
+          },
+        }
+      : {}),
+    ...(failure !== undefined
+      ? {
+          failure: {
+            ...(failure as unknown as NonNullable<X402StoreEntry['failure']>),
+            failedAt: date(failure.failedAt) ?? new Date(0),
+          },
+        }
+      : {}),
+  };
+}
+
+export class PostgresX402Store extends BaseX402Store {
+  constructor(
+    private readonly sql: Sql,
+    // Recorded on the row so operational queries ("what did agent X charge
+    // this week") don't have to join through the task table. Not part of the
+    // SDK entry, which is keyed by taskId alone.
+    private readonly agentId: string,
+  ) {
+    super();
+  }
+
+  async put(entry: X402StoreEntry): Promise<void> {
+    const expiresAt = entry.expiresAt ?? null;
+    // The entry is round-tripped through JSON — the repo's pattern for JSONB
+    // writes — which also lowers every Date to an ISO string, exactly what
+    // `reviveEntry` reverses on the way back out.
+    await this.sql`
+      INSERT INTO x402_offerings (task_id, agent_id, entry, expires_at, updated_at)
+      VALUES (
+        ${entry.taskId},
+        ${this.agentId},
+        ${this.sql.json(JSON.parse(JSON.stringify(entry)))},
+        ${expiresAt},
+        now()
+      )
+      ON CONFLICT (task_id) DO UPDATE
+        SET entry = EXCLUDED.entry,
+            agent_id = EXCLUDED.agent_id,
+            expires_at = EXCLUDED.expires_at,
+            updated_at = now()
+    `;
+  }
+
+  async get(taskId: string): Promise<X402StoreEntry | undefined> {
+    const rows = await this.sql<OfferingRow[]>`
+      SELECT task_id, entry
+      FROM x402_offerings
+      WHERE task_id = ${taskId}
+        AND (expires_at IS NULL OR expires_at > now())
+    `;
+    const row = rows[0];
+    return row ? reviveEntry(row.entry) : undefined;
+  }
+
+  async update(taskId: string, patch: X402StoreEntryPatch): Promise<void> {
+    // Read-modify-write rather than a JSONB merge: the patch carries nested
+    // Date values that would have to be hand-serialized into a jsonb_set
+    // chain anyway, and the round-trip stays inside one statement's worth of
+    // latency. Concurrent patches for one task don't occur — a task's
+    // payment round-trip is driven by a single in-flight request.
+    const current = await this.get(taskId);
+    if (!current) return;
+    await this.put({ ...current, ...patch, updatedAt: new Date() });
+  }
+
+  async delete(taskId: string): Promise<void> {
+    await this.sql`DELETE FROM x402_offerings WHERE task_id = ${taskId}`;
+  }
+
+  /**
+   * Drop rows whose expiry has passed. Lazy expiry already hides them from
+   * `get`, so this only reclaims space for offerings whose task was never
+   * completed or cancelled. Returns the number of rows removed.
+   */
+  async sweepExpired(): Promise<number> {
+    const rows = await this.sql`
+      DELETE FROM x402_offerings
+      WHERE expires_at IS NOT NULL AND expires_at <= now()
+      RETURNING task_id
+    `;
+    return rows.length;
+  }
+}

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -3,8 +3,23 @@ import {
   type X402StoreEntry,
   type X402StoreEntryPatch,
 } from '@a2x/sdk/x402';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Sql } from '../db.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
+
+// The pricing an in-flight `requestPayment` is publishing.
+//
+// The SDK owns the offering write, so the terms cannot be passed to it as an
+// argument — but they must land in the *same* statement. Storing them
+// separately leaves a window where two concurrent turn-1s racing a reprice
+// interleave into one offering paired with the other's terms: same scheme, so
+// no shape check catches it, and the caller is metered at rates they never
+// signed against.
+//
+// A module-level variable would have the same race. Async context is per-call,
+// so each `requestPayment` sees exactly the terms it is publishing no matter
+// how many run concurrently.
+const publishingPricing = new AsyncLocalStorage<{ taskId: string; pricing: X402Pricing }>();
 
 // Postgres-backed x402 offering store.
 //
@@ -87,43 +102,59 @@ export class PostgresX402Store extends BaseX402Store {
     super();
   }
 
+  /**
+   * Run `fn` with `pricing` attached to the offering it publishes.
+   *
+   * The write that `fn` triggers inside the SDK carries these terms in the
+   * same statement as the offering, which is what makes the pair atomic.
+   */
+  async publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T> {
+    return publishingPricing.run({ taskId, pricing }, fn);
+  }
+
   async put(entry: X402StoreEntry): Promise<void> {
     const expiresAt = entry.expiresAt ?? null;
+    // Terms are present only on the publishing write; the SDK's later
+    // lifecycle patches (verified, completed, failed) run outside that context
+    // and must leave the frozen snapshot alone. The taskId is checked rather
+    // than assumed: the context belongs to one offering, and applying its
+    // terms to a different task would be the very mix-up this exists to stop.
+    const ctx = publishingPricing.getStore();
+    const pricing = ctx?.taskId === entry.taskId ? ctx.pricing : undefined;
+
     // The entry is round-tripped through JSON — the repo's pattern for JSONB
     // writes — which also lowers every Date to an ISO string, exactly what
     // `reviveEntry` reverses on the way back out.
     //
-    // `pricing` and `claimed_at` are left alone on conflict: the SDK patches
-    // the entry repeatedly through the round-trip, and neither the pricing
-    // snapshot nor the claim may be reset by a lifecycle update.
+    // `claimed_at` is never touched here: the SDK patches the entry repeatedly
+    // through the round-trip, and under `exact` settlement happens before the
+    // work, so resetting the claim mid-task would let a resubmission be
+    // charged a second time.
     await this.sql`
-      INSERT INTO x402_offerings (task_id, agent_id, entry, expires_at, updated_at)
+      INSERT INTO x402_offerings (task_id, agent_id, entry, pricing, expires_at, updated_at)
       VALUES (
         ${entry.taskId},
         ${this.agentId},
         ${this.sql.json(JSON.parse(JSON.stringify(entry)))},
+        ${pricing === undefined ? null : this.sql.json(JSON.parse(JSON.stringify(pricing)))},
         ${expiresAt},
         now()
       )
       ON CONFLICT (agent_id, task_id) DO UPDATE
         SET entry = EXCLUDED.entry,
+            pricing = COALESCE(EXCLUDED.pricing, x402_offerings.pricing),
             expires_at = EXCLUDED.expires_at,
             updated_at = now()
     `;
   }
 
   async get(taskId: string): Promise<X402StoreEntry | undefined> {
-    // `jsonb_exists(entry, 'accepts')` skips the placeholder row that
-    // `putPricing` inserts before the SDK writes the real entry: a row without
-    // `accepts` is terms with no offering, and handing it back would present
-    // an empty offering as a real one.
     const rows = await this.sql<OfferingRow[]>`
       SELECT task_id, entry
       FROM x402_offerings
       WHERE agent_id = ${this.agentId}
         AND task_id = ${taskId}
         AND (expires_at IS NULL OR expires_at > now())
-        AND jsonb_exists(entry, 'accepts')
     `;
     const row = rows[0];
     return row ? reviveEntry(row.entry) : undefined;
@@ -148,39 +179,7 @@ export class PostgresX402Store extends BaseX402Store {
     `;
   }
 
-  /**
-   * Record the pricing an offering was published under.
-   *
-   * Settlement prices from this rather than from the agent's live pricing.
-   * The two turns of a payment are separate requests, so a reprice in between
-   * would otherwise meter turn 2 against terms turn 1 never signed.
-   */
-  async putPricing(taskId: string, pricing: X402Pricing): Promise<void> {
-    // Upsert, because this runs *before* the SDK writes the offering entry —
-    // the row may not exist yet. Sequencing it first means an entry never
-    // exists without terms; the reverse order can leave an offering that
-    // settlement has no price for.
-    //
-    // `entry` gets a placeholder on insert and is immediately overwritten by
-    // the SDK's `put`. It is never read in that state: `get` goes through the
-    // SDK's shape and the gate only reaches settlement via `classify`, which
-    // requires a real entry.
-    await this.sql`
-      INSERT INTO x402_offerings (task_id, agent_id, entry, pricing, updated_at)
-      VALUES (
-        ${taskId},
-        ${this.agentId},
-        '{}'::jsonb,
-        ${this.sql.json(JSON.parse(JSON.stringify(pricing)))},
-        now()
-      )
-      ON CONFLICT (agent_id, task_id) DO UPDATE
-        SET pricing = EXCLUDED.pricing,
-            updated_at = now()
-    `;
-  }
-
-  /** The pricing snapshot taken when the offering was published. */
+  /** The terms the offering was published under, written alongside it. */
   async getPricing(taskId: string): Promise<X402Pricing | undefined> {
     const rows = await this.sql<{ pricing: unknown }[]>`
       SELECT pricing
@@ -215,7 +214,6 @@ export class PostgresX402Store extends BaseX402Store {
         AND task_id = ${taskId}
         AND claimed_at IS NULL
         AND (expires_at IS NULL OR expires_at > now())
-        AND jsonb_exists(entry, 'accepts')
       RETURNING task_id
     `;
     return rows.length > 0;

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -4,6 +4,7 @@ import {
   type X402StoreEntryPatch,
 } from '@a2x/sdk/x402';
 import type { Sql } from '../db.js';
+import { parseX402Pricing, type X402Pricing } from './pricing.js';
 
 // Postgres-backed x402 offering store.
 //
@@ -72,9 +73,15 @@ function reviveEntry(raw: unknown): X402StoreEntry {
 export class PostgresX402Store extends BaseX402Store {
   constructor(
     private readonly sql: Sql,
-    // Recorded on the row so operational queries ("what did agent X charge
-    // this week") don't have to join through the task table. Not part of the
-    // SDK entry, which is keyed by taskId alone.
+    /**
+     * The agent this store is scoped to. **Every** operation filters on it.
+     *
+     * Not merely a label for operational queries: tasks resolve by id from a
+     * store shared across all agents (#453), so a task created at agent A can
+     * be resumed at agent B's endpoint. Were offerings keyed on `taskId`
+     * alone, B's gate would load A's offering and accept A's cheap signature
+     * as payment for B's work.
+     */
     private readonly agentId: string,
   ) {
     super();
@@ -85,6 +92,10 @@ export class PostgresX402Store extends BaseX402Store {
     // The entry is round-tripped through JSON — the repo's pattern for JSONB
     // writes — which also lowers every Date to an ISO string, exactly what
     // `reviveEntry` reverses on the way back out.
+    //
+    // `pricing` and `claimed_at` are left alone on conflict: the SDK patches
+    // the entry repeatedly through the round-trip, and neither the pricing
+    // snapshot nor the claim may be reset by a lifecycle update.
     await this.sql`
       INSERT INTO x402_offerings (task_id, agent_id, entry, expires_at, updated_at)
       VALUES (
@@ -94,9 +105,8 @@ export class PostgresX402Store extends BaseX402Store {
         ${expiresAt},
         now()
       )
-      ON CONFLICT (task_id) DO UPDATE
+      ON CONFLICT (agent_id, task_id) DO UPDATE
         SET entry = EXCLUDED.entry,
-            agent_id = EXCLUDED.agent_id,
             expires_at = EXCLUDED.expires_at,
             updated_at = now()
     `;
@@ -106,7 +116,8 @@ export class PostgresX402Store extends BaseX402Store {
     const rows = await this.sql<OfferingRow[]>`
       SELECT task_id, entry
       FROM x402_offerings
-      WHERE task_id = ${taskId}
+      WHERE agent_id = ${this.agentId}
+        AND task_id = ${taskId}
         AND (expires_at IS NULL OR expires_at > now())
     `;
     const row = rows[0];
@@ -117,28 +128,90 @@ export class PostgresX402Store extends BaseX402Store {
     // Read-modify-write rather than a JSONB merge: the patch carries nested
     // Date values that would have to be hand-serialized into a jsonb_set
     // chain anyway, and the round-trip stays inside one statement's worth of
-    // latency. Concurrent patches for one task don't occur — a task's
-    // payment round-trip is driven by a single in-flight request.
+    // latency. Racing writers are not a correctness problem here because the
+    // one operation that must not run twice — accepting a submission — is
+    // gated by `claim()` below rather than by the entry's status.
     const current = await this.get(taskId);
     if (!current) return;
     await this.put({ ...current, ...patch, updatedAt: new Date() });
   }
 
   async delete(taskId: string): Promise<void> {
-    await this.sql`DELETE FROM x402_offerings WHERE task_id = ${taskId}`;
+    await this.sql`
+      DELETE FROM x402_offerings
+      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+    `;
   }
 
   /**
-   * Drop rows whose expiry has passed. Lazy expiry already hides them from
-   * `get`, so this only reclaims space for offerings whose task was never
-   * completed or cancelled. Returns the number of rows removed.
+   * Record the pricing an offering was published under.
+   *
+   * Settlement prices from this rather than from the agent's live pricing.
+   * The two turns of a payment are separate requests, so a reprice in between
+   * would otherwise meter turn 2 against terms turn 1 never signed.
    */
-  async sweepExpired(): Promise<number> {
+  async putPricing(taskId: string, pricing: X402Pricing): Promise<void> {
+    await this.sql`
+      UPDATE x402_offerings
+      SET pricing = ${this.sql.json(JSON.parse(JSON.stringify(pricing)))}
+      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+    `;
+  }
+
+  /** The pricing snapshot taken when the offering was published. */
+  async getPricing(taskId: string): Promise<X402Pricing | undefined> {
+    const rows = await this.sql<{ pricing: unknown }[]>`
+      SELECT pricing
+      FROM x402_offerings
+      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+    `;
+    const raw = rows[0]?.pricing;
+    if (raw === undefined || raw === null) return undefined;
+    // Read-side parsing is lenient about unknown keys on purpose (see
+    // pricing.ts) — a snapshot written by a newer build must still price here.
+    return parseX402Pricing(raw);
+  }
+
+  /**
+   * Take the one-shot right to act on this task's submission.
+   *
+   * Returns `true` for the caller that wins and `false` for every other. The
+   * SDK's `classify()` does not inspect the entry's status, so without this a
+   * replayed submission classifies valid twice and the backend runs the work
+   * twice against a single authorization.
+   *
+   * Deliberately never released. A failed verify leaves the offering claimed
+   * and the payer starts a new task; re-opening the window on failure would
+   * restore the double-spend it exists to prevent, and nothing has been
+   * charged at that point.
+   */
+  async claim(taskId: string): Promise<boolean> {
     const rows = await this.sql`
-      DELETE FROM x402_offerings
-      WHERE expires_at IS NOT NULL AND expires_at <= now()
+      UPDATE x402_offerings
+      SET claimed_at = now(), updated_at = now()
+      WHERE agent_id = ${this.agentId}
+        AND task_id = ${taskId}
+        AND claimed_at IS NULL
+        AND (expires_at IS NULL OR expires_at > now())
       RETURNING task_id
     `;
-    return rows.length;
+    return rows.length > 0;
   }
+}
+
+/**
+ * Drop offerings whose expiry has passed, across every agent.
+ *
+ * Lazy expiry already hides them from `get`, so this only reclaims space — but
+ * it has to run: a caller that walks away at the `input-required` turn leaves
+ * a row behind, and on a public paid agent that is an unauthenticated way to
+ * grow the table. Returns the number of rows removed.
+ */
+export async function sweepExpiredX402Offerings(sql: Sql): Promise<number> {
+  const rows = await sql`
+    DELETE FROM x402_offerings
+    WHERE expires_at IS NOT NULL AND expires_at <= now()
+    RETURNING task_id
+  `;
+  return rows.length;
 }

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -113,12 +113,17 @@ export class PostgresX402Store extends BaseX402Store {
   }
 
   async get(taskId: string): Promise<X402StoreEntry | undefined> {
+    // `jsonb_exists(entry, 'accepts')` skips the placeholder row that
+    // `putPricing` inserts before the SDK writes the real entry: a row without
+    // `accepts` is terms with no offering, and handing it back would present
+    // an empty offering as a real one.
     const rows = await this.sql<OfferingRow[]>`
       SELECT task_id, entry
       FROM x402_offerings
       WHERE agent_id = ${this.agentId}
         AND task_id = ${taskId}
         AND (expires_at IS NULL OR expires_at > now())
+        AND jsonb_exists(entry, 'accepts')
     `;
     const row = rows[0];
     return row ? reviveEntry(row.entry) : undefined;
@@ -151,10 +156,27 @@ export class PostgresX402Store extends BaseX402Store {
    * would otherwise meter turn 2 against terms turn 1 never signed.
    */
   async putPricing(taskId: string, pricing: X402Pricing): Promise<void> {
+    // Upsert, because this runs *before* the SDK writes the offering entry —
+    // the row may not exist yet. Sequencing it first means an entry never
+    // exists without terms; the reverse order can leave an offering that
+    // settlement has no price for.
+    //
+    // `entry` gets a placeholder on insert and is immediately overwritten by
+    // the SDK's `put`. It is never read in that state: `get` goes through the
+    // SDK's shape and the gate only reaches settlement via `classify`, which
+    // requires a real entry.
     await this.sql`
-      UPDATE x402_offerings
-      SET pricing = ${this.sql.json(JSON.parse(JSON.stringify(pricing)))}
-      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+      INSERT INTO x402_offerings (task_id, agent_id, entry, pricing, updated_at)
+      VALUES (
+        ${taskId},
+        ${this.agentId},
+        '{}'::jsonb,
+        ${this.sql.json(JSON.parse(JSON.stringify(pricing)))},
+        now()
+      )
+      ON CONFLICT (agent_id, task_id) DO UPDATE
+        SET pricing = EXCLUDED.pricing,
+            updated_at = now()
     `;
   }
 
@@ -193,6 +215,7 @@ export class PostgresX402Store extends BaseX402Store {
         AND task_id = ${taskId}
         AND claimed_at IS NULL
         AND (expires_at IS NULL OR expires_at > now())
+        AND jsonb_exists(entry, 'accepts')
       RETURNING task_id
     `;
     return rows.length > 0;

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -4,7 +4,7 @@ import {
   type X402StoreEntryPatch,
 } from '@a2x/sdk/x402';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import type { Sql } from '../db.js';
+import type { Sql, SqlExecutor } from '../db.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
 
 // The pricing an in-flight `requestPayment` is publishing.
@@ -19,7 +19,15 @@ import { parseX402Pricing, type X402Pricing } from './pricing.js';
 // A module-level variable would have the same race. Async context is per-call,
 // so each `requestPayment` sees exactly the terms it is publishing no matter
 // how many run concurrently.
-const publishingPricing = new AsyncLocalStorage<{ taskId: string; pricing: X402Pricing }>();
+interface PublishingContext {
+  taskId: string;
+  pricing: X402Pricing;
+  sql: SqlExecutor;
+  /** A new offering may replace an expired row and must release its old claim. */
+  resetClaim: boolean;
+}
+
+const publishingPricing = new AsyncLocalStorage<PublishingContext>();
 
 // Postgres-backed x402 offering store.
 //
@@ -103,13 +111,58 @@ export class PostgresX402Store extends BaseX402Store {
   }
 
   /**
-   * Run `fn` with `pricing` attached to the offering it publishes.
+   * Serialize publishers for one task and run `fn` with its frozen terms.
    *
-   * The write that `fn` triggers inside the SDK carries these terms in the
-   * same statement as the offering, which is what makes the pair atomic.
+   * A live offering is immutable: an unpaid retry (including one racing a
+   * signed continuation) reuses its snapshot rather than replacing the rates
+   * underneath the signer. The advisory transaction lock also closes the
+   * no-row race between two initial publishers. `put` below detects this async
+   * context and uses the same transaction for the SDK-owned offering write.
    */
-  async publishing<T>(taskId: string, pricing: X402Pricing, fn: () => Promise<T>): Promise<T> {
-    return publishingPricing.run({ taskId, pricing }, fn);
+  async publishing<T>(
+    taskId: string,
+    pricing: X402Pricing,
+    fn: (frozenPricing: X402Pricing) => Promise<T>,
+  ): Promise<T> {
+    // postgres.js maps array-shaped transaction callback results specially;
+    // assign outside the callback so this method preserves an arbitrary T.
+    let published!: T;
+    await this.sql.begin(async (tx) => {
+      // A row lock cannot serialize the first insert because there is no row
+      // yet. This transaction-scoped lock covers both that case and retries.
+      // A hash collision only serializes unrelated tasks; it cannot mix data.
+      await tx`
+        SELECT pg_advisory_xact_lock(
+          hashtextextended(${`${this.agentId.length}:${this.agentId}:${taskId}`}, 0::bigint)
+        )
+      `;
+
+      const rows = await tx<{ pricing: unknown }[]>`
+        SELECT pricing
+        FROM x402_offerings
+        WHERE agent_id = ${this.agentId}
+          AND task_id = ${taskId}
+          AND (expires_at IS NULL OR expires_at > now())
+          AND jsonb_exists(entry, 'accepts')
+        FOR UPDATE
+      `;
+      const existing = rows[0];
+      const frozenPricing = existing ? parseX402Pricing(existing.pricing) : pricing;
+      if (frozenPricing === undefined) {
+        throw new Error(`live x402 offering ${taskId} has no pricing snapshot`);
+      }
+
+      published = await publishingPricing.run(
+        {
+          taskId,
+          pricing: frozenPricing,
+          sql: tx,
+          resetClaim: existing === undefined,
+        },
+        () => fn(frozenPricing),
+      );
+    });
+    return published;
   }
 
   async put(entry: X402StoreEntry): Promise<void> {
@@ -121,6 +174,8 @@ export class PostgresX402Store extends BaseX402Store {
     // terms to a different task would be the very mix-up this exists to stop.
     const ctx = publishingPricing.getStore();
     const pricing = ctx?.taskId === entry.taskId ? ctx.pricing : undefined;
+    const executor = ctx?.taskId === entry.taskId ? ctx.sql : this.sql;
+    const resetClaim = ctx?.taskId === entry.taskId && ctx.resetClaim === true;
 
     // The entry is round-tripped through JSON — the repo's pattern for JSONB
     // writes — which also lowers every Date to an ISO string, exactly what
@@ -130,7 +185,7 @@ export class PostgresX402Store extends BaseX402Store {
     // through the round-trip, and under `exact` settlement happens before the
     // work, so resetting the claim mid-task would let a resubmission be
     // charged a second time.
-    await this.sql`
+    await executor`
       INSERT INTO x402_offerings (task_id, agent_id, entry, pricing, expires_at, updated_at)
       VALUES (
         ${entry.taskId},
@@ -143,6 +198,10 @@ export class PostgresX402Store extends BaseX402Store {
       ON CONFLICT (agent_id, task_id) DO UPDATE
         SET entry = EXCLUDED.entry,
             pricing = COALESCE(EXCLUDED.pricing, x402_offerings.pricing),
+            claimed_at = CASE
+              WHEN ${resetClaim} THEN NULL
+              ELSE x402_offerings.claimed_at
+            END,
             expires_at = EXCLUDED.expires_at,
             updated_at = now()
     `;

--- a/packages/server/src/x402/usage.test.ts
+++ b/packages/server/src/x402/usage.test.ts
@@ -1,0 +1,114 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { readTaskUsage } from './usage.js';
+
+test('readTaskUsage reads the bare {usage} shape plain A2A callers receive', () => {
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      usage: { prompt_tokens: 120, completion_tokens: 30, total_tokens: 150, model: 'sonnet' },
+    },
+  });
+  assert.deepEqual(usage, {
+    prompt_tokens: 120,
+    completion_tokens: 30,
+    total_tokens: 150,
+    model: 'sonnet',
+  });
+});
+
+test('readTaskUsage reads the chat_completion envelope shape', () => {
+  // The backends switch to this shape when the caller activated the
+  // openai-compat extension; both must price identically.
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      chat_completion: {
+        id: 'chatcmpl-x',
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      },
+    },
+  });
+  assert.deepEqual(usage, { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
+});
+
+test('readTaskUsage extracts cached and model details', () => {
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      usage: {
+        prompt_tokens: 1000,
+        completion_tokens: 100,
+        total_tokens: 1100,
+        prompt_tokens_details: { cached_tokens: 900 },
+        completion_tokens_details: { reasoning_tokens: 40 },
+        model: 'claude-sonnet-4',
+      },
+    },
+  });
+  assert.equal(usage?.cached_tokens, 900);
+  assert.equal(usage?.model, 'claude-sonnet-4');
+});
+
+test('readTaskUsage recomputes the total rather than trusting the reported one', () => {
+  // The charge is derived from prompt + completion, so a backend that
+  // miscomputed `total_tokens` must not be able to move the price.
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 99999 },
+    },
+  });
+  assert.equal(usage?.total_tokens, 15);
+});
+
+test('readTaskUsage drops an incoherent cache count instead of discounting on it', () => {
+  // cached_tokens is a breakdown of prompt_tokens; a larger value is
+  // nonsense, and honouring it would discount tokens that were never cached.
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 0,
+        total_tokens: 100,
+        prompt_tokens_details: { cached_tokens: 5000 },
+      },
+    },
+  });
+  assert.equal(usage?.cached_tokens, undefined);
+  assert.equal(usage?.prompt_tokens, 100);
+});
+
+test('readTaskUsage returns undefined when there is nothing usable', () => {
+  assert.equal(readTaskUsage(undefined), undefined);
+  assert.equal(readTaskUsage({}), undefined);
+  assert.equal(readTaskUsage({ [OPENAI_COMPAT_EXTENSION_URI]: {} }), undefined);
+  // Missing required counts, negative, and non-integer values are all
+  // unusable — better to report "unpriceable" than to invent a number.
+  assert.equal(
+    readTaskUsage({ [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: 10 } } }),
+    undefined,
+  );
+  assert.equal(
+    readTaskUsage({
+      [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: -1, completion_tokens: 5 } },
+    }),
+    undefined,
+  );
+  assert.equal(
+    readTaskUsage({
+      [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: 1.5, completion_tokens: 5 } },
+    }),
+    undefined,
+  );
+});
+
+test('readTaskUsage surfaces the {0,0,0} placeholder as zero, not as absent', () => {
+  // codex emits this when its runtime dropped accounting. It must reach
+  // `meterUsage` as a real zero so that path is logged as unpriceable rather
+  // than silently priced — the two are handled identically there, but the
+  // reader must not paper over the difference here.
+  const usage = readTaskUsage({
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    },
+  });
+  assert.deepEqual(usage, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
+});

--- a/packages/server/src/x402/usage.test.ts
+++ b/packages/server/src/x402/usage.test.ts
@@ -1,15 +1,50 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { OPENAI_COMPAT_EXTENSION_URI, type TaskUsage as WireTaskUsage } from '@vicoop-bridge/protocol';
 import { readTaskUsage } from './usage.js';
 
-test('readTaskUsage reads the bare {usage} shape plain A2A callers receive', () => {
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
-      usage: { prompt_tokens: 120, completion_tokens: 30, total_tokens: 150, model: 'sonnet' },
-    },
+const oaiMetadata = (payload: Record<string, unknown>) => ({
+  [OPENAI_COMPAT_EXTENSION_URI]: payload,
+});
+
+test('readTaskUsage prefers the protocol frame field', () => {
+  const reported: WireTaskUsage = {
+    promptTokens: 120,
+    completionTokens: 30,
+    cachedInputTokens: 20,
+    model: 'sonnet',
+  };
+  const result = readTaskUsage(reported, undefined);
+  assert.equal(result.source, 'protocol');
+  assert.deepEqual(result.usage, {
+    prompt_tokens: 120,
+    completion_tokens: 30,
+    total_tokens: 150,
+    cached_tokens: 20,
+    model: 'sonnet',
   });
-  assert.deepEqual(usage, {
+});
+
+test('the protocol field wins even when openai-compat metadata disagrees', () => {
+  // Billing must not depend on which of two sources happens to be read first,
+  // and the protocol field is the one the bridge owns.
+  const result = readTaskUsage(
+    { promptTokens: 10, completionTokens: 5 },
+    oaiMetadata({ usage: { prompt_tokens: 9999, completion_tokens: 9999 } }),
+  );
+  assert.equal(result.source, 'protocol');
+  assert.equal(result.usage?.total_tokens, 15);
+});
+
+test('readTaskUsage falls back to the bare openai-compat usage shape', () => {
+  // A client too old to send the frame field must stay priceable rather than
+  // silently billing the floor.
+  const result = readTaskUsage(
+    undefined,
+    oaiMetadata({ usage: { prompt_tokens: 120, completion_tokens: 30, model: 'sonnet' } }),
+  );
+  assert.equal(result.source, 'openai-compat');
+  assert.deepEqual(result.usage, {
     prompt_tokens: 120,
     completion_tokens: 30,
     total_tokens: 150,
@@ -17,98 +52,100 @@ test('readTaskUsage reads the bare {usage} shape plain A2A callers receive', () 
   });
 });
 
-test('readTaskUsage reads the chat_completion envelope shape', () => {
-  // The backends switch to this shape when the caller activated the
-  // openai-compat extension; both must price identically.
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
+test('readTaskUsage falls back to the chat_completion envelope shape', () => {
+  const result = readTaskUsage(
+    undefined,
+    oaiMetadata({
       chat_completion: {
         id: 'chatcmpl-x',
         usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
       },
-    },
+    }),
+  );
+  assert.equal(result.source, 'openai-compat');
+  assert.deepEqual(result.usage, {
+    prompt_tokens: 10,
+    completion_tokens: 5,
+    total_tokens: 15,
   });
-  assert.deepEqual(usage, { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 });
-});
-
-test('readTaskUsage extracts cached and model details', () => {
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
-      usage: {
-        prompt_tokens: 1000,
-        completion_tokens: 100,
-        total_tokens: 1100,
-        prompt_tokens_details: { cached_tokens: 900 },
-        completion_tokens_details: { reasoning_tokens: 40 },
-        model: 'claude-sonnet-4',
-      },
-    },
-  });
-  assert.equal(usage?.cached_tokens, 900);
-  assert.equal(usage?.model, 'claude-sonnet-4');
 });
 
 test('readTaskUsage recomputes the total rather than trusting the reported one', () => {
-  // The charge is derived from prompt + completion, so a backend that
-  // miscomputed `total_tokens` must not be able to move the price.
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
-      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 99999 },
-    },
-  });
-  assert.equal(usage?.total_tokens, 15);
+  // The charge derives from prompt + completion, so a backend that
+  // miscomputed the total must not be able to move the price.
+  const result = readTaskUsage(
+    undefined,
+    oaiMetadata({ usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 99999 } }),
+  );
+  assert.equal(result.usage?.total_tokens, 15);
 });
 
 test('readTaskUsage drops an incoherent cache count instead of discounting on it', () => {
-  // cached_tokens is a breakdown of prompt_tokens; a larger value is
-  // nonsense, and honouring it would discount tokens that were never cached.
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
+  // cached is a breakdown of prompt; a larger value would discount tokens
+  // that were never cached.
+  const fromProtocol = readTaskUsage(
+    { promptTokens: 100, completionTokens: 0, cachedInputTokens: 5000 },
+    undefined,
+  );
+  assert.equal(fromProtocol.usage?.cached_tokens, undefined);
+  assert.equal(fromProtocol.usage?.prompt_tokens, 100);
+
+  const fromLegacy = readTaskUsage(
+    undefined,
+    oaiMetadata({
       usage: {
         prompt_tokens: 100,
         completion_tokens: 0,
-        total_tokens: 100,
         prompt_tokens_details: { cached_tokens: 5000 },
       },
-    },
-  });
-  assert.equal(usage?.cached_tokens, undefined);
-  assert.equal(usage?.prompt_tokens, 100);
+    }),
+  );
+  assert.equal(fromLegacy.usage?.cached_tokens, undefined);
 });
 
-test('readTaskUsage returns undefined when there is nothing usable', () => {
-  assert.equal(readTaskUsage(undefined), undefined);
-  assert.equal(readTaskUsage({}), undefined);
-  assert.equal(readTaskUsage({ [OPENAI_COMPAT_EXTENSION_URI]: {} }), undefined);
-  // Missing required counts, negative, and non-integer values are all
-  // unusable — better to report "unpriceable" than to invent a number.
+test('readTaskUsage reports nothing usable as undefined with no source', () => {
+  const nothing = readTaskUsage(undefined, undefined);
+  assert.equal(nothing.usage, undefined);
+  assert.equal(nothing.source, undefined);
+
+  assert.equal(readTaskUsage(undefined, {}).usage, undefined);
+  assert.equal(readTaskUsage(undefined, oaiMetadata({})).usage, undefined);
   assert.equal(
-    readTaskUsage({ [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: 10 } } }),
+    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: 10 } })).usage,
     undefined,
   );
   assert.equal(
-    readTaskUsage({
-      [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: -1, completion_tokens: 5 } },
-    }),
+    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: -1, completion_tokens: 5 } }))
+      .usage,
     undefined,
   );
   assert.equal(
-    readTaskUsage({
-      [OPENAI_COMPAT_EXTENSION_URI]: { usage: { prompt_tokens: 1.5, completion_tokens: 5 } },
-    }),
+    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: 1.5, completion_tokens: 5 } }))
+      .usage,
     undefined,
   );
 });
 
-test('readTaskUsage surfaces the {0,0,0} placeholder as zero, not as absent', () => {
-  // codex emits this when its runtime dropped accounting. It must reach
-  // `meterUsage` as a real zero so that path is logged as unpriceable rather
-  // than silently priced — the two are handled identically there, but the
-  // reader must not paper over the difference here.
-  const usage = readTaskUsage({
-    [OPENAI_COMPAT_EXTENSION_URI]: {
-      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-    },
+test('a malformed protocol field falls through to the legacy source', () => {
+  // Rather than treating a broken frame as "unpriceable" while a perfectly
+  // good legacy value sits right there.
+  const result = readTaskUsage(
+    { promptTokens: -1, completionTokens: 5 } as unknown as WireTaskUsage,
+    oaiMetadata({ usage: { prompt_tokens: 10, completion_tokens: 5 } }),
+  );
+  assert.equal(result.source, 'openai-compat');
+  assert.equal(result.usage?.total_tokens, 15);
+});
+
+test('a zero-token report is surfaced as a real zero, not as absent', () => {
+  // Some runtimes emit {0,0} when their accounting dropped. `meterUsage`
+  // treats that as unpriceable, but the reader must not paper over the
+  // difference between "reported zero" and "reported nothing".
+  const result = readTaskUsage({ promptTokens: 0, completionTokens: 0 }, undefined);
+  assert.equal(result.source, 'protocol');
+  assert.deepEqual(result.usage, {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
   });
-  assert.deepEqual(usage, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 });
 });

--- a/packages/server/src/x402/usage.ts
+++ b/packages/server/src/x402/usage.ts
@@ -1,0 +1,79 @@
+import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+
+// Token counts for one completed task, read off the terminal status message.
+//
+// No protocol change was needed to get these: the claude, codex, and
+// vicoop-codex backends already stamp per-turn usage onto the `task.complete`
+// frame, and `wireMessageToA2X` carries the metadata through untouched. This
+// module is just the reader.
+export interface TaskUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cached_tokens?: number;
+  model?: string;
+}
+
+function count(v: unknown): number | undefined {
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 && Number.isInteger(v)
+    ? v
+    : undefined;
+}
+
+function readUsageObject(raw: unknown): TaskUsage | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const u = raw as Record<string, unknown>;
+
+  const prompt = count(u.prompt_tokens);
+  const completion = count(u.completion_tokens);
+  if (prompt === undefined || completion === undefined) return undefined;
+
+  // Recompute rather than trust the reported total: the invariant
+  // `total === prompt + completion` is what the price is derived from, and a
+  // backend that got it wrong should not be able to move the charge.
+  const usage: TaskUsage = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+  };
+
+  const details = u.prompt_tokens_details;
+  if (typeof details === 'object' && details !== null) {
+    const cached = count((details as Record<string, unknown>).cached_tokens);
+    // A cache figure larger than the prompt it is a breakdown of is
+    // incoherent; dropping it prices the whole prompt at the full rate,
+    // which errs toward not silently discounting on bad data.
+    if (cached !== undefined && cached <= prompt) usage.cached_tokens = cached;
+  }
+  if (typeof u.model === 'string' && u.model.length > 0) usage.model = u.model;
+
+  return usage;
+}
+
+/**
+ * Extract token usage from a terminal status message's metadata.
+ *
+ * The backends publish it under the openai-compat extension URI in one of two
+ * shapes, depending on whether the caller activated that extension:
+ *
+ *   { usage: {...} }                        — plain A2A callers
+ *   { chat_completion: { usage: {...} } }   — openai-compat envelope
+ *
+ * Both are read here. Returns `undefined` when nothing usable is present,
+ * which callers must treat as "the runtime did not report" rather than
+ * "zero" — see `meterUsage`.
+ */
+export function readTaskUsage(metadata: Record<string, unknown> | undefined): TaskUsage | undefined {
+  const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
+  if (typeof ext !== 'object' || ext === null) return undefined;
+  const payload = ext as Record<string, unknown>;
+
+  const direct = readUsageObject(payload.usage);
+  if (direct) return direct;
+
+  const envelope = payload.chat_completion;
+  if (typeof envelope === 'object' && envelope !== null) {
+    return readUsageObject((envelope as Record<string, unknown>).usage);
+  }
+  return undefined;
+}

--- a/packages/server/src/x402/usage.ts
+++ b/packages/server/src/x402/usage.ts
@@ -1,11 +1,14 @@
-import { OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
+import { OPENAI_COMPAT_EXTENSION_URI, type TaskUsage as WireTaskUsage } from '@vicoop-bridge/protocol';
 
-// Token counts for one completed task, read off the terminal status message.
+// Token counts for one completed task, in the shape the pricing math wants.
 //
-// No protocol change was needed to get these: the claude, codex, and
-// vicoop-codex backends already stamp per-turn usage onto the `task.complete`
-// frame, and `wireMessageToA2X` carries the metadata through untouched. This
-// module is just the reader.
+// The canonical source is the protocol's own `TaskCompleteFrame.usage`, which
+// the bridge owns end to end. The openai-compat metadata key is read only as a
+// migration fallback: the same counts have long ridden there for that
+// extension's consumers, and a client too old to send the frame field would
+// otherwise become unpriceable — which bills the floor, silently, rather than
+// failing. `source` says which one answered so the fallback is visible in the
+// logs and can be retired once no old clients remain.
 export interface TaskUsage {
   prompt_tokens: number;
   completion_tokens: number;
@@ -14,66 +17,98 @@ export interface TaskUsage {
   model?: string;
 }
 
+export type TaskUsageSource = 'protocol' | 'openai-compat';
+
+export interface ReadTaskUsageResult {
+  usage: TaskUsage | undefined;
+  source?: TaskUsageSource;
+}
+
 function count(v: unknown): number | undefined {
   return typeof v === 'number' && Number.isFinite(v) && v >= 0 && Number.isInteger(v)
     ? v
     : undefined;
 }
 
-function readUsageObject(raw: unknown): TaskUsage | undefined {
-  if (typeof raw !== 'object' || raw === null) return undefined;
-  const u = raw as Record<string, unknown>;
-
-  const prompt = count(u.prompt_tokens);
-  const completion = count(u.completion_tokens);
-  if (prompt === undefined || completion === undefined) return undefined;
-
-  // Recompute rather than trust the reported total: the invariant
-  // `total === prompt + completion` is what the price is derived from, and a
-  // backend that got it wrong should not be able to move the charge.
+// Recompute the total rather than trust a reported one, and drop a cache
+// figure larger than the prompt it claims to be a breakdown of — an incoherent
+// value would otherwise discount tokens that were never cached.
+function build(
+  prompt: number,
+  completion: number,
+  cached: number | undefined,
+  model: string | undefined,
+): TaskUsage {
   const usage: TaskUsage = {
     prompt_tokens: prompt,
     completion_tokens: completion,
     total_tokens: prompt + completion,
   };
-
-  const details = u.prompt_tokens_details;
-  if (typeof details === 'object' && details !== null) {
-    const cached = count((details as Record<string, unknown>).cached_tokens);
-    // A cache figure larger than the prompt it is a breakdown of is
-    // incoherent; dropping it prices the whole prompt at the full rate,
-    // which errs toward not silently discounting on bad data.
-    if (cached !== undefined && cached <= prompt) usage.cached_tokens = cached;
-  }
-  if (typeof u.model === 'string' && u.model.length > 0) usage.model = u.model;
-
+  if (cached !== undefined && cached <= prompt) usage.cached_tokens = cached;
+  if (model !== undefined && model.length > 0) usage.model = model;
   return usage;
 }
 
+function fromProtocol(usage: WireTaskUsage | undefined): TaskUsage | undefined {
+  if (usage === undefined) return undefined;
+  const prompt = count(usage.promptTokens);
+  const completion = count(usage.completionTokens);
+  if (prompt === undefined || completion === undefined) return undefined;
+  return build(prompt, completion, count(usage.cachedInputTokens), usage.model);
+}
+
+function fromOpenAICompatPayload(raw: unknown): TaskUsage | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const u = raw as Record<string, unknown>;
+  const prompt = count(u.prompt_tokens);
+  const completion = count(u.completion_tokens);
+  if (prompt === undefined || completion === undefined) return undefined;
+
+  const details = u.prompt_tokens_details;
+  const cached =
+    typeof details === 'object' && details !== null
+      ? count((details as Record<string, unknown>).cached_tokens)
+      : undefined;
+  return build(prompt, completion, cached, typeof u.model === 'string' ? u.model : undefined);
+}
+
 /**
- * Extract token usage from a terminal status message's metadata.
+ * The openai-compat extension publishes the counts in one of two shapes,
+ * depending on whether the caller activated it. Both are read here.
  *
- * The backends publish it under the openai-compat extension URI in one of two
- * shapes, depending on whether the caller activated that extension:
- *
- *   { usage: {...} }                        — plain A2A callers
- *   { chat_completion: { usage: {...} } }   — openai-compat envelope
- *
- * Both are read here. Returns `undefined` when nothing usable is present,
- * which callers must treat as "the runtime did not report" rather than
- * "zero" — see `meterUsage`.
+ *   { usage: {...} }                        plain A2A callers
+ *   { chat_completion: { usage: {...} } }   openai-compat envelope
  */
-export function readTaskUsage(metadata: Record<string, unknown> | undefined): TaskUsage | undefined {
+function fromOpenAICompat(metadata: Record<string, unknown> | undefined): TaskUsage | undefined {
   const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
   if (typeof ext !== 'object' || ext === null) return undefined;
   const payload = ext as Record<string, unknown>;
 
-  const direct = readUsageObject(payload.usage);
+  const direct = fromOpenAICompatPayload(payload.usage);
   if (direct) return direct;
 
   const envelope = payload.chat_completion;
   if (typeof envelope === 'object' && envelope !== null) {
-    return readUsageObject((envelope as Record<string, unknown>).usage);
+    return fromOpenAICompatPayload((envelope as Record<string, unknown>).usage);
   }
   return undefined;
+}
+
+/**
+ * Resolve the task's token usage, preferring the protocol field.
+ *
+ * A `usage` of `undefined` means the runtime reported nothing, which callers
+ * must treat as "unpriceable" rather than "zero" — see `meterUsage`.
+ */
+export function readTaskUsage(
+  reported: WireTaskUsage | undefined,
+  metadata: Record<string, unknown> | undefined,
+): ReadTaskUsageResult {
+  const protocolUsage = fromProtocol(reported);
+  if (protocolUsage) return { usage: protocolUsage, source: 'protocol' };
+
+  const legacy = fromOpenAICompat(metadata);
+  if (legacy) return { usage: legacy, source: 'openai-compat' };
+
+  return { usage: undefined };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
     dependencies:
       '@a2x/sdk':
         specifier: ^0.18.0
-        version: 0.18.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@rainbow-me/rainbowkit':
         specifier: ^2
         version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
@@ -135,7 +135,7 @@ importers:
     dependencies:
       '@a2x/sdk':
         specifier: ^0.18.0
-        version: 0.18.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: ^3.0.69
         version: 3.0.69(zod@3.25.76)
@@ -151,6 +151,12 @@ importers:
       '@vicoop-bridge/protocol':
         specifier: workspace:*
         version: link:../protocol
+      '@x402/core':
+        specifier: ^2.21.0
+        version: 2.21.0
+      '@x402/evm':
+        specifier: ^2.21.0
+        version: 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       ai:
         specifier: ^6.0.162
         version: 6.0.162(zod@3.25.76)
@@ -178,12 +184,12 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      viem:
+        specifier: ^2
+        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       ws:
         specifier: ^8.18.0
         version: 8.20.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      x402:
-        specifier: ^1.2.0
-        version: 1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -1282,21 +1288,10 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
-  '@solana-program/compute-budget@0.11.0':
-    resolution: {integrity: sha512-7f1ePqB/eURkTwTOO9TNIdUXZcyrZoX3Uy2hNo7cXMfNhPFWp9AVgIyRNBc2jf15sdUa9gNpW+PfP2iV8AYAaw==}
-    peerDependencies:
-      '@solana/kit': ^5.0
-
   '@solana-program/system@0.10.0':
     resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
       '@solana/kit': ^5.0
-
-  '@solana-program/token-2022@0.6.1':
-    resolution: {integrity: sha512-Ex02cruDMGfBMvZZCrggVR45vdQQSI/unHVpt/7HPt/IwFYB4eTlXtO8otYZyqV/ce5GqZ8S6uwyRf0zy6fdbA==}
-    peerDependencies:
-      '@solana/kit': ^5.0
-      '@solana/sysvars': ^5.0
 
   '@solana-program/token@0.9.0':
     resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
@@ -1658,10 +1653,6 @@ packages:
       typescript:
         optional: true
 
-  '@solana/wallet-standard-features@1.3.0':
-    resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
-    engines: {node: '>=16'}
-
   '@spruceid/siwe-parser@2.1.2':
     resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
 
@@ -1935,18 +1926,6 @@ packages:
       typescript:
         optional: true
 
-  '@wallet-standard/app@1.1.0':
-    resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
-    engines: {node: '>=16'}
-
-  '@wallet-standard/base@1.1.0':
-    resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
-    engines: {node: '>=16'}
-
-  '@wallet-standard/features@1.1.0':
-    resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
-    engines: {node: '>=16'}
-
   '@walletconnect/core@2.21.0':
     resolution: {integrity: sha512-o6R7Ua4myxR8aRUAJ1z3gT9nM+jd2B2mfamu6arzy1Cc6vi10fIwFWb6vg3bC8xJ6o9H3n/cN5TOW3aA9Y1XVw==}
     engines: {node: '>=18'}
@@ -2039,6 +2018,12 @@ packages:
 
   '@walletconnect/window-metadata@1.0.1':
     resolution: {integrity: sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==}
+
+  '@x402/core@2.21.0':
+    resolution: {integrity: sha512-0djKE7V5/JKDMrjRe5he3DoMFzlbVnUcvMmLAb2j6OoAJDamupkFh6fFrXeoHwjkBIxOFUzjGI4FVixz2dMxSA==}
+
+  '@x402/evm@2.21.0':
+    resolution: {integrity: sha512-VZtPz26IxhfAQbHHmyG7nCY/0jLH9QIgNqRztT1ae93dc9uSGUyn5bofzA3Wxq7lND3WDFir0QAQ2LBqoFeMrg==}
 
   abitype@1.0.6:
     resolution: {integrity: sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==}
@@ -3579,6 +3564,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.33:
+    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
     peerDependencies:
@@ -4480,6 +4473,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.55.11:
+    resolution: {integrity: sha512-RR5MwtdUnFfqw6ZGoFptizywyLOkLuhTL7UafoP3Irf2upXpANakQkLgGqY4H7A7+8JBxjUs6lElGF5zuGjMEw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -4623,8 +4624,17 @@ packages:
       utf-8-validate:
         optional: true
 
-  x402@1.2.0:
-    resolution: {integrity: sha512-cqcB9LNw1e1Kv6wkKyyKvn7wcYBnJ9vd8336M9jZRgLKDcIDt2n3liiSXyzx4HJTv07f9M2OAk5uKhh/LcbKQQ==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -4724,8 +4734,10 @@ packages:
 
 snapshots:
 
-  '@a2x/sdk@0.18.0(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@a2x/sdk@0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     optionalDependencies:
+      '@x402/core': 2.21.0
+      '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
 
@@ -5715,41 +5727,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      valtio: 1.13.2(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -5758,42 +5735,6 @@ snapshots:
       '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-pay@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)
-      lit: 3.3.0
-      valtio: 1.13.2(react@19.2.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5863,82 +5804,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-scaffold-ui@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - valtio
-      - zod
-
   '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      lit: 3.3.0
-      qrcode: 1.5.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit-ui@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -6008,44 +5877,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      valtio: 1.13.2(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
   '@reown/appkit-wallet@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)
@@ -6071,49 +5902,6 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@reown/appkit@1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-pay': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(react@19.2.5))(zod@3.25.76)
-      '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      bs58: 6.0.0
-      valtio: 1.13.2(react@19.2.5)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6340,18 +6128,9 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
-  '@solana-program/compute-budget@0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-
   '@solana-program/system@0.10.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-
-  '@solana-program/token-2022@0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))':
-    dependencies:
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/sysvars': 5.5.1(typescript@5.9.3)
 
   '@solana-program/token@0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -6781,11 +6560,6 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/wallet-standard-features@1.3.0':
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-
   '@spruceid/siwe-parser@2.1.2':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -7111,59 +6885,6 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - react-native
-      - supports-color
-      - uploadthing
-      - use-sync-external-store
-      - utf-8-validate
-      - wagmi
-      - zod
-
   '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
       eventemitter3: 5.0.1
@@ -7178,16 +6899,6 @@ snapshots:
       - immer
       - react
       - use-sync-external-store
-
-  '@wallet-standard/app@1.1.0':
-    dependencies:
-      '@wallet-standard/base': 1.1.0
-
-  '@wallet-standard/base@1.1.0': {}
-
-  '@wallet-standard/features@1.1.0':
-    dependencies:
-      '@wallet-standard/base': 1.1.0
 
   '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
@@ -7284,47 +6995,6 @@ snapshots:
   '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/jsonrpc-http-connection': 1.0.8
-      '@walletconnect/jsonrpc-provider': 1.0.14
-      '@walletconnect/jsonrpc-types': 1.0.4
-      '@walletconnect/jsonrpc-utils': 1.0.8
-      '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      events: 3.3.0
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
-      - ioredis
-      - react
-      - typescript
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  '@walletconnect/ethereum-provider@2.21.1(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
-    dependencies:
-      '@reown/appkit': 1.7.8(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -7767,6 +7437,20 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
+  '@x402/core@2.21.0':
+    dependencies:
+      zod: 3.25.76
+
+  '@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.21.0
+      viem: 2.55.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
   abitype@1.0.6(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
       typescript: 5.9.3
@@ -8153,10 +7837,6 @@ snapshots:
   derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5)):
     dependencies:
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-
-  derive-valtio@0.1.0(valtio@1.13.2(react@19.2.5)):
-    dependencies:
-      valtio: 1.13.2(react@19.2.5)
 
   destr@2.0.5: {}
 
@@ -8870,6 +8550,10 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  isows@1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   iterall@1.3.0: {}
 
   jiti@2.6.1: {}
@@ -9549,14 +9233,29 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.33(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -9733,26 +9432,6 @@ snapshots:
       react: 19.2.5
       typescript: 5.9.3
       wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
-
-  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
-    dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      hono: 4.12.12
-      idb-keyval: 6.2.2
-      mipd: 0.0.7(typescript@5.9.3)
-      ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      zod: 4.3.6
-      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
-    optionalDependencies:
-      '@tanstack/react-query': 5.99.0(react@19.2.5)
-      react: 19.2.5
-      typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10487,14 +10166,6 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.5
 
-  valtio@1.13.2(react@19.2.5):
-    dependencies:
-      derive-valtio: 0.1.0(valtio@1.13.2(react@19.2.5))
-      proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.2.5)
-    optionalDependencies:
-      react: 19.2.5
-
   vary@1.1.2: {}
 
   vfile-message@4.0.3:
@@ -10558,6 +10229,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.55.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.33(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -10577,51 +10265,6 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      react: 19.2.5
-      use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@tanstack/query-core'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react-native
-      - supports-color
-      - uploadthing
-      - utf-8-validate
-      - zod
-
-  wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
-    dependencies:
-      '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@wagmi/core@2.22.1(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
@@ -10723,58 +10366,10 @@ snapshots:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
 
-  x402@1.2.0(@solana/sysvars@5.5.1(typescript@5.9.3))(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10):
-    dependencies:
-      '@scure/base': 1.2.6
-      '@solana-program/compute-budget': 0.11.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana-program/token': 0.9.0(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))
-      '@solana-program/token-2022': 0.6.1(@solana/kit@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/sysvars@5.5.1(typescript@5.9.3))
-      '@solana/kit': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/transaction-confirmation': 5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/wallet-standard-features': 1.3.0
-      '@wallet-standard/app': 1.1.0
-      '@wallet-standard/base': 1.1.0
-      '@wallet-standard/features': 1.1.0
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/react-query@5.99.0(react@19.2.5))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
-      - '@solana/sysvars'
-      - '@tanstack/query-core'
-      - '@tanstack/react-query'
-      - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - debug
-      - encoding
-      - expo-auth-session
-      - expo-crypto
-      - expo-web-browser
-      - fastestsmallesttextencoderdecoder
-      - immer
-      - ioredis
-      - react
-      - react-native
-      - supports-color
-      - typescript
-      - uploadthing
-      - utf-8-validate
+  ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
Rebased onto `main` now that #449 (the `@a2x/sdk` 0.18 bump this needs) has merged. Two commits: `exact` first, then `upto` on top — reviewable separately, though the second reshapes the pricing column the first introduced.

Both schemes ship together on purpose: the `agents.x402_pricing` migration lands once, with its final shape, instead of being reshaped a release later.

## What this adds

A per-agent x402 payment gate in front of the WS-forwarding path. An agent with no pricing row is free and takes no payment code path at all — `currentGate()` returns `undefined` and nothing else in the executor changes.

```
turn 1  unpaid request      → input-required + x402.payment.required
turn 2  signed resubmission → verify → forward to agent → settle
```

| scheme | caller pays | notes |
| --- | --- | --- |
| `exact` (default) | flat fee per call | works on every backend |
| `upto` | tokens actually consumed, up to an authorized ceiling | x402 V2 only; needs caller opt-in; not possible on openclaw |

Two properties fall out of the ordering, and they're the reason for it:

- **Unpaid calls never reach the agent.** The gate runs before the task is bound or forwarded, so an unpaid or malformed request costs the backend nothing.
- **Failed work is never charged.** Settlement runs only on a `completed` task; a failed, cancelled, or timed-out task leaves the payer's signed authorization unused. A settlement that itself fails turns the task `failed` rather than letting it report a success the merchant wasn't paid for. (Under `upto`, deferring settlement is also what makes metering possible — the token counts only exist once the work is done.)

## Metering needed no protocol change

Worth flagging because I previously claimed the opposite in this PR's own docs, and it was wrong.

The claude, codex, and vicoop-codex backends **already** stamp per-turn token counts onto `task.complete`, under the openai-compat extension URI in `status.message.metadata` — deliberately even when the caller didn't activate that extension, so that "billing telemetry" can read them (`openai-compat-usage.ts:57-63`). `wireMessageToA2X` (`ws.ts:193`) carries the metadata through untouched. The counts are therefore already on the terminal event `settleTerminal` receives; `readTaskUsage` just reads them, from either wire shape (`{usage}` or `{chat_completion:{usage}}`).

No backend change, no protocol change, no `TaskCompleteFrame` field.

This is **not** the `usage.request` RPC — that's a cumulative account-level quota snapshot (rolling subscription windows, rate-limited, 5-min cached) and is useless for metering one call.

## Design decisions worth reviewing

**What to charge when a completed call can't be priced.** The load-bearing judgement call. openclaw reports no usage at any layer; codex and vicoop-codex emit `{0,0,0}` when their runtime drops accounting for a turn. **Zero does not mean free.** The bridge charges the configured `minAmount` (zero if unset) and logs `x402_usage_unavailable` with what it charged.

The default direction is deliberately payer-favourable: billing the authorized ceiling because *our* instrumentation lost the token count would be a user-visible wrong, whereas undercharging is our own loss to fix. It's one config field, so the opposite policy is a one-line change if you'd rather. The docs tell operators plainly to set `minAmount` on metered agents.

**Pricing is DB-owned, not declared by the client.** `payTo` names the wallet that receives money and the `hello` frame is authored by the connecting agent, so pricing gets the same trust boundary as `allowed_callers`. A malformed row logs `x402_pricing_invalid` and connects the agent as **free** rather than taking it offline — an operator typo shouldn't become an outage, and nobody is charged against config the server couldn't parse.

**Offerings persist in Postgres, not the SDK's `InMemoryX402Store`.** Correctness, not optimization: the round-trip spans two HTTP requests and the bridge runs several Fly instances behind a load balancer, so turn 2 routinely lands on an instance that never saw turn 1. In memory that classifies as `no-stored-offering` and refuses a perfectly valid payment. Expiry is lazy (a `WHERE` clause), per the store contract — no reaper needed.

**Rates are per million tokens, in atomic units, BigInt throughout.** That's the unit vendors quote in, so a price list transcribes directly. The intermediate product leaves a double's exact range long before the amounts do, hence BigInt end to end. `cached_tokens` is a breakdown of `prompt_tokens` and `reasoning_tokens` of `completion_tokens` — neither additive, so neither double-counted. An absent `cachedInput` rate means "same as input", not "free"; treating an unstated discount as 100% would give away most of a cache-heavy call.

**Driving `X402Context` from a custom executor.** The SDK documents this flow inside `BaseAgent.run()`, which the bridge has no room for — `WSForwardingExecutor` overrides `execute`/`executeStream` outright. `X402Context`'s methods take a structural `{ taskId, message }` rather than a real `InvocationContext`, so they compose unchanged; only the `AgentEvent`s need translating into wire status events.

**`X402Gate` takes an injected context**, with `createPostgresX402Context()` building the production one. That's what makes the round-trip testable against a stub facilitator instead of a live chain.

## Two prerequisites for `upto` (not blockers for merging)

- **x402 V2.** We default to V2. If `BRIDGE_X402_VERSION=1`, an `upto` agent refuses every call with `invalid_x402_version` and logs `x402_config_invalid` — reported as the permanent misconfiguration it is, rather than as a transient outage.
- **Caller opt-in.** Signing `upto` authorizes spending up to the maximum at the merchant's discretion — broader consent than `exact` — so the SDK's default selector never auto-picks one. Clients must pass `allowUpto` or select the requirement explicitly. **An `upto`-only agent is unusable by a default-configured client**, so we should confirm `a2a-wallet` exposes it before switching any existing agent over.

## Also

Drops the dead `x402@1.2.0` dependency. SDK 0.16 replaced it with `@x402/core` + `@x402/evm`, and nothing in the repo imported it — it was also the source of the `wagmi`→`react` peer warning on install.

## Test plan

- [x] `pnpm -r build`, `pnpm -r typecheck`
- [x] `pnpm --filter @vicoop-bridge/server test` — 335 tests, 280 pass / 0 fail (55 skipped, env-gated)
- [x] `pnpm --filter @vicoop-bridge/client test` — 858 pass / 0 fail

New coverage (34 tests):

- `x402/gate.test.ts` (16) — the full round-trip against a stub facilitator that counts `verify`/`settle` calls and records the settled amount, so "not charged for failed work" and "settled the metered amount, not the ceiling" are asserted directly rather than implied. Includes every refusal path: unknown taskId, a payload redirecting funds to a different `payTo` (caught locally, before facilitator quota is spent), facilitator rejection, settle failure, settle throwing, and a payment-rail outage failing **closed**. On the metered side: a charge above the ceiling is confirmed clamped down to it, and an `exact` agent is confirmed to ignore usage entirely (metering an `exact` requirement throws in the SDK).
- `x402/pricing.test.ts` (19) — schema and rate arithmetic. `"0.01"` (dollars-not-atomic-units) and `10000` (a number, precision-lossy on 18-decimal assets) are both rejected; cache discounting doesn't double-count; a sub-unit charge rounds up rather than to zero; BigInt exactness holds on values past 2^53.
- `x402/usage.test.ts` (7) — both wire shapes, `total_tokens` recomputed rather than trusted, an incoherent cache count dropped instead of discounted on, and `{0,0,0}` surfaced as a real zero rather than as absent.
- `executor.test.ts` (+1) — a free agent is forwarded normally even when the payment path is configured, with an exploding `sql` proxy proving the store is never touched.

Not covered by automated tests: `PostgresX402Store` against a real database, and real on-chain settlement (both `exact` EIP-3009 and `upto` Permit2). Those want the Base Sepolia sandbox — see `docs/x402-payments.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
