### PR TITLE
fix(claude): preserve completed result after narrated retry

### DIFF
--- a/.changeset/preserve-claude-narrated-retry.md
+++ b/.changeset/preserve-claude-narrated-retry.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Preserve a completed Claude caller-tool result when the optional narrated-tool retry exits without capturing a tool call.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -6127,18 +6127,27 @@ function twoAttemptSpawn(
 ): FakeSpawn & {
   argvs: string[][];
   stdins: string[][];
+  assertAttemptHooksSucceeded: () => void;
 } {
   const argvs: string[][] = [];
   const stdins: string[][] = [];
+  let attemptHookError: Error | null = null;
   let n = 0;
   const base = makeFakeSpawn((child) => {
     const attempt = n++;
     const lines = scripts[Math.min(attempt, scripts.length - 1)] ?? [];
     const exitCode = exitCodes[Math.min(attempt, exitCodes.length - 1)] ?? 0;
-    setImmediate(async () => {
-      await beforeAttempt?.(attempt);
-      for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
-      setImmediate(() => child.finish(exitCode, null));
+    setImmediate(() => {
+      void Promise.resolve()
+        .then(() => beforeAttempt?.(attempt))
+        .then(() => {
+          for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
+          setImmediate(() => child.finish(exitCode, null));
+        })
+        .catch((err: unknown) => {
+          attemptHookError = err instanceof Error ? err : new Error(String(err));
+          child.finish(1, null);
+        });
     });
   });
   const wrapped = {
@@ -6151,8 +6160,15 @@ function twoAttemptSpawn(
     },
     argvs,
     stdins,
+    assertAttemptHooksSucceeded() {
+      if (attemptHookError) throw attemptHookError;
+    },
   };
-  return wrapped as FakeSpawn & { argvs: string[][]; stdins: string[][] };
+  return wrapped as FakeSpawn & {
+    argvs: string[][];
+    stdins: string[][];
+    assertAttemptHooksSucceeded: () => void;
+  };
 }
 
 const NARRATED = JSON.stringify({
@@ -6209,6 +6225,7 @@ test('narrated tool call: opt-in resumes once with the staged prompt still reada
   });
   const { emit, frames } = collect();
   await backend.handle(narratedToolCallTask(), emit, NEVER);
+  fake.assertAttemptHooksSucceeded();
 
   assert.equal(fake.argvs.length, 2, 'expected exactly one corrective retry');
   // Attempt 1 mints the session, attempt 2 continues it — same id either way.

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -6120,7 +6120,11 @@ function narratedToolCallTask(): TaskAssignFrame {
 
 // Scripts each spawn separately so attempt 1 can narrate and attempt 2 emit a
 // real tool call, and records the argv of every spawn.
-function twoAttemptSpawn(scripts: readonly (readonly string[])[]): FakeSpawn & {
+function twoAttemptSpawn(
+  scripts: readonly (readonly string[])[],
+  exitCodes: readonly (number | null)[] = [],
+  beforeAttempt?: (attempt: number) => void | Promise<void>,
+): FakeSpawn & {
   argvs: string[][];
   stdins: string[][];
 } {
@@ -6128,11 +6132,13 @@ function twoAttemptSpawn(scripts: readonly (readonly string[])[]): FakeSpawn & {
   const stdins: string[][] = [];
   let n = 0;
   const base = makeFakeSpawn((child) => {
-    const lines = scripts[Math.min(n, scripts.length - 1)] ?? [];
-    n++;
-    setImmediate(() => {
+    const attempt = n++;
+    const lines = scripts[Math.min(attempt, scripts.length - 1)] ?? [];
+    const exitCode = exitCodes[Math.min(attempt, exitCodes.length - 1)] ?? 0;
+    setImmediate(async () => {
+      await beforeAttempt?.(attempt);
       for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
-      setImmediate(() => child.finish(0, null));
+      setImmediate(() => child.finish(exitCode, null));
     });
   });
   const wrapped = {
@@ -6175,11 +6181,32 @@ const REAL_CALL = JSON.stringify({
 const OK_RESULT = JSON.stringify({ type: 'result', subtype: 'success', terminal_reason: 'completed', result: '' });
 
 test('narrated tool call: opt-in resumes once with the staged prompt still readable', async () => {
-  const fake = twoAttemptSpawn([
-    [NARRATED, OK_RESULT],
-    [REAL_CALL, OK_RESULT],
-  ]);
-  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  let invokeRetryTool: (() => Promise<void>) | null = null;
+  const fake = twoAttemptSpawn(
+    [
+      [NARRATED, OK_RESULT],
+      [REAL_CALL, OK_RESULT],
+    ],
+    [1, 1],
+    async (attempt) => {
+      if (attempt !== 1) return;
+      assert.ok(invokeRetryTool, 'caller-tools MCP must be ready before the retry');
+      await invokeRetryTool();
+    },
+  );
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    claudeRetryNarratedToolCall: true,
+    onCallerToolsMcpReady: (server) => {
+      invokeRetryTool = async () => {
+        await server.invokeForTest({
+          callId: 'toolu_1',
+          toolName: 'glob',
+          arguments: { pattern: '**/*' },
+        });
+      };
+    },
+  });
   const { emit, frames } = collect();
   await backend.handle(narratedToolCallTask(), emit, NEVER);
 
@@ -6203,6 +6230,43 @@ test('narrated tool call: opt-in resumes once with the staged prompt still reada
   assert.equal(frames.at(-1)?.type, 'task.complete');
   assert.equal(frames.some((frame) => frame.type === 'task.fail'), false);
   await assert.rejects(fs.stat(retryPromptPath), 'prompt file must be deleted after retry');
+});
+
+test('narrated tool call: a failed retry preserves the first completed result', async () => {
+  const finalReport = 'Final report: the registered `glob` tool rejected this request.';
+  const report = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-fable-5',
+      content: [{ type: 'text', text: finalReport }],
+    },
+  });
+  const completed = JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    terminal_reason: 'completed',
+    is_error: false,
+    result: finalReport,
+  });
+  const maxTurns = JSON.stringify({
+    type: 'result',
+    subtype: 'error_during_execution',
+    terminal_reason: 'max_turns',
+    is_error: true,
+    result: finalReport,
+    errors: ['Reached maximum number of turns (1)'],
+  });
+  const fake = twoAttemptSpawn([[report, completed], [maxTurns]], [1, 1]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit, frames } = collect();
+
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(fake.argvs.length, 2, 'expected exactly one corrective retry');
+  assert.equal(frames.some((frame) => frame.type === 'task.fail'), false);
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+  assert.equal(textOf(frames.at(-1)!), finalReport);
 });
 
 test('narrated tool call: off by default — no retry, no extra spawn', async () => {

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -6122,34 +6122,45 @@ function narratedToolCallTask(): TaskAssignFrame {
 // real tool call, and records the argv of every spawn.
 function twoAttemptSpawn(
   scripts: readonly (readonly string[])[],
-  exitCodes: readonly (number | null)[] = [],
-  beforeAttempt?: (attempt: number) => void | Promise<void>,
+  exitCodes: readonly number[] = [],
+  beforeAttempt?: (attempt: number, child: FakeChild) => void | Promise<void>,
 ): FakeSpawn & {
-  argvs: string[][];
-  stdins: string[][];
-  assertAttemptHooksSucceeded: () => void;
+  readonly argvs: string[][];
+  readonly stdins: string[][];
 } {
   const argvs: string[][] = [];
   const stdins: string[][] = [];
-  let attemptHookError: Error | null = null;
+  let attemptError: Error | null = null;
   let n = 0;
   const base = makeFakeSpawn((child) => {
     const attempt = n++;
     const lines = scripts[Math.min(attempt, scripts.length - 1)] ?? [];
-    const exitCode = exitCodes[Math.min(attempt, exitCodes.length - 1)] ?? 0;
+    const exitCode = exitCodes.length > 0
+      ? exitCodes[Math.min(attempt, exitCodes.length - 1)]!
+      : 0;
+    const failAttempt = (err: unknown): void => {
+      attemptError ??= err instanceof Error ? err : new Error(String(err));
+      child.finish(1, null);
+    };
     setImmediate(() => {
       void Promise.resolve()
-        .then(() => beforeAttempt?.(attempt))
-        .then(() => {
-          for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
-          setImmediate(() => child.finish(exitCode, null));
-        })
-        .catch((err: unknown) => {
-          attemptHookError = err instanceof Error ? err : new Error(String(err));
-          child.finish(1, null);
-        });
+        .then(() => beforeAttempt?.(attempt, child))
+        .then(
+          () => {
+            try {
+              for (const l of lines) child.emitStdout(l.endsWith('\n') ? l : `${l}\n`);
+              setImmediate(() => child.finish(exitCode, null));
+            } catch (err) {
+              failAttempt(err);
+            }
+          },
+          failAttempt,
+        );
     });
   });
+  const throwAttemptError = (): void => {
+    if (attemptError) throw attemptError;
+  };
   const wrapped = {
     ...base,
     spawn(cmd: string, args: readonly string[], options: ClaudeSpawnOptions) {
@@ -6158,16 +6169,18 @@ function twoAttemptSpawn(
       stdins.push((base.lastChild() as unknown as { stdinChunks?: string[] })?.stdinChunks ?? []);
       return handle;
     },
-    argvs,
-    stdins,
-    assertAttemptHooksSucceeded() {
-      if (attemptHookError) throw attemptHookError;
+    get argvs() {
+      throwAttemptError();
+      return argvs;
+    },
+    get stdins() {
+      throwAttemptError();
+      return stdins;
     },
   };
   return wrapped as FakeSpawn & {
-    argvs: string[][];
-    stdins: string[][];
-    assertAttemptHooksSucceeded: () => void;
+    readonly argvs: string[][];
+    readonly stdins: string[][];
   };
 }
 
@@ -6225,7 +6238,6 @@ test('narrated tool call: opt-in resumes once with the staged prompt still reada
   });
   const { emit, frames } = collect();
   await backend.handle(narratedToolCallTask(), emit, NEVER);
-  fake.assertAttemptHooksSucceeded();
 
   assert.equal(fake.argvs.length, 2, 'expected exactly one corrective retry');
   // Attempt 1 mints the session, attempt 2 continues it — same id either way.
@@ -6284,6 +6296,159 @@ test('narrated tool call: a failed retry preserves the first completed result', 
   assert.equal(frames.some((frame) => frame.type === 'task.fail'), false);
   assert.equal(frames.at(-1)?.type, 'task.complete');
   assert.equal(textOf(frames.at(-1)!), finalReport);
+});
+
+test('narrated tool call: discarded retry text stays off the wire and both attempts are metered', async () => {
+  const finalReport = 'Final report: the registered `glob` tool rejected this request.';
+  const retryText = 'RETRY TEXT that must not reach the caller.';
+  const result = (opts: { text: string; input: number; output: number; error: boolean }) =>
+    JSON.stringify({
+      type: 'result',
+      subtype: opts.error ? 'error_during_execution' : 'success',
+      terminal_reason: opts.error ? 'max_turns' : 'completed',
+      is_error: opts.error,
+      result: opts.text,
+      modelUsage: {
+        'claude-fable-5': {
+          inputTokens: opts.input,
+          outputTokens: opts.output,
+          cacheReadInputTokens: 0,
+          cacheCreationInputTokens: 0,
+        },
+      },
+    });
+  const assistant = (text: string) =>
+    JSON.stringify({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        model: 'claude-fable-5',
+        content: [{ type: 'text', text }],
+      },
+    });
+  const fake = twoAttemptSpawn(
+    [
+      [assistant(finalReport), result({ text: finalReport, input: 1000, output: 500, error: false })],
+      [assistant(retryText), result({ text: finalReport, input: 7, output: 3, error: true })],
+    ],
+    [1, 1],
+  );
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit, frames } = collect();
+
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (frame): frame is Extract<UpFrame, { type: 'task.artifact' }> => frame.type === 'task.artifact',
+  );
+  assert.deepEqual(artifacts.map(textOf), [finalReport]);
+  assert.equal(artifacts.some((artifact) => textOf(artifact).includes('RETRY TEXT')), false);
+  const complete = frames.at(-1);
+  assert.ok(complete?.type === 'task.complete');
+  assert.equal(textOf(complete), finalReport);
+  assert.deepEqual(complete.usage, {
+    promptTokens: 1007,
+    completionTokens: 503,
+    model: 'claude-fable-5',
+  });
+  const payload = complete.status.message?.metadata?.[OPENAI_COMPAT_EXTENSION_URI] as {
+    chat_completion?: { choices?: Array<{ message?: { content?: string } }>; usage?: Record<string, unknown> };
+  };
+  assert.equal(payload.chat_completion?.choices?.[0]?.message?.content, finalReport);
+  assert.equal(payload.chat_completion?.usage?.prompt_tokens, 1007);
+  assert.equal(payload.chat_completion?.usage?.completion_tokens, 503);
+});
+
+test('narrated tool call: a result-only first attempt still emits its fallback artifact', async () => {
+  const finalReport = 'Final report: the registered `glob` tool rejected this request.';
+  const completed = JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    terminal_reason: 'completed',
+    is_error: false,
+    result: finalReport,
+  });
+  const retryText = JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-fable-5',
+      content: [{ type: 'text', text: 'RETRY NOISE' }],
+    },
+  });
+  const maxTurns = JSON.stringify({
+    type: 'result',
+    subtype: 'error_during_execution',
+    terminal_reason: 'max_turns',
+    is_error: true,
+    result: finalReport,
+  });
+  const fake = twoAttemptSpawn([[completed], [retryText, maxTurns]], [1, 1]);
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit, frames } = collect();
+
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  const artifacts = frames.filter(
+    (frame): frame is Extract<UpFrame, { type: 'task.artifact' }> => frame.type === 'task.artifact',
+  );
+  assert.deepEqual(
+    artifacts.map((artifact) => [artifact.artifact.name, textOf(artifact)]),
+    [['claude-result', finalReport]],
+  );
+});
+
+test('narrated tool call: a better retry outcome still wins when the first attempt would fail', async () => {
+  const finalReport = 'Final report: the registered `glob` tool rejected this request.';
+  const retryAnswer = 'Retry completed cleanly without a caller tool.';
+  const assistant = (text: string) => JSON.stringify({
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      model: 'claude-fable-5',
+      content: [{ type: 'text', text }],
+    },
+  });
+  const result = (text: string) => JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    terminal_reason: 'completed',
+    is_error: false,
+    result: text,
+  });
+  const fake = twoAttemptSpawn(
+    [
+      [assistant(finalReport), result(finalReport)],
+      [assistant(retryAnswer), result(retryAnswer)],
+    ],
+    [1, 0],
+    (attempt, child) => {
+      if (attempt === 0) child.emitStderr('(node:1) ExperimentalWarning: something');
+    },
+  );
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit, frames } = collect();
+
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.equal(frames.at(-1)?.type, 'task.complete');
+  assert.equal(textOf(frames.at(-1)!), retryAnswer);
+  const artifacts = frames.filter(
+    (frame): frame is Extract<UpFrame, { type: 'task.artifact' }> => frame.type === 'task.artifact',
+  );
+  assert.deepEqual(artifacts.map(textOf), [finalReport, retryAnswer]);
+});
+
+test('twoAttemptSpawn: a rejected attempt hook cannot be silently ignored', async () => {
+  const fake = twoAttemptSpawn([[NARRATED, OK_RESULT]], [0], () => {
+    throw new Error('HOOK BOOM');
+  });
+  const backend = createClaudeBackend({ spawn: fake.spawn, claudeRetryNarratedToolCall: true });
+  const { emit } = collect();
+
+  await backend.handle(narratedToolCallTask(), emit, NEVER);
+
+  assert.throws(() => fake.argvs, /HOOK BOOM/);
 });
 
 test('narrated tool call: off by default — no retry, no extra spawn', async () => {

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -730,6 +730,35 @@ export function parseClaudeModelUsageForOpenAICompat(raw: unknown): OpenAICompat
   });
 }
 
