### PR TITLE
x402: migrate the merchant layer to @a2x/sdk MerchantGate

### DIFF
--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@a2x/sdk": "^0.18.0",
+    "@a2x/sdk": "^0.21.0",
     "@rainbow-me/rainbowkit": "^2",
     "@tanstack/react-query": "^5",
     "lucide-react": "^0.468",

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:20-alpine
+# Node 22: @a2x/sdk 0.21+ declares engines.node >=22.11.0 (0.20 allowed 20).
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
     "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@a2x/sdk": "^0.19.0",
+    "@a2x/sdk": "^0.20.0",
     "@ai-sdk/anthropic": "^3.0.69",
     "@hono/node-server": "^1.13.7",
     "@sentry/hono": "^10.57.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
     "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@a2x/sdk": "^0.20.0",
+    "@a2x/sdk": "^0.21.0",
     "@ai-sdk/anthropic": "^3.0.69",
     "@hono/node-server": "^1.13.7",
     "@sentry/hono": "^10.57.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=22.11.0"
+  },
   "main": "./dist/index.js",
   "bin": {
     "vicoop-server": "./dist/cli.js"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,7 +15,7 @@
     "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@a2x/sdk": "^0.18.0",
+    "@a2x/sdk": "^0.19.0",
     "@ai-sdk/anthropic": "^3.0.69",
     "@hono/node-server": "^1.13.7",
     "@sentry/hono": "^10.57.0",

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -897,8 +897,8 @@ COMMENT ON TABLE used_siwe_nonces IS E'@omit';
 -- 6c. x402 payment offerings
 -- ============================================================
 -- One row per x402 payment round-trip, keyed by the A2A task it gates.
--- Backs `PostgresX402Store` (src/x402/store.ts), which implements the SDK's
--- `BaseX402Store`.
+-- Backs `PostgresX402Store` (src/x402/store.ts), which implements both the
+-- SDK's `BaseX402Store` and its `MerchantOfferingSidecar` on the same row.
 --
 -- Why this must be in Postgres and not in process memory: the round-trip
 -- spans two HTTP requests — turn 1 advertises the offering and answers
@@ -922,11 +922,13 @@ COMMENT ON TABLE used_siwe_nonces IS E'@omit';
 -- gate would find A's offering and accept A's cheap signature as payment for
 -- B's work.
 --
--- `pricing` is the agent's pricing captured when the offering was published.
+-- `offer` is the full `MerchantOffer` frozen when the offering was published.
 -- Settlement must price from this, never from the agent's live pricing: the
 -- two turns of a payment are separate requests, and a reprice in between would
 -- otherwise meter turn 2 against a requirement turn 1 signed under different
--- terms — which settles the wrong amount.
+-- terms — which settles the wrong amount. (Earlier builds froze the bridge's
+-- own pricing row in a `pricing` column; the SDK's sidecar contract freezes
+-- the complete published offer instead.)
 --
 -- `claimed_at` is a one-shot concurrency guard. The SDK's `classify()` does not
 -- inspect the entry's status, so replaying one signed submission before
@@ -936,7 +938,7 @@ CREATE TABLE IF NOT EXISTS x402_offerings (
   task_id     TEXT NOT NULL,
   agent_id    TEXT NOT NULL,
   entry       JSONB NOT NULL,
-  pricing     JSONB,
+  offer       JSONB,
   claimed_at  TIMESTAMPTZ,
   expires_at  TIMESTAMPTZ,
   created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -947,8 +949,15 @@ CREATE TABLE IF NOT EXISTS x402_offerings (
 -- Converge a dev DB created from the first cut of this table, which keyed on
 -- task_id alone and had neither column. Never deployed, so this is only here
 -- so re-applying schema.sql on such a database doesn't fail.
-ALTER TABLE x402_offerings ADD COLUMN IF NOT EXISTS pricing JSONB;
 ALTER TABLE x402_offerings ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+-- Converge a deployed DB from the pre-MerchantGate builds. Their `pricing`
+-- column is deliberately NOT dropped here: instances of the previous build
+-- still write it during a rolling deploy, and a dropped column would fail
+-- their offering writes closed. Drop it in a follow-up once the fleet is on
+-- offer-based builds. An in-flight offering frozen only as `pricing` reads as
+-- "terms no longer available" under the new build — refused, never charged —
+-- and the window is bounded by the offering TTL.
+ALTER TABLE x402_offerings ADD COLUMN IF NOT EXISTS offer JSONB;
 DO $$
 BEGIN
   IF EXISTS (

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -898,7 +898,7 @@ COMMENT ON TABLE used_siwe_nonces IS E'@omit';
 -- ============================================================
 -- One row per x402 payment round-trip, keyed by the A2A task it gates.
 -- Backs `PostgresX402Store` (src/x402/store.ts), which implements both the
--- SDK's `BaseX402Store` and its `MerchantOfferingSidecar` on the same row.
+-- SDK's `BaseX402Store` and its `MerchantOfferStore` on the same row.
 --
 -- Why this must be in Postgres and not in process memory: the round-trip
 -- spans two HTTP requests — turn 1 advertises the offering and answers

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -13,7 +13,6 @@ import {
   type TaskStatusUpdateEvent,
   type TaskStore,
 } from '@a2x/sdk';
-import type { X402ValidClassification } from '@a2x/sdk/x402';
 import type { Registry, TaskBinding, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
@@ -170,10 +169,10 @@ export class WSForwardingExecutor extends AgentExecutor {
     }
     const key = JSON.stringify(pricing);
     if (this.gateCache?.key !== key) {
-      const { context, sidecar } = createPostgresX402Context(this.x402.sql, this.agentId);
+      const { context, offerStore } = createPostgresX402Context(this.x402.sql, this.agentId);
       this.gateCache = {
         key,
-        gate: new X402Gate(this.agentId, pricing, context, sidecar),
+        gate: new X402Gate(this.agentId, pricing, context, offerStore, this.x402.resource),
       };
     }
     return this.gateCache.gate;
@@ -253,9 +252,9 @@ export class WSForwardingExecutor extends AgentExecutor {
     const result = await gate.settle({
       taskId,
       contextId,
-      classified: settlement.classified,
-      pricing: settlement.pricing,
+      obligation: settlement.obligation,
       usage: read.usage,
+      ...(read.model !== undefined ? { model: read.model } : {}),
     });
     if (result.kind === 'failed') {
       // The caller already has the output — see the note above. This is the
@@ -310,12 +309,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     const gate = this.currentGate();
     let settlement: X402Settlement | undefined;
     if (gate) {
-      const outcome = await gate.open({
-        taskId,
-        contextId,
-        message,
-        resource: this.x402!.resource,
-      });
+      const outcome = await gate.open({ taskId, contextId, message });
       if (outcome.kind === 'halt') {
         task.status = outcome.event.status;
         task.history = appendHistoryMessage(

--- a/packages/server/src/x402/gate.test.ts
+++ b/packages/server/src/x402/gate.test.ts
@@ -1,20 +1,27 @@
+// The orchestration itself — classify, freeze, claim, verify, meter, clamp —
+// is the SDK's `MerchantGate` and is tested there. What these tests pin is the
+// bridge's side of the composition: outcomes rendered as the wire events this
+// executor emits, the pricing row mapped onto the published offer, and the
+// deployment's policy choices (settle-before-work for `exact`, floor for
+// unreported usage, zero for a trusted reported zero).
+
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { TaskState, type Message } from '@a2x/sdk';
 import {
-  X402Context,
+  InMemoryMerchantOfferStore,
   InMemoryX402Store,
+  X402Context,
   X402_METADATA_KEYS,
   X402_PAYMENT_STATUS,
+  type MerchantDeferredObligation,
   type X402Facilitator,
   type X402PaymentPayload,
-  type X402ValidClassification,
   type X402VerifyResponse,
   type X402FacilitatorSettleResponse,
 } from '@a2x/sdk/x402';
-import { X402Gate, type X402GateOutcome, type X402OfferingSidecar } from './gate.js';
+import { X402Gate, type X402GateOutcome } from './gate.js';
 import { parseX402Pricing, type X402Pricing } from './pricing.js';
-import type { TaskUsage } from './usage.js';
 
 const RESOURCE = 'https://bridge.test/agents/a1';
 const PAY_TO = '0x1111111111111111111111111111111111111111';
@@ -72,55 +79,17 @@ function stubFacilitator(
   return state as X402Facilitator & typeof state;
 }
 
-/**
- * In-memory stand-in for the Postgres sidecar: the pricing snapshot taken when
- * an offering is published, and the one-shot claim that stops a replayed
- * submission from running the work twice.
- */
-interface MemorySidecar extends X402OfferingSidecar {
-  /** Test hook: force the stored terms out of step with the offering. */
-  overwritePricing(taskId: string, pricing: X402Pricing): void;
-}
-
-function memorySidecar(): MemorySidecar {
-  const pricingByTask = new Map<string, X402Pricing>();
-  const claimed = new Set<string>();
-  return {
-    // The real store serializes publishers and keeps the first live terms.
-    // This double has no expiry, so an existing entry is always live.
-    async publishing<T>(
-      taskId: string,
-      pricing: X402Pricing,
-      fn: (frozenPricing: X402Pricing) => Promise<T>,
-    ): Promise<T> {
-      const frozenPricing = pricingByTask.get(taskId) ?? pricing;
-      pricingByTask.set(taskId, frozenPricing);
-      return fn(frozenPricing);
-    },
-    async getPricing(taskId) {
-      return pricingByTask.get(taskId);
-    },
-    async claim(taskId) {
-      if (claimed.has(taskId)) return false;
-      claimed.add(taskId);
-      return true;
-    },
-    overwritePricing(taskId, pricing) {
-      pricingByTask.set(taskId, pricing);
-    },
-  };
-}
-
 function makeGate(
   facilitator: X402Facilitator,
   pricing: X402Pricing = PRICING,
-  sidecar: X402OfferingSidecar = memorySidecar(),
+  offerStore: InMemoryMerchantOfferStore = new InMemoryMerchantOfferStore(),
 ): X402Gate {
   return new X402Gate(
     'a1',
     pricing,
     new X402Context({ store: new InMemoryX402Store(), facilitator, x402Version: 2 }),
-    sidecar,
+    offerStore,
+    RESOURCE,
   );
 }
 
@@ -181,7 +150,6 @@ test('turn 1 halts with input-required carrying the payment-required offering', 
     taskId: 't-1',
     contextId: 'ctx-1',
     message: userMessage(),
-    resource: RESOURCE,
   });
 
   assert.equal(outcome.kind, 'halt');
@@ -222,7 +190,6 @@ test('turn 2 with a valid signed payload verifies and proceeds', async () => {
     taskId: 't-2',
     contextId: 'ctx-2',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
@@ -231,7 +198,6 @@ test('turn 2 with a valid signed payload verifies and proceeds', async () => {
     taskId: 't-2',
     contextId: 'ctx-2',
     message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
 
   assert.equal(second.kind, 'proceed');
@@ -250,8 +216,9 @@ test('turn 2 with a valid signed payload verifies and proceeds', async () => {
 });
 
 test('a submission whose taskId was never offered is refused', async () => {
-  // The horizontally-scaled failure mode this store exists to prevent: if the
-  // offering is missing, the payload must be refused rather than trusted.
+  // The horizontally-scaled failure mode the Postgres offer store exists to
+  // prevent: if the offering is missing, the payload must be refused rather
+  // than trusted.
   const facilitator = stubFacilitator();
   const gate = makeGate(facilitator);
 
@@ -259,7 +226,6 @@ test('a submission whose taskId was never offered is refused', async () => {
     taskId: 't-known',
     contextId: 'ctx',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(offering.kind, 'halt');
   if (offering.kind !== 'halt') return;
@@ -268,7 +234,6 @@ test('a submission whose taskId was never offered is refused', async () => {
     taskId: 't-unknown',
     contextId: 'ctx',
     message: submissionMessage(offeredRequirement(offering.event)),
-    resource: RESOURCE,
   });
 
   assert.equal(outcome.kind, 'halt');
@@ -287,7 +252,6 @@ test('a payload paying the wrong recipient is refused before the facilitator', a
     taskId: 't-3',
     contextId: 'ctx-3',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
@@ -298,7 +262,6 @@ test('a payload paying the wrong recipient is refused before the facilitator', a
     message: submissionMessage(offeredRequirement(first.event), {
       to: '0x9999999999999999999999999999999999999999',
     }),
-    resource: RESOURCE,
   });
 
   assert.equal(outcome.kind, 'halt');
@@ -317,7 +280,6 @@ test('a failed facilitator verification halts without settling', async () => {
     taskId: 't-4',
     contextId: 'ctx-4',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
@@ -326,7 +288,6 @@ test('a failed facilitator verification halts without settling', async () => {
     taskId: 't-4',
     contextId: 'ctx-4',
     message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
 
   assert.equal(outcome.kind, 'halt');
@@ -354,7 +315,6 @@ test('a store or facilitator error fails closed instead of serving the call free
     taskId: 't-5',
     contextId: 'ctx-5',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
@@ -363,7 +323,6 @@ test('a store or facilitator error fails closed instead of serving the call free
     taskId: 't-5',
     contextId: 'ctx-5',
     message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
 
   // The important part is that it is NOT 'proceed' — an unpaid call must
@@ -383,7 +342,6 @@ async function exactTurnTwo(
     taskId,
     contextId: `ctx-${taskId}`,
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') throw new Error('unreachable');
@@ -391,7 +349,6 @@ async function exactTurnTwo(
     taskId,
     contextId: `ctx-${taskId}`,
     message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
 }
 
@@ -487,13 +444,12 @@ async function uptoVerified(
   facilitator: X402Facilitator,
   taskId: string,
   pricing: X402Pricing = UPTO_PRICING,
-): Promise<{ gate: X402Gate; classified: X402ValidClassification; pricing: X402Pricing }> {
+): Promise<{ gate: X402Gate; obligation: MerchantDeferredObligation }> {
   const gate = makeGate(facilitator, pricing);
   const first = await gate.open({
     taskId,
     contextId: `ctx-${taskId}`,
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') throw new Error('unreachable');
@@ -502,7 +458,6 @@ async function uptoVerified(
     taskId,
     contextId: `ctx-${taskId}`,
     message: uptoSubmissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
   assert.equal(second.kind, 'proceed', 'upto submission should verify');
   if (second.kind !== 'proceed' || second.settlement?.mode !== 'deferred') {
@@ -511,11 +466,7 @@ async function uptoVerified(
   // Metered agents must not have moved money yet — the charge does not exist
   // until the work has been done.
   assert.equal((facilitator as { settleCalls?: number }).settleCalls, 0);
-  return {
-    gate,
-    classified: second.settlement.classified,
-    pricing: second.settlement.pricing,
-  };
+  return { gate, obligation: second.settlement.obligation };
 }
 
 test('an upto offering advertises the ceiling and the facilitator address', async () => {
@@ -526,62 +477,42 @@ test('an upto offering advertises the ceiling and the facilitator address', asyn
     taskId: 'u-1',
     contextId: 'ctx-u1',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(outcome.kind, 'halt');
   if (outcome.kind !== 'halt') return;
 
   const requirement = offeredRequirement(outcome.event);
   assert.equal(requirement.scheme, 'upto');
+  // What the payer authorizes, not what they will be charged — the SDK
+  // flattens the rate table back off the wire shape entirely.
   assert.equal(requirement.amount, '1000000');
+  assert.equal(requirement.rates, undefined);
   assert.deepEqual(requirement.extra, { facilitatorAddress: FACILITATOR });
 });
 
 test('upto settles the metered charge, not the authorized ceiling', async () => {
   const facilitator = stubFacilitator();
-  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-2');
+  const { gate, obligation } = await uptoVerified(facilitator, 'u-2');
 
   // 100k in @ $3/MTok + 10k out @ $15/MTok = 450000 atomic, well under the
   // 1000000 ceiling the payer authorized.
-  const usage: TaskUsage = {
-    prompt_tokens: 100_000,
-    completion_tokens: 10_000,
-    total_tokens: 110_000,
-  };
   const result = await gate.settle({
     taskId: 'u-2',
     contextId: 'ctx-u-2',
-    classified,
-    pricing,
-    usage,
+    obligation,
+    usage: { kind: 'detailed', inputTokens: 100_000, outputTokens: 10_000 },
   });
 
   assert.equal(result.kind, 'settled');
   assert.equal(facilitator.settledAmount, '450000');
 });
 
-test('a metered charge above the ceiling is clamped down to it', async () => {
-  const facilitator = stubFacilitator();
-  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-3');
-
-  // 10M input tokens prices to 30000000 — 30x the authorized ceiling. The
-  // SDK clamps, which is what makes a pricing mistake unable to overcharge.
-  const result = await gate.settle({
-    taskId: 'u-3',
-    contextId: 'ctx-u-3',
-    classified,
-    pricing,
-    usage: { prompt_tokens: 10_000_000, completion_tokens: 0, total_tokens: 10_000_000 },
-  });
-
-  assert.equal(result.kind, 'settled');
-  assert.equal(facilitator.settledAmount, '1000000');
-});
-
 test('upto settles the floor when the backend reported no usage', async () => {
-  // openclaw reports nothing; codex can emit {0,0,0} when its runtime drops
-  // accounting. Charging zero for delivered work is a real loss, so an
-  // operator who sets minAmount gets that instead.
+  // openclaw reports nothing at all — the `unreportedUsage: 'floor'` policy
+  // the bridge maps every row with. Charging zero for delivered work is a
+  // real loss, so an operator who sets minAmount gets that floor; charging
+  // the authorized ceiling would be worse, billing the payer the maximum for
+  // a gap in *our* instrumentation.
   const facilitator = stubFacilitator();
   const priced = parseX402Pricing({
     scheme: 'upto',
@@ -593,100 +524,129 @@ test('upto settles the floor when the backend reported no usage', async () => {
     minAmount: '25000',
     facilitatorAddress: FACILITATOR,
   })!;
-  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-4', priced);
+  const { gate, obligation } = await uptoVerified(facilitator, 'u-4', priced);
 
   const result = await gate.settle({
     taskId: 'u-4',
     contextId: 'ctx-u-4',
-    classified,
-    pricing,
-    usage: undefined,
+    obligation,
+    usage: { kind: 'unreported' },
   });
 
   assert.equal(result.kind, 'settled');
   assert.equal(facilitator.settledAmount, '25000');
 });
 
-test('upto with no usage and no floor settles zero rather than the ceiling', async () => {
-  // The default direction is payer-favourable on purpose: billing the
-  // maximum because *our* instrumentation lost the token count would be a
-  // user-visible wrong, where undercharging is our own loss to fix.
+test('upto with unreported usage and no floor settles zero rather than the ceiling', async () => {
   const facilitator = stubFacilitator();
-  const { gate, classified, pricing } = await uptoVerified(facilitator, 'u-5');
+  const { gate, obligation } = await uptoVerified(facilitator, 'u-5');
 
   const result = await gate.settle({
     taskId: 'u-5',
     contextId: 'ctx-u-5',
-    classified,
-    pricing,
-    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    obligation,
+    usage: { kind: 'unreported' },
   });
 
   assert.equal(result.kind, 'settled');
   assert.equal(facilitator.settledAmount, '0');
 });
 
-test('an exact agent ignores usage and settles the signed amount', async () => {
-  // Metering an `exact` requirement throws in the SDK, so the gate must not
-  // pass an amount through for a flat-fee agent even when usage is present.
+test('a trusted reported zero settles zero, not the floor', async () => {
+  // The a2x#206 semantic change this migration ships: a backend that
+  // *reported* zero consumption is believed, even when a floor is set. The
+  // floor exists for work the bridge could not price, not as a minimum bill
+  // for work the backend priced at nothing. Runtimes that emit {0,0} as an
+  // "accounting dropped" sentinel now surface as `unreported` in
+  // `readTaskUsage`'s callers only when they truly reported nothing.
   const facilitator = stubFacilitator();
-  const gate = makeGate(facilitator);
+  const priced = parseX402Pricing({
+    scheme: 'upto',
+    network: 'eip155:84532',
+    asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    payTo: PAY_TO,
+    maxAmount: '1000000',
+    rates: { input: '3000000', output: '15000000' },
+    minAmount: '25000',
+    facilitatorAddress: FACILITATOR,
+  })!;
+  const { gate, obligation } = await uptoVerified(facilitator, 'u-zero', priced);
 
-  const first = await gate.open({
-    taskId: 'u-6',
-    contextId: 'ctx-u-6',
-    message: userMessage(),
-    resource: RESOURCE,
+  const result = await gate.settle({
+    taskId: 'u-zero',
+    contextId: 'ctx-u-zero',
+    obligation,
+    usage: { kind: 'detailed', inputTokens: 0, outputTokens: 0 },
   });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
 
-  const second = await gate.open({
-    taskId: 'u-6',
-    contextId: 'ctx-u-6',
-    message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
+  assert.equal(result.kind, 'settled');
+  assert.equal(facilitator.settledAmount, '0');
+});
+
+test('a failed deferred settlement replaces the terminal event', async () => {
+  // The merchant was not paid, so the task must not report success — the
+  // caller already has the output (nothing can be done about that under
+  // `upto`), but the terminal state and receipt say what actually happened.
+  const facilitator = stubFacilitator({
+    settle: { success: false, errorReason: 'INSUFFICIENT_FUNDS' },
   });
+  const { gate, obligation } = await uptoVerified(facilitator, 'u-fail');
+
+  const result = await gate.settle({
+    taskId: 'u-fail',
+    contextId: 'ctx-u-fail',
+    obligation,
+    usage: { kind: 'detailed', inputTokens: 100, outputTokens: 100 },
+  });
+
+  assert.equal(result.kind, 'failed');
+  if (result.kind !== 'failed') return;
+  assert.equal(result.event.status.state, TaskState.FAILED);
+  assert.equal(
+    result.event.status.message?.metadata?.[X402_METADATA_KEYS.STATUS],
+    X402_PAYMENT_STATUS.FAILED,
+  );
+});
+
+test('an exact agent ignores usage and settles the signed amount', async () => {
   // Settled inside `open`, at the signed amount, with usage nowhere in play —
   // metering an `exact` requirement throws in the SDK.
-  assert.equal(second.kind, 'proceed');
-  if (second.kind !== 'proceed') return;
-  assert.equal(second.settlement?.mode, 'settled');
+  const facilitator = stubFacilitator();
+  const outcome = await exactTurnTwo(facilitator, 'u-6');
+  assert.equal(outcome.kind, 'proceed');
+  if (outcome.kind !== 'proceed') return;
+  assert.equal(outcome.settlement?.mode, 'settled');
   assert.equal(facilitator.settledAmount, '10000');
 });
 
-// ── the offering's terms are frozen, and usable once ──────────────────────
+// ── the offering's terms are frozen across a reprice ──────────────────────
 
 test('settlement prices from the offering, not from a reprice that landed between turns', async () => {
-  // The two turns are separate requests, so the agent can be repriced in
-  // between. Settling from live pricing would meter turn 2 against terms turn
-  // 1 never signed — and when an `upto` offering met `exact` pricing, the
-  // metering branch was skipped and the SDK settled the full authorized
-  // ceiling instead of the metered charge.
+  // The freezing itself is the SDK offer store's contract; what this pins is the
+  // bridge wiring around it — the executor rebuilds the gate when an admin
+  // reprices, so turn 2 runs on a *different* gate instance over the same
+  // store and offer store, and must still settle under turn 1's terms.
   const facilitator = stubFacilitator();
   const store = new InMemoryX402Store();
-  const sidecar = memorySidecar();
-  const context = () =>
-    new X402Context({ store, facilitator, x402Version: 2 });
+  const offerStore = new InMemoryMerchantOfferStore();
+  const context = () => new X402Context({ store, facilitator, x402Version: 2 });
 
-  const atOfferTime = new X402Gate('a1', UPTO_PRICING, context(), sidecar);
+  const atOfferTime = new X402Gate('a1', UPTO_PRICING, context(), offerStore, RESOURCE);
   const first = await atOfferTime.open({
     taskId: 'reprice',
     contextId: 'ctx-reprice',
     message: userMessage(),
-    resource: RESOURCE,
   });
   assert.equal(first.kind, 'halt');
   if (first.kind !== 'halt') return;
 
   // Admin reprices to a flat fee. The executor rebuilds the gate on the next
   // turn, so turn 2 runs with entirely different live pricing.
-  const afterReprice = new X402Gate('a1', PRICING, context(), sidecar);
+  const afterReprice = new X402Gate('a1', PRICING, context(), offerStore, RESOURCE);
   const second = await afterReprice.open({
     taskId: 'reprice',
     contextId: 'ctx-reprice',
     message: uptoSubmissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
   });
   assert.equal(second.kind, 'proceed');
   if (second.kind !== 'proceed' || second.settlement?.mode !== 'deferred') return;
@@ -694,171 +654,15 @@ test('settlement prices from the offering, not from a reprice that landed betwee
   // `open` hands back the frozen terms, not what the agent charges now — and
   // defers, because the offering was metered even though the agent is now
   // flat-fee. Settling here as `exact` would have charged the ceiling.
-  assert.equal(second.settlement.pricing.scheme, 'upto');
+  assert.equal(second.settlement.obligation.pricing.scheme, 'upto');
 
   await afterReprice.settle({
     taskId: 'reprice',
     contextId: 'ctx-reprice',
-    classified: second.settlement.classified,
-    pricing: second.settlement.pricing,
-    usage: { prompt_tokens: 100_000, completion_tokens: 10_000, total_tokens: 110_000 },
+    obligation: second.settlement.obligation,
+    usage: { kind: 'detailed', inputTokens: 100_000, outputTokens: 10_000 },
   });
 
-  // Metered, not the 1000000 ceiling the old code would have settled.
+  // Metered under the frozen rates, not the 1000000 ceiling.
   assert.equal(facilitator.settledAmount, '450000');
-});
-
-test('a repeated unpaid turn reuses the live offering terms after a reprice', async () => {
-  // A continuation without payment metadata is classified as `no-submission`
-  // without consulting the store. It must not replace the snapshot that a
-  // concurrent signed continuation may already have classified.
-  const facilitator = stubFacilitator();
-  const store = new InMemoryX402Store();
-  const sidecar = memorySidecar();
-  const context = () => new X402Context({ store, facilitator, x402Version: 2 });
-
-  const original = new X402Gate('a1', UPTO_PRICING, context(), sidecar);
-  const first = await original.open({
-    taskId: 'unpaid-retry',
-    contextId: 'ctx-unpaid-retry',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-
-  const repriced = parseX402Pricing({
-    ...UPTO_PRICING,
-    rates: { input: '9000000', output: '45000000', cachedInput: '900000' },
-  })!;
-  const afterReprice = new X402Gate('a1', repriced, context(), sidecar);
-
-  const repeated = await afterReprice.open({
-    taskId: 'unpaid-retry',
-    contextId: 'ctx-unpaid-retry',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(repeated.kind, 'halt');
-  if (repeated.kind !== 'halt') return;
-
-  const submitted = await afterReprice.open({
-    taskId: 'unpaid-retry',
-    contextId: 'ctx-unpaid-retry',
-    message: uptoSubmissionMessage(offeredRequirement(repeated.event)),
-    resource: RESOURCE,
-  });
-  assert.equal(submitted.kind, 'proceed');
-  if (submitted.kind !== 'proceed' || submitted.settlement?.mode !== 'deferred') return;
-  assert.deepEqual(submitted.settlement.pricing, UPTO_PRICING);
-});
-
-test('a replayed submission is refused instead of running the work twice', async () => {
-  // `classify()` does not inspect the entry's status, so the same signed
-  // payload classifies valid every time it is sent. Without the claim the
-  // backend would run again for one authorization.
-  const facilitator = stubFacilitator();
-  const gate = makeGate(facilitator);
-
-  const first = await gate.open({
-    taskId: 'replay',
-    contextId: 'ctx-replay',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-
-  const submission = submissionMessage(offeredRequirement(first.event));
-  const attempt = () =>
-    gate.open({
-      taskId: 'replay',
-      contextId: 'ctx-replay',
-      message: submission,
-      resource: RESOURCE,
-    });
-
-  assert.equal((await attempt()).kind, 'proceed');
-
-  const replay = await attempt();
-  assert.equal(replay.kind, 'halt');
-  if (replay.kind !== 'halt') return;
-  assert.equal(replay.event.status.state, TaskState.FAILED);
-  // The claim is taken before verify, so the replay costs no facilitator call.
-  assert.equal(facilitator.verifyCalls, 1);
-});
-
-test('a snapshot that disagrees with the signed requirement is refused, not silently unmetered', async () => {
-  // Concurrent turn-1s racing a reprice can leave the offering and the
-  // snapshot describing different schemes. Merely skipping the metering
-  // branch is the expensive failure: an `upto` requirement with no amount
-  // settles the full authorized ceiling.
-  const facilitator = stubFacilitator();
-  const store = new InMemoryX402Store();
-  const sidecar = memorySidecar();
-
-  // Publish an `upto` offering, then corrupt the snapshot to `exact`.
-  const gate = new X402Gate(
-    'a1',
-    UPTO_PRICING,
-    new X402Context({ store, facilitator, x402Version: 2 }),
-    sidecar,
-  );
-  const first = await gate.open({
-    taskId: 'mismatch',
-    contextId: 'ctx-mismatch',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-  sidecar.overwritePricing('mismatch', PRICING);
-
-  const second = await gate.open({
-    taskId: 'mismatch',
-    contextId: 'ctx-mismatch',
-    message: uptoSubmissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
-  });
-
-  assert.equal(second.kind, 'halt');
-  if (second.kind !== 'halt') return;
-  assert.equal(second.event.status.state, TaskState.FAILED);
-  assert.equal(facilitator.verifyCalls, 0, 'refused before the facilitator is involved');
-  assert.equal(facilitator.settleCalls, 0);
-});
-
-test('a missing pricing snapshot refuses the call rather than guessing a price', async () => {
-  // Written in the same breath as the offering, so absence means corruption.
-  // Falling back to live pricing here is exactly the bug the snapshot exists
-  // to prevent, so the safe direction is to refuse.
-  const facilitator = stubFacilitator();
-  const sidecar = memorySidecar();
-  const forgetful: X402OfferingSidecar = {
-    publishing: (_t, pricing, fn) => fn(pricing),
-    getPricing: async () => undefined,
-    claim: (taskId) => sidecar.claim(taskId),
-  };
-  const gate = makeGate(facilitator, PRICING, forgetful);
-
-  const first = await gate.open({
-    taskId: 'no-snapshot',
-    contextId: 'ctx-no-snapshot',
-    message: userMessage(),
-    resource: RESOURCE,
-  });
-  assert.equal(first.kind, 'halt');
-  if (first.kind !== 'halt') return;
-
-  const second = await gate.open({
-    taskId: 'no-snapshot',
-    contextId: 'ctx-no-snapshot',
-    message: submissionMessage(offeredRequirement(first.event)),
-    resource: RESOURCE,
-  });
-
-  assert.equal(second.kind, 'halt');
-  if (second.kind !== 'halt') return;
-  assert.equal(second.event.status.state, TaskState.FAILED);
-  assert.equal(facilitator.verifyCalls, 0);
-  assert.equal(facilitator.settleCalls, 0);
 });

--- a/packages/server/src/x402/gate.ts
+++ b/packages/server/src/x402/gate.ts
@@ -1,17 +1,19 @@
 import {
+  MerchantGate,
   X402Context,
   X402_FOUNDATION_EXTENSION_URI,
-  requirementScheme,
   type BaseX402Context,
-  type X402ValidClassification,
+  type MerchantDeferredObligation,
+  type MerchantMeterableUsage,
+  type MerchantOfferStore,
+  type MerchantPricing,
   type X402SettleResponse,
 } from '@a2x/sdk/x402';
 import { TaskState, type Message, type TaskStatusUpdateEvent } from '@a2x/sdk';
 import type { Sql } from '../db.js';
 import { logEvent } from '../log.js';
 import { PostgresX402Store } from './store.js';
-import { meterUsage, pricingToAccepts, type X402Pricing } from './pricing.js';
-import type { TaskUsage } from './usage.js';
+import { pricingToOffer, type X402Pricing } from './pricing.js';
 
 export { X402_FOUNDATION_EXTENSION_URI };
 
@@ -43,7 +45,7 @@ const OFFERING_TTL_SECONDS = (() => {
 export function createPostgresX402Context(
   sql: Sql,
   agentId: string,
-): { context: X402Context; sidecar: X402OfferingSidecar } {
+): { context: X402Context; offerStore: MerchantOfferStore } {
   const url = process.env.BRIDGE_X402_FACILITATOR_URL;
   const store = new PostgresX402Store(sql, agentId);
   return {
@@ -52,21 +54,12 @@ export function createPostgresX402Context(
       x402Version: X402_VERSION,
       ...(url ? { facilitator: { url } } : {}),
     }),
-    // Same instance: the sidecar rows live on the offering row, so they share
-    // the store's agent scoping rather than re-deriving it.
-    sidecar: store,
+    // Same instance: the frozen offer lives on the offering row, so the offer
+    // store shares the SDK store's agent scoping rather than re-deriving it.
+    offerStore: store,
   };
 }
 
-/**
- * Outcome of running the payment gate on an inbound turn.
- *
- * - `proceed` — nothing to charge for, or the payment verified. Run the work.
- *   `classified` is present exactly when a settlement is owed afterwards.
- * - `halt` — emit `event` and end the turn. Either the payment was requested
- *   (`input-required`, awaiting the client's signed resubmission) or it was
- *   refused (`failed`).
- */
 /**
  * What the caller still owes, once the gate has cleared a turn to run.
  *
@@ -77,23 +70,27 @@ export function createPostgresX402Context(
  * - `settled` (`exact`): already charged, before the agent was contacted. The
  *   amount is fixed and known up front, so there is no reason to hand over the
  *   work first and hope the authorization is still good afterwards.
+ *   `metadata` is the receipt to merge onto the task's terminal message.
  * - `deferred` (`upto`): the charge comes from consumption, which does not
  *   exist until the work is done, so settlement can only follow it.
+ *   `obligation` carries the classified submission and the terms the offering
+ *   was published under, frozen by the SDK's offer store — settlement uses
+ *   these, never the agent's live pricing, because a reprice between the two
+ *   turns would otherwise meter against terms the payer never signed.
  */
 export type X402Settlement =
   | { mode: 'settled'; metadata: Record<string, unknown> }
-  | {
-      mode: 'deferred';
-      classified: X402ValidClassification;
-      /**
-       * The pricing the offering was published under, read back from the
-       * store. Settlement uses this, never the agent's live pricing — the two
-       * turns are separate requests and a reprice in between would otherwise
-       * meter against terms the payer never signed.
-       */
-      pricing: X402Pricing;
-    };
+  | { mode: 'deferred'; obligation: MerchantDeferredObligation };
 
+/**
+ * Outcome of running the payment gate on an inbound turn.
+ *
+ * - `proceed` — nothing to charge for, or the payment verified. Run the work.
+ *   `settlement` is present exactly when the payment round-trip is live.
+ * - `halt` — emit `event` and end the turn. Either the payment was requested
+ *   (`input-required`, awaiting the client's signed resubmission) or it was
+ *   refused (`failed`).
+ */
 export type X402GateOutcome =
   | { kind: 'proceed'; settlement?: X402Settlement }
   | { kind: 'halt'; event: TaskStatusUpdateEvent };
@@ -102,8 +99,6 @@ export interface X402GateParams {
   taskId: string;
   contextId: string;
   message: Message;
-  /** Public URL of the agent being paid for — shown in the payer's wallet. */
-  resource: string;
 }
 
 /**
@@ -115,62 +110,72 @@ export interface X402GateParams {
  *   turn 1  unpaid request      → `input-required` + `x402.payment.required`
  *   turn 2  signed resubmission → verify → forward to the agent → settle
  *
- * The bridge drives this through the SDK's `X402Context` rather than the
- * `BaseAgent.run()` path the SDK documents, because `WSForwardingExecutor`
- * overrides `execute`/`executeStream` outright — there is no in-process agent
- * to host the flow. `X402Context`'s methods take a structural
- * `{ taskId, message }`, so they compose with a custom executor unchanged;
- * only the events need translating, which `haltEvent` does.
+ * The orchestration — classify, freeze the offered terms, claim the one-shot
+ * right to a submission, verify, meter, clamp, settle — is the SDK's
+ * `MerchantGate`; this class is the bridge-side composition of it. What stays
+ * here is exactly what the SDK leaves to the host: rendering outcomes as the
+ * `TaskStatusUpdateEvent`s this executor emits, the telemetry stream, mapping
+ * the stored pricing row onto a `MerchantOffer`, and the deployment's policy
+ * choices (`exactTiming: 'before-work'`, `unreportedUsage: 'floor'`, the
+ * offering TTL, and the wire version).
  *
- * Settlement is deliberately deferred until the agent has finished
- * successfully: payment buys delivered work, so a task that fails or is
- * cancelled is never settled and the payer's signed authorization simply goes
- * unused. Under `upto` that deferral is also what makes metering possible —
- * the token counts only exist once the work is done.
+ * The SDK fails closed on its own: a facilitator or store error surfaces as a
+ * `refuse` outcome, never a `proceed`, so an unpaid call cannot fall through
+ * to the agent because the payment rail was unavailable. `onError` below is
+ * the operator's view of those errors.
  */
-/**
- * The per-offering state the bridge keeps alongside the SDK's entry: the
- * pricing an offering was published under, and a one-shot claim.
- *
- * Separate from `BaseX402Store` because the SDK owns that shape, and separate
- * from the gate's constructor argument so tests can drive the round-trip
- * without a database.
- */
-export interface X402OfferingSidecar {
-  /**
-   * Serialize publishers for this task and run `fn` with the terms frozen for
-   * its live offering. The first live offering wins; later unpaid turns reuse
-   * it instead of replacing terms underneath an in-flight signed submission.
-   * The implementation also binds the returned pricing to the SDK's offering
-   * write so the two land in one statement.
-   */
-  publishing<T>(
-    taskId: string,
-    pricing: X402Pricing,
-    fn: (frozenPricing: X402Pricing) => Promise<T>,
-  ): Promise<T>;
-  getPricing(taskId: string): Promise<X402Pricing | undefined>;
-  /** `true` for the one caller that wins the right to act on a submission. */
-  claim(taskId: string): Promise<boolean>;
-}
-
 export class X402Gate {
+  private readonly gate: MerchantGate;
+
   constructor(
     private readonly agentId: string,
     private readonly pricing: X402Pricing,
     private readonly x402: BaseX402Context,
-    private readonly sidecar: X402OfferingSidecar,
-  ) {}
+    offerStore: MerchantOfferStore,
+    /** Public URL of the agent being paid for — shown in the payer's wallet. */
+    resource: string,
+  ) {
+    this.gate = new MerchantGate({
+      x402,
+      // Resolved fresh on every turn 1 and then frozen by the offer store, so
+      // a signed turn 2 settles under the terms it was offered even when the
+      // agent has been repriced in between.
+      pricing: () => ({
+        ...pricingToOffer(this.pricing, resource),
+        expiresInSeconds: OFFERING_TTL_SECONDS,
+      }),
+      offerStore,
+      // Flat fees charge before the agent is contacted: the amount was fixed
+      // at offer time and the payer signed for exactly it, so there is nothing
+      // to learn by doing the work first — and doing it first means handing
+      // over the result and only then discovering the authorization has been
+      // drained. A failure costs nobody: no charge, no work.
+      exactTiming: 'before-work',
+      onError: (error, ctx) => {
+        // Facilitator unreachable, DB down, malformed offering. The payer sees
+        // a generic refusal; this is where the operator sees why.
+        logEvent('x402_gate_error', {
+          agentId: this.agentId,
+          taskId: ctx.taskId,
+          operation: ctx.operation,
+          error: String(error),
+        });
+      },
+    });
+  }
 
   /**
-   * Scheme-independent description of an offering, for logs. Under `upto` the
-   * amount is the authorized ceiling, so it is labelled as such rather than
-   * reported as a price that will be charged.
+   * Scheme-independent description of an offering's terms, for logs. Under a
+   * metered scheme the amount is the authorized ceiling, so it is labelled as
+   * such rather than reported as a price that will be charged. Takes either
+   * the stored row or the SDK's frozen pricing — the discriminants agree
+   * (`batch-settlement` exists only on the SDK side; the bridge never stores
+   * such a row, but frozen pricing is typed to admit it).
    */
-  private offeringFields(pricing: X402Pricing): Record<string, string> {
-    return pricing.scheme === 'upto'
+  private offeringFields(pricing: X402Pricing | MerchantPricing): Record<string, string> {
+    return pricing.scheme === 'upto' || pricing.scheme === 'batch-settlement'
       ? {
-          scheme: 'upto',
+          scheme: pricing.scheme,
           ceiling: pricing.maxAmount,
           network: pricing.network,
           asset: pricing.asset,
@@ -186,18 +191,13 @@ export class X402Gate {
   /**
    * Classify the inbound turn and either request payment, refuse it, or clear
    * the request to run.
-   *
-   * Facilitator or store failures resolve to a `halt` rather than throwing:
-   * an unpaid request must never fall through to the agent, so the safe
-   * direction on an unexpected error is to refuse the call.
    */
   async open(params: X402GateParams): Promise<X402GateOutcome> {
-    const { taskId, contextId, message, resource } = params;
-    const ctx = { taskId, message };
+    const { taskId, contextId, message } = params;
 
     // `upto` exists only in x402 V2. The SDK would throw from
-    // `requestPayment`, which the catch below would report as a transient
-    // outage — misleading for what is a permanent misconfiguration.
+    // `requestPayment`, which its fail-closed catch would report as a
+    // transient outage — misleading for what is a permanent misconfiguration.
     if (this.pricing.scheme === 'upto' && X402_VERSION === 1) {
       logEvent('x402_config_invalid', {
         agentId: this.agentId,
@@ -215,42 +215,16 @@ export class X402Gate {
       };
     }
 
-    try {
-      const classified = await this.x402.classify(ctx);
+    const outcome = await this.gate.open({ taskId, contextId, message });
 
-      if (classified.kind === 'no-submission') {
-        // Turn 1. `requestPayment` persists the offering (status `offered`,
-        // with the TTL) and yields the `request-input` event we translate.
-        let metadata: Record<string, unknown> | undefined;
-        let text: string | undefined;
-        let offeredPricing = this.pricing;
-        // The terms ride along with the offering write the SDK performs inside
-        // here, in one statement. Publishers for one task are serialized and
-        // reuse a still-live snapshot, so a new unpaid turn cannot replace the
-        // rates after a signed turn has classified but before it claims.
-        await this.sidecar.publishing(taskId, this.pricing, async (frozenPricing) => {
-          offeredPricing = frozenPricing;
-          const accepts = pricingToAccepts(frozenPricing, resource);
-          for await (const event of this.x402.requestPayment(ctx, {
-            accepts,
-            expiresInSeconds: OFFERING_TTL_SECONDS,
-          })) {
-            if (event.type === 'request-input') {
-              metadata = event.metadata;
-              text = event.message;
-            }
-          }
-        });
-        if (metadata === undefined) {
-          // `requestPayment` always yields a `request-input`; reaching here
-          // means the SDK contract changed under us. Refuse rather than
-          // silently serve the call for free.
-          throw new Error('x402 requestPayment yielded no request-input event');
-        }
+    switch (outcome.kind) {
+      case 'request-payment':
+        // Turn 1. The SDK persisted the offering (status `offered`, with the
+        // TTL) and froze its terms; only the event needs translating.
         logEvent('x402_payment_required', {
           agentId: this.agentId,
           taskId,
-          ...this.offeringFields(offeredPricing),
+          ...this.offeringFields(this.pricing),
         });
         return {
           kind: 'halt',
@@ -258,166 +232,113 @@ export class X402Gate {
             taskId,
             contextId,
             state: TaskState.INPUT_REQUIRED,
-            text: text ?? 'Payment required to invoke this agent.',
-            metadata,
+            text: outcome.text,
+            metadata: outcome.metadata,
           }),
         };
-      }
 
-      if (classified.kind !== 'valid') {
-        // `classify` has already recorded the failure on the store entry.
+      case 'refuse':
+        // Covers every refusal the SDK produces — a malformed or mismatched
+        // submission, a failed verify, a replayed claim, a lapsed offering, a
+        // flat fee that could not be collected, or an infra error failing
+        // closed. `code` is the spec §9.1 discriminator between them.
         logEvent('x402_payment_refused', {
           agentId: this.agentId,
           taskId,
-          reason: classified.kind,
-          code: classified.code,
+          code: outcome.code,
+          reason: outcome.reason,
         });
+        if (outcome.failureReceipt !== undefined) {
+          // Money was in motion when this refusal happened: a `before-work`
+          // exact settlement was attempted and the facilitator said no.
+          logEvent('x402_settle_failed', {
+            agentId: this.agentId,
+            taskId,
+            reason: outcome.failureReceipt.errorReason ?? 'unknown',
+          });
+        }
         return {
           kind: 'halt',
           event: this.failedEvent({
             taskId,
             contextId,
-            code: classified.code,
-            reason: classified.reason,
+            code: outcome.code,
+            reason: outcome.reason,
+            ...(outcome.failureReceipt !== undefined
+              ? { failureReceipt: outcome.failureReceipt }
+              : {}),
           }),
         };
-      }
 
-      // One submission, one execution. `classify` above does not inspect the
-      // entry's status, so a replayed `payment-submitted` classifies valid
-      // every time; without this the backend would run the work again for the
-      // same authorization. The claim is never released — see `claim`.
-      if (!(await this.sidecar.claim(taskId))) {
-        logEvent('x402_submission_replayed', { agentId: this.agentId, taskId });
-        return {
-          kind: 'halt',
-          event: this.failedEvent({
-            taskId,
-            contextId,
-            code: 'DUPLICATE_NONCE',
-            reason: 'This payment has already been submitted for this task.',
-          }),
-        };
-      }
-
-      // Terms are the ones the offering was published under, not whatever the
-      // agent charges right now.
-      const settlementPricing = await this.sidecar.getPricing(taskId);
-      if (settlementPricing === undefined) {
-        // Written before the offering row carries an entry, so absence here
-        // is corruption rather than a normal state. Refuse instead of
-        // guessing a price.
-        logEvent('x402_pricing_snapshot_missing', { agentId: this.agentId, taskId });
-        return {
-          kind: 'halt',
-          event: this.failedEvent({
-            taskId,
-            contextId,
-            code: 'SETTLEMENT_FAILED',
-            reason: 'The terms this payment was offered under are no longer available.',
-          }),
-        };
-      }
-
-      // The snapshot and the requirement the payer actually signed must name
-      // the same scheme. Concurrent turn-1s racing a reprice can leave the two
-      // disagreeing, and the disagreement is expensive in one specific
-      // direction: an `upto` requirement paired with an `exact` snapshot skips
-      // the metering branch, which hands the SDK no amount and settles the
-      // full authorized ceiling. Refuse rather than let a mismatch pick a
-      // price — merely skipping the metering is not a safe default here.
-      const signedScheme = requirementScheme(classified.requirement);
-      if (signedScheme !== settlementPricing.scheme) {
-        logEvent('x402_scheme_mismatch', {
+      case 'handled': {
+        // A batch-settlement refund the SDK settled without running any work.
+        // Unreachable today: the bridge never publishes batch-settlement
+        // pricing, so no frozen offer can select it — but the outcome union
+        // carries it, and the safe defensive mapping is a terminal halt. The
+        // money already moved (the SDK holds a successful refund receipt), so
+        // the receipt must reach the payer on a completed terminal status;
+        // running the work or reporting failure would both misstate what
+        // happened. The extra log is the operator's tripwire that a path this
+        // deployment cannot produce fired anyway.
+        logEvent('x402_unexpected_outcome', {
           agentId: this.agentId,
           taskId,
-          signed: signedScheme,
-          snapshot: settlementPricing.scheme,
+          outcome: 'handled',
+          operation: outcome.operation,
         });
+        this.logSettled(taskId, outcome.receipt);
         return {
           kind: 'halt',
-          event: this.failedEvent({
+          event: this.statusEvent({
             taskId,
             contextId,
-            code: 'SETTLEMENT_FAILED',
-            reason: 'The offered terms and the signed payment disagree; start a new task.',
+            state: TaskState.COMPLETED,
+            text: 'The payment operation completed; no agent work was performed.',
+            metadata: outcome.receiptMetadata,
           }),
         };
       }
 
-      const verify = await this.x402.verify(ctx, classified);
-      if (!verify.isValid) {
-        const reason = verify.invalidReason ?? 'Payment verification failed.';
-        logEvent('x402_verify_failed', { agentId: this.agentId, taskId, reason });
-        return {
-          kind: 'halt',
-          event: this.failedEvent({
-            taskId,
-            contextId,
-            code: 'VERIFY_FAILED',
-            reason,
-          }),
-        };
-      }
+      case 'proceed': {
+        const obligation = outcome.obligation;
+        if (obligation === undefined) {
+          // The resolver above never returns null for a priced agent, so a
+          // bare proceed cannot happen here; tolerate it as "free" anyway.
+          return { kind: 'proceed' };
+        }
 
-      logEvent('x402_payment_verified', {
-        agentId: this.agentId,
-        taskId,
-        ...this.offeringFields(settlementPricing),
-      });
-
-      if (settlementPricing.scheme === 'upto') {
-        // Metered: the charge does not exist until the work has been done, so
-        // settlement has to follow it. See the note on `settleTerminal`.
-        return {
-          kind: 'proceed',
-          settlement: { mode: 'deferred', classified, pricing: settlementPricing },
-        };
-      }
-
-      // Flat fee: charge now, before the agent is contacted. The amount was
-      // fixed at offer time and the payer has signed for exactly it, so there
-      // is nothing to learn by doing the work first — and doing it first means
-      // handing over the result and only then discovering the authorization
-      // has been drained. A failure here costs nobody: no charge, no work.
-      //
-      // Safe to do here only because `claim` above is a one-shot: without it a
-      // replayed submission would settle a second time.
-      const settled = await this.settle({
-        taskId,
-        contextId,
-        classified,
-        pricing: settlementPricing,
-      });
-      if (settled.kind === 'failed') return { kind: 'halt', event: settled.event };
-      return { kind: 'proceed', settlement: { mode: 'settled', metadata: settled.metadata } };
-    } catch (err) {
-      // Facilitator unreachable, DB down, malformed offering — fail closed.
-      logEvent('x402_gate_error', {
-        agentId: this.agentId,
-        taskId,
-        error: String(err),
-      });
-      return {
-        kind: 'halt',
-        event: this.failedEvent({
+        logEvent('x402_payment_verified', {
+          agentId: this.agentId,
           taskId,
-          contextId,
-          code: 'SETTLEMENT_FAILED',
-          reason: 'Payment processing is temporarily unavailable.',
-        }),
-      };
+          ...this.offeringFields(obligation.pricing),
+        });
+
+        if (obligation.kind === 'deferred') {
+          // Metered: the charge does not exist until the work has been done,
+          // so settlement has to follow it — see `settle`.
+          return { kind: 'proceed', settlement: { mode: 'deferred', obligation } };
+        }
+
+        // Flat fee, already settled by the SDK before the agent is contacted
+        // (`exactTiming: 'before-work'`). Safe because the claim inside the
+        // SDK is a one-shot: a replayed submission cannot settle twice.
+        this.logSettled(taskId, obligation.receipt);
+        const done = this.x402.completedEvent({ receipt: obligation.receipt });
+        const metadata = done.type === 'done' ? (done.metadata ?? {}) : {};
+        return { kind: 'proceed', settlement: { mode: 'settled', metadata } };
+      }
     }
   }
 
   /**
-   * Settle a verified payment after the agent completed the work.
+   * Settle a deferred (`upto`) payment after the agent completed the work.
    *
-   * Under `exact` the charge is the amount the payer already signed for and
-   * `usage` is ignored. Under `upto` the charge is metered from `usage` and
-   * the SDK clamps it down to the minimum of the metered value, the offered
-   * ceiling, and the payer's signed cap — so a pricing or metering mistake
-   * here can only ever undercharge.
+   * The charge is metered from `usage` under the obligation's frozen terms,
+   * and the SDK clamps it down to the minimum of the metered value, the
+   * offered ceiling, and the payer's signed cap — so a pricing or metering
+   * mistake here can only ever undercharge. An `unreported` usage bills the
+   * floor (`unreportedUsage: 'floor'`), a trusted reported zero settles zero
+   * (a2x#206).
    *
    * Returns metadata to merge onto the task's final status message on
    * success, or a replacement terminal event when settlement failed — the
@@ -426,44 +347,59 @@ export class X402Gate {
   async settle(params: {
     taskId: string;
     contextId: string;
-    classified: X402ValidClassification;
-    /** The offering's frozen terms, from `open`. Never the live pricing. */
-    pricing: X402Pricing;
-    usage?: TaskUsage | undefined;
+    /** The verified submission and its frozen terms, from `open`. */
+    obligation: MerchantDeferredObligation;
+    usage: MerchantMeterableUsage;
+    /** The model the backend reported, for the metering log only. */
+    model?: string | undefined;
   }): Promise<
     | { kind: 'settled'; metadata: Record<string, unknown> }
     | { kind: 'failed'; event: TaskStatusUpdateEvent }
   > {
-    const { taskId, contextId, classified, pricing, usage } = params;
-    const ctx = { taskId };
+    const { taskId, contextId, obligation, usage, model } = params;
 
-    // Metering an `exact` requirement throws in the SDK — the signature binds
-    // it to one value — so the option is only ever passed for `upto`.
-    //
-    // Gated on the *requirement* the payer actually signed as well as on the
-    // snapshot: the two agree by construction, and requiring both means no
-    // single stale value can send a metered amount at an exact signature or
-    // vice versa.
-    let settleOpts: { amountAtomic?: string } | undefined;
-    if (pricing.scheme === 'upto' && requirementScheme(classified.requirement) === 'upto') {
-      const charge = meterUsage(pricing, usage);
-      settleOpts = { amountAtomic: charge.amountAtomic };
+    const result = await this.gate.settle({ taskId, obligation, usage });
+
+    if (result.kind === 'failed') {
+      logEvent('x402_settle_failed', {
+        agentId: this.agentId,
+        taskId,
+        reason: result.reason,
+      });
+      return {
+        kind: 'failed',
+        event: this.failedEvent({
+          taskId,
+          contextId,
+          code: result.code,
+          reason: result.reason,
+          ...(result.failureReceipt !== undefined
+            ? { failureReceipt: result.failureReceipt }
+            : {}),
+        }),
+      };
+    }
+
+    if (obligation.scheme === 'upto' && result.charge !== undefined) {
+      const charge = result.charge;
       logEvent('x402_metered', {
         agentId: this.agentId,
         taskId,
         basis: charge.basis,
-        amount: charge.amountAtomic,
-        ceiling: pricing.maxAmount,
-        ...(usage !== undefined
+        amount: charge.requestedAtomic,
+        ceiling: obligation.pricing.maxAmount,
+        ...(usage.kind === 'detailed'
           ? {
-              promptTokens: usage.prompt_tokens,
-              completionTokens: usage.completion_tokens,
-              ...(usage.cached_tokens !== undefined ? { cachedTokens: usage.cached_tokens } : {}),
-              ...(usage.model !== undefined ? { model: usage.model } : {}),
+              promptTokens: usage.inputTokens,
+              completionTokens: usage.outputTokens,
+              ...(usage.cachedInputTokens !== undefined
+                ? { cachedTokens: usage.cachedInputTokens }
+                : {}),
             }
           : {}),
+        ...(model !== undefined ? { model } : {}),
       });
-      if (charge.basis === 'no-usage') {
+      if (charge.basis === 'unreported-floor') {
         // Loud on purpose: the backend delivered work the bridge could not
         // price. Either the runtime dropped its accounting (codex #351) or
         // the backend has none at all (openclaw), and both mean this agent
@@ -476,44 +412,20 @@ export class X402Gate {
       }
     }
 
-    let receipt: X402SettleResponse;
+    this.logSettled(taskId, result.receipt);
+    return { kind: 'settled', metadata: result.receiptMetadata };
+  }
+
+  /** Drop the lifecycle record once the task has terminated. Best-effort. */
+  async clear(taskId: string): Promise<void> {
     try {
-      receipt = await this.x402.settle(ctx, classified, settleOpts);
+      await this.x402.clearOffering({ taskId });
     } catch (err) {
-      logEvent('x402_settle_error', {
-        agentId: this.agentId,
-        taskId,
-        error: String(err),
-      });
-      return {
-        kind: 'failed',
-        event: this.failedEvent({
-          taskId,
-          contextId,
-          code: 'SETTLEMENT_FAILED',
-          reason: 'Payment settlement failed.',
-        }),
-      };
+      logEvent('x402_clear_error', { agentId: this.agentId, taskId, error: String(err) });
     }
+  }
 
-    if (!receipt.success) {
-      logEvent('x402_settle_failed', {
-        agentId: this.agentId,
-        taskId,
-        reason: receipt.errorReason ?? 'unknown',
-      });
-      return {
-        kind: 'failed',
-        event: this.failedEvent({
-          taskId,
-          contextId,
-          code: 'SETTLEMENT_FAILED',
-          reason: receipt.errorReason ?? 'Payment settlement failed.',
-          failureReceipt: receipt,
-        }),
-      };
-    }
-
+  private logSettled(taskId: string, receipt: X402SettleResponse): void {
     logEvent('x402_settled', {
       agentId: this.agentId,
       taskId,
@@ -526,23 +438,6 @@ export class X402Gate {
       // backfill it from what was requested.
       ...(receipt.amount !== undefined ? { amount: receipt.amount } : {}),
     });
-
-    const done = this.x402.completedEvent({ receipt });
-    const metadata = done.type === 'done' ? (done.metadata ?? {}) : {};
-    // Deliberately does not clear the offering. Under `exact` this runs before
-    // the work, and dropping the row would release the claim mid-task — a
-    // resubmission would then be treated as a fresh payment and charged again.
-    // The executor clears once the task reaches a terminal state.
-    return { kind: 'settled', metadata };
-  }
-
-  /** Drop the lifecycle record once the task has terminated. Best-effort. */
-  async clear(taskId: string): Promise<void> {
-    try {
-      await this.x402.clearOffering({ taskId });
-    } catch (err) {
-      logEvent('x402_clear_error', { agentId: this.agentId, taskId, error: String(err) });
-    }
   }
 
   private failedEvent(input: {
@@ -569,7 +464,7 @@ export class X402Gate {
   }
 
   /**
-   * Translate an x402 `AgentEvent` into the wire event this executor emits.
+   * Translate an x402 outcome into the wire event this executor emits.
    * `final: true` on both states: an `input-required` turn ends the stream
    * without terminating the task, which is exactly what the flag means here.
    */

--- a/packages/server/src/x402/pricing.test.ts
+++ b/packages/server/src/x402/pricing.test.ts
@@ -1,12 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { merchantPricingToAccept } from '@a2x/sdk/x402';
 import {
   X402PricingSchema,
   X402PricingWriteSchema,
   formatPricingError,
-  meterUsage,
   parseX402Pricing,
-  pricingToAccepts,
+  pricingToOffer,
   type X402UptoPricing,
 } from './pricing.js';
 
@@ -16,6 +16,8 @@ const VALID = {
   asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
   payTo: '0x1111111111111111111111111111111111111111',
 };
+
+const RESOURCE = 'https://bridge.test/agents/a1';
 
 test('parseX402Pricing treats NULL and undefined as "free agent"', () => {
   assert.equal(parseX402Pricing(null), undefined);
@@ -64,28 +66,30 @@ test('parseX402Pricing keeps a large atomic amount exact', () => {
   assert.equal(parsed?.scheme === 'exact' ? parsed.amount : undefined, big);
 });
 
-test('pricingToAccepts builds a single exact offering bound to the resource URL', () => {
-  const accepts = pricingToAccepts(parseX402Pricing(VALID)!, 'https://bridge.test/agents/a1');
-  assert.equal(accepts.length, 1);
-  assert.deepEqual(accepts[0], {
+// ── row → MerchantOffer mapping ───────────────────────────────────────────
+
+test('pricingToOffer builds a single exact offering bound to the resource URL', () => {
+  const offer = pricingToOffer(parseX402Pricing(VALID)!, RESOURCE);
+  assert.equal(offer.accepts.length, 1);
+  assert.deepEqual(offer.accepts[0], {
     scheme: 'exact',
     network: 'eip155:84532',
     amount: '10000',
     asset: VALID.asset,
     payTo: VALID.payTo,
-    resource: 'https://bridge.test/agents/a1',
+    resource: RESOURCE,
     description: 'Agent invocation',
   });
 });
 
-test('pricingToAccepts forwards a custom description and EIP-712 extra', () => {
+test('pricingToOffer forwards a custom description and EIP-712 extra', () => {
   const extra = { name: 'USD Coin', version: '2' };
-  const accepts = pricingToAccepts(
+  const offer = pricingToOffer(
     parseX402Pricing({ ...VALID, description: 'Premium research', extra })!,
-    'https://bridge.test/agents/a1',
+    RESOURCE,
   );
-  assert.equal(accepts[0]!.description, 'Premium research');
-  assert.deepEqual(accepts[0]!.extra, extra);
+  assert.equal(offer.accepts[0]!.description, 'Premium research');
+  assert.deepEqual(offer.accepts[0]!.extra, extra);
 });
 
 // ── upto (metered) pricing ────────────────────────────────────────────────
@@ -125,85 +129,57 @@ test('parseX402Pricing requires atomic-unit rates for upto', () => {
   assert.throws(() => parseX402Pricing({ ...UPTO, rates: { input: 3000000, output: '15' } }));
 });
 
-test('pricingToAccepts offers the ceiling and the facilitator address for upto', () => {
-  const accepts = pricingToAccepts(upto(), 'https://bridge.test/agents/a1');
-  assert.equal(accepts.length, 1);
-  assert.equal(accepts[0]!.scheme, 'upto');
-  // `amount` on the wire is what the payer authorizes, not what is charged.
-  assert.equal(accepts[0]!.amount, '1000000');
-  assert.deepEqual(accepts[0]!.extra, { facilitatorAddress: UPTO.facilitatorAddress });
-});
-
-test('meterUsage prices input and output at their separate rates', () => {
-  // 100k in @ $3/MTok = 300000 atomic; 10k out @ $15/MTok = 150000 atomic.
-  const charge = meterUsage(upto(), {
-    prompt_tokens: 100_000,
-    completion_tokens: 10_000,
-    total_tokens: 110_000,
+test('pricingToOffer maps an upto row onto the SDK rate model with the floor policy', () => {
+  // The row stores rates as {input, output, cachedInput}; the SDK names them
+  // per-million explicitly. `unreportedUsage` is the bridge's standing risk
+  // allocation: an instrumentation gap bills the floor, never the cap.
+  const offer = pricingToOffer(
+    upto({ minAmount: '25000', rates: { ...UPTO.rates, cachedInput: '300000' } }),
+    RESOURCE,
+  );
+  assert.equal(offer.accepts.length, 1);
+  const pricing = offer.accepts[0]!;
+  assert.equal(pricing.scheme, 'upto');
+  if (pricing.scheme !== 'upto') return;
+  assert.equal(pricing.maxAmount, '1000000');
+  assert.equal(pricing.minAmount, '25000');
+  assert.deepEqual(pricing.rates, {
+    inputPerMillion: '3000000',
+    outputPerMillion: '15000000',
+    cachedInputPerMillion: '300000',
   });
-  assert.equal(charge.basis, 'metered');
-  assert.equal(charge.amountAtomic, '450000');
+  assert.equal(pricing.unreportedUsage, 'floor');
+  assert.deepEqual(pricing.extra, { facilitatorAddress: UPTO.facilitatorAddress });
 });
 
-test('meterUsage discounts cached input without double-counting it', () => {
-  // cached_tokens is a breakdown of prompt_tokens, never additive: 100k
-  // prompt of which 90k cached = 10k fresh @ $3 + 90k cached @ $0.30.
-  const charge = meterUsage(upto({ rates: { ...UPTO.rates, cachedInput: '300000' } }), {
-    prompt_tokens: 100_000,
-    completion_tokens: 0,
-    total_tokens: 100_000,
-    cached_tokens: 90_000,
+test('pricingToOffer leaves the optional upto fields absent, not defaulted', () => {
+  // Absent cachedInput means "same as input" — the SDK owns that default, so
+  // the mapping must not materialize one. Absent minAmount likewise.
+  const offer = pricingToOffer(upto(), RESOURCE);
+  const pricing = offer.accepts[0]!;
+  assert.equal(pricing.scheme, 'upto');
+  if (pricing.scheme !== 'upto') return;
+  assert.equal(pricing.minAmount, undefined);
+  assert.deepEqual(pricing.rates, {
+    inputPerMillion: '3000000',
+    outputPerMillion: '15000000',
   });
-  assert.equal(charge.amountAtomic, '57000');
 });
 
-test('meterUsage charges cached input at the full rate when no discount is set', () => {
-  // Absent cachedInput means "same as input", not "free" — treating an
-  // unstated discount as 100% would give away most of a cache-heavy call.
-  const charge = meterUsage(upto(), {
-    prompt_tokens: 100_000,
-    completion_tokens: 0,
-    total_tokens: 100_000,
-    cached_tokens: 90_000,
+test('the upto wire shape is unchanged: ceiling as amount, no rate table', () => {
+  // What the SDK advertises from this mapping must be what the old
+  // `pricingToAccepts` put on the wire — the payer-visible contract.
+  const accept = merchantPricingToAccept(pricingToOffer(upto(), RESOURCE).accepts[0]!);
+  assert.deepEqual(accept, {
+    scheme: 'upto',
+    network: 'eip155:84532',
+    amount: '1000000',
+    asset: UPTO.asset,
+    payTo: UPTO.payTo,
+    resource: RESOURCE,
+    description: 'Metered agent invocation — billed per token',
+    extra: { facilitatorAddress: UPTO.facilitatorAddress },
   });
-  assert.equal(charge.amountAtomic, '300000');
-});
-
-test('meterUsage rounds a sub-unit charge up rather than down to zero', () => {
-  // A fractional result must not floor to 0, which downstream is
-  // indistinguishable from "nothing was reported".
-  const charge = meterUsage(upto({ rates: { input: '1', output: '1' } }), {
-    prompt_tokens: 1,
-    completion_tokens: 0,
-    total_tokens: 1,
-  });
-  assert.equal(charge.amountAtomic, '1');
-  assert.equal(charge.basis, 'metered');
-});
-
-test('meterUsage applies the floor when the metered charge is below it', () => {
-  const charge = meterUsage(upto({ minAmount: '50000' }), {
-    prompt_tokens: 100,
-    completion_tokens: 0,
-    total_tokens: 100,
-  });
-  assert.equal(charge.basis, 'floor');
-  assert.equal(charge.amountAtomic, '50000');
-});
-
-test('meterUsage treats missing or zero usage as unpriceable, not free', () => {
-  // The distinction that matters for revenue: openclaw reports no usage at
-  // all, and codex/vicoop-codex emit {0,0,0} when their runtime dropped
-  // accounting. Neither means the call was free.
-  for (const usage of [undefined, { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }]) {
-    const withoutFloor = meterUsage(upto(), usage);
-    assert.equal(withoutFloor.basis, 'no-usage');
-    assert.equal(withoutFloor.amountAtomic, '0');
-
-    const withFloor = meterUsage(upto({ minAmount: '25000' }), usage);
-    assert.equal(withFloor.basis, 'no-usage');
-    assert.equal(withFloor.amountAtomic, '25000');
-  }
 });
 
 // ── write-time strictness ─────────────────────────────────────────────────
@@ -283,15 +259,4 @@ test('formatPricingError names the offending field on one line', () => {
     assert.match(message, /minamount/);
     assert.equal(message.includes('\n'), false, 'must stay a single line for the CLI');
   }
-});
-
-test('meterUsage stays exact on values that would break a double', () => {
-  // 1e9 tokens * 3e12 rate = 3e21 before division — far past 2^53, which is
-  // why the arithmetic is BigInt end to end.
-  const charge = meterUsage(upto({ rates: { input: '3000000000000', output: '0' } }), {
-    prompt_tokens: 1_000_000_000,
-    completion_tokens: 0,
-    total_tokens: 1_000_000_000,
-  });
-  assert.equal(charge.amountAtomic, '3000000000000000');
 });

--- a/packages/server/src/x402/pricing.ts
+++ b/packages/server/src/x402/pricing.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
-import type { X402Accept } from '@a2x/sdk/x402';
-import type { TaskUsage } from './usage.js';
+import type { MerchantOffer } from '@a2x/sdk/x402';
 
 // Per-agent x402 pricing, persisted on `agents.x402_pricing` and carried on
 // the live `ClientConnection`. Deliberately DB-owned rather than declared in
@@ -13,6 +12,9 @@ import type { TaskUsage } from './usage.js';
 //   exact — a fixed charge per call, agreed before the work happens.
 //   upto  — the payer authorizes up to a ceiling and the bridge settles the
 //           metered token consumption. x402 V2 only.
+//
+// The metering itself lives in the SDK's `MerchantGate` — this module only
+// owns the stored row shape and its mapping onto the SDK's `MerchantOffer`.
 
 // An EVM address. Stored as given (checksummed or not) — the x402 payload
 // checks compare case-insensitively.
@@ -69,8 +71,9 @@ const UptoPricingSchema = z.object({
   // the SDK, so it doubles as the blast radius of a metering bug.
   maxAmount: PositiveAtomicAmount,
   rates: RatesSchema,
-  // Floor for a completed call. Also what is charged when the backend
-  // reported no usage at all — see `meterUsage`. Absent means zero.
+  // Floor for a completed call that metered below it. Also what is charged
+  // when the backend reported no usage at all — the bridge maps this row with
+  // `unreportedUsage: 'floor'`, see `pricingToOffer`. Absent means zero.
   minAmount: AtomicAmount.optional(),
   // The payer's Permit2 witness binds to this address, so it must match the
   // facilitator that will settle. Read it from the facilitator's
@@ -156,12 +159,17 @@ export function formatPricingError(err: unknown): string {
 }
 
 /**
- * Build the offering advertised to the payer. `resource` must be the public
- * URL of what is being paid for — strict facilitators reject non-URL values,
- * and wallets show it in the consent prompt, so it is the agent's own
- * endpoint rather than an opaque id.
+ * Map a stored pricing row onto the offer the SDK's `MerchantGate` publishes.
+ *
+ * `resource` must be the public URL of what is being paid for — strict
+ * facilitators reject non-URL values, and wallets show it in the consent
+ * prompt, so it is the agent's own endpoint rather than an opaque id.
+ *
+ * The wire shape is unchanged from the pre-MerchantGate builds: the SDK
+ * flattens an `upto` entry back to `{ scheme: 'upto', amount: maxAmount }`
+ * when it advertises, and the rate table only ever drives settlement.
  */
-export function pricingToAccepts(pricing: X402Pricing, resource: string): X402Accept[] {
+export function pricingToOffer(pricing: X402Pricing, resource: string): MerchantOffer {
   const common = {
     network: pricing.network,
     asset: pricing.asset,
@@ -170,80 +178,41 @@ export function pricingToAccepts(pricing: X402Pricing, resource: string): X402Ac
   };
 
   if (pricing.scheme === 'upto') {
-    return [
+    return {
+      accepts: [
+        {
+          ...common,
+          scheme: 'upto',
+          maxAmount: pricing.maxAmount,
+          ...(pricing.minAmount !== undefined ? { minAmount: pricing.minAmount } : {}),
+          rates: {
+            inputPerMillion: pricing.rates.input,
+            outputPerMillion: pricing.rates.output,
+            ...(pricing.rates.cachedInput !== undefined
+              ? { cachedInputPerMillion: pricing.rates.cachedInput }
+              : {}),
+          },
+          // Bridge policy: a backend that reported no usage bills the floor,
+          // never the authorized ceiling — a gap in *our* instrumentation must
+          // not charge the payer the maximum. A trusted reported zero is
+          // different and settles zero (a2x#206); see `readTaskUsage`.
+          unreportedUsage: 'floor',
+          description: pricing.description ?? 'Metered agent invocation — billed per token',
+          extra: { ...(pricing.extra ?? {}), facilitatorAddress: pricing.facilitatorAddress },
+        },
+      ],
+    };
+  }
+
+  return {
+    accepts: [
       {
         ...common,
-        scheme: 'upto',
-        // What the payer authorizes, not what they will be charged.
-        amount: pricing.maxAmount,
-        description: pricing.description ?? 'Metered agent invocation — billed per token',
-        extra: { ...(pricing.extra ?? {}), facilitatorAddress: pricing.facilitatorAddress },
+        scheme: 'exact',
+        amount: pricing.amount,
+        description: pricing.description ?? 'Agent invocation',
+        ...(pricing.extra !== undefined ? { extra: pricing.extra } : {}),
       },
-    ];
-  }
-
-  return [
-    {
-      ...common,
-      scheme: 'exact',
-      amount: pricing.amount,
-      description: pricing.description ?? 'Agent invocation',
-      ...(pricing.extra !== undefined ? { extra: pricing.extra } : {}),
-    },
-  ];
-}
-
-/** What `meterUsage` decided to charge, and why — the `why` is logged. */
-export interface MeteredCharge {
-  amountAtomic: string;
-  /**
-   * - `metered`  — priced from reported token counts.
-   * - `floor`    — the metered value was below `minAmount`.
-   * - `no-usage` — the backend reported nothing; `minAmount` (or zero) applied.
-   */
-  basis: 'metered' | 'floor' | 'no-usage';
-}
-
-/**
- * Price a completed call from its reported token usage.
- *
- * Arithmetic is BigInt throughout: rates are per million tokens, so the
- * intermediate product overflows a double's exact range long before the
- * amounts do. The division rounds **up** — standard for billing, and it keeps
- * a genuinely tiny call from pricing to zero, which would be
- * indistinguishable from "the runtime told us nothing".
- *
- * That distinction is the reason `basis` exists. `total_tokens: 0` does not
- * mean the call was free: codex and vicoop-codex emit `{0,0,0}` as an honest
- * "the runtime did not report" placeholder, and openclaw reports no usage at
- * all. Charging zero for delivered work is a real loss, so an operator who
- * cares sets `minAmount` and gets that floor instead. Charging the authorized
- * ceiling in this case would be worse: it bills the payer the maximum for a
- * gap in *our* instrumentation.
- */
-export function meterUsage(pricing: X402UptoPricing, usage: TaskUsage | undefined): MeteredCharge {
-  const floor = BigInt(pricing.minAmount ?? '0');
-
-  if (usage === undefined || usage.total_tokens === 0) {
-    return { amountAtomic: floor.toString(), basis: 'no-usage' };
-  }
-
-  const cached = BigInt(usage.cached_tokens ?? 0);
-  // `cached_tokens` is a breakdown of `prompt_tokens`, never additive, so the
-  // full-price share is what remains after taking the cached part out.
-  const freshInput = BigInt(usage.prompt_tokens) - cached;
-  const cachedRate = BigInt(pricing.rates.cachedInput ?? pricing.rates.input);
-
-  const micros =
-    (freshInput > 0n ? freshInput : 0n) * BigInt(pricing.rates.input) +
-    cached * cachedRate +
-    // `reasoning_tokens` is likewise a breakdown of `completion_tokens`, so
-    // completion alone already covers it.
-    BigInt(usage.completion_tokens) * BigInt(pricing.rates.output);
-
-  const PER = 1_000_000n;
-  const metered = micros === 0n ? 0n : (micros + PER - 1n) / PER;
-
-  if (metered < floor) return { amountAtomic: floor.toString(), basis: 'floor' };
-  return { amountAtomic: metered.toString(), basis: 'metered' };
+    ],
+  };
 }

--- a/packages/server/src/x402/store.test.ts
+++ b/packages/server/src/x402/store.test.ts
@@ -1,23 +1,29 @@
 // Integration tests for the x402 offering store against a real Postgres.
-// The three properties here are the ones a unit test with an in-memory stub
-// cannot establish: agent scoping is a WHERE clause, the claim is a conditional
-// UPDATE, and the sweep is a DELETE.
+// The properties here are the ones a unit test with an in-memory stub cannot
+// establish: agent scoping is a WHERE clause, the claim is a conditional
+// UPDATE, the sweep is a DELETE, and the offer store's frozen offer is a
+// JSONB column bound to the SDK's offering write in one statement.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import postgres from 'postgres';
-import type { X402StoreEntry } from '@a2x/sdk/x402';
+import type { MerchantOffer, X402StoreEntry } from '@a2x/sdk/x402';
 import { PostgresX402Store, sweepExpiredX402Offerings } from './store.js';
-import { parseX402Pricing, type X402Pricing } from './pricing.js';
+import { parseX402Pricing, pricingToOffer } from './pricing.js';
 
 const hasDb = !!process.env.DATABASE_URL;
 
-const PRICING = parseX402Pricing({
-  network: 'eip155:84532',
-  amount: '10000',
-  asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-  payTo: '0x1111111111111111111111111111111111111111',
-})!;
+const RESOURCE = 'https://bridge.test/agents/a';
+
+const OFFER: MerchantOffer = pricingToOffer(
+  parseX402Pricing({
+    network: 'eip155:84532',
+    amount: '10000',
+    asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    payTo: '0x1111111111111111111111111111111111111111',
+  })!,
+  RESOURCE,
+);
 
 function entry(taskId: string, overrides: Partial<X402StoreEntry> = {}): X402StoreEntry {
   return {
@@ -29,7 +35,7 @@ function entry(taskId: string, overrides: Partial<X402StoreEntry> = {}): X402Sto
         amount: '10000',
         asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
         payTo: '0x1111111111111111111111111111111111111111',
-        resource: 'https://bridge.test/agents/a',
+        resource: RESOURCE,
         description: 'test',
       },
     ],
@@ -64,11 +70,11 @@ test(
       const a = new PostgresX402Store(sql, `${tag}-agent-a`);
       const b = new PostgresX402Store(sql, `${tag}-agent-b`);
 
-      await a.publishing(taskId, PRICING, () => a.put(entry(taskId)));
+      await a.publishing(taskId, OFFER, () => a.put(entry(taskId)));
 
       assert.ok(await a.get(taskId), 'the owning agent sees its own offering');
       assert.equal(await b.get(taskId), undefined, 'another agent must not');
-      assert.equal(await b.getPricing(taskId), undefined);
+      assert.equal(await b.getOffer(taskId), undefined);
       assert.equal(await b.claim(taskId), false, 'and must not be able to claim it');
 
       // B's delete must not reach A's row either.
@@ -125,7 +131,62 @@ test(
 );
 
 test(
-  'a lifecycle update does not reset the claim or the pricing snapshot',
+  'release re-opens the claim, scoped to the owning agent',
+  { skip: !hasDb },
+  async () => {
+    // `release` is the contract's one sanctioned un-claim — the SDK invokes
+    // it when a retryable scheme cancels verified work. It must actually
+    // re-open the window (a later claim wins again) and must be scoped like
+    // every other operation: another agent releasing the same taskId must not
+    // hand this agent's one-shot right back.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-release`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+      const other = new PostgresX402Store(sql, `${tag}-agent-other`);
+      await store.put(entry(taskId));
+
+      assert.equal(await store.claim(taskId), true);
+      await other.release(taskId);
+      assert.equal(
+        await store.claim(taskId),
+        false,
+        "another agent's release must not un-claim it",
+      );
+
+      await store.release(taskId);
+      assert.equal(
+        await store.claim(taskId),
+        true,
+        'a released claim can be taken exactly once again',
+      );
+      assert.equal(await store.claim(taskId), false, 'and stays one-shot after that');
+    });
+  },
+);
+
+test(
+  'the offer store delete removes the row for its own agent',
+  { skip: !hasDb },
+  async () => {
+    // `delete` serves both the SDK store and the offer store contract — the
+    // MerchantGate calls it on cleanup after settlement, and a deleted row
+    // must read as absent on every surface at once.
+    await withDb(async (sql, tag) => {
+      const taskId = `${tag}-delete`;
+      const store = new PostgresX402Store(sql, `${tag}-agent`);
+      await store.publishing(taskId, OFFER, () => store.put(entry(taskId)));
+
+      await store.delete(taskId);
+
+      assert.equal(await store.get(taskId), undefined);
+      assert.equal(await store.getOffer(taskId), undefined);
+      assert.equal(await store.claim(taskId), false, 'a deleted offering cannot be claimed');
+    });
+  },
+);
+
+test(
+  'a lifecycle update does not reset the claim or the frozen offer',
   { skip: !hasDb },
   async () => {
     // `put` runs repeatedly as the SDK patches the entry through verify and
@@ -133,14 +194,14 @@ test(
     await withDb(async (sql, tag) => {
       const taskId = `${tag}-patch`;
       const store = new PostgresX402Store(sql, `${tag}-agent`);
-      await store.publishing(taskId, PRICING, () => store.put(entry(taskId)));
+      await store.publishing(taskId, OFFER, () => store.put(entry(taskId)));
       assert.equal(await store.claim(taskId), true);
 
       await store.update(taskId, { status: 'verified', verifiedAt: new Date() });
 
       assert.equal((await store.get(taskId))?.status, 'verified');
       assert.equal(await store.claim(taskId), false, 'the claim survives the patch');
-      assert.deepEqual(await store.getPricing(taskId), PRICING);
+      assert.deepEqual(await store.getOffer(taskId), OFFER);
     });
   },
 );
@@ -154,12 +215,17 @@ test(
       const lapsed = `${tag}-lapsed`;
       const store = new PostgresX402Store(sql, `${tag}-agent`);
 
-      await store.put(entry(live, { expiresAt: new Date(Date.now() + 600_000) }));
-      await store.put(entry(lapsed, { expiresAt: new Date(Date.now() - 1_000) }));
+      await store.publishing(live, OFFER, () =>
+        store.put(entry(live, { expiresAt: new Date(Date.now() + 600_000) })),
+      );
+      await store.publishing(lapsed, OFFER, () =>
+        store.put(entry(lapsed, { expiresAt: new Date(Date.now() - 1_000) })),
+      );
 
       // Lazy expiry: hidden from reads before anything deletes it.
       assert.ok(await store.get(live));
       assert.equal(await store.get(lapsed), undefined);
+      assert.equal(await store.getOffer(lapsed), undefined, 'lapsed terms are not live terms');
       assert.equal(await store.claim(lapsed), false, 'an expired offering cannot be claimed');
 
       const deleted = await sweepExpiredX402Offerings(sql);
@@ -178,25 +244,32 @@ test(
 );
 
 test(
-  'the pricing snapshot round-trips through JSONB',
+  'the frozen offer round-trips through JSONB in full',
   { skip: !hasDb },
   async () => {
+    // The offer store freezes the complete MerchantOffer — rates, floor,
+    // policy
+    // and all — not just the fields the wire shape shows. Settlement reads
+    // them back verbatim.
     await withDb(async (sql, tag) => {
-      const taskId = `${tag}-pricing`;
+      const taskId = `${tag}-offer`;
       const store = new PostgresX402Store(sql, `${tag}-agent`);
-      const upto = parseX402Pricing({
-        scheme: 'upto',
-        network: 'eip155:84532',
-        asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-        payTo: '0x1111111111111111111111111111111111111111',
-        facilitatorAddress: '0x3333333333333333333333333333333333333333',
-        maxAmount: '1000000',
-        minAmount: '1000',
-        rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
-      })!;
+      const uptoOffer = pricingToOffer(
+        parseX402Pricing({
+          scheme: 'upto',
+          network: 'eip155:84532',
+          asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+          payTo: '0x1111111111111111111111111111111111111111',
+          facilitatorAddress: '0x3333333333333333333333333333333333333333',
+          maxAmount: '1000000',
+          minAmount: '1000',
+          rates: { input: '3000000', output: '15000000', cachedInput: '300000' },
+        })!,
+        RESOURCE,
+      );
 
-      await store.publishing(taskId, upto, () => store.put(entry(taskId)));
-      assert.deepEqual(await store.getPricing(taskId), upto);
+      await store.publishing(taskId, uptoOffer, () => store.put(entry(taskId)));
+      assert.deepEqual(await store.getOffer(taskId), uptoOffer);
     });
   },
 );
@@ -214,26 +287,35 @@ test(
       const taskId = `${tag}-race`;
       const store = new PostgresX402Store(sql, `${tag}-agent`);
 
-      const cheap = parseX402Pricing({ ...PRICING, amount: '10000' })!;
-      const dear = parseX402Pricing({ ...PRICING, amount: '990000' })!;
+      const priced = (amount: string): MerchantOffer =>
+        pricingToOffer(
+          parseX402Pricing({
+            network: 'eip155:84532',
+            amount,
+            asset: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+            payTo: '0x1111111111111111111111111111111111111111',
+          })!,
+          RESOURCE,
+        );
       const offering = (amount: string) =>
         entry(taskId, {
           accepts: [{ ...entry(taskId).accepts[0]!, amount }],
         });
 
       const publishedAmounts: string[] = [];
-      const publish = (requested: X402Pricing) =>
+      const publish = (requested: MerchantOffer) =>
         store.publishing(taskId, requested, async (frozen) => {
-          assert.equal(frozen.scheme, 'exact');
-          const amount = frozen.scheme === 'exact' ? frozen.amount : '';
+          const pricing = frozen.accepts[0]!;
+          assert.equal(pricing.scheme, 'exact');
+          const amount = pricing.scheme === 'exact' ? pricing.amount : '';
           publishedAmounts.push(amount);
           await store.put(offering(amount));
         });
 
-      await Promise.all([publish(cheap), publish(dear)]);
+      await Promise.all([publish(priced('10000')), publish(priced('990000'))]);
 
       const stored = await store.get(taskId);
-      const terms = await store.getPricing(taskId);
+      const terms = await store.getOffer(taskId);
       assert.ok(stored && terms);
       assert.equal(publishedAmounts.length, 2);
       assert.equal(
@@ -241,8 +323,9 @@ test(
         publishedAmounts[1],
         'the later publisher must reuse the first live terms',
       );
+      const frozenPricing = terms.accepts[0]!;
       assert.equal(
-        terms.scheme === 'exact' ? terms.amount : undefined,
+        frozenPricing.scheme === 'exact' ? frozenPricing.amount : undefined,
         stored.accepts[0]!.amount,
         'the stored terms must be the ones that produced the stored offering',
       );

--- a/packages/server/src/x402/store.ts
+++ b/packages/server/src/x402/store.ts
@@ -1,13 +1,14 @@
 import {
   BaseX402Store,
+  type MerchantOffer,
+  type MerchantOfferStore,
   type X402StoreEntry,
   type X402StoreEntryPatch,
 } from '@a2x/sdk/x402';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Sql, SqlExecutor } from '../db.js';
-import { parseX402Pricing, type X402Pricing } from './pricing.js';
 
-// The pricing an in-flight `requestPayment` is publishing.
+// The offer an in-flight `requestPayment` is publishing.
 //
 // The SDK owns the offering write, so the terms cannot be passed to it as an
 // argument — but they must land in the *same* statement. Storing them
@@ -21,13 +22,13 @@ import { parseX402Pricing, type X402Pricing } from './pricing.js';
 // how many run concurrently.
 interface PublishingContext {
   taskId: string;
-  pricing: X402Pricing;
+  offer: MerchantOffer;
   sql: SqlExecutor;
   /** A new offering may replace an expired row and must release its old claim. */
   resetClaim: boolean;
 }
 
-const publishingPricing = new AsyncLocalStorage<PublishingContext>();
+const publishingOffer = new AsyncLocalStorage<PublishingContext>();
 
 // Postgres-backed x402 offering store.
 //
@@ -93,7 +94,17 @@ function reviveEntry(raw: unknown): X402StoreEntry {
   };
 }
 
-export class PostgresX402Store extends BaseX402Store {
+// The frozen offer is stored verbatim as JSONB. Reads are lenient on purpose,
+// mirroring `parseX402Pricing`: an offer written by a newer build must still
+// settle here, so only the one property everything downstream relies on is
+// checked. It carries no Dates, so no revival is needed.
+function reviveOffer(raw: unknown): MerchantOffer | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const offer = raw as MerchantOffer;
+  return Array.isArray(offer.accepts) && offer.accepts.length > 0 ? offer : undefined;
+}
+
+export class PostgresX402Store extends BaseX402Store implements MerchantOfferStore {
   constructor(
     private readonly sql: Sql,
     /**
@@ -111,7 +122,7 @@ export class PostgresX402Store extends BaseX402Store {
   }
 
   /**
-   * Serialize publishers for one task and run `fn` with its frozen terms.
+   * Serialize publishers for one task and run `publish` with its frozen terms.
    *
    * A live offering is immutable: an unpaid retry (including one racing a
    * signed continuation) reuses its snapshot rather than replacing the rates
@@ -121,8 +132,8 @@ export class PostgresX402Store extends BaseX402Store {
    */
   async publishing<T>(
     taskId: string,
-    pricing: X402Pricing,
-    fn: (frozenPricing: X402Pricing) => Promise<T>,
+    offer: MerchantOffer,
+    publish: (frozenOffer: MerchantOffer) => Promise<T>,
   ): Promise<T> {
     // postgres.js maps array-shaped transaction callback results specially;
     // assign outside the callback so this method preserves an arbitrary T.
@@ -137,8 +148,8 @@ export class PostgresX402Store extends BaseX402Store {
         )
       `;
 
-      const rows = await tx<{ pricing: unknown }[]>`
-        SELECT pricing
+      const rows = await tx<{ offer: unknown }[]>`
+        SELECT offer
         FROM x402_offerings
         WHERE agent_id = ${this.agentId}
           AND task_id = ${taskId}
@@ -147,19 +158,19 @@ export class PostgresX402Store extends BaseX402Store {
         FOR UPDATE
       `;
       const existing = rows[0];
-      const frozenPricing = existing ? parseX402Pricing(existing.pricing) : pricing;
-      if (frozenPricing === undefined) {
-        throw new Error(`live x402 offering ${taskId} has no pricing snapshot`);
+      const frozenOffer = existing ? reviveOffer(existing.offer) : offer;
+      if (frozenOffer === undefined) {
+        throw new Error(`live x402 offering ${taskId} has no frozen offer`);
       }
 
-      published = await publishingPricing.run(
+      published = await publishingOffer.run(
         {
           taskId,
-          pricing: frozenPricing,
+          offer: frozenOffer,
           sql: tx,
           resetClaim: existing === undefined,
         },
-        () => fn(frozenPricing),
+        () => publish(frozenOffer),
       );
     });
     return published;
@@ -172,8 +183,8 @@ export class PostgresX402Store extends BaseX402Store {
     // and must leave the frozen snapshot alone. The taskId is checked rather
     // than assumed: the context belongs to one offering, and applying its
     // terms to a different task would be the very mix-up this exists to stop.
-    const ctx = publishingPricing.getStore();
-    const pricing = ctx?.taskId === entry.taskId ? ctx.pricing : undefined;
+    const ctx = publishingOffer.getStore();
+    const offer = ctx?.taskId === entry.taskId ? ctx.offer : undefined;
     const executor = ctx?.taskId === entry.taskId ? ctx.sql : this.sql;
     const resetClaim = ctx?.taskId === entry.taskId && ctx.resetClaim === true;
 
@@ -186,18 +197,18 @@ export class PostgresX402Store extends BaseX402Store {
     // work, so resetting the claim mid-task would let a resubmission be
     // charged a second time.
     await executor`
-      INSERT INTO x402_offerings (task_id, agent_id, entry, pricing, expires_at, updated_at)
+      INSERT INTO x402_offerings (task_id, agent_id, entry, offer, expires_at, updated_at)
       VALUES (
         ${entry.taskId},
         ${this.agentId},
         ${this.sql.json(JSON.parse(JSON.stringify(entry)))},
-        ${pricing === undefined ? null : this.sql.json(JSON.parse(JSON.stringify(pricing)))},
+        ${offer === undefined ? null : this.sql.json(JSON.parse(JSON.stringify(offer)))},
         ${expiresAt},
         now()
       )
       ON CONFLICT (agent_id, task_id) DO UPDATE
         SET entry = EXCLUDED.entry,
-            pricing = COALESCE(EXCLUDED.pricing, x402_offerings.pricing),
+            offer = COALESCE(EXCLUDED.offer, x402_offerings.offer),
             claimed_at = CASE
               WHEN ${resetClaim} THEN NULL
               ELSE x402_offerings.claimed_at
@@ -231,6 +242,7 @@ export class PostgresX402Store extends BaseX402Store {
     await this.put({ ...current, ...patch, updatedAt: new Date() });
   }
 
+  /** One row backs both halves, so this serves the store and the offer store. */
   async delete(taskId: string): Promise<void> {
     await this.sql`
       DELETE FROM x402_offerings
@@ -239,17 +251,17 @@ export class PostgresX402Store extends BaseX402Store {
   }
 
   /** The terms the offering was published under, written alongside it. */
-  async getPricing(taskId: string): Promise<X402Pricing | undefined> {
-    const rows = await this.sql<{ pricing: unknown }[]>`
-      SELECT pricing
+  async getOffer(taskId: string): Promise<MerchantOffer | undefined> {
+    const rows = await this.sql<{ offer: unknown }[]>`
+      SELECT offer
       FROM x402_offerings
-      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+      WHERE agent_id = ${this.agentId}
+        AND task_id = ${taskId}
+        AND (expires_at IS NULL OR expires_at > now())
     `;
-    const raw = rows[0]?.pricing;
+    const raw = rows[0]?.offer;
     if (raw === undefined || raw === null) return undefined;
-    // Read-side parsing is lenient about unknown keys on purpose (see
-    // pricing.ts) — a snapshot written by a newer build must still price here.
-    return parseX402Pricing(raw);
+    return reviveOffer(raw);
   }
 
   /**
@@ -260,10 +272,12 @@ export class PostgresX402Store extends BaseX402Store {
    * replayed submission classifies valid twice and the backend runs the work
    * twice against a single authorization.
    *
-   * Deliberately never released. A failed verify leaves the offering claimed
-   * and the payer starts a new task; re-opening the window on failure would
-   * restore the double-spend it exists to prevent, and nothing has been
-   * charged at that point.
+   * Deliberately not released on a failed verify: the offering stays claimed
+   * and the payer starts a new task, because re-opening the window on failure
+   * would restore the double-spend this exists to prevent — and nothing has
+   * been charged at that point. `release` below is the contract's one
+   * sanctioned exception, and the SDK only invokes it on paths this bridge
+   * does not offer.
    */
   async claim(taskId: string): Promise<boolean> {
     const rows = await this.sql`
@@ -276,6 +290,26 @@ export class PostgresX402Store extends BaseX402Store {
       RETURNING task_id
     `;
     return rows.length > 0;
+  }
+
+  /**
+   * Hand the one-shot right back so a later submission can claim it again.
+   *
+   * The SDK calls this only when a *retryable* scheme cancels verified work —
+   * batch-settlement rolling back the payment side, where keeping the claim
+   * would strand the payer with a cancelled payment and no way to retry. The
+   * bridge never publishes batch-settlement pricing, so today this is
+   * dormant; it exists because the `MerchantOfferStore` contract requires it
+   * and it must already be correct when the gate grows a caller. Unclaiming
+   * is unconditional within the agent scope: the row's expiry is irrelevant
+   * to giving the right back, and `claim` re-checks liveness anyway.
+   */
+  async release(taskId: string): Promise<void> {
+    await this.sql`
+      UPDATE x402_offerings
+      SET claimed_at = NULL, updated_at = now()
+      WHERE agent_id = ${this.agentId} AND task_id = ${taskId}
+    `;
   }
 }
 

--- a/packages/server/src/x402/usage.test.ts
+++ b/packages/server/src/x402/usage.test.ts
@@ -16,12 +16,12 @@ test('readTaskUsage prefers the protocol frame field', () => {
   };
   const result = readTaskUsage(reported, undefined);
   assert.equal(result.source, 'protocol');
+  assert.equal(result.model, 'sonnet');
   assert.deepEqual(result.usage, {
-    prompt_tokens: 120,
-    completion_tokens: 30,
-    total_tokens: 150,
-    cached_tokens: 20,
-    model: 'sonnet',
+    kind: 'detailed',
+    inputTokens: 120,
+    outputTokens: 30,
+    cachedInputTokens: 20,
   });
 });
 
@@ -33,7 +33,7 @@ test('the protocol field wins even when openai-compat metadata disagrees', () =>
     oaiMetadata({ usage: { prompt_tokens: 9999, completion_tokens: 9999 } }),
   );
   assert.equal(result.source, 'protocol');
-  assert.equal(result.usage?.total_tokens, 15);
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 10, outputTokens: 5 });
 });
 
 test('readTaskUsage falls back to the bare openai-compat usage shape', () => {
@@ -44,12 +44,8 @@ test('readTaskUsage falls back to the bare openai-compat usage shape', () => {
     oaiMetadata({ usage: { prompt_tokens: 120, completion_tokens: 30, model: 'sonnet' } }),
   );
   assert.equal(result.source, 'openai-compat');
-  assert.deepEqual(result.usage, {
-    prompt_tokens: 120,
-    completion_tokens: 30,
-    total_tokens: 150,
-    model: 'sonnet',
-  });
+  assert.equal(result.model, 'sonnet');
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 120, outputTokens: 30 });
 });
 
 test('readTaskUsage falls back to the chat_completion envelope shape', () => {
@@ -63,32 +59,29 @@ test('readTaskUsage falls back to the chat_completion envelope shape', () => {
     }),
   );
   assert.equal(result.source, 'openai-compat');
-  assert.deepEqual(result.usage, {
-    prompt_tokens: 10,
-    completion_tokens: 5,
-    total_tokens: 15,
-  });
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 10, outputTokens: 5 });
 });
 
-test('readTaskUsage recomputes the total rather than trusting the reported one', () => {
-  // The charge derives from prompt + completion, so a backend that
-  // miscomputed the total must not be able to move the price.
+test('readTaskUsage never reads a reported total', () => {
+  // The charge derives from prompt + completion — the SDK sums them itself —
+  // so a backend that miscomputed (or inflated) the total cannot move the
+  // price.
   const result = readTaskUsage(
     undefined,
     oaiMetadata({ usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 99999 } }),
   );
-  assert.equal(result.usage?.total_tokens, 15);
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 10, outputTokens: 5 });
 });
 
 test('readTaskUsage drops an incoherent cache count instead of discounting on it', () => {
   // cached is a breakdown of prompt; a larger value would discount tokens
-  // that were never cached.
+  // that were never cached. Dropping it here also keeps the SDK from calling
+  // the whole report unpriceable, which would downgrade the call to the floor.
   const fromProtocol = readTaskUsage(
     { promptTokens: 100, completionTokens: 0, cachedInputTokens: 5000 },
     undefined,
   );
-  assert.equal(fromProtocol.usage?.cached_tokens, undefined);
-  assert.equal(fromProtocol.usage?.prompt_tokens, 100);
+  assert.deepEqual(fromProtocol.usage, { kind: 'detailed', inputTokens: 100, outputTokens: 0 });
 
   const fromLegacy = readTaskUsage(
     undefined,
@@ -100,30 +93,23 @@ test('readTaskUsage drops an incoherent cache count instead of discounting on it
       },
     }),
   );
-  assert.equal(fromLegacy.usage?.cached_tokens, undefined);
+  assert.deepEqual(fromLegacy.usage, { kind: 'detailed', inputTokens: 100, outputTokens: 0 });
 });
 
-test('readTaskUsage reports nothing usable as undefined with no source', () => {
+test('readTaskUsage reports nothing usable as unreported with no source', () => {
   const nothing = readTaskUsage(undefined, undefined);
-  assert.equal(nothing.usage, undefined);
+  assert.deepEqual(nothing.usage, { kind: 'unreported' });
   assert.equal(nothing.source, undefined);
 
-  assert.equal(readTaskUsage(undefined, {}).usage, undefined);
-  assert.equal(readTaskUsage(undefined, oaiMetadata({})).usage, undefined);
-  assert.equal(
-    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: 10 } })).usage,
-    undefined,
-  );
-  assert.equal(
-    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: -1, completion_tokens: 5 } }))
-      .usage,
-    undefined,
-  );
-  assert.equal(
-    readTaskUsage(undefined, oaiMetadata({ usage: { prompt_tokens: 1.5, completion_tokens: 5 } }))
-      .usage,
-    undefined,
-  );
+  for (const metadata of [
+    {},
+    oaiMetadata({}),
+    oaiMetadata({ usage: { prompt_tokens: 10 } }),
+    oaiMetadata({ usage: { prompt_tokens: -1, completion_tokens: 5 } }),
+    oaiMetadata({ usage: { prompt_tokens: 1.5, completion_tokens: 5 } }),
+  ]) {
+    assert.deepEqual(readTaskUsage(undefined, metadata).usage, { kind: 'unreported' });
+  }
 });
 
 test('a malformed protocol field falls through to the legacy source', () => {
@@ -134,18 +120,15 @@ test('a malformed protocol field falls through to the legacy source', () => {
     oaiMetadata({ usage: { prompt_tokens: 10, completion_tokens: 5 } }),
   );
   assert.equal(result.source, 'openai-compat');
-  assert.equal(result.usage?.total_tokens, 15);
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 10, outputTokens: 5 });
 });
 
-test('a zero-token report is surfaced as a real zero, not as absent', () => {
-  // Some runtimes emit {0,0} when their accounting dropped. `meterUsage`
-  // treats that as unpriceable, but the reader must not paper over the
-  // difference between "reported zero" and "reported nothing".
+test('a zero-token report is a trusted zero, not unreported', () => {
+  // The a2x#206 semantic: a backend that *reported* zero consumption is
+  // believed, and the SDK settles it as a genuine '0' (basis `zero`) rather
+  // than billing the floor. Only a task with no usable report at all becomes
+  // `unreported` — the case the floor exists for.
   const result = readTaskUsage({ promptTokens: 0, completionTokens: 0 }, undefined);
   assert.equal(result.source, 'protocol');
-  assert.deepEqual(result.usage, {
-    prompt_tokens: 0,
-    completion_tokens: 0,
-    total_tokens: 0,
-  });
+  assert.deepEqual(result.usage, { kind: 'detailed', inputTokens: 0, outputTokens: 0 });
 });

--- a/packages/server/src/x402/usage.ts
+++ b/packages/server/src/x402/usage.ts
@@ -1,6 +1,8 @@
+import type { MerchantMeterableUsage } from '@a2x/sdk/x402';
 import { OPENAI_COMPAT_EXTENSION_URI, type TaskUsage as WireTaskUsage } from '@vicoop-bridge/protocol';
 
-// Token counts for one completed task, in the shape the pricing math wants.
+// Token counts for one completed task, in the shape the SDK's `MerchantGate`
+// meters.
 //
 // The canonical source is the protocol's own `TaskCompleteFrame.usage`, which
 // the bridge owns end to end. The openai-compat metadata key is read only as a
@@ -9,19 +11,27 @@ import { OPENAI_COMPAT_EXTENSION_URI, type TaskUsage as WireTaskUsage } from '@v
 // otherwise become unpriceable — which bills the floor, silently, rather than
 // failing. `source` says which one answered so the fallback is visible in the
 // logs and can be retired once no old clients remain.
-export interface TaskUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-  cached_tokens?: number;
-  model?: string;
-}
+//
+// A reported zero maps to detailed zero counts, which the SDK settles as a
+// genuine `'0'` charge (basis `zero`) — agreed in a2x#206. Only a task with
+// *no* usable report at all maps to `{ kind: 'unreported' }`, which under the
+// bridge's `unreportedUsage: 'floor'` policy bills `minAmount`.
 
 export type TaskUsageSource = 'protocol' | 'openai-compat';
 
 export interface ReadTaskUsageResult {
-  usage: TaskUsage | undefined;
+  usage: MerchantMeterableUsage;
   source?: TaskUsageSource;
+  /** The model the backend reported. Telemetry only — never priced on. */
+  model?: string;
+}
+
+/** One source's counts, validated but not yet in the SDK's shape. */
+interface ReportedCounts {
+  prompt: number;
+  completion: number;
+  cached?: number;
+  model?: string;
 }
 
 function count(v: unknown): number | undefined {
@@ -30,26 +40,23 @@ function count(v: unknown): number | undefined {
     : undefined;
 }
 
-// Recompute the total rather than trust a reported one, and drop a cache
-// figure larger than the prompt it claims to be a breakdown of — an incoherent
-// value would otherwise discount tokens that were never cached.
+// Drop a cache figure larger than the prompt it claims to be a breakdown of —
+// an incoherent value would otherwise discount tokens that were never cached.
+// (The SDK would refuse to price it at all, which downgrades a merely broken
+// cache count to the floor; charging the full input rate is the closer read.)
 function build(
   prompt: number,
   completion: number,
   cached: number | undefined,
   model: string | undefined,
-): TaskUsage {
-  const usage: TaskUsage = {
-    prompt_tokens: prompt,
-    completion_tokens: completion,
-    total_tokens: prompt + completion,
-  };
-  if (cached !== undefined && cached <= prompt) usage.cached_tokens = cached;
-  if (model !== undefined && model.length > 0) usage.model = model;
-  return usage;
+): ReportedCounts {
+  const counts: ReportedCounts = { prompt, completion };
+  if (cached !== undefined && cached <= prompt) counts.cached = cached;
+  if (model !== undefined && model.length > 0) counts.model = model;
+  return counts;
 }
 
-function fromProtocol(usage: WireTaskUsage | undefined): TaskUsage | undefined {
+function fromProtocol(usage: WireTaskUsage | undefined): ReportedCounts | undefined {
   if (usage === undefined) return undefined;
   const prompt = count(usage.promptTokens);
   const completion = count(usage.completionTokens);
@@ -57,7 +64,7 @@ function fromProtocol(usage: WireTaskUsage | undefined): TaskUsage | undefined {
   return build(prompt, completion, count(usage.cachedInputTokens), usage.model);
 }
 
-function fromOpenAICompatPayload(raw: unknown): TaskUsage | undefined {
+function fromOpenAICompatPayload(raw: unknown): ReportedCounts | undefined {
   if (typeof raw !== 'object' || raw === null) return undefined;
   const u = raw as Record<string, unknown>;
   const prompt = count(u.prompt_tokens);
@@ -79,7 +86,7 @@ function fromOpenAICompatPayload(raw: unknown): TaskUsage | undefined {
  *   { usage: {...} }                        plain A2A callers
  *   { chat_completion: { usage: {...} } }   openai-compat envelope
  */
-function fromOpenAICompat(metadata: Record<string, unknown> | undefined): TaskUsage | undefined {
+function fromOpenAICompat(metadata: Record<string, unknown> | undefined): ReportedCounts | undefined {
   const ext = metadata?.[OPENAI_COMPAT_EXTENSION_URI];
   if (typeof ext !== 'object' || ext === null) return undefined;
   const payload = ext as Record<string, unknown>;
@@ -94,21 +101,44 @@ function fromOpenAICompat(metadata: Record<string, unknown> | undefined): TaskUs
   return undefined;
 }
 
+function toMeterable(counts: ReportedCounts): MerchantMeterableUsage {
+  return {
+    kind: 'detailed',
+    inputTokens: counts.prompt,
+    outputTokens: counts.completion,
+    ...(counts.cached !== undefined ? { cachedInputTokens: counts.cached } : {}),
+  };
+}
+
 /**
  * Resolve the task's token usage, preferring the protocol field.
  *
- * A `usage` of `undefined` means the runtime reported nothing, which callers
- * must treat as "unpriceable" rather than "zero" — see `meterUsage`.
+ * `{ kind: 'unreported' }` means the runtime reported nothing, which the SDK
+ * treats as "unpriceable" — under the bridge's `floor` policy that bills
+ * `minAmount`, never the ceiling. A reported `{0,0}` is NOT unreported: it is
+ * a trusted zero and settles `'0'` (a2x#206).
  */
 export function readTaskUsage(
   reported: WireTaskUsage | undefined,
   metadata: Record<string, unknown> | undefined,
 ): ReadTaskUsageResult {
-  const protocolUsage = fromProtocol(reported);
-  if (protocolUsage) return { usage: protocolUsage, source: 'protocol' };
+  const protocolCounts = fromProtocol(reported);
+  if (protocolCounts) {
+    return {
+      usage: toMeterable(protocolCounts),
+      source: 'protocol',
+      ...(protocolCounts.model !== undefined ? { model: protocolCounts.model } : {}),
+    };
+  }
 
   const legacy = fromOpenAICompat(metadata);
-  if (legacy) return { usage: legacy, source: 'openai-compat' };
+  if (legacy) {
+    return {
+      usage: toMeterable(legacy),
+      source: 'openai-compat',
+      ...(legacy.model !== undefined ? { model: legacy.model } : {}),
+    };
+  }
 
-  return { usage: undefined };
+  return { usage: { kind: 'unreported' } };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
   packages/server:
     dependencies:
       '@a2x/sdk':
-        specifier: ^0.20.0
-        version: 0.20.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.21.0
+        version: 0.21.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: ^3.0.69
         version: 3.0.69(zod@3.25.76)
@@ -236,9 +236,9 @@ packages:
       zod:
         optional: true
 
-  '@a2x/sdk@0.20.0':
-    resolution: {integrity: sha512-Findvt0BaG4khsGW7ZDyqGgoljZoYBn9Zkhb8SsTRIoiS31kHAkDKxK5tVmi8rm1rEO0veSOBossuqPssazrBA==}
-    engines: {node: '>=20.0.0'}
+  '@a2x/sdk@0.21.0':
+    resolution: {integrity: sha512-o7R6//RQzCz96tO595Z68uhoeZJKIu1foqZjHPuk3sh/8ZpxQJVRJUnDc+/U6s8kz2ur5/k2gYwpKJHti61krw==}
+    engines: {node: '>=22.11.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.52.0'
       '@google/genai': '>=1.0.0'
@@ -4768,7 +4768,7 @@ snapshots:
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
 
-  '@a2x/sdk@0.20.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@a2x/sdk@0.21.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     optionalDependencies:
       '@x402/core': 2.21.0
       '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,10 +30,10 @@ importers:
     dependencies:
       '@a2x/sdk':
         specifier: ^0.18.0
-        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
       '@rainbow-me/rainbowkit':
         specifier: ^2
-        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+        version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
       '@tanstack/react-query':
         specifier: ^5
         version: 5.99.0(react@19.2.5)
@@ -57,10 +57,10 @@ importers:
         version: 2.3.2(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       viem:
         specifier: ^2
-        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        version: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: ^2
-        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        version: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
@@ -134,8 +134,8 @@ importers:
   packages/server:
     dependencies:
       '@a2x/sdk':
-        specifier: ^0.18.0
-        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.20.0
+        version: 0.20.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: ^3.0.69
         version: 3.0.69(zod@3.25.76)
@@ -217,6 +217,33 @@ packages:
       '@google/genai': '>=1.0.0'
       '@x402/core': '>=2.19.0 <3'
       '@x402/evm': '>=2.19.0 <3'
+      openai: '>=4.0.0'
+      viem: '>=2.21.0'
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      '@anthropic-ai/sdk':
+        optional: true
+      '@google/genai':
+        optional: true
+      '@x402/core':
+        optional: true
+      '@x402/evm':
+        optional: true
+      openai:
+        optional: true
+      viem:
+        optional: true
+      zod:
+        optional: true
+
+  '@a2x/sdk@0.20.0':
+    resolution: {integrity: sha512-Findvt0BaG4khsGW7ZDyqGgoljZoYBn9Zkhb8SsTRIoiS31kHAkDKxK5tVmi8rm1rEO0veSOBossuqPssazrBA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.52.0'
+      '@google/genai': '>=1.0.0'
+      '@x402/core': '>=2.20.0 <3'
+      '@x402/evm': '>=2.20.0 <3'
       openai: '>=4.0.0'
       viem: '>=2.21.0'
       zod: ^3.0.0
@@ -4734,7 +4761,14 @@ packages:
 
 snapshots:
 
-  '@a2x/sdk@0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@a2x/sdk@0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)':
+    optionalDependencies:
+      '@x402/core': 2.21.0
+      '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zod: 4.3.6
+
+  '@a2x/sdk@0.20.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     optionalDependencies:
       '@x402/core': 2.21.0
       '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -4883,16 +4917,16 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@base-org/account@2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@coinbase/cdp-sdk': 1.47.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -5083,15 +5117,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
       eventemitter3: 5.0.1
       idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.9(typescript@5.9.3)(zod@4.3.6)
       preact: 10.24.2
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.3(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     transitivePeerDependencies:
       - '@types/react'
@@ -5285,11 +5319,11 @@ snapshots:
       ethereum-cryptography: 2.2.1
       micro-ftch: 0.3.1
 
-  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@gemini-wallet/core@0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -5651,7 +5685,7 @@ snapshots:
 
   '@paulmillr/qr@0.2.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))':
+  '@rainbow-me/rainbowkit@2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))':
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       '@vanilla-extract/css': 1.17.3
@@ -5663,8 +5697,8 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       react-remove-scroll: 2.6.2(@types/react@19.2.14)(react@19.2.5)
       ua-parser-js: 1.0.41
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
@@ -5681,24 +5715,24 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-common@1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5727,12 +5761,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       lit: 3.3.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
     transitivePeerDependencies:
@@ -5767,12 +5801,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -5804,10 +5838,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -5839,16 +5873,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5888,21 +5922,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@reown/appkit@1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit-common': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@3.25.76)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.2.14)(react@19.2.5))(zod@4.3.6)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@19.2.14)(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6008,9 +6042,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
 
-  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-provider@0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -6018,10 +6052,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -6832,19 +6866,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)':
+  '@wagmi/connectors@6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@base-org/account': 2.4.0(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@gemini-wallet/core': 0.3.2(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       '@metamask/sdk': 0.33.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      porto: 0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6885,11 +6919,11 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.99.0
@@ -6900,7 +6934,7 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -6914,7 +6948,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -6944,7 +6978,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/core@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-provider': 1.0.14
@@ -6958,7 +6992,7 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/window-getters': 1.0.1
       es-toolkit: 1.33.0
       events: 3.3.0
@@ -6992,18 +7026,18 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@reown/appkit': 1.7.8(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/universal-provider': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7126,16 +7160,16 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7162,16 +7196,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/sign-client@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
-      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/core': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/logger': 2.1.2
       '@walletconnect/time': 1.0.2
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       events: 3.3.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -7260,7 +7294,7 @@ snapshots:
       - ioredis
       - uploadthing
 
-  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7269,9 +7303,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.0
-      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7300,7 +7334,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/universal-provider@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@walletconnect/events': 1.0.1
       '@walletconnect/jsonrpc-http-connection': 1.0.8
@@ -7309,9 +7343,9 @@ snapshots:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/keyvaluestorage': 1.1.1
       '@walletconnect/logger': 2.1.2
-      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/sign-client': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       '@walletconnect/types': 2.21.1
-      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@walletconnect/utils': 2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       es-toolkit: 1.33.0
       events: 3.3.0
     transitivePeerDependencies:
@@ -7340,7 +7374,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7358,7 +7392,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7384,7 +7418,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@walletconnect/utils@2.21.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)':
     dependencies:
       '@noble/ciphers': 1.2.1
       '@noble/curves': 1.8.1
@@ -7402,7 +7436,7 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
-      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7456,10 +7490,10 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
-  abitype@1.0.8(typescript@5.9.3)(zod@3.25.76):
+  abitype@1.0.8(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
       typescript: 5.9.3
-      zod: 3.25.76
+      zod: 4.3.6
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
@@ -9233,6 +9267,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.14.17(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.14.33(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -9248,28 +9297,28 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.7(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.6.9(typescript@5.9.3)(zod@3.25.76):
+  ox@0.6.9(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -9417,21 +9466,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)):
+  porto@0.2.35(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)):
     dependencies:
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       hono: 4.12.12
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.3.6)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -10178,15 +10227,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+  viem@2.23.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
-      abitype: 1.0.8(typescript@5.9.3)(zod@3.25.76)
+      abitype: 1.0.8(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.6.7(typescript@5.9.3)(zod@3.25.76)
+      ox: 0.6.7(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
@@ -10229,6 +10278,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.17(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.55.11(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
@@ -10261,14 +10327,14 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
     dependencies:
       '@tanstack/react-query': 5.99.0(react@19.2.5)
-      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))(zod@3.25.76)
-      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(@wagmi/core@2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)))(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))(zod@4.3.6)
+      '@wagmi/core': 2.22.1(@tanstack/query-core@5.99.0)(@types/react@19.2.14)(react@19.2.5)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
   packages/admin-ui:
     dependencies:
       '@a2x/sdk':
-        specifier: ^0.18.0
-        version: 0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+        specifier: ^0.21.0
+        version: 0.21.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
       '@rainbow-me/rainbowkit':
         specifier: ^2
         version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6))
@@ -208,33 +208,6 @@ importers:
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
 packages:
-
-  '@a2x/sdk@0.18.0':
-    resolution: {integrity: sha512-Bgr29nAwfQMqe0zXG/c/9OcR9JZNzVAZ86/Un/VwMnPjLv2RGOdueBHR37y9vN2wHjED18ckLUFSIuUIF7367w==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@anthropic-ai/sdk': '>=0.52.0'
-      '@google/genai': '>=1.0.0'
-      '@x402/core': '>=2.19.0 <3'
-      '@x402/evm': '>=2.19.0 <3'
-      openai: '>=4.0.0'
-      viem: '>=2.21.0'
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      '@anthropic-ai/sdk':
-        optional: true
-      '@google/genai':
-        optional: true
-      '@x402/core':
-        optional: true
-      '@x402/evm':
-        optional: true
-      openai:
-        optional: true
-      viem:
-        optional: true
-      zod:
-        optional: true
 
   '@a2x/sdk@0.21.0':
     resolution: {integrity: sha512-o7R6//RQzCz96tO595Z68uhoeZJKIu1foqZjHPuk3sh/8ZpxQJVRJUnDc+/U6s8kz2ur5/k2gYwpKJHti61krw==}
@@ -4761,19 +4734,19 @@ packages:
 
 snapshots:
 
-  '@a2x/sdk@0.18.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)':
-    optionalDependencies:
-      '@x402/core': 2.21.0
-      '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
-      zod: 4.3.6
-
   '@a2x/sdk@0.21.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     optionalDependencies:
       '@x402/core': 2.21.0
       '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
+
+  '@a2x/sdk@0.21.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)':
+    optionalDependencies:
+      '@x402/core': 2.21.0
+      '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      viem: 2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zod: 4.3.6
 
   '@adraffy/ens-normalize@1.10.1': {}
 


### PR DESCRIPTION
## Summary

- replace the server's hand-rolled x402 gate/pricing/metering with the SDK's `MerchantGate` (planetarium/a2x#207); `X402Gate` becomes a thin bridge-side composition (outcome→`TaskStatusUpdateEvent` translation, telemetry, `BRIDGE_X402_VERSION` check)
- keep bridge policy explicit and unchanged: `exactTiming: 'before-work'`, `unreportedUsage: 'floor'`, detailed per-million rates (`rates.input/output/cachedInput` → `inputPerMillion/outputPerMillion/cachedInputPerMillion`)
- migrate `PostgresX402Store`'s sidecar half to the SDK `MerchantOfferingSidecar` contract: freezes the full `MerchantOffer` (new `offer` JSONB column) instead of a single pricing row, adds `delete`; same advisory-lock publish binding and atomic one-shot claim
- net **+647 / −969** — orchestration, frozen-terms bookkeeping, replay claim, metering math, and the clamp all move to the SDK (tested there 378/378)

Closes #464.

## Semantic changes (each deliberate, all fail-closed)

1. **Trusted reported-zero usage settles `'0'`, not the `minAmount` floor** — the planetarium/a2x#206-agreed semantics; the floor still applies to unreported usage. Pinned in `gate.test.ts` / `usage.test.ts`.
2. Refusal telemetry granularity: per-cause events (`x402_verify_failed`, `x402_submission_replayed`, `x402_scheme_mismatch`, `x402_pricing_snapshot_missing`) collapse into `x402_payment_refused` discriminated by the SDK `code`/`reason`; `x402_settle_error` folds into `x402_gate_error`. Payer-visible events unchanged.
3. A resubmission after an exact before-work settlement is refused as "no stored offering" (the SDK cleans the offering up on settle) instead of `DUPLICATE_NONCE` — still refused, still never double-charged.
4. A floor > ceiling misconfiguration now refuses turn 1 (`validateMerchantOffer`, fail-closed) instead of publishing and clamping at settle time.
5. On an unpaid retry after a reprice, `x402_payment_required` logs the current row's terms; the frozen terms still govern settlement, unchanged.

## Rollout

- `schema.sql` adds `offer JSONB` (idempotent `ADD COLUMN IF NOT EXISTS`); the legacy `pricing` column is deliberately kept so old instances keep writing during a rolling deploy — dropping it is a documented follow-up.
- Offerings frozen only under the legacy column at deploy time are refused as "terms no longer available" — the payer restarts and is never charged; window bounded by the 600s offering TTL.

## Verification (against the packed build of planetarium/a2x#207 (now merged))

- typecheck + build clean
- full suite: 359 tests / 290 pass / 0 fail / 69 skipped (baseline on main: 366 / 298 / 0 / 68 — the delta is SDK-owned cases removed)
- DB-gated x402 store tests against a local Postgres with the migrated schema: 8/8, including concurrent claim, concurrent publish freeze, and the new sidecar `delete` + frozen-offer round-trip
- 2 failures appearing only with `DATABASE_URL` set are in `src/auth/siwe-exchange.test.ts`, pre-existing and reproduced identically on the pre-migration source (no `@a2x/sdk` imports)

## Release status

✅ **Unblocked** — pinned to `@a2x/sdk@^0.21.0` (published), tracking the gateway (planetarium/foundry-x402-gateway#16, merged) onto the same release. 0.21 adds the session opening-turn reservation API (planetarium/a2x#216), which the bridge does not use, so the bump from the module's first release (0.20) is straight. Lockfile regenerated against the real npm package; server typecheck clean and the full suite re-run (290 pass / 0 fail). Previous note kept for history:

⛔ ~~ **The `@a2x/sdk` release containing planetarium/a2x#207.** npm's published `0.19.0` predates the merchant module, so the pending changesets ship it as **0.20.0**; `packages/server/package.json` points at `^0.20.0` and `pnpm-lock.yaml` is intentionally untouched — it will be regenerated (and this PR taken out of draft) when the release lands.~~

## Related issues

- Closes #464 (merchant-layer migration)
- Design: planetarium/a2x#206 · module: planetarium/a2x#207 (merged)
- Durable `MerchantOfferStore` standardization + claimed-state fast path (this host's Postgres impl is the natural candidate): planetarium/a2x#209
- Replay lifecycle semantics (SDK-side follow-up behind the post-verify claim): planetarium/a2x#211
- Follow-up tracked in-repo: drop the legacy `pricing` column once the fleet runs offer-based builds (see schema.sql comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


