### PR TITLE
feat(claude): report the dropped model and the session id on session init

### DIFF
--- a/.changeset/olive-pugs-tickle.md
+++ b/.changeset/olive-pugs-tickle.md
@@ -1,0 +1,10 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+claude backend: the `session init` log line now reports the claude session id
+(`session=`), and the requested model that the advertised-models gate rejected
+(`requestedDropped=`). The session id is the join key to the CLI's OTEL records
+and its on-disk transcript, and previously appeared only in a `debug` line. The
+dropped model previously left no trace on this line at all, making a task whose
+model request was rejected indistinguishable from one that requested nothing.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -5591,7 +5591,8 @@ test('describeClaudeSessionInit: names the requested model alongside the served 
     requestedModel: 'claude-fable-5',
   });
   assert.match(line, /model=claude-opus-4-8/);
-  assert.match(line, /requested=claude-fable-5/);
+  // Quoted: caller-supplied, see the forgery test below.
+  assert.match(line, /requested="claude-fable-5"/);
 });
 
 test('describeClaudeSessionInit: omits `requested` on the agentic path', () => {
@@ -5622,19 +5623,63 @@ test('describeClaudeSessionInit: a dropped model is reported, not silently absen
     model: 'claude-opus-4-8',
   });
   assert.notEqual(dropped, nothingRequested);
-  assert.match(dropped, /requestedDropped=a2a\/https/);
+  assert.match(dropped, /requestedDropped="a2a\/https/);
   // `requested` must keep meaning "what rode to --model", so a dropped value
   // never appears under it — the line would otherwise lie about argv.
   assert.doesNotMatch(dropped, /(^| )requested=/);
 });
 
-test('describeClaudeSessionInit: a dropped routing key survives at full length', () => {
-  // Routing keys run past the 60-char cap the model fields use, and the tail is
-  // what identifies the sender.
+test('describeClaudeSessionInit: a dropped routing key survives the 60-char model cap', () => {
+  // Routing keys run well past the cap the model fields use, and 60 would cut
+  // one mid-host.
   const key = `a2a/https://example.com/agents/${'x'.repeat(60)}/.well-known/agent-card.json`;
+  assert.ok(key.length > 60 && key.length < 200);
   const line = describeClaudeSessionInit({ taskId: 't', model: 'm', droppedModel: key });
   assert.match(line, /well-known\/agent-card\.json/);
   assert.doesNotMatch(line, /…/);
+});
+
+test('describeClaudeSessionInit: a dropped value past the cap is truncated, not dumped', () => {
+  // The roomier cap raises the threshold; it does not promise the whole key.
+  // Guard the ceiling too — a caller must not be able to write an unbounded
+  // string into the journal.
+  const line = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'm',
+    droppedModel: 'a2a/https://example.com/' + 'y'.repeat(5000),
+  });
+  assert.match(line, /…/);
+  assert.ok(line.length < 400, `line grew to ${line.length}`);
+});
+
+test('describeClaudeSessionInit: a caller cannot forge sibling fields on the line', () => {
+  // `requestedDropped` carries the caller's envelope.model verbatim, and by
+  // construction only values the gate REJECTED land there — i.e. arbitrary
+  // remote strings. `safeToken` stops a newline but not a space or an `=`, so
+  // rendering it bare would let a caller plant tokens that read exactly like
+  // real ones, including a `session=` pointing at somebody else's transcript.
+  const line = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'claude-opus-4-8',
+    sessionId: 'real-session',
+    droppedModel: 'x model=trusted requested=trusted session=other-session',
+  });
+  assert.equal(line.includes('\n'), false);
+  // What quoting buys: the injected tokens are enclosed and attributable to the
+  // field that carried them, so an operator reading the line sees planted text
+  // rather than a second set of real-looking tokens.
+  assert.match(line, /requestedDropped="x model=trusted requested=trusted session=other-session"/);
+  // The genuine fields are intact and come first, so a reader (or a
+  // first-match grep) lands on the real session id.
+  assert.match(line, / session=real-session model=claude-opus-4-8 /);
+  assert.ok(
+    line.indexOf(' session=real-session') < line.indexOf('requestedDropped='),
+    'the real session field must precede any caller-supplied text',
+  );
+  // Deliberately NOT asserted: that ` session=` occurs once. Quoting makes an
+  // injection visible, it does not stop a naive whole-line grep from matching
+  // inside the quotes — same limitation the gate's own rejection warn has, and
+  // the reason nothing in this repo parses these lines positionally.
 });
 
 test('describeClaudeSessionInit: carries the session id as the transcript/OTEL join key', () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -5607,6 +5607,47 @@ test('describeClaudeSessionInit: omits `requested` on the agentic path', () => {
   }
 });
 