+// A narrated-tool-call correction is a second paid Claude invocation even
+// when its response is discarded in favour of the first completed turn.
+// Keep response selection and accounting independent: callers should see one
+// coherent response, while billing receives the token cost of every attempt.
+function sumClaudeAttemptUsage(
+  first: OpenAICompatUsage | null,
+  second: OpenAICompatUsage | null,
+): OpenAICompatUsage | null {
+  if (!first) return second;
+  if (!second) return first;
+  const firstCached = first.prompt_tokens_details?.cached_tokens;
+  const secondCached = second.prompt_tokens_details?.cached_tokens;
+  const firstReasoning = first.completion_tokens_details?.reasoning_tokens;
+  const secondReasoning = second.completion_tokens_details?.reasoning_tokens;
+  return buildOpenAICompatUsage({
+    prompt_tokens: first.prompt_tokens + second.prompt_tokens,
+    completion_tokens: first.completion_tokens + second.completion_tokens,
+    model: second.model ?? first.model,
+    cached_tokens:
+      firstCached !== undefined || secondCached !== undefined
+        ? (firstCached ?? 0) + (secondCached ?? 0)
+        : undefined,
+    reasoning_tokens:
+      firstReasoning !== undefined || secondReasoning !== undefined
+        ? (firstReasoning ?? 0) + (secondReasoning ?? 0)
+        : undefined,
+  });
+}
+
 // Assemble a complete OpenAI ChatCompletion envelope for the openai-compat/v1
 // envelope contract (oai2a2a#80). The codec on the gateway unwraps this
 // verbatim, so we own every required field — id / object / created / model /
