### PR TITLE
docs(claude): observability + the OTEL recipe that actually works (#459)

### DIFF
--- a/.changeset/olive-donkeys-report.md
+++ b/.changeset/olive-donkeys-report.md
@@ -3,9 +3,11 @@
 ---
 
 docs: add `docs/claude-telemetry.md` — observability for the `claude` backend.
-Covers what the journal already reports without any setup (served + requested
-model per task, tokens/cost, silent model switches), and the OTLP recipe for
-collecting the Claude Code CLI's own OpenTelemetry stream when per-request
-granularity or `request_id` is needed. Notably: `OTEL_LOGS_EXPORTER=console`
-emits nothing under the bridge, so operators running it today are collecting
-nothing — use `otlp`.
+Covers what the journal already reports without any setup (the served and
+requested model per CLI spawn, silent model switches) and, just as usefully,
+what it does not (token counts go to the openai-compat response envelope rather
+than the journal; cost is never computed). Adds the OTLP recipe for collecting
+the Claude Code CLI's own OpenTelemetry stream when per-request granularity,
+`request_id`, or cost is needed. Notably: `OTEL_LOGS_EXPORTER=console` emits
+nothing under the bridge, so operators running it today are collecting nothing
+— use `otlp`.

--- a/.changeset/olive-donkeys-report.md
+++ b/.changeset/olive-donkeys-report.md
@@ -1,0 +1,11 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+docs: add `docs/claude-telemetry.md` — observability for the `claude` backend.
+Covers what the journal already reports without any setup (served + requested
+model per task, tokens/cost, silent model switches), and the OTLP recipe for
+collecting the Claude Code CLI's own OpenTelemetry stream when per-request
+granularity or `request_id` is needed. Notably: `OTEL_LOGS_EXPORTER=console`
+emits nothing under the bridge, so operators running it today are collecting
+nothing — use `otlp`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,4 @@ authoring or cleaning up changesets.**
 - [`docs/claude-e2e.md`](./docs/claude-e2e.md), [`docs/openclaw-e2e.md`](./docs/openclaw-e2e.md) — backend-specific E2E
 - [`docs/container.md`](./docs/container.md) — container runtime profiles (bundled-direct + external-runtime)
 - [`docs/x402-payments.md`](./docs/x402-payments.md) — per-agent x402 pricing, the payment round-trip, and settlement
+- [`docs/claude-telemetry.md`](./docs/claude-telemetry.md) — what the journal already reports about the claude backend, and how to collect the CLI's own OTEL stream

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Docs:
 - [`docs/remote-testing.md`](./docs/remote-testing.md) — end-to-end testing against a deployed bridge
 - [`docs/local-testing.md`](./docs/local-testing.md) — running both bridge and client from source
 - [`docs/openclaw-e2e.md`](./docs/openclaw-e2e.md) — exercising the `openclaw` backend directly against the gateway Docker image
+- [`docs/claude-telemetry.md`](./docs/claude-telemetry.md) — observability for the `claude` backend: what the journal already reports, and collecting the CLI's OTEL stream
 
 ## Client Releases
 

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -58,10 +58,14 @@ OTEL_EXPORTER_OTLP_PROTOCOL=http/json
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
 ```
 
-Point the endpoint at any OTLP collector you already run. Short-lived tasks may
-finish before the default export interval elapses — cut
-`OTEL_LOGS_EXPORT_INTERVAL` / `OTEL_METRIC_EXPORT_INTERVAL` (milliseconds) if
-you are debugging a single run and want a prompt flush.
+Point the endpoint at any OTLP collector you already run.
+
+You do not need to tune the export intervals for short tasks: the CLI flushes
+on shutdown, so a run that exits well inside the default interval still
+delivers everything. Verified on a ~6s task with the block above verbatim —
+all log record types and all four metrics arrived, just batched into fewer
+HTTP posts. `OTEL_LOGS_EXPORT_INTERVAL` / `OTEL_METRIC_EXPORT_INTERVAL`
+(milliseconds) only change how promptly records show up *during* a long run.
 
 ## What arrives
 

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -6,30 +6,41 @@ bridge's journal. This page is about getting it somewhere useful.
 
 ## Do you need it?
 
-Often not. The bridge already puts the two most-asked-for facts in its own
-journal, with no collector and no configuration:
+Maybe not, if all you want is the model question. Two things are already in the
+journal at the default `info` level, with no collector and no configuration:
 
-- **Which model served a task** — one `info` line per task, from the CLI's
-  `system/init` event, carrying both the served model and the requested one:
+- **Which model served a task** — a line per CLI spawn, from the `system/init`
+  event:
 
   ```text
   [claude] session init taskId=<id> model=claude-opus-4-8[1m] requested=claude-opus-4-8
   ```
 
-- **Tokens and cost** — parsed off the terminal `result` event's `modelUsage`.
+  `requested=` is the model the bridge put on `--model`, and it appears only
+  when there was one: openai-compat tasks carrying `envelope.model`. It is
+  absent on the agentic path (which lets claude choose) and also when the
+  requested id was not among this install's advertised models — that case is
+  dropped and reported on its own `warn` line instead.
 
 - **Silent model switches** — every non-`init` `system` event is logged, and a
   `model_refusal_fallback` (claude retrying your turn on a different model)
   warns with `from=` / `to=`.
 
-Reach for OTEL when you want what those *can't* give you: per-**request**
-granularity rather than per-task (a turn that retried internally shows up as
-several `api_request` records), the Anthropic-side `request_id`, or
-`duration_ms` / `effort` / `speed`.
+Everything else on this page is what the journal does **not** give you:
 
-Note that OTEL does **not** report the *requested* model — only what served.
-Only the bridge knows what was asked for, which is why the `session init` line
-above carries `requested=`.
+- **Tokens and cost.** Token counts are parsed off the terminal `result`
+  event's `modelUsage`, but they go into the openai-compat response envelope,
+  not the journal — and only on that path. Cost is not computed at all. If you
+  want either in your own records, OTEL is the route.
+- **Per-request granularity.** The journal is per CLI spawn; OTEL emits an
+  `api_request` record per underlying request, so a turn that retried
+  internally is visible as several records.
+- **`request_id`**, the Anthropic-side id worth quoting in a support thread,
+  plus `duration_ms` / `effort` / `speed`.
+
+Going the other way, OTEL does **not** report the *requested* model — only what
+served. Only the bridge knows what was asked for, which is why the `session
+init` line carries `requested=`.
 
 ## Do not use the console exporter
 
@@ -92,8 +103,16 @@ user.id, user.email, user.account_id,
 ### Joining a record back to a task
 
 The bridge mints the CLI session id itself and passes it as `--session-id`, so
-OTEL's `session.id` is the same value the bridge logs alongside `taskId`. No
-extra correlation work is needed.
+OTEL's `session.id` is a value the bridge knows. Two caveats before you rely on
+the join:
+
+- **The journal only prints it at `debug`.** The session id appears in the
+  `claude.spawn.start … argv=` line, which is `debug`-level, so at the default
+  `info` you will not find it. Raise `VICOOP_CLIENT_LOG_LEVEL=debug` on the
+  client if you need to correlate.
+- **It is not one-to-one with tasks.** Follow-up tasks sharing an A2A
+  `contextId` reuse the same claude session via `--resume`, so one `session.id`
+  can cover several `taskId`s.
 
 ### Operator-account attributes
 

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -13,14 +13,15 @@ journal at the default `info` level, with no collector and no configuration:
   event:
 
   ```text
-  [claude] session init taskId=<id> model=claude-opus-4-8[1m] requested=claude-opus-4-8
+  [claude] session init taskId=<id> session=<session-id> model=claude-opus-4-8[1m] requested=claude-opus-4-8
   ```
 
   `requested=` is the model the bridge put on `--model`, and it appears only
   when there was one: openai-compat tasks carrying `envelope.model`. It is
-  absent on the agentic path (which lets claude choose) and also when the
-  requested id was not among this install's advertised models — that case is
-  dropped and reported on its own `warn` line instead.
+  absent on the agentic path, which lets claude choose. When the requested id
+  was not among this install's advertised models the bridge drops it and lets
+  claude fall back — that shows up as `requestedDropped=<id>` instead, plus a
+  `warn` line from the gate.
 
 - **Silent model switches** — every non-`init` `system` event is logged, and a
   `model_refusal_fallback` (claude retrying your turn on a different model)
@@ -103,16 +104,21 @@ user.id, user.email, user.account_id,
 ### Joining a record back to a task
 
 The bridge mints the CLI session id itself and passes it as `--session-id`, so
-OTEL's `session.id` is a value the bridge knows. Two caveats before you rely on
-the join:
+OTEL's `session.id` is a value the bridge knows. The `session init` line prints
+it at `info`:
 
-- **The journal only prints it at `debug`.** The session id appears in the
-  `claude.spawn.start … argv=` line, which is `debug`-level, so at the default
-  `info` you will not find it. Raise `VICOOP_CLIENT_LOG_LEVEL=debug` on the
-  client if you need to correlate.
-- **It is not one-to-one with tasks.** Follow-up tasks sharing an A2A
-  `contextId` reuse the same claude session via `--resume`, so one `session.id`
-  can cover several `taskId`s.
+```text
+[claude] session init taskId=<id> session=<session-id> model=…
+```
+
+One caveat: **the join is not one-to-one.** Follow-up tasks sharing an A2A
+`contextId` reuse the same claude session via `--resume`, and a resumed run
+reports the *same* `session.id` (measured, not assumed). So one `session.id` can
+cover several `taskId`s, and you should join in that direction — session to
+tasks, not task to session.
+
+The same id also names the on-disk session transcript, which is what an
+incident investigation ends up reading when the logs run out.
 
 ### Operator-account attributes
 

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -1,0 +1,106 @@
+# Claude Code telemetry (OTEL)
+
+The `claude` backend runs the Claude Code CLI as a child process. That CLI
+carries its own OpenTelemetry instrumentation, entirely separate from the
+bridge's journal. This page is about getting it somewhere useful.
+
+## Do you need it?
+
+Often not. The bridge already puts the two most-asked-for facts in its own
+journal, with no collector and no configuration:
+
+- **Which model served a task** — one `info` line per task, from the CLI's
+  `system/init` event, carrying both the served model and the requested one:
+
+  ```text
+  [claude] session init taskId=<id> model=claude-opus-4-8[1m] requested=claude-opus-4-8
+  ```
+
+- **Tokens and cost** — parsed off the terminal `result` event's `modelUsage`.
+
+- **Silent model switches** — every non-`init` `system` event is logged, and a
+  `model_refusal_fallback` (claude retrying your turn on a different model)
+  warns with `from=` / `to=`.
+
+Reach for OTEL when you want what those *can't* give you: per-**request**
+granularity rather than per-task (a turn that retried internally shows up as
+several `api_request` records), the Anthropic-side `request_id`, or
+`duration_ms` / `effort` / `speed`.
+
+Note that OTEL does **not** report the *requested* model — only what served.
+Only the bridge knows what was asked for, which is why the `session init` line
+above carries `requested=`.
+
+## Do not use the console exporter
+
+`OTEL_LOGS_EXPORTER=console` **produces no output at all** under the bridge —
+measured on CLI 2.1.226 in the bridge's exact spawn shape (stream-json on
+stdout, both streams piped): stdout was 14/14 valid stream-json lines with zero
+non-JSON output, and stderr was 0 bytes. Nothing is being swallowed by the
+bridge's stream parsing; nothing is emitted in the first place.
+
+If you have `CLAUDE_CODE_ENABLE_TELEMETRY=1` and a console exporter set today,
+you are collecting nothing. Use OTLP.
+
+## Recipe
+
+The client does not read these — they ride to the CLI child through
+`process.env`, so set them wherever the client process gets its environment
+(systemd unit, container env, shell). This is passthrough, not runtime config:
+see the "Env vars are out of the runtime-config chain" note in
+[`install-client.md`](./install-client.md).
+
+```bash
+CLAUDE_CODE_ENABLE_TELEMETRY=1
+OTEL_LOGS_EXPORTER=otlp
+OTEL_METRICS_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/json
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+```
+
+Point the endpoint at any OTLP collector you already run. Short-lived tasks may
+finish before the default export interval elapses — cut
+`OTEL_LOGS_EXPORT_INTERVAL` / `OTEL_METRIC_EXPORT_INTERVAL` (milliseconds) if
+you are debugging a single run and want a prompt flush.
+
+## What arrives
+
+| kind | records |
+| --- | --- |
+| logs | `api_request`, `assistant_response`, `user_prompt`, `hook_execution_start` / `hook_execution_complete`, `hook_registered`, `mcp_server_connection`, `plugin_loaded` |
+| metrics | `claude_code.token.usage`, `claude_code.cost.usage`, `claude_code.session.count`, `claude_code.active_time.total` |
+
+An `api_request` log record carries:
+
+```text
+model                                          the model that served this request
+input_tokens, output_tokens,
+  cache_read_tokens, cache_creation_tokens
+cost_usd, cost_usd_micros, duration_ms
+request_id                                     Anthropic-side; quote it in support threads
+prompt.id, client_request_id
+speed, effort, query_source
+session.id                                     joins to the bridge's taskId — see below
+user.id, user.email, user.account_id,
+  user.account_uuid, organization.id           operator-account attributes
+```
+
+### Joining a record back to a task
+
+The bridge mints the CLI session id itself and passes it as `--session-id`, so
+OTEL's `session.id` is the same value the bridge logs alongside `taskId`. No
+extra correlation work is needed.
+
+### Operator-account attributes
+
+Every record carries the operator's account identity (`user.email`,
+`user.account_id`, `user.account_uuid`, `organization.id`). On a collector you
+run yourself this is unremarkable — it is your own account, on your own host.
+It matters if you forward the stream anywhere shared or off-host: filter those
+attribute keys at the collector before it leaves.
+
+This is a different channel from the caller-facing one. The bridge separately
+prevents the model from disclosing operator-account metadata *in its responses*
+to whoever is talking to the agent (`OPENAI_COMPAT_OPERATOR_PRIVACY_CLAUSE`);
+that protection is about the response, and says nothing about where you route
+telemetry.


### PR DESCRIPTION
Option A from #459 — the env/docs half, which needs no bridge code.

Adds `docs/claude-telemetry.md`, indexed from `README.md` and `AGENTS.md`.

## Why

Two things an operator could not learn from this repo:

1. **What the journal already tells them about a claude task.** Quite a lot, as
   of #457 — served *and* requested model per task, tokens/cost off
   `result.modelUsage`, and a `model_refusal_fallback` warning with `from=` /
   `to=` (#442). The doc leads with "do you need it?" for exactly this reason;
   most operators reaching for OTEL already have what they wanted.

2. **Why their OTEL setup collects nothing.** Measured on CLI 2.1.226 in the
   bridge's exact spawn shape, `OTEL_LOGS_EXPORTER=console` emits nothing at
   all — stdout was 14/14 valid stream-json with zero non-JSON lines, stderr 0
   bytes. Anyone running `CLAUDE_CODE_ENABLE_TELEMETRY=1` with a console
   exporter today is collecting nothing and gets no signal that they are. That
   warning is the sharpest thing in the page.

Swapping to OTLP delivers everything with no bridge change at all —
`defaultSpawn` already inherits `process.env`, which is how
`CLAUDE_CODE_ENABLE_TELEMETRY=1` was reaching the CLI in the first place.

## Contents

- Do you need it? — what lands in the journal for free, and the narrow band
  OTEL actually adds (per-**request** granularity, `request_id`, `duration_ms` /
  `effort` / `speed`). Also states plainly that OTEL cannot report the
  *requested* model; only the bridge knows that.
- The console-exporter warning.
- The OTLP recipe, framed as passthrough to the CLI child rather than runtime
  config — cross-referenced to the "Env vars are out of the runtime-config
  chain" note in `install-client.md` so it doesn't read as a contradiction of
  #189 §5.
- What arrives: log records / metrics table, and the `api_request` attribute
  list.
- `session.id` → `taskId` joining, which is free because the bridge mints the
  session id and passes `--session-id`.
- Operator-account attributes on every record: unremarkable on a collector you
  run yourself, worth filtering before the stream leaves the host. Called out as
  a *different channel* from the caller-facing one
  `OPENAI_COMPAT_OPERATOR_PRIVACY_CLAUSE` guards, so the two don't get conflated.

## Not included

Option B from #459 — an in-process loopback receiver that interleaves these
records into the bridge's own journal. It stays open there, gated on the
unresolved question an unauthenticated inbound listener raises: any local
process could POST forged records into the operator's journal.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