+test('describeClaudeSessionInit: a dropped model is reported, not silently absent', () => {
+  // The gate drops a requested id this install does not advertise, so nothing
+  // rode to `--model`. Without `requestedDropped` this line is byte-identical
+  // to a task where nothing was requested at all — and this is the task an
+  // operator is hunting when they ask who requests models we do not serve.
+  const dropped = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'claude-opus-4-8',
+    droppedModel: 'a2a/https://example.com/agents/x/.well-known/agent-card.json',
+  });
+  const nothingRequested = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'claude-opus-4-8',
+  });
+  assert.notEqual(dropped, nothingRequested);
+  assert.match(dropped, /requestedDropped=a2a\/https/);
+  // `requested` must keep meaning "what rode to --model", so a dropped value
+  // never appears under it — the line would otherwise lie about argv.
+  assert.doesNotMatch(dropped, /(^| )requested=/);
+});
+
+test('describeClaudeSessionInit: a dropped routing key survives at full length', () => {
+  // Routing keys run past the 60-char cap the model fields use, and the tail is
+  // what identifies the sender.
+  const key = `a2a/https://example.com/agents/${'x'.repeat(60)}/.well-known/agent-card.json`;
+  const line = describeClaudeSessionInit({ taskId: 't', model: 'm', droppedModel: key });
+  assert.match(line, /well-known\/agent-card\.json/);
+  assert.doesNotMatch(line, /…/);
+});
+
+test('describeClaudeSessionInit: carries the session id as the transcript/OTEL join key', () => {
+  const line = describeClaudeSessionInit({
+    taskId: 't',
+    model: 'm',
+    sessionId: 'ce946054-eb5d-4820-b94d-f6af9f9cdca4',
+  });
+  assert.match(line, /session=ce946054-eb5d-4820-b94d-f6af9f9cdca4/);
+  // Absent rather than empty when the event carried none.
+  assert.doesNotMatch(describeClaudeSessionInit({ taskId: 't', model: 'm' }), /session=/);
+});
+
 test('describeClaudeSessionInit: still reports an init whose model is missing', () => {
   // `unknown` is itself the finding — it means the envelope fallback got
   // nothing — and "did this task init at all" must not hinge on the field
@@ -5622,6 +5663,8 @@ test('describeClaudeSessionInit: a hostile model string cannot forge a log line'
     taskId: 't',
     model: 'evil\n[client] FAKE ENTRY',
     requestedModel: 'also\nevil',
+    droppedModel: 'dropped\nevil',
+    sessionId: 'sid\nevil',
   });
   assert.equal(line.includes('\n'), false);
 });

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -37,7 +37,7 @@ import {
   INPUT_IMAGE_MIME,
   type FetchUriPolicy,
 } from './fetch-uri-file.js';