@@ -2831,6 +2860,19 @@ export function createClaudeBackend(
       const activeTaskRuns = new Map<string, string>();
       const seenAssistantToolUseIds = new Set<string>();
 
+      // The corrective narrated-tool-call retry is speculative. Its artifacts
+      // cannot go on the wire until we know whether that attempt replaces the
+      // first response; otherwise discarded retry prose leaks into streaming
+      // clients and suppresses the first result-only fallback artifact.
+      let speculativeRetryArtifacts: Parameters<typeof emit>[0][] | null = null;
+      const emitArtifactFrame = (frame: Parameters<typeof emit>[0]): void => {
+        if (speculativeRetryArtifacts) {
+          speculativeRetryArtifacts.push(frame);
+          return;
+        }
+        emit(frame);
+      };
+
       // Register this task with the send_file MCP server (if running) so
       // tool calls landing during this run resolve to this task's emit().
       // Released in the terminal block so a crashed/timed-out task doesn't
@@ -2841,7 +2883,7 @@ export function createClaudeBackend(
           taskId: task.taskId,
           contextId: task.contextId,
           emit: (artifact) => {
-            emit({
+            emitArtifactFrame({
               type: 'task.artifact',
               taskId: task.taskId,
               artifact,
@@ -2862,7 +2904,7 @@ export function createClaudeBackend(
         // (natural-language answers, or any turn from a task that didn't
         // request the extension) are emitted unchanged as a `text` part
         // artifact for A2A debuggability and non-OpenAI consumers.
-        emit({
+        emitArtifactFrame({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
@@ -2888,7 +2930,7 @@ export function createClaudeBackend(
       const emitReasoningArtifact = (text: string): void => {
         if (!text) return;
         reasoningArtifactId ??= randomUUID();
-        emit({
+        emitArtifactFrame({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
@@ -2925,7 +2967,7 @@ export function createClaudeBackend(
       const emitToolResultMedia = (parts: Part[]): void => {
         if (!emitTraceArtifacts) return;
         if (parts.length === 0) return;
-        emit({
+        emitArtifactFrame({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
@@ -2962,7 +3004,7 @@ export function createClaudeBackend(
               ? 'completed'
               : 'failed';
         const label = description || 'Task';
-        emit({
+        emitArtifactFrame({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
@@ -2982,7 +3024,7 @@ export function createClaudeBackend(
 
       const emitToolCallArtifact = (block: ToolUseBlock): void => {
         if (!emitTraceArtifacts) return;
-        emit({
+        emitArtifactFrame({
           type: 'task.artifact',
           taskId: task.taskId,
           artifact: {
@@ -3411,20 +3453,36 @@ export function createClaudeBackend(
           registeredToolNames: [...callerToolNameSet],
         })
       ) {
-        // The first attempt is already a valid completed result. The retry is
-        // speculative: only a newly captured caller tool call is allowed to
-        // replace that outcome. Keep every field that participates in the
-        // terminal decision or response identity so an error/max_turns result
-        // from the corrective child cannot poison the completed turn (#471).
+        // The retry is speculative whenever the first attempt would already
+        // pass the terminal decision below. Keep every response, streaming,
+        // and diagnostic field so a discarded retry cannot poison that turn.
+        // If the first attempt would fail (for example exit 1 plus stderr), the
+        // retry retains the pre-#471 behaviour and is allowed to improve it.
+        const firstAttemptWouldSucceed =
+          !exit.error &&
+          (exit.code === 0 ||
+            (exit.code !== 0 &&
+              sawCompletedResult &&
+              !sawErrorResult &&
+              stderrTail.trim() === '' &&
+              stdinError === null &&
+              !aborted));
         const firstAttempt = {
           exit,
+          emittedAnyArtifact,
+          emittedAskUserQuestion,
           pendingInputRequest,
           finalText,
+          finalUsage,
           sawBlockingLimit,
           assistantModel,
           initModel,
+          responseArtifactId,
+          reasoningArtifactId,
+          streamedResponseText,
           sawCompletedResult,
           sawErrorResult,
+          emittedToolUseCount,
           sawUnknownToolError,
           stdoutTail,
           stderrTail,
@@ -3432,6 +3490,10 @@ export function createClaudeBackend(
         };
         const callerToolCallCountBeforeRetry = capturedToolCalls.length;
         let retrySettled = false;
+        speculativeRetryArtifacts = [];
+        // `handleEvent` assigns the latest result usage. Isolate the second
+        // attempt so it can be summed with (rather than overwrite) attempt 1.
+        finalUsage = null;
         // Only the session flag changes: `--session-id` mints, `--resume`
         // continues. Everything else — mcp config, model, turn cap, system
         // prompt — must stay byte-identical or the corrective turn lands in a
@@ -3468,7 +3530,14 @@ export function createClaudeBackend(
           );
         }
 
-        if (capturedToolCalls.length === callerToolCallCountBeforeRetry) {
+        const retryArtifacts = speculativeRetryArtifacts;
+        speculativeRetryArtifacts = null;
+        const combinedUsage = sumClaudeAttemptUsage(firstAttempt.finalUsage, finalUsage);
+
+        if (
+          capturedToolCalls.length === callerToolCallCountBeforeRetry &&
+          firstAttemptWouldSucceed
+        ) {
           // The corrective attempt did not produce the only useful outcome it
           // can add. Restore the authoritative first attempt, including stderr
           // and stdin diagnostics: either one would otherwise make
@@ -3476,23 +3545,38 @@ export function createClaudeBackend(
           // restoring its exit/result flags.
           ({
             exit,
+            emittedAnyArtifact,
+            emittedAskUserQuestion,
             pendingInputRequest,
             finalText,
+            finalUsage,
             sawBlockingLimit,
             assistantModel,
             initModel,
+            responseArtifactId,
+            reasoningArtifactId,
+            streamedResponseText,
             sawCompletedResult,
             sawErrorResult,
+            emittedToolUseCount,
             sawUnknownToolError,
             stdoutTail,
             stderrTail,
             stdinError,
           } = firstAttempt);
+          finalUsage = combinedUsage;
           if (retrySettled) {
             timingLogger.warn?.(
               `[claude] narrated-tool-call retry produced no caller tool call; preserving first completed result taskId=${task.taskId}`,
             );
           }
+        } else {
+          // The retry produced a caller tool call, or the first attempt was not
+          // independently successful. Commit its previously buffered artifact
+          // stream in order and retain its outcome, while accounting for both
+          // invocations.
+          for (const frame of retryArtifacts) emit(frame);
+          finalUsage = combinedUsage;
         }
       }
 

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -3411,6 +3411,27 @@ export function createClaudeBackend(
           registeredToolNames: [...callerToolNameSet],
         })
       ) {
+        // The first attempt is already a valid completed result. The retry is
+        // speculative: only a newly captured caller tool call is allowed to
+        // replace that outcome. Keep every field that participates in the
+        // terminal decision or response identity so an error/max_turns result
+        // from the corrective child cannot poison the completed turn (#471).
+        const firstAttempt = {
+          exit,
+          pendingInputRequest,
+          finalText,
+          sawBlockingLimit,
+          assistantModel,
+          initModel,
+          sawCompletedResult,
+          sawErrorResult,
+          sawUnknownToolError,
+          stdoutTail,
+          stderrTail,
+          stdinError,
+        };
+        const callerToolCallCountBeforeRetry = capturedToolCalls.length;
+        let retrySettled = false;
         // Only the session flag changes: `--session-id` mints, `--resume`
         // continues. Everything else — mcp config, model, turn cap, system
         // prompt — must stay byte-identical or the corrective turn lands in a
@@ -3437,6 +3458,7 @@ export function createClaudeBackend(
             }) + '\n',
           );
           exit = await awaitChild();
+          retrySettled = true;
         } catch (err) {
           // A failed retry must not fail the task: the first attempt already
           // produced a legitimate (if useless) completed result, and surfacing
@@ -3444,6 +3466,33 @@ export function createClaudeBackend(
           timingLogger.warn?.(
             `[claude] narrated-tool-call retry failed taskId=${task.taskId} error=${safeToken(errorMessage(err), 300)}`,
           );
+        }
+
+        if (capturedToolCalls.length === callerToolCallCountBeforeRetry) {
+          // The corrective attempt did not produce the only useful outcome it
+          // can add. Restore the authoritative first attempt, including stderr
+          // and stdin diagnostics: either one would otherwise make
+          // treatExitAsSuccess reject the original completed result even after
+          // restoring its exit/result flags.
+          ({
+            exit,
+            pendingInputRequest,
+            finalText,
+            sawBlockingLimit,
+            assistantModel,
+            initModel,
+            sawCompletedResult,
+            sawErrorResult,
+            sawUnknownToolError,
+            stdoutTail,
+            stderrTail,
+            stdinError,
+          } = firstAttempt);
+          if (retrySettled) {
+            timingLogger.warn?.(
+              `[claude] narrated-tool-call retry produced no caller tool call; preserving first completed result taskId=${task.taskId}`,
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- treat the narrated-tool retry as speculative and keep the first completed result unless the retry captures a new caller tool call
- restore terminal flags, diagnostics, response text, and model identity when the retry produces no caller tool call
- strengthen the retry-success test with a real caller-tools MCP invocation and production-like exit code 1
- add an exact regression for completed → max_turns/is_error → exit 1

Fixes #471.

## Verification

- `pnpm --filter @vicoop-bridge/client typecheck`
- `pnpm --filter @vicoop-bridge/client build`
- `pnpm --filter @vicoop-bridge/client test` — 895 passed
- `pnpm changeset status`