### PR TITLE
docs(claude): the session-init line fires per spawn, not per task

### DIFF
--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -381,10 +381,11 @@ export function normalizeClaudeModelId(raw: string): string {
 //     itself the finding, and "did this task init at all" must not depend on
 //     the field being well-formed.
 //
-// The caller logs it at `info`: it fires once per task, so it carries none of
-// the per-delta flood risk that puts `thinking_tokens` on debug (below), and a
-// post-hoc diagnosis is worthless if it required debug to have been on before
-// the incident.
+// The caller logs it at `info`: it fires once per CLI spawn — so once on a
+// normal task, twice on one the narrated-tool-call retry re-spawns, and never
+// per-delta. That carries none of the flood risk that puts `thinking_tokens`
+// on debug (below), and a post-hoc diagnosis is worthless if it required debug
+// to have been on before the incident.
 //
 // Exported for unit tests.
 export function describeClaudeSessionInit(opts: {
@@ -2935,9 +2936,12 @@ export function createClaudeBackend(
             const normalised = normalizeClaudeModelId(evt.model);
             if (normalised.length > 0) initModel = normalised;
           }
-          // …and say it out loud, once per task, with the tier suffix intact
-          // (#457). This is the only place the served model is knowable before
-          // something goes wrong.
+          // …and say it out loud (#457) — on a normal task this is the only
+          // record of what served it. Fires per SPAWN, not per task: the
+          // narrated-tool-call retry re-spawns and re-attaches these handlers,
+          // so a retried task emits a second line. That is wanted, not a leak
+          // — the retry is a fresh CLI invocation and can resolve a different
+          // model than the attempt it is correcting.
           timingLogger.info?.(
             describeClaudeSessionInit({
               taskId: task.taskId,


### PR DESCRIPTION
Follow-up to #458, from an adversarial review of it.

## The claim that failed

#458 justified logging the `session init` line at `info` rather than `debug`
with "it fires once per task". That is false on the #441 narrated-tool-call
retry path: it re-spawns the child and calls `attachStreams(child)` again on
the same `handleEvent` closure (`claude.ts:3305-3307`), and the `init` branch
carries no fired-once guard. Every stream-json run emits `system/init` as its
first event, so a retried task logs the line twice.

Not a fringe combination either — that retry is gated on the openai-compat
dispatch path, i.e. exactly the path where `requested=` is populated.

## What changes

Comments only.

The behaviour stays as-is, because it is the behaviour you want: a retry is a
fresh CLI invocation and can resolve a *different* model than the attempt it is
correcting, which is worth its own line. The `info` choice also survives on its
own merits — two lines per task is still nowhere near the per-delta flood that
put `thinking_tokens` on `debug`.

What was actually broken was the stated invariant, and an invariant a reader
cannot trust is worse than no invariant at all. Both comments now say **per
spawn**, name the retry as the second case, and say why the second line is
wanted rather than a leak.

Also drops the adjacent "this is the only place the served model is knowable
before something goes wrong" — the same retry path falsifies it, since that
path logs the model too.

## Verification

- `pnpm -r typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` ✅ 879 pass / 0 fail

No test is added: the property is a call-site one (how many times the logger is
invoked across a respawn), and `timingLogger` is constructed internally with no
injection point, so asserting on it would mean reshaping the backend's logger
wiring — out of proportion to a comment correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