-import { createLogger, safeToken } from '../logger.js';
+import { createLogger, safeForLog, safeToken } from '../logger.js';
 import { createTimingRecorder } from './timing.js';
 import {
   createClaudeUsageProvider,
@@ -410,19 +410,32 @@ export function describeClaudeSessionInit(opts: {
 }): string {
   const model =
     typeof opts.model === 'string' && opts.model.length > 0 ? opts.model : 'unknown';
-  const field = (label: string, value: unknown, max = 60): string =>
-    typeof value === 'string' && value.length > 0
-      ? ` ${label}=${safeToken(value, max)}`
-      : '';
+  const field = (label: string, value: unknown, render: (v: string) => string): string =>
+    typeof value === 'string' && value.length > 0 ? ` ${label}=${render(value)}` : '';
   return (
     `[claude] session init taskId=${opts.taskId}` +
-    field('session', opts.sessionId, 80) +
+    // Bridge/CLI-derived, so bare — `session=` is a join key people paste into
+    // a grep and quotes would be in the way.
+    field('session', opts.sessionId, (v) => safeToken(v, 80)) +
     ` model=${safeToken(model, 60)}` +
-    field('requested', opts.requestedModel) +
-    // Longer cap than the other model fields: an unadvertised value is often a
-    // whole routing key (`a2a/<card-url>`), and truncating it to 60 can strip
-    // the part that identifies who sent it.
-    field('requestedDropped', opts.droppedModel, 200)
+    // QUOTED, unlike the fields above, because these two are the only values on
+    // this line that arrive verbatim from the remote caller's envelope.
+    // `safeToken` blocks a newline but not a space or an `=`, so a bare render
+    // lets a caller name its model
+    // `x model=trusted requested=trusted session=<some-other-session>` and plant
+    // tokens that read exactly like real ones — including a fake join key
+    // pointing at somebody else's transcript. Quoting is what the gate's own
+    // rejection warn already does with the same value, and `safeForLog` exists
+    // for precisely this "what value was rejected" shape. It makes an injection
+    // visible and attributable, not impossible: a whole-line grep still matches
+    // inside the quotes. The real fields being emitted first is what keeps a
+    // first-match read honest.
+    field('requested', opts.requestedModel, (v) => safeForLog(v, 80)) +
+    // Roomier cap: a rejected value is typically a whole routing key
+    // (`a2a/<card-url>`) and 60 would cut it mid-host. Truncation still drops
+    // the tail, so this raises the threshold rather than guaranteeing the whole
+    // key survives.
+    field('requestedDropped', opts.droppedModel, (v) => safeForLog(v, 200))
   );
 }
 
@@ -2965,6 +2978,7 @@ export function createClaudeBackend(
             const normalised = normalizeClaudeModelId(evt.model);
             if (normalised.length > 0) initModel = normalised;
           }
+          const evtSessionId = (evt as { session_id?: unknown }).session_id;
           // …and say it out loud (#457) — on a normal task this is the only
           // record of what served it. Fires per SPAWN, not per task: the
           // narrated-tool-call retry re-spawns and re-attaches these handlers,
@@ -2975,13 +2989,20 @@ export function createClaudeBackend(
             describeClaudeSessionInit({
               taskId: task.taskId,
               model: evt.model,
-              // The event's own id, not the `sessionId` the bridge passed in.
-              // They are the same value by construction (`--session-id` /
-              // `--resume`), but this one is what the CLI is actually running
-              // under and therefore what its OTEL records and on-disk
-              // transcript are keyed by — if the two ever diverge, the join
-              // key is this one.
-              sessionId: (evt as { session_id?: unknown }).session_id ?? sessionId,
+              // Prefer the event's own id over the `sessionId` the bridge
+              // passed in: the bridge's is what it ASKED for via `--session-id`
+              // / `--resume`, the event's is what the CLI is actually running
+              // under, and the CLI's OTEL records and on-disk transcript are
+              // keyed by the latter. Observed equal, but nothing in the CLI's
+              // contract promises it (`--fork-session` exists precisely because
+              // a resume can go either way), so read it rather than assume it.
+              // Falls back on any unusable value — NOT `??`, which passes a
+              // number or an empty string straight through to a field that then
+              // renders nothing and loses an id the bridge knew all along.
+              sessionId:
+                typeof evtSessionId === 'string' && evtSessionId.length > 0
+                  ? evtSessionId
+                  : sessionId,
               requestedModel: envelopeModel,
               droppedModel: droppedEnvelopeModel,
             }),

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -364,7 +364,7 @@ export function normalizeClaudeModelId(raw: string): string {
 // router-side `requestedModel`, the `--model` argv, a prompt size only one
 // tier could have held. One line settles it directly.
 //
-// Three details:
+// The details that matter:
 //
 //   - The `model` string VERBATIM. A diagnostic line records what the CLI
 //     actually reported; normalising is the envelope's need — it has to match
@@ -377,6 +377,19 @@ export function normalizeClaudeModelId(raw: string): string {
 //     so "asked for X, served Y" is legible in a single line instead of a join
 //     against the router. Absent on the agentic path, which sends no
 //     `--model` and lets claude pick.
+//   - `requestedDropped` for the case `requested` cannot cover: the caller
+//     named a model this install does not advertise, so the gate dropped the
+//     override and claude fell back to its own default. `requested` has to
+//     keep meaning "what rode to `--model`" or the line lies about argv, but
+//     without a second field this task is indistinguishable from one where
+//     nothing was requested at all — and it is precisely the task an operator
+//     is hunting when they ask who is requesting models we do not serve. The
+//     gate's own `warn` records it too; this puts it on the line people grep.
+//   - `session`, the claude session id. It is the join key to both the CLI's
+//     OTEL `session.id` and the on-disk session transcript — the record #457
+//     was reduced to reading by hand — and the only other place it reaches a
+//     log is the `claude.spawn.start` argv dump, which is `debug`. A join key
+//     that requires debug to have been on ahead of time is no join key.
 //   - Always a line, even when `model` is missing or malformed — `unknown` is
 //     itself the finding, and "did this task init at all" must not depend on
 //     the field being well-formed.
@@ -391,15 +404,26 @@ export function normalizeClaudeModelId(raw: string): string {
 export function describeClaudeSessionInit(opts: {
   taskId: string;
   model: unknown;
+  sessionId?: unknown;
   requestedModel?: string | undefined;
+  droppedModel?: string | undefined;
 }): string {
   const model =
     typeof opts.model === 'string' && opts.model.length > 0 ? opts.model : 'unknown';
-  const requested =
-    typeof opts.requestedModel === 'string' && opts.requestedModel.length > 0
-      ? ` requested=${safeToken(opts.requestedModel, 60)}`
+  const field = (label: string, value: unknown, max = 60): string =>
+    typeof value === 'string' && value.length > 0
+      ? ` ${label}=${safeToken(value, max)}`
       : '';
-  return `[claude] session init taskId=${opts.taskId} model=${safeToken(model, 60)}${requested}`;
+  return (
+    `[claude] session init taskId=${opts.taskId}` +
+    field('session', opts.sessionId, 80) +
+    ` model=${safeToken(model, 60)}` +
+    field('requested', opts.requestedModel) +
+    // Longer cap than the other model fields: an unadvertised value is often a
+    // whole routing key (`a2a/<card-url>`), and truncating it to 60 can strip
+    // the part that identifies who sent it.
+    field('requestedDropped', opts.droppedModel, 200)
+  );
 }
 
 // Render a non-`init` SDK `system` event into one log line, and decide how
@@ -1988,6 +2012,10 @@ export function createClaudeBackend(
       // called yet) the validation is skipped and `envelope.model` rides
       // through unchanged.
       let envelopeModel: string | undefined = envelopeModelRaw;
+      // Set only by the drop below, so the `session init` line can report the
+      // rejected value without inferring it from `envelopeModel === undefined`
+      // (which is also true when nothing was requested at all).
+      let droppedEnvelopeModel: string | undefined;
       if (
         envelopeModelRaw !== undefined &&
         cachedAllowedModels instanceof Set &&
@@ -1997,6 +2025,7 @@ export function createClaudeBackend(
           `[claude] envelope.model=${JSON.stringify(envelopeModelRaw)} is not among this claude install's advertised models (${JSON.stringify([...cachedAllowedModels])}); falling back to claude default`,
         );
         envelopeModel = undefined;
+        droppedEnvelopeModel = envelopeModelRaw;
       }
 
       // Native MCP dispatch (#213): when the openai-compat extension is
@@ -2946,7 +2975,15 @@ export function createClaudeBackend(
             describeClaudeSessionInit({
               taskId: task.taskId,
               model: evt.model,
+              // The event's own id, not the `sessionId` the bridge passed in.
+              // They are the same value by construction (`--session-id` /
+              // `--resume`), but this one is what the CLI is actually running
+              // under and therefore what its OTEL records and on-disk
+              // transcript are keyed by — if the two ever diverge, the join
+              // key is this one.
+              sessionId: (evt as { session_id?: unknown }).session_id ?? sessionId,
               requestedModel: envelopeModel,
+              droppedModel: droppedEnvelopeModel,
             }),
           );
           return;

--- a/packages/client/src/logger.ts
+++ b/packages/client/src/logger.ts
@@ -72,7 +72,7 @@ export function escapeLineSeparators(s: string): string {
 // where the surrounding quotes help operators see the exact string the
 // client received. Newlines and control chars are escaped; long inputs
 // are truncated with an ellipsis.
-function safeForLog(value: string, maxLen = 120): string {
+export function safeForLog(value: string, maxLen = 120): string {
   const escaped = escapeLineSeparators(JSON.stringify(value));
   if (escaped.length <= maxLen) return escaped;
   // Trim to maxLen and tack on an ellipsis. The result intentionally


### PR DESCRIPTION
> **Stacked on #462** (comments-only) because both touch the same helper. Merge
> #462 first and GitHub will retarget this to `main`.

Two gaps an adversarial review of #458 found in the line it added. Both are
cases where the line goes silent about the very thing it exists to surface.

## `requestedDropped`

When a caller names a model this install does not advertise, the gate drops the
override and claude falls back to its own default (#302). `requested=` correctly
stays absent — nothing rode to `--model` — but that leaves the line
byte-identical to a task where nothing was requested at all:

```text
before   [claude] session init taskId=X model=claude-opus-5   ← nothing requested
before   [claude] session init taskId=Y model=claude-opus-5   ← request rejected

after    [claude] session init taskId=Y session=… model=claude-opus-5 \
           requestedDropped=a2a/https://example.com/…/agent-card.json
```

So the one task an operator is hunting when they ask *"who is requesting models
we don't serve?"* was exactly the one they could not find by grepping
`session init`. The gate does already warn, but on a separate line; this puts it
on the line people grep.

Kept as its own field rather than widening `requested`, which has to keep
meaning "what rode to argv" or the line starts lying about the spawn. Capped at
200 instead of 60 because these are usually whole routing keys whose *tail* is
what identifies the sender.

## `session`

The claude session id is the join key to both the CLI's OTEL `session.id` and
the on-disk session transcript — the record #457 was reduced to reading by hand.
Its only other appearance in any log is the `claude.spawn.start … argv=` dump at
`debug`, so at the default `info` level the journal carried no join key at all.
A key that requires debug to have been enabled *before* the incident is not a
key.

Taken from the init event rather than the value the bridge passed in. They are
the same by construction (`--session-id` / `--resume`), but the event's is what
the CLI is actually running under, so if they ever diverge the log follows
reality.

## Verification

Against the real CLI, not scripted streams:

```text
[claude] envelope.model="a2a/https://…/agent-card.json" is not among this claude
  install's advertised models (["claude-opus-5"]); falling back to claude default
[claude] session init taskId=live-dropped session=86ec0402-… model=claude-opus-5[1m]
  requestedDropped=a2a/https://example.com/agents/x/.well-known/agent-card.json

[claude] session init taskId=live-sess-1 session=223837a8-… model=claude-opus-5[1m]
[claude] session init taskId=live-sess-2 session=223837a8-… model=claude-opus-5
```

The second pair also settles a question the review raised and the repo asserted
nowhere: **a `--resume` run reports the same session id**, so the join survives
a resumed session and is many-to-one with `taskId` — which is what #461's doc
tells operators.

- `pnpm -r typecheck` ✅
- `pnpm --filter @vicoop-bridge/client test` ✅ 882 pass / 0 fail (3 new)

New tests cover: a dropped model is distinguishable from nothing-requested and
never appears under `requested=`; a full-length routing key is not truncated;
the session id is carried and is absent rather than empty when missing; and the
existing forgery test now feeds hostile values through all four fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
