### PR TITLE
fix(claude): log the resolved model from system/init (#457)

### DIFF
--- a/.changeset/clever-moons-shake.md
+++ b/.changeset/clever-moons-shake.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: log the resolved model once per task at `info`. The
+`system/init` event was the one `system` subtype that never reached a log, so a
+task that went fine left no record of which model actually served it. The line
+carries the model string verbatim (the normalised id is the openai-compat
+envelope's need, not the log's) plus the requested `envelope.model` when there
+was one, making "asked for X, served Y" — the `model_refusal_fallback` failure
+mode — legible from a single log line.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -13,6 +13,7 @@ import {
   OPENAI_COMPAT_OPERATOR_PRIVACY_CLAUSE,
   createClaudeBackend,
   enrichEntriesWithModelLimits,
+  describeClaudeSessionInit,
   describeClaudeSystemEvent,
   describeEmptyDispatchTurn,
   resolveTurnText,
@@ -5560,6 +5561,69 @@ test('claude backend resolveCapabilities short-circuits when probeTimeoutMs is 0
   const caps = await backend.resolveCapabilities!();
   assert.deepEqual(caps, {});
   assert.equal(spawned, 0, 'probeTimeoutMs:0 must skip the spawn entirely');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// describeClaudeSessionInit — the one `system` subtype that used to reach no
+// log at all (#457), so a task that went fine left no record of which model
+// served it.
+// ───────────────────────────────────────────────────────────────────────────
+
+test('describeClaudeSessionInit: reports the model verbatim, not the normalised id', () => {
+  // A diagnostic line records what the CLI reported. `normalizeClaudeModelId`
+  // exists for the envelope (it must match the advertised id), and running the
+  // value through it here would only discard detail — the `[1m]` tier suffix
+  // being the visible case.
+  const line = describeClaudeSessionInit({
+    taskId: 'task-1',
+    model: 'claude-fable-5[1m]',
+  });
+  assert.match(line, /taskId=task-1/);
+  assert.match(line, /model=claude-fable-5\[1m\]/);
+});
+
+test('describeClaudeSessionInit: names the requested model alongside the served one', () => {
+  // "asked for X, served Y" has to be legible from this line alone — the
+  // incident that motivated it was answered by joining three indirect signals.
+  const line = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'claude-opus-4-8',
+    requestedModel: 'claude-fable-5',
+  });
+  assert.match(line, /model=claude-opus-4-8/);
+  assert.match(line, /requested=claude-fable-5/);
+});
+
+test('describeClaudeSessionInit: omits `requested` on the agentic path', () => {
+  // No `envelope.model` there, so nothing was requested and claude picked —
+  // an empty `requested=` would read as a model named "".
+  for (const requestedModel of [undefined, '']) {
+    const line = describeClaudeSessionInit({
+      taskId: 't',
+      model: 'claude-opus-4-8',
+      requestedModel,
+    });
+    assert.doesNotMatch(line, /requested=/);
+  }
+});
+
+test('describeClaudeSessionInit: still reports an init whose model is missing', () => {
+  // `unknown` is itself the finding — it means the envelope fallback got
+  // nothing — and "did this task init at all" must not hinge on the field
+  // being well-formed.
+  for (const model of [undefined, null, '', 42, {}]) {
+    const line = describeClaudeSessionInit({ taskId: 't', model });
+    assert.match(line, /\[claude\] session init taskId=t model=unknown/);
+  }
+});
+
+test('describeClaudeSessionInit: a hostile model string cannot forge a log line', () => {
+  const line = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'evil\n[client] FAKE ENTRY',
+    requestedModel: 'also\nevil',
+  });
+  assert.equal(line.includes('\n'), false);
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -355,6 +355,52 @@ export function normalizeClaudeModelId(raw: string): string {
   return raw.replace(/\[[^\]]+\]$/, '');
 }
 
+// Render the per-task `system/init` event into one log line.
+//
+// `init` was the one `system` subtype that never reached a log: the branch
+// captured `model` for the openai-compat envelope fallback and returned, so a
+// task that went fine left no record of which model actually served it (#457).
+// The answer had to be assembled from circumstantial signals instead —
+// router-side `requestedModel`, the `--model` argv, a prompt size only one
+// tier could have held. One line settles it directly.
+//
+// Three details:
+//
+//   - The `model` string VERBATIM. A diagnostic line records what the CLI
+//     actually reported; normalising is the envelope's need — it has to match
+//     the advertised id and `usage.model` — not the log's, and logging the
+//     normalised form would discard detail for nothing in return. The tier
+//     suffix `[1m]` surviving is a side benefit rather than the point;
+//     `ProbedClaudeModel` keeps `id` and `raw` side by side for the one case
+//     that does turn on it.
+//   - `requested` alongside it whenever the task carried an `envelope.model`,
+//     so "asked for X, served Y" is legible in a single line instead of a join
+//     against the router. Absent on the agentic path, which sends no
+//     `--model` and lets claude pick.
+//   - Always a line, even when `model` is missing or malformed — `unknown` is
+//     itself the finding, and "did this task init at all" must not depend on
+//     the field being well-formed.
+//
+// The caller logs it at `info`: it fires once per task, so it carries none of
+// the per-delta flood risk that puts `thinking_tokens` on debug (below), and a
+// post-hoc diagnosis is worthless if it required debug to have been on before
+// the incident.
+//
+// Exported for unit tests.
+export function describeClaudeSessionInit(opts: {
+  taskId: string;
+  model: unknown;
+  requestedModel?: string | undefined;
+}): string {
+  const model =
+    typeof opts.model === 'string' && opts.model.length > 0 ? opts.model : 'unknown';
+  const requested =
+    typeof opts.requestedModel === 'string' && opts.requestedModel.length > 0
+      ? ` requested=${safeToken(opts.requestedModel, 60)}`
+      : '';
+  return `[claude] session init taskId=${opts.taskId} model=${safeToken(model, 60)}${requested}`;
+}
+
 // Render a non-`init` SDK `system` event into one log line, and decide how
 // loudly to say it.
 //
@@ -2889,6 +2935,16 @@ export function createClaudeBackend(
             const normalised = normalizeClaudeModelId(evt.model);
             if (normalised.length > 0) initModel = normalised;
           }
+          // …and say it out loud, once per task, with the tier suffix intact
+          // (#457). This is the only place the served model is knowable before
+          // something goes wrong.
+          timingLogger.info?.(
+            describeClaudeSessionInit({
+              taskId: task.taskId,
+              model: evt.model,
+              requestedModel: envelopeModel,
+            }),
+          );
           return;
         }
         if (evt.type === 'system') {


### PR DESCRIPTION
Closes #457.

## Problem

`system/init` was the one `system` subtype that never reached a log. The branch
captured `model` into `initModel` for the openai-compat envelope fallback (#348)
and returned — so on a task that went fine there was no record anywhere of which
model actually served the turn. #442 closed exactly this gap for every *other*
subtype.

`initModel` is consumed only by the openai-compat envelope; the single place it
reached a log was the narrated-tool-call retry path — i.e. only once a task was
already going wrong.

This is not a hypothetical concern: `model_refusal_fallback` (claude silently
retries the turn on a different model) hit 7 of the 8 turns in one measured
conversation. Answering *"is this task actually being served by
`claude-fable-5`?"* required assembling circumstantial signals — the router's
`requestedModel` and the `["--model", envelopeModel]` argv construction.

## Change

Adds the pure helper `describeClaudeSessionInit` and calls it once per task at
`info` from the existing `init` branch:

```
[claude] session init taskId=<id> model=claude-opus-4-8[1m] requested=claude-opus-4-8
```

Three details:

- **The model string verbatim.** A diagnostic line records what the CLI
  reported. `normalizeClaudeModelId` exists for the envelope — it has to match
  the advertised id and `usage.model` — and running the value through it here
  would only discard detail for nothing in return.
- **`requested` alongside it** — beyond what the issue proposed. The failure
  mode is *"requested X, served Y"*, and nothing else in the system carries the
  requested side: #442 reports a transition only once claude announces one, and
  the CLI's own telemetry reports only what served. The value is the post-gate
  `envelopeModel`, i.e. what actually rode to argv. Omitted on the agentic path,
  which sends no `--model` (an empty `requested=` would read as a model named
  `""`).
- **`info`, not `debug`.** Fires once per task, so it carries none of the
  per-delta flood risk that puts `thinking_tokens` on debug — and a post-hoc
  diagnosis is worthless if it required debug to have been on before the
  incident.

A line is emitted even when `model` is missing or malformed (`model=unknown`):
that's itself the finding — it means the envelope fallback got nothing — and
"did this task init at all" must not hinge on the field being well-formed.

Scope is one branch in `handleEvent`; no change to the spawn/pipe structure.
`initModel` and its consumers are untouched.

## Tests

Five unit tests on the helper, following the `describeClaudeSystemEvent` /
`describeEmptyDispatchTurn` precedent: verbatim model, `requested` pairing,
omission on the agentic path, malformed `model`, and log-line forgery via a
hostile model string.

The wiring itself is exercised by the existing spawn-driven integration tests,
which now emit the line on real `handle()` runs:

```
[claude] session init taskId=task-zi7d41 model=claude-opus-4-8[1m] requested=claude-opus-4-8
```

- `pnpm -r build` ✅
- `pnpm -r typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` ✅ 879 pass / 0 fail

## Not in scope: the CLI's own OTEL telemetry

#457 also notes that no Claude Code telemetry reaches the journal, and
attributes that to the spawn/pipe structure (stdout parsed as stream-json with
non-JSON lines dropped, stderr only into a capped `stderrTail`). Measured
against the real CLI (2.1.226) in the bridge's spawn shape, that diagnosis is
wrong in a useful way:

- With `OTEL_LOGS_EXPORTER=console`, **nothing is emitted at all** — stdout was
  14/14 valid stream-json (zero non-JSON lines) and stderr was 0 bytes. The
  pipes are not losing telemetry; there is none to lose. Logging the dropped
  non-JSON stdout lines would therefore fix nothing.
- Switching to `OTEL_LOGS_EXPORTER=otlp` against a loopback receiver delivers
  everything, **with no change to the spawn or pipes** — `defaultSpawn` already
  inherits `process.env`. `api_request` records carry `model`, token counts,
  `cost_usd`, `duration_ms` and `request_id`; metrics carry
  `claude_code.token.usage` / `cost.usage` / `session.count`.

So it is an env/docs matter first, and only becomes a code change if the records
should interleave into the bridge's own journal (which would need an inbound
listener plus port allocation; `session.id` → `taskId` correlation is already
free because the bridge mints `--session-id`). Either way it is orthogonal to
this PR, and none of it carries the *requested* model. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
