### PR TITLE
fix(server): hold in-flight tasks across a recoverable WS disconnect

### DIFF
--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -20,11 +20,13 @@ with `client_buffer_overflow` rather than replaying a partial stream — an hone
 failure the caller can retry beats a silently truncated answer.
 
 The buffer is bounded by frame count (`maxPendingFrames`, default 2000),
-encoded size (`maxPendingBytes`, default 4 MiB) and age (`maxPendingAgeMs`,
-default 45s). The age bound matters for correctness, not just memory: a taskId
-is reusable across A2A turns, so replaying output the bridge would no longer
-honour could inject a dead run's frames into a live one. Setting any of them to
-`0` disables buffering and restores the previous behavior.
+encoded size (`maxPendingBytes`, default 4 MiB) and outage duration
+(`maxPendingAgeMs`, default 25s). The last one matters for correctness, not just
+memory: a taskId is reusable across A2A turns, so replaying output the bridge
+would no longer honour could inject a dead run's frames into a live one. It is
+measured from the disconnect and must stay at or below the bridge's
+`BRIDGE_DISCONNECT_GRACE_MS`. Setting any of them to `0` disables buffering and
+restores the previous behavior.
 
 Requires a bridge with reconnect replay support. Against an older bridge the
 replay is rejected (close 4003); the client detects this, logs a warning naming

--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -19,5 +19,7 @@ to receive them. A task that loses frames to the buffer cap fails explicitly
 with `client_buffer_overflow` rather than replaying a partial stream — an honest
 failure the caller can retry beats a silently truncated answer.
 
-`maxPendingFrames` bounds the buffer (default 2000); `0` disables it and
-restores the previous behavior.
+The buffer is bounded by both frame count (`maxPendingFrames`, default 2000)
+and encoded size (`maxPendingBytes`, default 4 MiB) — a count alone bounds
+nothing, since the protocol puts no size limit on text, file or data parts.
+Setting either to `0` disables buffering and restores the previous behavior.

--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -1,0 +1,23 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Buffer task frames produced while the bridge connection is down and replay them
+on reconnect, instead of dropping them on the floor.
+
+`send()` silently discarded any frame written while the socket was not OPEN. A
+backend that kept working through a reconnect therefore lost whatever it emitted
+during the outage: streamed deltas vanished mid-answer while the backend's own
+bookkeeping advanced past them, so the end-of-turn catch-up never re-sent them
+and the task completed with a hole. A backend that *finished* during the outage
+lost its terminal frame outright and never re-emitted it, so a fully successful
+task was reported as failed.
+
+Frames are now held in arrival order and replayed on the next connection, where
+the server's reconnect grace hold (vicoop-bridge#474) is keeping the task alive
+to receive them. A task that loses frames to the buffer cap fails explicitly
+with `client_buffer_overflow` rather than replaying a partial stream — an honest
+failure the caller can retry beats a silently truncated answer.
+
+`maxPendingFrames` bounds the buffer (default 2000); `0` disables it and
+restores the previous behavior.

--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -28,6 +28,15 @@ measured from the disconnect and must stay at or below the bridge's
 `BRIDGE_DISCONNECT_GRACE_MS`. Setting any of them to `0` disables buffering and
 restores the previous behavior.
 
+A replay is sent exactly once and never retried: the protocol carries no
+acceptance signal, and re-sending could hand a stale terminal to a later turn
+that has since reused the same task id. A lost replay fails the task on the
+bridge's grace deadline instead — visible and retryable, unlike a corrupted run.
+
+`maxPendingFrames` and `maxPendingBytes` are clamped to what a bridge accepts in
+a single replay, so raising them past that degrades the buffer rather than
+breaking the connection it exists to survive.
+
 Requires a bridge with reconnect replay support. Against an older bridge the
 replay is rejected (close 4003); the client detects this, logs a warning naming
 the bridge upgrade as the fix, and falls back to the previous behavior instead

--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -19,7 +19,14 @@ to receive them. A task that loses frames to the buffer cap fails explicitly
 with `client_buffer_overflow` rather than replaying a partial stream — an honest
 failure the caller can retry beats a silently truncated answer.
 
-The buffer is bounded by both frame count (`maxPendingFrames`, default 2000)
-and encoded size (`maxPendingBytes`, default 4 MiB) — a count alone bounds
-nothing, since the protocol puts no size limit on text, file or data parts.
-Setting either to `0` disables buffering and restores the previous behavior.
+The buffer is bounded by frame count (`maxPendingFrames`, default 2000),
+encoded size (`maxPendingBytes`, default 4 MiB) and age (`maxPendingAgeMs`,
+default 45s). The age bound matters for correctness, not just memory: a taskId
+is reusable across A2A turns, so replaying output the bridge would no longer
+honour could inject a dead run's frames into a live one. Setting any of them to
+`0` disables buffering and restores the previous behavior.
+
+Requires a bridge with reconnect replay support. Against an older bridge the
+replay is rejected (close 4003); the client detects this, logs a warning naming
+the bridge upgrade as the fix, and falls back to the previous behavior instead
+of reconnecting in a loop.

--- a/docs/design.md
+++ b/docs/design.md
@@ -65,6 +65,37 @@ vicoop-bridge/
 - `task.cancel`   — `{ taskId }`
 - `ping`
 
+### 4.1 Disconnect handling (reconnect grace hold)
+
+A `TaskBinding` is not tied to the connection that created it — it holds only
+`agentId`, and outbound sends re-resolve the live socket at send time. So a
+dropped WebSocket does not by itself invalidate an in-flight task.
+
+When a client's socket closes, the server therefore keeps the binding alive for
+`BRIDGE_DISCONNECT_GRACE_MS` (default 30s) instead of failing the task at once.
+Any frame for that task on the client's next connection — a liveness heartbeat
+is enough — resumes the binding and the task continues down the normal path.
+An unresumed hold expires into exactly the terminal that path always produced:
+`disconnected` for a drop, `superseded` for a same-token reconnect.
+
+The grace is therefore *how long to wait before declaring a client dead*, not a
+cap on task duration; a long task is governed by
+`BRIDGE_TASK_INACTIVITY_TIMEOUT_MS` as before.
+
+Two closes skip the hold, because they are this server's own verdict rather
+than a transport failure: any app-level close code it issues (`4000`–`4999`)
+and a clean `1000`. Since the code the server *observes* is not always the one
+it *sent* (a peer that never echoes the close frame surfaces as `1006`), the
+intent is recorded when the close is issued and takes precedence.
+
+Setting `BRIDGE_DISCONNECT_GRACE_MS=0` disables the hold and restores the
+previous fail-immediately behavior exactly — the rollback lever if holds ever
+delay failover more than they save.
+
+Background: issue #474. Frames a client emits *while* its socket is down are
+buffered by the client and replayed on reconnect, so a recovered drop loses no
+output; see `packages/client/src/client.ts`.
+
 ## 5. Client Backends
 
 ```bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -82,11 +82,19 @@ The grace is therefore *how long to wait before declaring a client dead*, not a
 cap on task duration; a long task is governed by
 `BRIDGE_TASK_INACTIVITY_TIMEOUT_MS` as before.
 
-Two closes skip the hold, because they are this server's own verdict rather
-than a transport failure: any app-level close code it issues (`4000`–`4999`)
-and a clean `1000`. Since the code the server *observes* is not always the one
-it *sent* (a peer that never echoes the close frame surfaces as `1006`), the
-intent is recorded when the close is issued and takes precedence.
+Closes that are this server's own verdict rather than a transport failure skip
+the hold: the app-level codes it issues (`4000`–`4999`) and a clean `1000`.
+Since the code the server *observes* is not always the one it *sent* (a peer
+that never echoes the close frame surfaces as `1006`), the intent is recorded
+when the close is issued and takes precedence.
+
+One app-level close is deliberately excepted. `4009` — a second daemon
+authenticating with the same `CLIENT_TOKEN` — is *usually* the same client
+coming back rather than a rival, and the server cannot tell the two apart
+(`readyState` reports only what it has observed, and the client's own heartbeat
+normally detects a dead path first). So a `4009` collision holds like any other
+reconnect and expires as `superseded` if the task is never reclaimed. Operators
+reading a delayed collision failure should expect that delay.
 
 Setting `BRIDGE_DISCONNECT_GRACE_MS=0` disables the hold and restores the
 previous fail-immediately behavior exactly — the rollback lever if holds ever

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1266,3 +1266,210 @@ test('usage.request: a throwing backend.usage() replies ok:false / usage_failed'
   assert.equal(resp.error?.code, 'usage_failed');
   assert.match(resp.error?.message ?? '', /serve down/);
 });
+
+// ---------------------------------------------------------------------------
+// Offline frame buffer (vicoop-bridge#474 follow-up).
+//
+// `send()` used to drop any frame produced while the socket was down. The
+// server-side reconnect grace keeps the task alive across the drop, but that
+// only helps if the client's output actually arrives — so frames produced
+// during the outage are buffered and replayed on the next connection.
+// ---------------------------------------------------------------------------
+
+test('frames produced while disconnected are replayed on the next connection', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  // Every frame the server ever receives, across both connections.
+  const received: Array<Record<string, unknown>> = [];
+  let connections = 0;
+  let firstSocket: WebSocket | undefined;
+  wss.on('connection', (ws) => {
+    connections++;
+    if (connections === 1) firstSocket = ws;
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => received.some((f) => f.type === 'hello'), 'first hello');
+
+    // Kill the connection from the server side and let the client notice.
+    firstSocket!.close(1012, 'restarting');
+    await waitFor(() => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1, 'socket down');
+
+    // The backend keeps working through the outage: a delta, then the terminal.
+    const send = (client as never as { send(f: unknown): void }).send.bind(client);
+    send({
+      type: 'task.artifact',
+      taskId: 't-1',
+      artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: 'lost text' }] },
+      append: true,
+      lastChunk: false,
+    });
+    send({
+      type: 'task.complete',
+      taskId: 't-1',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    // Nothing reached the server yet — the socket was down.
+    assert.equal(received.filter((f) => f.taskId === 't-1').length, 0);
+
+    await waitFor(() => connections >= 2, 'reconnect');
+    await waitFor(
+      () => received.some((f) => f.type === 'task.complete' && f.taskId === 't-1'),
+      'the buffered terminal to be replayed',
+    );
+
+    const forTask = received.filter((f) => f.taskId === 't-1');
+    assert.deepEqual(
+      forTask.map((f) => f.type),
+      ['task.artifact', 'task.complete'],
+      'replay must preserve production order',
+    );
+    // The artifact must arrive intact — this is the text that used to vanish.
+    const artifact = forTask[0] as { artifact: { parts: Array<{ text: string }> } };
+    assert.equal(artifact.artifact.parts[0]?.text, 'lost text');
+
+    // And it lands behind the new hello, so the server has claimed the
+    // connection before the replay reaches it.
+    const helloIdx = received.findIndex((f, i) => f.type === 'hello' && i > 0);
+    const replayIdx = received.findIndex((f) => f.taskId === 't-1');
+    assert.ok(helloIdx >= 0 && helloIdx < replayIdx, 'replay must follow the reconnect hello');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('a task that overflows the buffer is failed rather than replayed with a hole', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  const received: Array<Record<string, unknown>> = [];
+  let connections = 0;
+  let firstSocket: WebSocket | undefined;
+  wss.on('connection', (ws) => {
+    connections++;
+    if (connections === 1) firstSocket = ws;
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 2,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => received.some((f) => f.type === 'hello'), 'first hello');
+    firstSocket!.close(1012, 'restarting');
+    await waitFor(() => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1, 'socket down');
+
+    const send = (client as never as { send(f: unknown): void }).send.bind(client);
+    for (const text of ['one', 'two', 'three', 'four']) {
+      send({
+        type: 'task.artifact',
+        taskId: 't-big',
+        artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text }] },
+        append: true,
+        lastChunk: false,
+      });
+    }
+
+    await waitFor(() => connections >= 2, 'reconnect');
+    await waitFor(
+      () => received.some((f) => f.type === 'task.fail' && f.taskId === 't-big'),
+      'the truncated task to be failed',
+    );
+
+    const forTask = received.filter((f) => f.taskId === 't-big');
+    // A partial replay would be the silent hole this whole mechanism exists to
+    // prevent, so the surviving frames are discarded in favour of an honest
+    // failure the caller can retry.
+    assert.deepEqual(forTask.map((f) => f.type), ['task.fail']);
+    const failure = forTask[0] as { error: { code: string } };
+    assert.equal(failure.error.code, 'client_buffer_overflow');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('maxPendingFrames: 0 restores the previous drop-on-the-floor behavior', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  const received: Array<Record<string, unknown>> = [];
+  let connections = 0;
+  let firstSocket: WebSocket | undefined;
+  wss.on('connection', (ws) => {
+    connections++;
+    if (connections === 1) firstSocket = ws;
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => received.some((f) => f.type === 'hello'), 'first hello');
+    firstSocket!.close(1012, 'restarting');
+    await waitFor(() => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1, 'socket down');
+
+    (client as never as { send(f: unknown): void }).send.call(client, {
+      type: 'task.complete',
+      taskId: 't-off',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(() => connections >= 2, 'reconnect');
+    // Give any replay a chance to arrive before asserting its absence.
+    await new Promise((r) => setTimeout(r, 50));
+    assert.deepEqual(received.filter((f) => f.taskId === 't-off'), []);
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1788,3 +1788,100 @@ test('a replay onto a connection that dies before proving itself is retried, not
     await closeServer(h.server, h.wss);
   }
 });
+test('a confirmed replay is never sent a second time on a later reconnect', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 15,
+    reconnectMaxDelayMs: 15,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+    sendOffline(client, {
+      type: 'task.complete',
+      taskId: 't-once',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(
+      () => h.received.some((f) => f.taskId === 't-once'),
+      'the replay to be delivered',
+    );
+    assert.equal(h.connections, 2);
+
+    h.sockets[1]!.close(1012, 'restarting');
+    await waitOffline(client);
+    await waitFor(() => h.connections >= 3, 'a third connection');
+    await new Promise((r) => setTimeout(r, 80));
+
+    assert.equal(
+      h.received.filter((f) => f.taskId === 't-once').length,
+      1,
+      'a delivered replay must not be re-sent',
+    );
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});
+
+test('replay eligibility is judged on the outage, not on each frame\'s own age', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 400,
+    reconnectMaxDelayMs: 400,
+    reconnectJitterRatio: 0,
+    maxPendingAgeMs: 100,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    await new Promise((r) => setTimeout(r, 250));
+    sendOffline(client, {
+      type: 'task.complete',
+      taskId: 't-late',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(() => h.connections >= 2, 'reconnect');
+    await waitFor(
+      () => h.received.some((f) => f.type === 'task.fail' && f.taskId === 't-late'),
+      'the late frame to be failed rather than replayed',
+    );
+
+    assert.deepEqual(
+      h.received.filter((f) => f.taskId === 't-late').map((f) => f.type),
+      ['task.fail'],
+      'output from an over-long outage must never be replayed',
+    );
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1742,8 +1742,17 @@ test('a bridge that rejects pipelined replay (4003) disables it instead of loopi
   }
 });
 
-test('a replay onto a connection that dies before proving itself is retried, not lost', async () => {
+test('a replay is never re-sent, even when the connection dies right after it', async () => {
+  // There is no acceptance signal in the protocol, so "not yet confirmed"
+  // cannot be told apart from "already processed". A replayed `task.complete`
+  // may already have unbound an `input-required` task, after which A2A reuses
+  // that taskId for the next turn — re-sending would hand the old terminal to
+  // the new binding, which the bridge matches by agent and task id.
+  //
+  // So a replay goes out exactly once. If it is lost, the bridge's grace
+  // deadline fails the task: visible and retryable, unlike a corrupted run.
   const h = replayHarness((ws, n) => {
+    // Kill the second connection immediately after its hello — mid-replay.
     if (n === 2) {
       ws.on('message', (raw) => {
         const f = JSON.parse(raw.toString('utf8')) as { type?: string };
@@ -1762,7 +1771,6 @@ test('a replay onto a connection that dies before proving itself is retried, not
     reconnectDelayMs: 20,
     reconnectMaxDelayMs: 20,
     reconnectJitterRatio: 0,
-    reconnectStableMs: 5_000,
     logLevel: 'silent',
   });
 
@@ -1774,14 +1782,18 @@ test('a replay onto a connection that dies before proving itself is retried, not
 
     sendOffline(client, {
       type: 'task.complete',
-      taskId: 't-retry',
+      taskId: 't-once-only',
       status: { state: 'completed', timestamp: new Date().toISOString() },
     });
 
     await waitFor(() => h.connections >= 3, 'a third connection');
-    await waitFor(
-      () => h.received.filter((f) => f.taskId === 't-retry').length >= 2,
-      'the replay to be retried after the failed attempt',
+    // Let any erroneous retry land before asserting it did not happen.
+    await new Promise((r) => setTimeout(r, 120));
+
+    assert.equal(
+      h.received.filter((f) => f.taskId === 't-once-only').length,
+      1,
+      'a replay must go out exactly once, never retried onto a later connection',
     );
   } finally {
     client.stop();

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1885,3 +1885,128 @@ test('replay eligibility is judged on the outage, not on each frame\'s own age',
     await closeServer(h.server, h.wss);
   }
 });
+test('a truncated run is silenced, so its late canceled terminal never reaches the bridge', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  let release!: () => void;
+  const held = new Promise<void>((r) => {
+    release = r;
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('slow', async (task, emit) => {
+      await held;
+      emit({
+        type: 'task.complete',
+        taskId: task.taskId,
+        status: { state: 'completed', timestamp: new Date().toISOString() },
+      });
+    }),
+    reconnectDelayMs: 15,
+    reconnectMaxDelayMs: 15,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 1,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+
+    h.sockets[0]!.send(JSON.stringify({
+      type: 'task.assign',
+      taskId: 't-late-cancel',
+      contextId: 'ctx',
+      message: { role: 'user', parts: [{ kind: 'text', text: 'hi' }], messageId: 'm1' },
+    }));
+    await new Promise((r) => setTimeout(r, 20));
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    for (const text of ['a', 'b']) {
+      sendOffline(client, {
+        type: 'task.artifact',
+        taskId: 't-late-cancel',
+        artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text }] },
+        append: true,
+        lastChunk: false,
+      });
+    }
+
+    await waitFor(
+      () => h.received.some((f) => f.type === 'task.fail' && f.taskId === 't-late-cancel'),
+      'the truncation failure',
+    );
+
+    release();
+    await new Promise((r) => setTimeout(r, 80));
+
+    const terminals = h.received.filter(
+      (f) => f.taskId === 't-late-cancel' && (f.type === 'task.complete' || f.type === 'task.fail'),
+    );
+    assert.deepEqual(
+      terminals.map((f) => f.type),
+      ['task.fail'],
+      'a suppressed run must not emit a second terminal',
+    );
+  } finally {
+    release();
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});
+
+test('overflowing the truncated-task bookkeeping discards the buffer rather than replaying part of it', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 20,
+    reconnectMaxDelayMs: 20,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 1,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    for (let i = 0; i < 40; i++) {
+      sendOffline(client, {
+        type: 'task.artifact',
+        taskId: `t-many-${i}`,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: `chunk-${i}` }] },
+        append: true,
+        lastChunk: false,
+      });
+    }
+
+    await waitFor(() => h.connections >= 2, 'reconnect');
+    await new Promise((r) => setTimeout(r, 80));
+
+    for (let i = 0; i < 40; i++) {
+      const forTask = h.received.filter((f) => f.taskId === `t-many-${i}`);
+      const kinds = new Set(forTask.map((f) => f.type));
+      assert.ok(
+        !kinds.has('task.artifact') || !kinds.has('task.fail'),
+        `task ${i} got both a replayed artifact and a failure`,
+      );
+    }
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1607,3 +1607,184 @@ test('a single frame larger than the whole budget is refused without evicting th
     await closeServer(server, wss);
   }
 });
+function replayHarness(onConnect?: (ws: WebSocket, n: number) => void) {
+  const received: Array<Record<string, unknown>> = [];
+  const sockets: WebSocket[] = [];
+  let connections = 0;
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  wss.on('connection', (ws) => {
+    connections++;
+    sockets.push(ws);
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+    onConnect?.(ws, connections);
+  });
+  return {
+    server,
+    wss,
+    received,
+    sockets,
+    get connections() {
+      return connections;
+    },
+  };
+}
+
+function sendOffline(client: Client, frame: Record<string, unknown>): void {
+  (client as never as { send(f: unknown): void }).send.call(client, frame);
+}
+
+async function waitOffline(client: Client): Promise<void> {
+  await waitFor(
+    () => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1,
+    'socket down',
+  );
+}
+
+test('buffered output older than the replay window is failed, not replayed', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 60,
+    reconnectMaxDelayMs: 60,
+    reconnectJitterRatio: 0,
+    maxPendingAgeMs: 1,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    sendOffline(client, {
+      type: 'task.complete',
+      taskId: 't-stale',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(() => h.connections >= 2, 'reconnect');
+    await waitFor(
+      () => h.received.some((f) => f.type === 'task.fail' && f.taskId === 't-stale'),
+      'the stale entry to be failed instead',
+    );
+
+    assert.deepEqual(
+      h.received.filter((f) => f.taskId === 't-stale').map((f) => f.type),
+      ['task.fail'],
+      'a stale terminal must never be replayed',
+    );
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});
+
+test('a bridge that rejects pipelined replay (4003) disables it instead of looping', async () => {
+  const captured = makeSink();
+  const h = replayHarness((ws, n) => {
+    if (n === 2) {
+      ws.on('message', (raw) => {
+        const f = JSON.parse(raw.toString('utf8')) as { type?: string };
+        if (f.type !== 'hello') ws.close(4003, 'expected hello');
+      });
+    }
+  });
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 20,
+    reconnectMaxDelayMs: 20,
+    reconnectJitterRatio: 0,
+    logLevel: 'warn',
+    logSink: captured.sink,
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    sendOffline(client, {
+      type: 'task.complete',
+      taskId: 't-old-bridge',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(
+      () => captured.warn.some((l) => l.includes('predates reconnect replay support')),
+      'the incompatibility warning',
+    );
+
+    await waitFor(() => h.connections >= 3, 'a third connection');
+    await new Promise((r) => setTimeout(r, 150));
+    const settled = h.connections;
+    await new Promise((r) => setTimeout(r, 150));
+    assert.equal(h.connections, settled, 'the client must stop reconnecting in a loop');
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});
+
+test('a replay onto a connection that dies before proving itself is retried, not lost', async () => {
+  const h = replayHarness((ws, n) => {
+    if (n === 2) {
+      ws.on('message', (raw) => {
+        const f = JSON.parse(raw.toString('utf8')) as { type?: string };
+        if (f.type === 'hello') setTimeout(() => ws.close(1012, 'restarting'), 5);
+      });
+    }
+  });
+  const serverUrl = await listen(h.server);
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 20,
+    reconnectMaxDelayMs: 20,
+    reconnectJitterRatio: 0,
+    reconnectStableMs: 5_000,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    sendOffline(client, {
+      type: 'task.complete',
+      taskId: 't-retry',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+
+    await waitFor(() => h.connections >= 3, 'a third connection');
+    await waitFor(
+      () => h.received.filter((f) => f.taskId === 't-retry').length >= 2,
+      'the replay to be retried after the failed attempt',
+    );
+  } finally {
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -2022,3 +2022,71 @@ test('overflowing the truncated-task bookkeeping discards the buffer rather than
     await closeServer(h.server, h.wss);
   }
 });
+test('poisoning the buffer silences the runs it abandoned, through the reconnect', async () => {
+  const h = replayHarness();
+  const serverUrl = await listen(h.server);
+
+  let release!: () => void;
+  const held = new Promise<void>((r) => {
+    release = r;
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('slow', async (task, emit) => {
+      await held;
+      emit({
+        type: 'task.complete',
+        taskId: task.taskId,
+        status: { state: 'completed', timestamp: new Date().toISOString() },
+      });
+    }),
+    reconnectDelayMs: 15,
+    reconnectMaxDelayMs: 15,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 1,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => h.received.some((f) => f.type === 'hello'), 'first hello');
+
+    h.sockets[0]!.send(JSON.stringify({
+      type: 'task.assign',
+      taskId: 't-poisoned-run',
+      contextId: 'ctx',
+      message: { role: 'user', parts: [{ kind: 'text', text: 'hi' }], messageId: 'm1' },
+    }));
+    await new Promise((r) => setTimeout(r, 20));
+    h.sockets[0]!.close(1012, 'restarting');
+    await waitOffline(client);
+
+    for (let i = 0; i <= 10_001; i++) {
+      sendOffline(client, {
+        type: 'task.artifact',
+        taskId: `t-flood-${i}`,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'x' }] },
+        append: true,
+        lastChunk: false,
+      });
+    }
+
+    await waitFor(() => h.connections >= 2, 'reconnect');
+    release();
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.deepEqual(
+      h.received.filter((f) => f.taskId === 't-poisoned-run'),
+      [],
+      'an abandoned run must stay silent, not emit into a rebound task id',
+    );
+  } finally {
+    release();
+    client.stop();
+    await closeServer(h.server, h.wss);
+  }
+});

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1473,3 +1473,137 @@ test('maxPendingFrames: 0 restores the previous drop-on-the-floor behavior', asy
     await closeServer(server, wss);
   }
 });
+test('the offline buffer is bounded by bytes, not just frame count', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  const received: Array<Record<string, unknown>> = [];
+  let connections = 0;
+  let firstSocket: WebSocket | undefined;
+  wss.on('connection', (ws) => {
+    connections++;
+    if (connections === 1) firstSocket = ws;
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    maxPendingFrames: 1_000,
+    maxPendingBytes: 4_000,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => received.some((f) => f.type === 'hello'), 'first hello');
+    firstSocket!.close(1012, 'restarting');
+    await waitFor(
+      () => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1,
+      'socket down',
+    );
+
+    const send = (client as never as { send(f: unknown): void }).send.bind(client);
+    const chunk = 'x'.repeat(1_500);
+    for (let i = 0; i < 6; i++) {
+      send({
+        type: 'task.artifact',
+        taskId: 't-bytes',
+        artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: chunk }] },
+        append: true,
+        lastChunk: false,
+      });
+    }
+
+    await waitFor(() => connections >= 2, 'reconnect');
+    await waitFor(
+      () => received.some((f) => f.type === 'task.fail' && f.taskId === 't-bytes'),
+      'the byte-budget eviction to fail the task',
+    );
+
+    const forTask = received.filter((f) => f.taskId === 't-bytes');
+    assert.deepEqual(forTask.map((f) => f.type), ['task.fail']);
+    const failure = forTask[0] as { error: { code: string } };
+    assert.equal(failure.error.code, 'client_buffer_overflow');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('a single frame larger than the whole budget is refused without evicting the queue', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+
+  const received: Array<Record<string, unknown>> = [];
+  let connections = 0;
+  let firstSocket: WebSocket | undefined;
+  wss.on('connection', (ws) => {
+    connections++;
+    if (connections === 1) firstSocket = ws;
+    ws.on('message', (raw) => {
+      received.push(JSON.parse(raw.toString('utf8')) as Record<string, unknown>);
+    });
+  });
+
+  const client = new Client({
+    serverUrl,
+    token: 'client-token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('stub', async () => undefined),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    maxPendingBytes: 4_000,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => received.some((f) => f.type === 'hello'), 'first hello');
+    firstSocket!.close(1012, 'restarting');
+    await waitFor(
+      () => (client as never as { ws?: { readyState: number } }).ws?.readyState !== 1,
+      'socket down',
+    );
+
+    const send = (client as never as { send(f: unknown): void }).send.bind(client);
+    send({
+      type: 'task.complete',
+      taskId: 't-small',
+      status: { state: 'completed', timestamp: new Date().toISOString() },
+    });
+    send({
+      type: 'task.artifact',
+      taskId: 't-huge',
+      artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: 'y'.repeat(10_000) }] },
+      append: true,
+      lastChunk: false,
+    });
+
+    await waitFor(() => connections >= 2, 'reconnect');
+    await waitFor(
+      () => received.some((f) => f.type === 'task.fail' && f.taskId === 't-huge'),
+      'the oversized frame to fail its own task',
+    );
+
+    assert.deepEqual(
+      received.filter((f) => f.taskId === 't-small').map((f) => f.type),
+      ['task.complete'],
+    );
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -145,6 +145,13 @@ const DEFAULT_MAX_PENDING_BYTES = 4 * 1024 * 1024;
 // as it did before this buffer existed. Erring long risks corrupting a
 // different run, which is not recoverable and not even visible.
 const DEFAULT_MAX_PENDING_AGE_MS = 25_000;
+// Ceilings the bridge enforces on a pipelined replay (MAX_PRE_AUTH_FRAMES /
+// MAX_PRE_AUTH_BYTES in packages/server/src/ws.ts). Exceeding either makes the
+// bridge close the connection mid-replay, so an operator who raises the knobs
+// past them would be configuring an outage into a failure. Clamped rather than
+// rejected: the buffer still works, just no larger than it can be delivered.
+const BRIDGE_MAX_REPLAY_FRAMES = 4_096;
+const BRIDGE_MAX_REPLAY_BYTES = 8 * 1024 * 1024;
 // Bound on the truncated-task bookkeeping. It is not covered by the frame
 // budgets — one entry per distinct task, retained until reconnect — so a long
 // outage across many tasks could otherwise grow it without limit.
@@ -201,12 +208,6 @@ export class Client {
   // actually sends, and it is the only honest measure of what the buffer costs.
   private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number }> = [];
   private pendingBytes = 0;
-  // Entries handed to a socket but not yet known to have been accepted. They
-  // stay here until the connection proves itself, so a replay that dies
-  // mid-flight — an old bridge rejecting it, a second drop — is retried rather
-  // than lost. Kept separate from `pendingFrames` so frames produced after the
-  // flush cannot be sent twice.
-  private replayInFlight: Array<{ taskId: string; encoded: string; bytes: number }> = [];
   // When the current outage began, i.e. when the socket last went down with
   // nothing yet confirmed. Reset only when the buffer is emptied — a requeued
   // replay keeps the ORIGINAL start, because its frames are exactly as stale as
@@ -217,11 +218,11 @@ export class Client {
   // loop, so we fall back to the old drop-on-the-floor behavior for the rest of
   // the process and tell the operator why.
   private replaySupported = true;
-  private replayConfirmTimer: ReturnType<typeof setTimeout> | null = null;
   // Set when truncation bookkeeping overflowed and the buffer had to be
   // abandoned wholesale. Nothing further is buffered for this outage, so no
   // partial suffix can survive to be replayed; cleared on the next flush.
   private bufferPoisoned = false;
+  private warnedOnce = new Set<string>();
   // Tasks that lost at least one frame to the cap. Their replay would be a
   // hole rather than a delay, so they are failed explicitly instead — a caller
   // is far better served by an honest failure it can retry than by a silently
@@ -248,7 +249,6 @@ export class Client {
     this.stopped = true;
     this.clearReconnectTimer();
     this.clearReconnectResetTimer();
-    this.clearReplayConfirmTimer();
     this.clearHeartbeat();
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
@@ -491,16 +491,12 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
-      this.clearReplayConfirmTimer();
       // Start the outage clock here, not at the first buffered frame: the
       // bridge's grace counts from the disconnect, and a backend whose first
       // output lands late in the outage must not get a fresh window for it.
       // `??=` keeps the earliest start when output from a previous attempt is
       // still pending — those frames are that much staler, not fresher.
       this.bufferingSince ??= Date.now();
-      // The connection died without ever proving itself, so anything we
-      // replayed onto it may never have been processed. Put it back.
-      this.requeueReplay();
       // 4003 "expected hello" means this bridge predates the pre-auth queueing
       // that pipelined replay depends on — it rejected our frames for arriving
       // while it was still authenticating. Retrying would loop forever, so drop
@@ -708,8 +704,8 @@ export class Client {
   private bufferUnsent(frame: UpFrame): void {
     if (this.stopped || this.bufferPoisoned) return;
     if (!('taskId' in frame)) return;
-    const limit = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
-    const byteLimit = this.opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    const limit = this.replayFrameLimit();
+    const byteLimit = this.replayByteLimit();
     if (limit <= 0 || byteLimit <= 0) return;
 
     const encoded = encodeFrame(frame);
@@ -735,6 +731,35 @@ export class Client {
         `offline frame buffer full (${this.pendingFrames.length + 1}/${limit} frames, ${this.pendingBytes + dropped.bytes}/${byteLimit} bytes)`,
       );
     }
+  }
+
+  // Both limits are clamped to what the bridge accepts, and warned about once,
+  // so a misconfigured knob degrades the buffer instead of breaking the
+  // connection it is meant to survive.
+  private replayFrameLimit(): number {
+    const requested = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
+    if (requested <= BRIDGE_MAX_REPLAY_FRAMES) return requested;
+    this.warnOnce(
+      'maxPendingFrames',
+      `maxPendingFrames=${requested} exceeds what the bridge accepts in one replay (${BRIDGE_MAX_REPLAY_FRAMES}); clamping`,
+    );
+    return BRIDGE_MAX_REPLAY_FRAMES;
+  }
+
+  private replayByteLimit(): number {
+    const requested = this.opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    if (requested <= BRIDGE_MAX_REPLAY_BYTES) return requested;
+    this.warnOnce(
+      'maxPendingBytes',
+      `maxPendingBytes=${requested} exceeds what the bridge accepts in one replay (${BRIDGE_MAX_REPLAY_BYTES}); clamping`,
+    );
+    return BRIDGE_MAX_REPLAY_BYTES;
+  }
+
+  private warnOnce(key: string, message: string): void {
+    if (this.warnedOnce.has(key)) return;
+    this.warnedOnce.add(key);
+    this.logger.warn(message);
   }
 
   private markTruncated(taskId: string, why: string): void {
@@ -800,15 +825,27 @@ export class Client {
     const truncated = this.truncatedTasks;
     this.pendingFrames = [];
     this.pendingBytes = 0;
+    this.bufferingSince = null;
     this.truncatedTasks = new Set();
 
+    // Sent once, never retained for a retry. Retention looked attractive — a
+    // connection that dies mid-replay would get another go — but there is no
+    // acceptance signal in the protocol, so "not yet confirmed" cannot be
+    // distinguished from "already processed". A replayed `task.complete` may
+    // already have unbound an `input-required` task, after which A2A
+    // legitimately reuses that taskId for the next turn; re-sending would hand
+    // the old terminal to the new binding, which the bridge matches by
+    // agent and task id and would accept.
+    //
+    // So the trade is made the same way as the outage window above: losing a
+    // replay fails the task on the bridge's grace deadline, which is visible
+    // and retryable, while duplicating one corrupts a different run invisibly.
+    // Retrying safely needs a run generation or a server ack — a protocol
+    // change, and not one this fix requires.
     let replayed = 0;
     for (const entry of fresh) {
       if (truncated.has(entry.taskId)) continue;
       ws.send(entry.encoded);
-      // Retained, not discarded: if this connection turns out to be unusable
-      // the frames go back on the queue instead of vanishing.
-      this.replayInFlight.push(entry);
       replayed++;
     }
     for (const taskId of truncated) {
@@ -834,60 +871,10 @@ export class Client {
       `replayed ${replayed} buffered frame(s) after reconnect` +
         (truncated.size > 0 ? `; failed ${truncated.size} truncated task(s)` : ''),
     );
-    this.scheduleReplayConfirm(ws);
-  }
-
-  // Release the retained replay once this connection has stayed up long enough
-  // to be believed. Armed HERE rather than at `open`, because the flush happens
-  // after an async card probe: a window started at `open` can elapse before
-  // there is anything to confirm, leaving the replay retained forever and every
-  // later close re-sending frames the bridge already has.
-  private scheduleReplayConfirm(ws: WebSocket): void {
-    this.clearReplayConfirmTimer();
-    if (this.replayInFlight.length === 0) return;
-    const stableMs = this.opts.reconnectStableMs ?? DEFAULT_RECONNECT_STABLE_MS;
-    if (stableMs <= 0) {
-      this.confirmReplay();
-      return;
-    }
-    this.replayConfirmTimer = setTimeout(() => {
-      this.replayConfirmTimer = null;
-      if (!this.stopped && this.ws === ws && ws.readyState === WebSocket.OPEN) {
-        this.confirmReplay();
-      }
-    }, stableMs);
-    this.replayConfirmTimer.unref?.();
-  }
-
-  private clearReplayConfirmTimer(): void {
-    if (this.replayConfirmTimer) {
-      clearTimeout(this.replayConfirmTimer);
-      this.replayConfirmTimer = null;
-    }
-  }
-
-  // The replay reached a connection that stayed up — let it go.
-  private confirmReplay(): void {
-    if (this.replayInFlight.length === 0) return;
-    this.replayInFlight = [];
-    // Delivered. If nothing else is waiting, the outage is over.
-    if (this.pendingFrames.length === 0) this.bufferingSince = null;
-  }
-
-  // The connection died before proving itself. Put the replay back at the FRONT
-  // of the queue so ordering against anything produced since is preserved.
-  private requeueReplay(): void {
-    if (this.replayInFlight.length === 0) return;
-    const back = this.replayInFlight;
-    this.replayInFlight = [];
-    this.pendingFrames = [...back, ...this.pendingFrames];
-    this.pendingBytes += back.reduce((n, e) => n + e.bytes, 0);
   }
 
   private dropPendingFrames(): void {
-    this.clearReplayConfirmTimer();
     this.pendingFrames = [];
-    this.replayInFlight = [];
     this.pendingBytes = 0;
     this.bufferingSince = null;
     this.truncatedTasks.clear();

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -775,8 +775,23 @@ export class Client {
       if (!this.bufferPoisoned) {
         this.bufferPoisoned = true;
         this.logger.error(
-          `truncated-task list full (${MAX_TRUNCATED_TASKS}); discarding all buffered output for this outage rather than replay it partially`,
+          `truncated-task list full (${MAX_TRUNCATED_TASKS}); abandoning this outage's output rather than replay it partially`,
         );
+        // Dropping the buffer is not enough on its own: the identity of the
+        // affected runs goes with it, so their backends would carry on and
+        // their later frames would go out live on the next connection —
+        // resuming or completing a held binding with the prefix missing, which
+        // is the corruption this path exists to avoid.
+        //
+        // Every run alive during this outage is therefore silenced and aborted.
+        // They die on the bridge's grace deadline, which is exactly what would
+        // have happened before this buffer existed. Reaching this cap at all is
+        // pathological, so the bluntness is the point: it is the one outcome
+        // here that cannot corrupt a different run.
+        for (const run of this.inflight.values()) {
+          run.suppressed = true;
+          run.controller.abort();
+        }
       }
       this.dropPendingFrames();
       return;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -42,6 +42,10 @@ export interface ClientOptions {
   reconnectMaxDelayMs?: number;
   reconnectJitterRatio?: number;
   reconnectStableMs?: number;
+  // Maximum number of task frames held for replay while the bridge connection
+  // is down (see `pendingFrames`). `0` disables buffering and restores the
+  // previous drop-on-the-floor behavior.
+  maxPendingFrames?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
   // same CLIENT_TOKEN colliding at the registry's clientId check. The
@@ -101,6 +105,12 @@ const DEFAULT_PROBE_DEADLINE_MS = 12_000;
 const DEFAULT_RECONNECT_DELAY_MS = 3000;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;
+// Cap on frames held for replay across a reconnect. Sized for the realistic
+// worst case — a turn's streamed text is a few hundred small artifact frames —
+// with headroom, while still bounding a daemon that keeps producing into a long
+// outage. A task that loses frames to this cap is failed rather than replayed
+// with a hole; see bufferUnsent(). `0` disables buffering entirely.
+const DEFAULT_MAX_PENDING_FRAMES = 2_000;
 const DEFAULT_RECONNECT_STABLE_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_COLLISION_BACKOFF_MS = 300_000;
@@ -124,6 +134,28 @@ export class Client {
   // don't re-probe on every bridge WS reconnect — the underlying upstream
   // doesn't change mid-process.
   private effectiveCardPromise: Promise<AgentCard | undefined> | null = null;
+  // Task frames `send()` could not put on the wire because the socket was
+  // down, held in arrival order for replay on the next connection.
+  //
+  // Without this, a reconnect silently loses whatever the backend produced
+  // during the outage: streamed deltas vanish mid-answer while the backend's
+  // own bookkeeping advances past them, so the end-of-turn catch-up never
+  // re-sends them and the task completes with a hole. Worse, a backend that
+  // FINISHES during the outage loses its terminal frame outright and never
+  // re-emits it, so a fully successful task is reported as failed once the
+  // server's reconnect grace expires (vicoop-bridge#474).
+  //
+  // Replaying is safe and needs no server support beyond that grace hold: a
+  // TaskBinding is not tied to a connection, so a frame arriving on the new
+  // socket lands on the original task untouched. Frames for a task whose hold
+  // already expired are dropped by the server as `dropped_terminal_frame`,
+  // which is what would have happened anyway.
+  private pendingFrames: Array<{ taskId: string; frame: UpFrame }> = [];
+  // Tasks that lost at least one frame to the cap. Their replay would be a
+  // hole rather than a delay, so they are failed explicitly instead — a caller
+  // is far better served by an honest failure it can retry than by a silently
+  // truncated answer.
+  private truncatedTasks = new Set<string>();
   private readonly logger: Logger;
 
   constructor(private readonly opts: ClientOptions) {
@@ -149,6 +181,9 @@ export class Client {
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
     for (const controller of this.inflight.values()) controller.abort();
+    // Nothing will replay these — the process is going away.
+    this.pendingFrames = [];
+    this.truncatedTasks.clear();
     this.ws?.close();
     // Tear down long-lived backend resources (e.g. codex app-server child).
     // Per-task abort above covers per-handle subprocesses; this hook is for
@@ -310,6 +345,10 @@ export class Client {
             protocolCapabilities: [CALLER_CONTEXT_CAPABILITY],
           }),
         );
+        // Immediately behind the hello, on this same socket, so the replay is
+        // the first thing the server sees for these tasks — before any frame
+        // the backend produces next.
+        this.flushPendingFrames(ws);
       };
       // The internal catch inside resolveEffectiveCard() already coerces
       // every failure into "return base", so this `.catch` is defense in
@@ -556,8 +595,75 @@ export class Client {
   }
 
   private send(frame: UpFrame): void {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-    this.ws.send(encodeFrame(frame));
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(encodeFrame(frame));
+      return;
+    }
+    this.bufferUnsent(frame);
+  }
+
+  // Queue a frame the socket could not take. Only task-scoped frames are worth
+  // keeping: `pong` answers a ping that has long since timed out, and
+  // `usage.response` answers a requestId the server forgot when the connection
+  // died. Replaying either would be noise at best.
+  private bufferUnsent(frame: UpFrame): void {
+    if (this.stopped) return;
+    if (!('taskId' in frame)) return;
+    const limit = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
+    if (limit <= 0) return;
+    this.pendingFrames.push({ taskId: frame.taskId, frame });
+    while (this.pendingFrames.length > limit) {
+      // Drop the OLDEST, so what survives is the tail nearest the terminal —
+      // but record the victim's task, because a partial replay of a text
+      // stream is exactly the silent hole this buffer exists to prevent.
+      const dropped = this.pendingFrames.shift()!;
+      if (!this.truncatedTasks.has(dropped.taskId)) {
+        this.truncatedTasks.add(dropped.taskId);
+        this.logger.warn(
+          `offline frame buffer full (${limit}); task ${safeToken(dropped.taskId)} will be failed instead of replayed`,
+        );
+      }
+    }
+  }
+
+  // Replay buffered frames onto a freshly authenticated connection, in the
+  // order they were produced. Sent on the captured socket rather than through
+  // `send()` so a replay can never re-enter the buffer and loop.
+  //
+  // These are pipelined immediately behind `hello`: the server queues frames
+  // that arrive while its (async) authentication is still settling and
+  // processes them once it completes, so no ack round-trip is needed.
+  private flushPendingFrames(ws: WebSocket): void {
+    const queued = this.pendingFrames;
+    const truncated = this.truncatedTasks;
+    this.pendingFrames = [];
+    this.truncatedTasks = new Set();
+    if (queued.length === 0 && truncated.size === 0) return;
+    if (ws.readyState !== WebSocket.OPEN) return;
+
+    let replayed = 0;
+    for (const entry of queued) {
+      if (truncated.has(entry.taskId)) continue;
+      ws.send(encodeFrame(entry.frame));
+      replayed++;
+    }
+    for (const taskId of truncated) {
+      this.inflight.get(taskId)?.abort();
+      ws.send(
+        encodeFrame({
+          type: 'task.fail',
+          taskId,
+          error: {
+            code: 'client_buffer_overflow',
+            message: 'output was lost while the bridge connection was down',
+          },
+        }),
+      );
+    }
+    this.logger.info(
+      `replayed ${replayed} buffered frame(s) after reconnect` +
+        (truncated.size > 0 ? `; failed ${truncated.size} truncated task(s)` : ''),
+    );
   }
 
   // Answer a server-initiated usage.request by querying the backend's optional

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,7 +49,8 @@ export interface ClientOptions {
   // Companion byte budget for that buffer, over the encoded frames. Keep at or
   // below the server's pre-auth byte budget; see DEFAULT_MAX_PENDING_BYTES.
   maxPendingBytes?: number;
-  // How long a buffered frame stays replayable; see DEFAULT_MAX_PENDING_AGE_MS.
+  // How long an outage's buffered output stays replayable. Must not exceed the
+  // bridge's `BRIDGE_DISCONNECT_GRACE_MS`; see DEFAULT_MAX_PENDING_AGE_MS.
   maxPendingAgeMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
@@ -126,15 +127,24 @@ const DEFAULT_MAX_PENDING_FRAMES = 2_000;
 // authentication settles. A client allowed to buffer more than the server will
 // accept pre-auth would be closed mid-replay and reconnect into a loop.
 const DEFAULT_MAX_PENDING_BYTES = 4 * 1024 * 1024;
-// How long a buffered frame is worth replaying. Past the server's own reconnect
-// grace the binding it belonged to is gone, and — because A2A reuses a taskId
-// across turns — a NEW run may already hold that id. Replaying then would inject
-// a dead run's artifacts, or its terminal, into a live one. Anything older than
-// this is dropped and its task failed instead.
+// How long an outage may last before its buffered output stops being replayable,
+// measured from when buffering STARTED — not from each frame's own creation.
 //
-// Kept above the server's default grace (BRIDGE_DISCONNECT_GRACE_MS, 30s) so a
-// recovery the server would still have honored is never discarded here.
-const DEFAULT_MAX_PENDING_AGE_MS = 45_000;
+// The distinction is the whole safety argument. The bridge deletes a held
+// binding at its grace deadline, counted from the disconnect. A backend that
+// keeps running past that deadline keeps producing frames, and a per-frame age
+// would judge each of them young: a frame created 5s before a reconnect looks
+// fresh even though the binding it belongs to died 10s earlier. Because A2A
+// reuses a taskId across turns, replaying into that gap can hand a dead run's
+// artifacts — or its terminal — to a live one, and the bridge only checks agent
+// ownership, not which run.
+//
+// So the window is the outage's, and it must stay at or BELOW the bridge's
+// effective grace (`BRIDGE_DISCONNECT_GRACE_MS`, 30s by default). Erring short
+// costs a recovery the bridge might still have honoured — the task simply fails
+// as it did before this buffer existed. Erring long risks corrupting a
+// different run, which is not recoverable and not even visible.
+const DEFAULT_MAX_PENDING_AGE_MS = 25_000;
 // Bound on the truncated-task bookkeeping. It is not covered by the frame
 // budgets — one entry per distinct task, retained until reconnect — so a long
 // outage across many tasks could otherwise grow it without limit.
@@ -180,19 +190,25 @@ export class Client {
   // which is what would have happened anyway.
   // Entries hold the ENCODED frame, not the frame object: it is what replay
   // actually sends, and it is the only honest measure of what the buffer costs.
-  private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number; at: number }> = [];
+  private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number }> = [];
   private pendingBytes = 0;
   // Entries handed to a socket but not yet known to have been accepted. They
   // stay here until the connection proves itself, so a replay that dies
   // mid-flight — an old bridge rejecting it, a second drop — is retried rather
   // than lost. Kept separate from `pendingFrames` so frames produced after the
   // flush cannot be sent twice.
-  private replayInFlight: Array<{ taskId: string; encoded: string; bytes: number; at: number }> = [];
+  private replayInFlight: Array<{ taskId: string; encoded: string; bytes: number }> = [];
+  // When the current outage began, i.e. when the socket last went down with
+  // nothing yet confirmed. Reset only when the buffer is emptied — a requeued
+  // replay keeps the ORIGINAL start, because its frames are exactly as stale as
+  // the outage that produced them.
+  private bufferingSince: number | null = null;
   // Set when a bridge rejects pipelined replay (4003 "expected hello"), i.e. it
   // predates the pre-auth queueing this depends on. Replaying again would just
   // loop, so we fall back to the old drop-on-the-floor behavior for the rest of
   // the process and tell the operator why.
   private replaySupported = true;
+  private replayConfirmTimer: ReturnType<typeof setTimeout> | null = null;
   // Tasks that lost at least one frame to the cap. Their replay would be a
   // hole rather than a delay, so they are failed explicitly instead — a caller
   // is far better served by an honest failure it can retry than by a silently
@@ -219,6 +235,7 @@ export class Client {
     this.stopped = true;
     this.clearReconnectTimer();
     this.clearReconnectResetTimer();
+    this.clearReplayConfirmTimer();
     this.clearHeartbeat();
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
@@ -461,6 +478,13 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
+      this.clearReplayConfirmTimer();
+      // Start the outage clock here, not at the first buffered frame: the
+      // bridge's grace counts from the disconnect, and a backend whose first
+      // output lands late in the outage must not get a fresh window for it.
+      // `??=` keeps the earliest start when output from a previous attempt is
+      // still pending — those frames are that much staler, not fresher.
+      this.bufferingSince ??= Date.now();
       // The connection died without ever proving itself, so anything we
       // replayed onto it may never have been processed. Put it back.
       this.requeueReplay();
@@ -606,16 +630,12 @@ export class Client {
     const stableMs = this.opts.reconnectStableMs ?? DEFAULT_RECONNECT_STABLE_MS;
     if (stableMs <= 0) {
       this.reconnectAttempt = 0;
-      this.confirmReplay();
       return;
     }
     this.reconnectResetTimer = setTimeout(() => {
       this.reconnectResetTimer = null;
       if (!this.stopped && this.ws === ws && ws.readyState === WebSocket.OPEN) {
         this.reconnectAttempt = 0;
-        // The same signal that says this connection is real says the replay
-        // landed: a bridge that was going to reject it would have closed by now.
-        this.confirmReplay();
       }
     }, stableMs);
     this.reconnectResetTimer.unref?.();
@@ -688,7 +708,7 @@ export class Client {
       return;
     }
 
-    this.pendingFrames.push({ taskId: frame.taskId, encoded, bytes, at: Date.now() });
+    this.pendingFrames.push({ taskId: frame.taskId, encoded, bytes });
     this.pendingBytes += bytes;
     // Drop the OLDEST first, so what survives is the tail nearest the terminal
     // — but record each victim's task, because a partial replay of a text
@@ -736,18 +756,19 @@ export class Client {
       return;
     }
 
-    // Anything the server would no longer honour is not merely useless to send,
-    // it is dangerous: the binding is gone and a new run may already hold that
-    // taskId. Fail those tasks instead of injecting a dead run's output.
+    // Output the bridge would no longer honour is not merely useless to send, it
+    // is dangerous: the binding is gone and a new run may already hold that
+    // taskId. The whole outage is judged at once — every frame in the buffer is
+    // as stale as the outage that produced it, whatever its own age.
     const maxAge = this.opts.maxPendingAgeMs ?? DEFAULT_MAX_PENDING_AGE_MS;
-    const cutoff = Date.now() - maxAge;
+    const outageMs = this.bufferingSince === null ? 0 : Date.now() - this.bufferingSince;
     const fresh: typeof this.pendingFrames = [];
-    for (const entry of this.pendingFrames) {
-      if (entry.at < cutoff) {
-        this.markTruncated(entry.taskId, `buffered output is older than ${maxAge}ms`);
-        continue;
+    if (outageMs > maxAge) {
+      for (const entry of this.pendingFrames) {
+        this.markTruncated(entry.taskId, `the ${outageMs}ms outage exceeds the ${maxAge}ms replay window`);
       }
-      fresh.push(entry);
+    } else {
+      fresh.push(...this.pendingFrames);
     }
 
     const truncated = this.truncatedTasks;
@@ -781,12 +802,44 @@ export class Client {
       `replayed ${replayed} buffered frame(s) after reconnect` +
         (truncated.size > 0 ? `; failed ${truncated.size} truncated task(s)` : ''),
     );
+    this.scheduleReplayConfirm(ws);
+  }
+
+  // Release the retained replay once this connection has stayed up long enough
+  // to be believed. Armed HERE rather than at `open`, because the flush happens
+  // after an async card probe: a window started at `open` can elapse before
+  // there is anything to confirm, leaving the replay retained forever and every
+  // later close re-sending frames the bridge already has.
+  private scheduleReplayConfirm(ws: WebSocket): void {
+    this.clearReplayConfirmTimer();
+    if (this.replayInFlight.length === 0) return;
+    const stableMs = this.opts.reconnectStableMs ?? DEFAULT_RECONNECT_STABLE_MS;
+    if (stableMs <= 0) {
+      this.confirmReplay();
+      return;
+    }
+    this.replayConfirmTimer = setTimeout(() => {
+      this.replayConfirmTimer = null;
+      if (!this.stopped && this.ws === ws && ws.readyState === WebSocket.OPEN) {
+        this.confirmReplay();
+      }
+    }, stableMs);
+    this.replayConfirmTimer.unref?.();
+  }
+
+  private clearReplayConfirmTimer(): void {
+    if (this.replayConfirmTimer) {
+      clearTimeout(this.replayConfirmTimer);
+      this.replayConfirmTimer = null;
+    }
   }
 
   // The replay reached a connection that stayed up — let it go.
   private confirmReplay(): void {
     if (this.replayInFlight.length === 0) return;
     this.replayInFlight = [];
+    // Delivered. If nothing else is waiting, the outage is over.
+    if (this.pendingFrames.length === 0) this.bufferingSince = null;
   }
 
   // The connection died before proving itself. Put the replay back at the FRONT
@@ -800,9 +853,11 @@ export class Client {
   }
 
   private dropPendingFrames(): void {
+    this.clearReplayConfirmTimer();
     this.pendingFrames = [];
     this.replayInFlight = [];
     this.pendingBytes = 0;
+    this.bufferingSince = null;
     this.truncatedTasks.clear();
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -46,6 +46,9 @@ export interface ClientOptions {
   // is down (see `pendingFrames`). `0` disables buffering and restores the
   // previous drop-on-the-floor behavior.
   maxPendingFrames?: number;
+  // Companion byte budget for that buffer, over the encoded frames. Keep at or
+  // below the server's pre-auth byte budget; see DEFAULT_MAX_PENDING_BYTES.
+  maxPendingBytes?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
   // same CLIENT_TOKEN colliding at the registry's clientId check. The
@@ -111,6 +114,16 @@ const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;
 // outage. A task that loses frames to this cap is failed rather than replayed
 // with a hole; see bufferUnsent(). `0` disables buffering entirely.
 const DEFAULT_MAX_PENDING_FRAMES = 2_000;
+// Companion byte budget for the same buffer. A frame count alone bounds
+// nothing useful: the protocol puts no size limit on text, file or data parts,
+// so 2,000 frames can be any number of megabytes. Both limits apply.
+//
+// MUST stay at or below the server's pre-auth byte budget
+// (MAX_PRE_AUTH_BYTES in packages/server/src/ws.ts), because a replay is
+// pipelined behind `hello` and the server holds it in memory until its
+// authentication settles. A client allowed to buffer more than the server will
+// accept pre-auth would be closed mid-replay and reconnect into a loop.
+const DEFAULT_MAX_PENDING_BYTES = 4 * 1024 * 1024;
 const DEFAULT_RECONNECT_STABLE_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_COLLISION_BACKOFF_MS = 300_000;
@@ -150,7 +163,10 @@ export class Client {
   // socket lands on the original task untouched. Frames for a task whose hold
   // already expired are dropped by the server as `dropped_terminal_frame`,
   // which is what would have happened anyway.
-  private pendingFrames: Array<{ taskId: string; frame: UpFrame }> = [];
+  // Entries hold the ENCODED frame, not the frame object: it is what replay
+  // actually sends, and it is the only honest measure of what the buffer costs.
+  private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number }> = [];
+  private pendingBytes = 0;
   // Tasks that lost at least one frame to the cap. Their replay would be a
   // hole rather than a delay, so they are failed explicitly instead — a caller
   // is far better served by an honest failure it can retry than by a silently
@@ -183,6 +199,7 @@ export class Client {
     for (const controller of this.inflight.values()) controller.abort();
     // Nothing will replay these — the process is going away.
     this.pendingFrames = [];
+    this.pendingBytes = 0;
     this.truncatedTasks.clear();
     this.ws?.close();
     // Tear down long-lived backend resources (e.g. codex app-server child).
@@ -610,20 +627,40 @@ export class Client {
     if (this.stopped) return;
     if (!('taskId' in frame)) return;
     const limit = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
-    if (limit <= 0) return;
-    this.pendingFrames.push({ taskId: frame.taskId, frame });
-    while (this.pendingFrames.length > limit) {
-      // Drop the OLDEST, so what survives is the tail nearest the terminal —
-      // but record the victim's task, because a partial replay of a text
-      // stream is exactly the silent hole this buffer exists to prevent.
-      const dropped = this.pendingFrames.shift()!;
-      if (!this.truncatedTasks.has(dropped.taskId)) {
-        this.truncatedTasks.add(dropped.taskId);
-        this.logger.warn(
-          `offline frame buffer full (${limit}); task ${safeToken(dropped.taskId)} will be failed instead of replayed`,
-        );
-      }
+    const byteLimit = this.opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    if (limit <= 0 || byteLimit <= 0) return;
+
+    const encoded = encodeFrame(frame);
+    const bytes = Buffer.byteLength(encoded, 'utf8');
+    if (bytes > byteLimit) {
+      // A single frame nobody could ever replay. Buffering it would evict the
+      // whole rest of the queue for nothing.
+      this.markTruncated(frame.taskId, `frame of ${bytes} bytes exceeds the ${byteLimit}-byte buffer`);
+      return;
     }
+
+    this.pendingFrames.push({ taskId: frame.taskId, encoded, bytes });
+    this.pendingBytes += bytes;
+    // Drop the OLDEST first, so what survives is the tail nearest the terminal
+    // — but record each victim's task, because a partial replay of a text
+    // stream is exactly the silent hole this buffer exists to prevent.
+    while (this.pendingFrames.length > limit || this.pendingBytes > byteLimit) {
+      const dropped = this.pendingFrames.shift();
+      if (!dropped) break;
+      this.pendingBytes -= dropped.bytes;
+      this.markTruncated(
+        dropped.taskId,
+        `offline frame buffer full (${this.pendingFrames.length + 1}/${limit} frames, ${this.pendingBytes + dropped.bytes}/${byteLimit} bytes)`,
+      );
+    }
+  }
+
+  private markTruncated(taskId: string, why: string): void {
+    if (this.truncatedTasks.has(taskId)) return;
+    this.truncatedTasks.add(taskId);
+    this.logger.warn(
+      `${why}; task ${safeToken(taskId)} will be failed instead of replayed`,
+    );
   }
 
   // Replay buffered frames onto a freshly authenticated connection, in the
@@ -637,6 +674,7 @@ export class Client {
     const queued = this.pendingFrames;
     const truncated = this.truncatedTasks;
     this.pendingFrames = [];
+    this.pendingBytes = 0;
     this.truncatedTasks = new Set();
     if (queued.length === 0 && truncated.size === 0) return;
     if (ws.readyState !== WebSocket.OPEN) return;
@@ -644,7 +682,7 @@ export class Client {
     let replayed = 0;
     for (const entry of queued) {
       if (truncated.has(entry.taskId)) continue;
-      ws.send(encodeFrame(entry.frame));
+      ws.send(entry.encoded);
       replayed++;
     }
     for (const taskId of truncated) {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -165,7 +165,16 @@ export class Client {
   // is logged exactly once on first successful connect — same data on every
   // reconnect would just be noise, and we don't want to wait for whoami.
   private identityLogged = false;
-  private inflight = new Map<string, AbortController>();
+  // Per-run state, keyed by taskId for the life of that run. `suppressed` is
+  // set when we have already reported the run's outcome ourselves (a truncated
+  // replay); nothing the backend emits afterwards may reach the wire, because
+  // aborting a backend does not silence it — `processTask` still sends a
+  // `canceled` terminal once the abort is observed, and by then the bridge may
+  // have rebound that taskId to a later turn which would accept it.
+  //
+  // Run-scoped rather than taskId-scoped: a genuinely new turn for the same
+  // taskId gets a fresh entry and is unaffected.
+  private inflight = new Map<string, { controller: AbortController; suppressed: boolean }>();
   // Resolved once per process via backend.resolveCapabilities(); the bridge
   // hello frame is held until this settles so the advertised card matches the
   // backend's actual upstream capability. Cached across reconnects so we
@@ -209,6 +218,10 @@ export class Client {
   // the process and tell the operator why.
   private replaySupported = true;
   private replayConfirmTimer: ReturnType<typeof setTimeout> | null = null;
+  // Set when truncation bookkeeping overflowed and the buffer had to be
+  // abandoned wholesale. Nothing further is buffered for this outage, so no
+  // partial suffix can survive to be replayed; cleared on the next flush.
+  private bufferPoisoned = false;
   // Tasks that lost at least one frame to the cap. Their replay would be a
   // hole rather than a delay, so they are failed explicitly instead — a caller
   // is far better served by an honest failure it can retry than by a silently
@@ -239,7 +252,7 @@ export class Client {
     this.clearHeartbeat();
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
-    for (const controller of this.inflight.values()) controller.abort();
+    for (const run of this.inflight.values()) run.controller.abort();
     // Nothing will replay these — the process is going away.
     this.dropPendingFrames();
     this.ws?.close();
@@ -453,7 +466,7 @@ export class Client {
           break;
         case 'task.cancel':
           this.logger.info(`task.cancel taskId=${safeToken(frame.taskId)}`);
-          this.inflight.get(frame.taskId)?.abort();
+          this.inflight.get(frame.taskId)?.controller.abort();
           break;
         case 'ping':
           this.send({ type: 'pong' });
@@ -531,7 +544,7 @@ export class Client {
         this.logger.error(`${label}; stopping (code=${code})`);
         this.stopped = true;
         this.clearReconnectTimer();
-        for (const controller of this.inflight.values()) controller.abort();
+        for (const run of this.inflight.values()) run.controller.abort();
         // Nothing will ever replay these — this daemon is not reconnecting. The
         // host process may keep running (onFatal owns that decision), so
         // release the buffer rather than hold it for a reconnect that is not
@@ -693,7 +706,7 @@ export class Client {
   // `usage.response` answers a requestId the server forgot when the connection
   // died. Replaying either would be noise at best.
   private bufferUnsent(frame: UpFrame): void {
-    if (this.stopped) return;
+    if (this.stopped || this.bufferPoisoned) return;
     if (!('taskId' in frame)) return;
     const limit = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
     const byteLimit = this.opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
@@ -727,12 +740,20 @@ export class Client {
   private markTruncated(taskId: string, why: string): void {
     if (this.truncatedTasks.has(taskId)) return;
     if (this.truncatedTasks.size >= MAX_TRUNCATED_TASKS) {
-      // Degrade to the pre-buffer behavior for further tasks rather than let
-      // the bookkeeping outgrow the buffer it describes: the server's own grace
-      // expiry still fails them, just without our explicit reason.
-      this.logger.warn(
-        `truncated-task list full (${MAX_TRUNCATED_TASKS}); task ${safeToken(taskId)} will be left to the bridge's grace expiry`,
-      );
+      // Silently declining to record this would be the worst outcome: the
+      // task's SURVIVING frames would still be replayed, handing the bridge a
+      // partial answer to complete — the exact hole truncation exists to
+      // prevent — and those same frames would resume the hold, so the grace
+      // expiry would not catch it either. Fail closed for the whole buffer
+      // instead: replay nothing this outage and let every affected task die on
+      // the bridge's own deadline.
+      if (!this.bufferPoisoned) {
+        this.bufferPoisoned = true;
+        this.logger.error(
+          `truncated-task list full (${MAX_TRUNCATED_TASKS}); discarding all buffered output for this outage rather than replay it partially`,
+        );
+      }
+      this.dropPendingFrames();
       return;
     }
     this.truncatedTasks.add(taskId);
@@ -749,6 +770,11 @@ export class Client {
   // that arrive while its (async) authentication is still settling and
   // processes them once it completes, so no ack round-trip is needed.
   private flushPendingFrames(ws: WebSocket): void {
+    if (this.bufferPoisoned) {
+      this.dropPendingFrames();
+      this.bufferPoisoned = false;
+      return;
+    }
     if (this.pendingFrames.length === 0 && this.truncatedTasks.size === 0) return;
     if (ws.readyState !== WebSocket.OPEN) return;
     if (!this.replaySupported) {
@@ -786,7 +812,13 @@ export class Client {
       replayed++;
     }
     for (const taskId of truncated) {
-      this.inflight.get(taskId)?.abort();
+      const run = this.inflight.get(taskId);
+      if (run) {
+        // Order matters: suppress before aborting, so the `canceled` terminal
+        // the abort provokes is already barred when it arrives.
+        run.suppressed = true;
+        run.controller.abort();
+      }
       ws.send(
         encodeFrame({
           type: 'task.fail',
@@ -903,11 +935,18 @@ export class Client {
   private async runTask(frame: import('@vicoop-bridge/protocol').DownFrame): Promise<void> {
     if (frame.type !== 'task.assign') return;
     const controller = new AbortController();
-    this.inflight.set(frame.taskId, controller);
+    const run = { controller, suppressed: false };
+    this.inflight.set(frame.taskId, run);
     try {
       await processTask(frame, controller.signal, {
         backend: this.opts.backend,
-        send: (f) => this.send(f),
+        // A suppressed run is over as far as the bridge is concerned; anything
+        // still trickling out of the backend must not reach a taskId that may
+        // now belong to someone else.
+        send: (f) => {
+          if (run.suppressed) return;
+          this.send(f);
+        },
         logger: this.logger,
       });
     } finally {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -49,6 +49,8 @@ export interface ClientOptions {
   // Companion byte budget for that buffer, over the encoded frames. Keep at or
   // below the server's pre-auth byte budget; see DEFAULT_MAX_PENDING_BYTES.
   maxPendingBytes?: number;
+  // How long a buffered frame stays replayable; see DEFAULT_MAX_PENDING_AGE_MS.
+  maxPendingAgeMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
   // same CLIENT_TOKEN colliding at the registry's clientId check. The
@@ -124,6 +126,19 @@ const DEFAULT_MAX_PENDING_FRAMES = 2_000;
 // authentication settles. A client allowed to buffer more than the server will
 // accept pre-auth would be closed mid-replay and reconnect into a loop.
 const DEFAULT_MAX_PENDING_BYTES = 4 * 1024 * 1024;
+// How long a buffered frame is worth replaying. Past the server's own reconnect
+// grace the binding it belonged to is gone, and — because A2A reuses a taskId
+// across turns — a NEW run may already hold that id. Replaying then would inject
+// a dead run's artifacts, or its terminal, into a live one. Anything older than
+// this is dropped and its task failed instead.
+//
+// Kept above the server's default grace (BRIDGE_DISCONNECT_GRACE_MS, 30s) so a
+// recovery the server would still have honored is never discarded here.
+const DEFAULT_MAX_PENDING_AGE_MS = 45_000;
+// Bound on the truncated-task bookkeeping. It is not covered by the frame
+// budgets — one entry per distinct task, retained until reconnect — so a long
+// outage across many tasks could otherwise grow it without limit.
+const MAX_TRUNCATED_TASKS = 10_000;
 const DEFAULT_RECONNECT_STABLE_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_COLLISION_BACKOFF_MS = 300_000;
@@ -165,8 +180,19 @@ export class Client {
   // which is what would have happened anyway.
   // Entries hold the ENCODED frame, not the frame object: it is what replay
   // actually sends, and it is the only honest measure of what the buffer costs.
-  private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number }> = [];
+  private pendingFrames: Array<{ taskId: string; encoded: string; bytes: number; at: number }> = [];
   private pendingBytes = 0;
+  // Entries handed to a socket but not yet known to have been accepted. They
+  // stay here until the connection proves itself, so a replay that dies
+  // mid-flight — an old bridge rejecting it, a second drop — is retried rather
+  // than lost. Kept separate from `pendingFrames` so frames produced after the
+  // flush cannot be sent twice.
+  private replayInFlight: Array<{ taskId: string; encoded: string; bytes: number; at: number }> = [];
+  // Set when a bridge rejects pipelined replay (4003 "expected hello"), i.e. it
+  // predates the pre-auth queueing this depends on. Replaying again would just
+  // loop, so we fall back to the old drop-on-the-floor behavior for the rest of
+  // the process and tell the operator why.
+  private replaySupported = true;
   // Tasks that lost at least one frame to the cap. Their replay would be a
   // hole rather than a delay, so they are failed explicitly instead — a caller
   // is far better served by an honest failure it can retry than by a silently
@@ -198,9 +224,7 @@ export class Client {
     // running to completion after the WS is gone.
     for (const controller of this.inflight.values()) controller.abort();
     // Nothing will replay these — the process is going away.
-    this.pendingFrames = [];
-    this.pendingBytes = 0;
-    this.truncatedTasks.clear();
+    this.dropPendingFrames();
     this.ws?.close();
     // Tear down long-lived backend resources (e.g. codex app-server child).
     // Per-task abort above covers per-handle subprocesses; this hook is for
@@ -437,6 +461,22 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
+      // The connection died without ever proving itself, so anything we
+      // replayed onto it may never have been processed. Put it back.
+      this.requeueReplay();
+      // 4003 "expected hello" means this bridge predates the pre-auth queueing
+      // that pipelined replay depends on — it rejected our frames for arriving
+      // while it was still authenticating. Retrying would loop forever, so drop
+      // back to the pre-buffer behavior and say so loudly: a bridge upgrade is
+      // what restores it.
+      if (code === 4003) {
+        this.replaySupported = false;
+        this.logger.warn(
+          'bridge rejected buffered replay (4003); it predates reconnect replay support — ' +
+            'output produced during a disconnect will be dropped until the bridge is upgraded',
+        );
+        this.dropPendingFrames();
+      }
       // Terminal auth failures the daemon cannot recover from by waiting:
       //
       //   - **4014 "client deleted"** (issue #166). The DB row was just
@@ -468,6 +508,11 @@ export class Client {
         this.stopped = true;
         this.clearReconnectTimer();
         for (const controller of this.inflight.values()) controller.abort();
+        // Nothing will ever replay these — this daemon is not reconnecting. The
+        // host process may keep running (onFatal owns that decision), so
+        // release the buffer rather than hold it for a reconnect that is not
+        // coming.
+        this.dropPendingFrames();
         this.opts.onFatal?.({ code, reason: reason.toString() });
         return;
       }
@@ -561,12 +606,16 @@ export class Client {
     const stableMs = this.opts.reconnectStableMs ?? DEFAULT_RECONNECT_STABLE_MS;
     if (stableMs <= 0) {
       this.reconnectAttempt = 0;
+      this.confirmReplay();
       return;
     }
     this.reconnectResetTimer = setTimeout(() => {
       this.reconnectResetTimer = null;
       if (!this.stopped && this.ws === ws && ws.readyState === WebSocket.OPEN) {
         this.reconnectAttempt = 0;
+        // The same signal that says this connection is real says the replay
+        // landed: a bridge that was going to reject it would have closed by now.
+        this.confirmReplay();
       }
     }, stableMs);
     this.reconnectResetTimer.unref?.();
@@ -639,7 +688,7 @@ export class Client {
       return;
     }
 
-    this.pendingFrames.push({ taskId: frame.taskId, encoded, bytes });
+    this.pendingFrames.push({ taskId: frame.taskId, encoded, bytes, at: Date.now() });
     this.pendingBytes += bytes;
     // Drop the OLDEST first, so what survives is the tail nearest the terminal
     // — but record each victim's task, because a partial replay of a text
@@ -657,6 +706,15 @@ export class Client {
 
   private markTruncated(taskId: string, why: string): void {
     if (this.truncatedTasks.has(taskId)) return;
+    if (this.truncatedTasks.size >= MAX_TRUNCATED_TASKS) {
+      // Degrade to the pre-buffer behavior for further tasks rather than let
+      // the bookkeeping outgrow the buffer it describes: the server's own grace
+      // expiry still fails them, just without our explicit reason.
+      this.logger.warn(
+        `truncated-task list full (${MAX_TRUNCATED_TASKS}); task ${safeToken(taskId)} will be left to the bridge's grace expiry`,
+      );
+      return;
+    }
     this.truncatedTasks.add(taskId);
     this.logger.warn(
       `${why}; task ${safeToken(taskId)} will be failed instead of replayed`,
@@ -671,18 +729,39 @@ export class Client {
   // that arrive while its (async) authentication is still settling and
   // processes them once it completes, so no ack round-trip is needed.
   private flushPendingFrames(ws: WebSocket): void {
-    const queued = this.pendingFrames;
+    if (this.pendingFrames.length === 0 && this.truncatedTasks.size === 0) return;
+    if (ws.readyState !== WebSocket.OPEN) return;
+    if (!this.replaySupported) {
+      this.dropPendingFrames();
+      return;
+    }
+
+    // Anything the server would no longer honour is not merely useless to send,
+    // it is dangerous: the binding is gone and a new run may already hold that
+    // taskId. Fail those tasks instead of injecting a dead run's output.
+    const maxAge = this.opts.maxPendingAgeMs ?? DEFAULT_MAX_PENDING_AGE_MS;
+    const cutoff = Date.now() - maxAge;
+    const fresh: typeof this.pendingFrames = [];
+    for (const entry of this.pendingFrames) {
+      if (entry.at < cutoff) {
+        this.markTruncated(entry.taskId, `buffered output is older than ${maxAge}ms`);
+        continue;
+      }
+      fresh.push(entry);
+    }
+
     const truncated = this.truncatedTasks;
     this.pendingFrames = [];
     this.pendingBytes = 0;
     this.truncatedTasks = new Set();
-    if (queued.length === 0 && truncated.size === 0) return;
-    if (ws.readyState !== WebSocket.OPEN) return;
 
     let replayed = 0;
-    for (const entry of queued) {
+    for (const entry of fresh) {
       if (truncated.has(entry.taskId)) continue;
       ws.send(entry.encoded);
+      // Retained, not discarded: if this connection turns out to be unusable
+      // the frames go back on the queue instead of vanishing.
+      this.replayInFlight.push(entry);
       replayed++;
     }
     for (const taskId of truncated) {
@@ -702,6 +781,29 @@ export class Client {
       `replayed ${replayed} buffered frame(s) after reconnect` +
         (truncated.size > 0 ? `; failed ${truncated.size} truncated task(s)` : ''),
     );
+  }
+
+  // The replay reached a connection that stayed up — let it go.
+  private confirmReplay(): void {
+    if (this.replayInFlight.length === 0) return;
+    this.replayInFlight = [];
+  }
+
+  // The connection died before proving itself. Put the replay back at the FRONT
+  // of the queue so ordering against anything produced since is preserved.
+  private requeueReplay(): void {
+    if (this.replayInFlight.length === 0) return;
+    const back = this.replayInFlight;
+    this.replayInFlight = [];
+    this.pendingFrames = [...back, ...this.pendingFrames];
+    this.pendingBytes += back.reduce((n, e) => n + e.bytes, 0);
+  }
+
+  private dropPendingFrames(): void {
+    this.pendingFrames = [];
+    this.replayInFlight = [];
+    this.pendingBytes = 0;
+    this.truncatedTasks.clear();
   }
 
   // Answer a server-initiated usage.request by querying the backend's optional

--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -38,6 +38,22 @@ primary_region = "nrt"
   # healthily-heartbeating long task is never reaped. "0" disables it. Must sit
   # above the longest legitimate silent gap for non-heartbeating backends.
   BRIDGE_TASK_INACTIVITY_TIMEOUT_MS = "600000"
+  # Reconnect grace hold (ms) for an in-flight task whose client's WebSocket
+  # drops (issue #474). Rather than failing the task the instant the socket
+  # goes, the bridge keeps its binding alive for this long so the client — which
+  # reconnects in ~3s and is usually still working — can land its result on it.
+  # ANY frame for that task on the new connection (a heartbeat is enough)
+  # resumes the binding, so this is "how long to wait before declaring a client
+  # dead", NOT a cap on task duration. An unresumed hold then fails exactly as
+  # an ungraced drop always did, just this much later.
+  #
+  # Sized off the 2026-08-20 fly-proxy incident, where the recovered clients'
+  # terminal frames arrived +9s/+10s/+15s after the drop — so it has to cover
+  # task completion, not the 3.2s reconnect.
+  #
+  # "0" disables it and restores the previous fail-immediately behavior exactly:
+  # this is the rollback lever if holds ever delay failover more than they save.
+  BRIDGE_DISCONNECT_GRACE_MS = "30000"
 
 [http_service]
   internal_port = 8787

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -1266,6 +1266,17 @@ test('resolveDisconnectGraceMs covers default, env, clamp and rejection', () => 
     ms: FALLBACK_DISCONNECT_GRACE_MS,
     source: 'default',
   });
+  // `Number(' ')` is 0, so without a trim a whitespace-only value would read as
+  // a deliberate kill switch and silently disable recovery.
+  for (const blank of [' ', '\t', '  \n ']) {
+    assert.deepEqual(
+      resolveDisconnectGraceMs(blank),
+      { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' },
+      `blank value ${JSON.stringify(blank)} must not disable the grace`,
+    );
+  }
+  // A surrounding-whitespace value is still the number the operator meant.
+  assert.deepEqual(resolveDisconnectGraceMs(' 45000 '), { ms: 45_000, source: 'env' });
   assert.deepEqual(resolveDisconnectGraceMs('45000'), { ms: 45_000, source: 'env' });
   // 0 is the documented kill switch and must survive as a real 0, not be
   // mistaken for "unset".

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -4,11 +4,19 @@ import type { WebSocket } from 'ws';
 import { OPENAI_COMPAT_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
 import { Registry } from './registry.js';
 
-// Minimal WebSocket stub — Registry only uses `.close()` on replacement and
-// equality (`existing.ws !== ws`) on unregister. Nothing else on the real ws
-// interface is exercised here.
-function makeWs(): WebSocket {
-  return { close: () => undefined } as unknown as WebSocket;
+// Mirrors the `ws` library's ReadyState constants; the stubs below are typed as
+// WebSocket, so these have to agree with the real values.
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+// Minimal WebSocket stub — Registry uses `.close()` on replacement, equality
+// (`existing.ws !== ws`) on unregister, and `readyState` to tell a live
+// duplicate-token collision from a client that is merely reconnecting after its
+// socket already died (issue #474). Defaults to OPEN, which is what every
+// pre-#474 test implicitly assumed. Nothing else on the real ws interface is
+// exercised here.
+function makeWs(readyState: number = WS_OPEN): WebSocket {
+  return { close: () => undefined, readyState, OPEN: WS_OPEN } as unknown as WebSocket;
 }
 
 interface RecordingWs extends WebSocket {
@@ -19,6 +27,8 @@ function makeRecordingWs(): RecordingWs {
   const closeArgs: Array<{ code: number; reason: string }> = [];
   const ws = {
     closeArgs,
+    readyState: WS_OPEN,
+    OPEN: WS_OPEN,
     close(code: number, reason: string) {
       closeArgs.push({ code, reason });
     },
@@ -126,6 +136,11 @@ test('onAgentChange fires on disconnect (unregister) so stale transports do not 
   assert.deepEqual(seen, ['a1']);
 });
 
+// 4009 (duplicate CLIENT_TOKEN) stands in for any app-level close: the bridge
+// only sends 4xxx when it has decided the connection must not continue, so
+// those skip the reconnect grace hold and fail in-flight tasks immediately
+// (issue #474). The terminal shape asserted here is the one a graced task also
+// ends up with once its hold expires — see the grace tests below.
 test('unregisterAgent reports mid-task disconnect with structured error metadata', () => {
   const registry = new Registry();
   const ws = makeWs();
@@ -155,7 +170,7 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
     },
   });
 
-  registry.unregisterAgent('a1', ws);
+  registry.unregisterAgent('a1', ws, 4009);
 
   assert.equal(finished, true);
   assert.equal(registry.getBinding('t-disc'), undefined);
@@ -199,8 +214,11 @@ test('unregisterAgent omits terminal error metadata when openai-compat extension
     },
   });
 
-  registry.unregisterAgent('a1', ws);
+  registry.unregisterAgent('a1', ws, 4009);
 
+  // Assert a terminal was actually pushed before asserting what it omits —
+  // without this the two checks below pass vacuously on an empty array.
+  assert.equal(statuses.length, 1);
   assert.equal(statuses[0]?.status.message?.metadata, undefined);
   assert.equal(statuses[0]?.status.message?.extensions, undefined);
 });
@@ -607,4 +625,235 @@ test('bindTask displacing a live binding emits a superseded terminal on the old 
   assert.equal(terminal?.final, true);
   assert.equal(terminal?.status?.state, 'failed');
   assert.match(terminal?.status?.message?.parts?.[0]?.text ?? '', /superseded/);
+});
+interface CapturedTask {
+  statuses: unknown[];
+  state: { finished: boolean };
+}
+
+// Terminal-status reader, matching recordingBinding's `unknown[]` idiom above:
+// the sink receives full TaskStatusUpdateEvents, and these tests only care
+// about the human-readable reason on the first one.
+function terminalText(task: CapturedTask): string {
+  const first = task.statuses[0] as
+    | { status?: { message?: { parts?: Array<{ text?: string }> } } }
+    | undefined;
+  return first?.status?.message?.parts?.[0]?.text ?? '';
+}
+
+function bindCapturing(registry: Registry, agentId: string, taskId: string): CapturedTask {
+  const statuses: unknown[] = [];
+  const state = { finished: false };
+  registry.bindTask({
+    agentId,
+    taskId,
+    contextId: `ctx-${taskId}`,
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        state.finished = true;
+      },
+    },
+  });
+  return { statuses, state };
+}
+
+function registerFor(registry: Registry, ws: WebSocket, agentId = 'a1', clientId = 'c1'): void {
+  registry.registerAgent({
+    agentId,
+    clientId,
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+test('grace hold keeps the binding alive across a recoverable disconnect instead of failing it', () => {
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-grace');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.ok(registry.getBinding('t-grace'), 'binding must survive the disconnect');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, [], 'no terminal may be emitted during the hold');
+  assert.equal(registry.getAgent('a1'), undefined);
+});
+
+test('a frame from the reconnected client resumes a held binding and cancels its expiry', async () => {
+  const registry = new Registry(25);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-resume');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-resume', 'a1');
+
+  await sleep(80);
+
+  assert.ok(registry.getBinding('t-resume'), 'resumed binding must not be reaped');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, []);
+});
+
+test('grace hold expires into the identical disconnected terminal it always produced', async () => {
+  const registry = new Registry(15);
+  const ws = makeWs();
+  registerFor(registry, ws);
+
+  const statuses: Array<{ status: { message?: { metadata?: unknown } } }> = [];
+  let finished = false;
+  registry.bindTask({
+    agentId: 'a1',
+    taskId: 't-expire',
+    contextId: 'ctx-expire',
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        finished = true;
+      },
+    },
+  });
+
+  registry.unregisterAgent('a1', ws, 1012);
+  await sleep(80);
+
+  assert.equal(finished, true);
+  assert.equal(registry.getBinding('t-expire'), undefined);
+  assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      terminal_error: {
+        code: 'disconnected',
+        message: 'client disconnected mid-task',
+      },
+    },
+    error: {
+      code: 'disconnected',
+      message: 'client disconnected mid-task',
+    },
+  });
+});
+
+test('a task completing during the hold is not failed by the expiry timer afterwards', async () => {
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-late-complete');
+  const binding = registry.getBinding('t-late-complete');
+  assert.ok(binding);
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-late-complete', 'a1');
+  registry.unbindTask('t-late-complete', binding);
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, false, 'a completed task must not be failed later');
+  assert.deepEqual(task.statuses, []);
+});
+
+test('app-level close codes skip the hold entirely and fail in-flight tasks at once', () => {
+  for (const code of [4014, 4009, 1000]) {
+    const registry = new Registry(10_000);
+    const ws = makeWs();
+    registerFor(registry, ws);
+    const task = bindCapturing(registry, 'a1', `t-terminal-${code}`);
+
+    registry.unregisterAgent('a1', ws, code);
+
+    assert.equal(
+      registry.getBinding(`t-terminal-${code}`),
+      undefined,
+      `close code ${code} must not be graced`,
+    );
+    assert.equal(task.state.finished, true);
+    assert.match(terminalText(task), /disconnected mid-task/);
+  }
+});
+
+test('a grace of 0 restores the pre-#474 fail-immediately behavior', () => {
+  const registry = new Registry(0);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-nograce');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.equal(registry.getBinding('t-nograce'), undefined);
+  assert.equal(task.state.finished, true);
+});
+
+test('reconnect arriving BEFORE the old socket close holds the task instead of superseding it', () => {
+  const registry = new Registry(10_000);
+  const deadWs = makeWs(WS_CLOSED);
+  registerFor(registry, deadWs);
+  const task = bindCapturing(registry, 'a1', 't-race');
+
+  registerFor(registry, makeWs());
+
+  assert.ok(registry.getBinding('t-race'), 'a reconnect must not supersede its own in-flight task');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, []);
+
+  registry.resumeBinding('t-race', 'a1');
+  assert.ok(registry.getBinding('t-race'));
+});
+
+test('a genuine duplicate-token collision (old socket still OPEN) still supersedes immediately', () => {
+  const registry = new Registry(10_000);
+  registerFor(registry, makeWs(WS_OPEN));
+  const task = bindCapturing(registry, 'a1', 't-collision');
+
+  registerFor(registry, makeWs());
+
+  assert.equal(registry.getBinding('t-collision'), undefined);
+  assert.equal(task.state.finished, true);
+  assert.match(terminalText(task), /superseded/);
+});
+
+test('the late close of an already-replaced socket does not re-hold or double-fail', () => {
+  const registry = new Registry(10_000);
+  const deadWs = makeWs(WS_CLOSED);
+  registerFor(registry, deadWs);
+  const task = bindCapturing(registry, 'a1', 't-late-close');
+
+  registerFor(registry, makeWs()); // holds t-late-close
+  registry.resumeBinding('t-late-close', 'a1'); // client's first frame resumes it
+
+  registry.unregisterAgent('a1', deadWs, 1006);
+
+  assert.ok(registry.getBinding('t-late-close'));
+  assert.equal(task.state.finished, false);
+});
+
+test("resumeBinding cannot be used by one agent to rescue another agent's held task", () => {
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  bindCapturing(registry, 'a1', 't-owned');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-owned', 'other-agent');
+
+  assert.ok(registry.getBinding('t-owned'));
+});
+test('with the grace disabled, the reconnect race keeps its original superseded terminal', () => {
+  const registry = new Registry(0);
+  registerFor(registry, makeWs(WS_CLOSED));
+  const task = bindCapturing(registry, 'a1', 't-nograce-race');
+
+  registerFor(registry, makeWs());
+
+  assert.equal(registry.getBinding('t-nograce-race'), undefined);
+  assert.equal(task.state.finished, true);
+  assert.match(terminalText(task), /superseded/);
 });

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -2,7 +2,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
 import { OPENAI_COMPAT_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
-import { Registry, type TaskBinding } from './registry.js';
+import {
+  FALLBACK_DISCONNECT_GRACE_MS,
+  MAX_DISCONNECT_GRACE_MS,
+  Registry,
+  resolveDisconnectGraceMs,
+  type TaskBinding,
+} from './registry.js';
 
 // Mirrors the `ws` library's ReadyState constants; the stubs below are typed as
 // WebSocket, so these have to agree with the real values.
@@ -434,13 +440,19 @@ test('registerAgent emits client_collision and closes the prior ws with the desc
   assert.equal(parsed.previousConnectedAt, 1000);
 });
 
-test('same-token reconnect fails the displaced connection in-flight bindings (issue #365)', () => {
+test('same-token reconnect eventually fails the displaced connection in-flight bindings (issue #365)', () => {
   // A second daemon authenticating with the same CLIENT_TOKEN replaces the
   // incumbent. The old connection's in-flight task must receive a terminal
   // `failed` status and have its sink finished + binding dropped — otherwise
-  // the task's HTTP stream hangs forever (the new daemon is a separate process
-  // that never knew the old taskId, so it can't complete it either).
-  const registry = new Registry();
+  // the task's HTTP stream hangs forever (if the new daemon is a separate
+  // process that never knew the old taskId, it can't complete it either).
+  //
+  // Since #474 that outcome is delayed by the reconnect grace, which exists
+  // because the new daemon is USUALLY the same client coming back and can
+  // finish the task. Grace 0 keeps this test on its original subject — that a
+  // displaced binding is never orphaned, and that this path's terminal is
+  // `superseded` — while the graced variants are covered separately below.
+  const registry = new Registry(0);
   const oldWs = makeWs();
   const base = {
     agentId: 'a1',
@@ -819,20 +831,97 @@ test('reconnect arriving BEFORE the old socket close holds the task instead of s
   assert.equal(task.state.finished, false);
   assert.deepEqual(task.statuses, []);
 
-  registry.resumeBinding('t-race', 'a1');
-  assert.ok(registry.getBinding('t-race'));
 });
 
-test('a genuine duplicate-token collision (old socket still OPEN) still supersedes immediately', () => {
-  const registry = new Registry(10_000);
+test('a hold armed by the reconnect branch really is a hold: it resumes and it expires', async () => {
+  // Presence of the binding right after the reconnect proves nothing — a
+  // binding simply left alone, with no timer at all, looks identical at that
+  // instant and would then hang until the executor's 10-minute backstop. Drive
+  // both ends of the lifecycle instead.
+  const armed = new Registry(20);
+  registerFor(armed, makeWs(WS_CLOSED));
+  const abandoned = bindCapturing(armed, 'a1', 't-race-expire');
+  registerFor(armed, makeWs());
+  await sleep(80);
+  assert.equal(abandoned.state.finished, true, 'the reconnect branch armed no expiry');
+  assert.equal(armed.getBinding('t-race-expire'), undefined);
+
+  const resumed = new Registry(20);
+  registerFor(resumed, makeWs(WS_CLOSED));
+  const reclaimed = bindCapturing(resumed, 'a1', 't-race-resume');
+  registerFor(resumed, makeWs());
+  resumed.resumeBinding('t-race-resume', 'a1');
+  await sleep(80);
+  assert.equal(reclaimed.state.finished, false, 'a resumed hold must not expire');
+  assert.ok(resumed.getBinding('t-race-resume'));
+});
+
+test('a same-token reconnect is held whether or not the old socket looks live', async () => {
+  // `readyState === OPEN` is NOT a liveness test — it only means the server has
+  // not observed a close. The server runs no keepalive, and the client pings
+  // every 30s and terminates on a missed pong, so on a dead path the client
+  // notices first and its next hello arrives here with the old socket still
+  // nominally OPEN. Killing on "looks live" would kill the common recovered
+  // drop — the exact bug #474 exists to fix, relabeled `superseded`.
+  //
+  // So both socket states take the hold, and an unresumed hold expires into the
+  // `superseded` terminal this path has always produced.
+  for (const [label, state] of [
+    ['live-looking', WS_OPEN],
+    ['dead', WS_CLOSED],
+  ] as const) {
+    const registry = new Registry(20);
+    registerFor(registry, makeWs(state));
+    const task = bindCapturing(registry, 'a1', `t-collision-${label}`);
+
+    registerFor(registry, makeWs());
+
+    assert.ok(registry.getBinding(`t-collision-${label}`), `${label}: must be held, not killed`);
+    assert.equal(task.state.finished, false, `${label}: no premature terminal`);
+
+    await sleep(80);
+
+    assert.equal(task.state.finished, true, `${label}: an unresumed hold must expire`);
+    assert.equal(registry.getBinding(`t-collision-${label}`), undefined);
+    assert.match(terminalText(task), /superseded/, `${label}: expiry keeps this path's terminal`);
+  }
+});
+
+test('a reconnect reclaiming its task survives, even when the old socket still looked live', async () => {
+  // The payoff of the above: the client that reconnected is normally the SAME
+  // client, and one frame on the new connection rescues its in-flight work.
+  const registry = new Registry(20);
   registerFor(registry, makeWs(WS_OPEN));
-  const task = bindCapturing(registry, 'a1', 't-collision');
+  const task = bindCapturing(registry, 'a1', 't-collision-reclaim');
 
   registerFor(registry, makeWs());
+  registry.resumeBinding('t-collision-reclaim', 'a1');
 
-  assert.equal(registry.getBinding('t-collision'), undefined);
+  await sleep(80);
+
+  assert.equal(task.state.finished, false, 'a reclaimed task must not be failed');
+  assert.ok(registry.getBinding('t-collision-reclaim'));
+});
+
+test('a connection this server condemned is never rescued by a reconnect', () => {
+  // disconnectClient() closes with 4014 because the owner deleted the client.
+  // A hello arriving on that token before the close event lands must not
+  // resurrect its tasks through the reconnect branch.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-condemned');
+
+  assert.equal(registry.disconnectClient('c1'), 1);
+  registerFor(registry, makeWs(), 'a1', 'c1'); // the racing reconnect
+
+  assert.equal(
+    registry.getBinding('t-condemned'),
+    undefined,
+    'a deleted client must not be graced',
+  );
   assert.equal(task.state.finished, true);
-  assert.match(terminalText(task), /superseded/);
+  assert.match(terminalText(task), /disconnected mid-task/);
 });
 
 test('the late close of an already-replaced socket does not re-hold or double-fail', () => {
@@ -1077,4 +1166,151 @@ test('unregisterAgent with no close code holds (the #364 reconcile path)', () =>
 
   assert.ok(registry.getBinding('t-nocode'));
   assert.equal(task.state.finished, false);
+});
+
+// ---------------------------------------------------------------------------
+// Blast radius: a hold or a failure must touch ONE agent's tasks.
+//
+// The agent filters in failBindingsForAgent/holdBindingsForAgent were entirely
+// unconstrained — deleting either left the suite green, because no test had two
+// agents holding bindings at the same time. Without them a single client's
+// disconnect fails (or, 30s later, kills) every other client's in-flight work.
+// ---------------------------------------------------------------------------
+
+test('one agent disconnecting does not fail another agent\'s in-flight task', () => {
+  const registry = new Registry(0); // grace off: the immediate-fail path
+  const wsA = makeWs();
+  const wsB = makeWs();
+  registerFor(registry, wsA, 'a1', 'c1');
+  registerFor(registry, wsB, 'a2', 'c2');
+  const mine = bindCapturing(registry, 'a1', 't-mine');
+  const theirs = bindCapturing(registry, 'a2', 't-theirs');
+
+  registry.unregisterAgent('a1', wsA, 1012);
+
+  assert.equal(mine.state.finished, true);
+  assert.equal(theirs.state.finished, false, "another agent's task was failed");
+  assert.ok(registry.getBinding('t-theirs'));
+  assert.deepEqual(theirs.statuses, []);
+});
+
+test('one agent disconnecting does not hold — or later kill — another agent\'s task', async () => {
+  const registry = new Registry(20); // grace on: the hold path
+  const wsA = makeWs();
+  const wsB = makeWs();
+  registerFor(registry, wsA, 'a1', 'c1');
+  registerFor(registry, wsB, 'a2', 'c2');
+  bindCapturing(registry, 'a1', 't-a-task');
+  const theirs = bindCapturing(registry, 'a2', 't-b-task');
+
+  registry.unregisterAgent('a1', wsA, 1012);
+
+  // Past the deadline: a1's task expires, a2's — never held — must be untouched.
+  await sleep(80);
+
+  assert.equal(registry.getBinding('t-a-task'), undefined, "the disconnecting agent's task expired");
+  assert.equal(theirs.state.finished, false, "another agent's task was swept up in the hold");
+  assert.ok(registry.getBinding('t-b-task'));
+  assert.ok(registry.getAgent('a2'), 'the other agent is still connected');
+});
+
+// ---------------------------------------------------------------------------
+// The expiry timer's own cleanup is a FOURTH clear site.
+//
+// The guard-coverage note above lists three explicit clearGraceHold calls, but
+// the timer deletes its own map entry too. Leave that out and a naturally
+// expired hold's entry outlives it, and the `has()` skip then denies the next
+// binding for that taskId a hold of its own — the same successor failure the
+// three explicit sites are tested through.
+// ---------------------------------------------------------------------------
+
+test('a naturally expired hold clears its own entry, so the taskId can be held again', async () => {
+  const registry = new Registry(20);
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  const first = bindCapturing(registry, 'a1', 't-reexpire');
+
+  registry.unregisterAgent('a1', ws1, 1012);
+  await sleep(80);
+  assert.equal(first.state.finished, true, 'precondition: the first hold expired');
+  assert.equal(registry.getBinding('t-reexpire'), undefined);
+
+  // The same taskId comes round again (A2A reuses a taskId across turns) and
+  // its client drops too.
+  const successor = bindCapturing(registry, 'a1', 't-reexpire');
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  await sleep(80);
+
+  assert.equal(successor.state.finished, true, 'a stale entry denied the successor its hold');
+  assert.equal(registry.getBinding('t-reexpire'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// The production configuration path.
+//
+// `index.ts` constructs `new Registry()` with no argument, so the default, the
+// env parse and the clamp are exactly the code no other test reaches — every
+// grace test injects its value through the constructor. A typo'd default or a
+// broken parse would ship with a green suite.
+// ---------------------------------------------------------------------------
+
+test('resolveDisconnectGraceMs covers default, env, clamp and rejection', () => {
+  assert.deepEqual(resolveDisconnectGraceMs(undefined), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'default',
+  });
+  assert.deepEqual(resolveDisconnectGraceMs(''), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'default',
+  });
+  assert.deepEqual(resolveDisconnectGraceMs('45000'), { ms: 45_000, source: 'env' });
+  // 0 is the documented kill switch and must survive as a real 0, not be
+  // mistaken for "unset".
+  assert.deepEqual(resolveDisconnectGraceMs('0'), { ms: 0, source: 'env' });
+  assert.deepEqual(resolveDisconnectGraceMs(String(MAX_DISCONNECT_GRACE_MS)), {
+    ms: MAX_DISCONNECT_GRACE_MS,
+    source: 'env',
+  });
+  // Past setTimeout's ceiling the timer would collapse to 1ms — i.e. asking for
+  // a very long hold would silently give none at all.
+  assert.deepEqual(resolveDisconnectGraceMs(String(MAX_DISCONNECT_GRACE_MS + 1)), {
+    ms: MAX_DISCONNECT_GRACE_MS,
+    source: 'clamped',
+  });
+  // `-1` is a common "disable" idiom; silently restoring the 30s default would
+  // be the opposite of the operator's intent, so it is reported as invalid.
+  assert.deepEqual(resolveDisconnectGraceMs('-1'), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'invalid',
+  });
+  assert.deepEqual(resolveDisconnectGraceMs('30s'), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'invalid',
+  });
+});
+
+test('a default-constructed Registry actually grants a grace hold', async () => {
+  // The shape production runs (`new Registry()`, index.ts). Guards the default
+  // constant itself: at 0 the feature is off and this binding would be failed
+  // on the spot.
+  const registry = new Registry();
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-default');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.ok(registry.getBinding('t-default'), 'the default grace is disabled');
+  assert.equal(task.state.finished, false);
+
+  // Long enough to prove it is not a near-zero timer, short enough to stay a
+  // unit test. The real deadline is minutes away in wall-clock terms.
+  await sleep(60);
+  assert.ok(registry.getBinding('t-default'), 'the default grace is far too short');
+
+  // Don't leave a live 30s hold behind for the runner to trip over.
+  registry.unbindTask('t-default', registry.getBinding('t-default')!);
 });

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -2,21 +2,34 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
 import { OPENAI_COMPAT_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
-import { Registry } from './registry.js';
+import { Registry, type TaskBinding } from './registry.js';
 
 // Mirrors the `ws` library's ReadyState constants; the stubs below are typed as
 // WebSocket, so these have to agree with the real values.
 const WS_OPEN = 1;
+const WS_CLOSING = 2;
 const WS_CLOSED = 3;
 
 // Minimal WebSocket stub — Registry uses `.close()` on replacement, equality
 // (`existing.ws !== ws`) on unregister, and `readyState` to tell a live
 // duplicate-token collision from a client that is merely reconnecting after its
 // socket already died (issue #474). Defaults to OPEN, which is what every
-// pre-#474 test implicitly assumed. Nothing else on the real ws interface is
-// exercised here.
+// pre-#474 test implicitly assumed.
+//
+// `close()` MUST move readyState to CLOSING, because the real `ws` library does
+// so synchronously inside close() — and a stub that froze readyState instead
+// would let `registry.ts` read it *after* closing the socket and still appear
+// to work, certifying a branch that real sockets can never take. That is not
+// hypothetical: it is exactly the bug this stub previously hid.
 function makeWs(readyState: number = WS_OPEN): WebSocket {
-  return { close: () => undefined, readyState, OPEN: WS_OPEN } as unknown as WebSocket;
+  const ws = {
+    readyState,
+    OPEN: WS_OPEN,
+    close: () => {
+      ws.readyState = WS_CLOSING;
+    },
+  };
+  return ws as unknown as WebSocket;
 }
 
 interface RecordingWs extends WebSocket {
@@ -31,8 +44,10 @@ function makeRecordingWs(): RecordingWs {
     OPEN: WS_OPEN,
     close(code: number, reason: string) {
       closeArgs.push({ code, reason });
+      // Same fidelity requirement as makeWs().
+      ws.readyState = WS_CLOSING;
     },
-  } as unknown as RecordingWs;
+  } as unknown as RecordingWs & { readyState: number };
   return ws;
 }
 
@@ -856,4 +871,210 @@ test('with the grace disabled, the reconnect race keeps its original superseded 
   assert.equal(registry.getBinding('t-nograce-race'), undefined);
   assert.equal(task.state.finished, true);
   assert.match(terminalText(task), /superseded/);
+});
+
+// ---------------------------------------------------------------------------
+// Guard coverage.
+//
+// The three `clearGraceHold` call sites and the "don't slide the deadline" skip
+// are individually invisible to a test that only checks the binding right after
+// the event: the timer's own identity guard independently suppresses a stale
+// fire, so deleting either half of that pair changes nothing observable at that
+// moment. What DOES expose a missing clear is the *next* hold for the same
+// taskId — `holdBindingsForAgent` skips a taskId that already has an entry, so
+// a hold left behind by a finished binding silently denies its successor a
+// hold, and that successor then never expires. Each test below drives exactly
+// that sequence through one of the clear sites.
+//
+// Not covered, deliberately: the identity guards inside `resumeBinding` and the
+// expiry timer. With every clear site intact, `graceHolds` can only ever hold
+// an entry for the binding currently occupying that taskId, so those guards are
+// unreachable defense-in-depth against a future missing clear — no behavioral
+// test can distinguish them. They are kept precisely because the tests here
+// cannot speak for them.
+// ---------------------------------------------------------------------------
+
+// Re-hold a taskId after its previous binding is gone, and prove the new
+// binding still gets a working hold of its own (i.e. that the old one's entry
+// was cleared). `settle` performs whatever terminated the previous binding.
+async function assertSuccessorIsHeld(
+  registry: Registry,
+  settle: (binding: TaskBinding) => void,
+  taskId: string,
+): Promise<void> {
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  bindCapturing(registry, 'a1', taskId);
+  const first = registry.getBinding(taskId);
+  assert.ok(first);
+
+  registry.unregisterAgent('a1', ws1, 1012); // first binding is now held
+  settle(first);
+
+  // A new run claims the same taskId, then its client drops too.
+  const successor = bindCapturing(registry, 'a1', taskId);
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  await sleep(80);
+
+  // The successor must have been held and then expired. A stale entry from the
+  // first binding would have made `holdBindingsForAgent` skip it, leaving it
+  // bound and unfinished forever.
+  assert.equal(successor.state.finished, true, 'successor was never held, so it never expired');
+  assert.equal(registry.getBinding(taskId), undefined);
+  assert.match(terminalText(successor), /disconnected mid-task/);
+}
+
+test('unbindTask clears the hold, so the next binding for that taskId can be held', async () => {
+  const registry = new Registry(20);
+  await assertSuccessorIsHeld(
+    registry,
+    (binding) => registry.unbindTask(binding.taskId, binding),
+    't-clear-unbind',
+  );
+});
+
+test('a displacing bindTask clears the hold, so the displacing binding can be held', async () => {
+  const registry = new Registry(20);
+  // bindCapturing inside the helper is what displaces the held binding here.
+  await assertSuccessorIsHeld(registry, () => undefined, 't-clear-rebind');
+});
+
+test('failBindingsForAgent clears the hold, so the next binding for that taskId can be held', async () => {
+  const registry = new Registry(20);
+  await assertSuccessorIsHeld(
+    registry,
+    () => {
+      // Reconnect and take an app-level close: fails the held binding outright.
+      const ws = makeWs();
+      registerFor(registry, ws);
+      registry.unregisterAgent('a1', ws, 4009);
+    },
+    't-clear-fail',
+  );
+});
+
+test('a second disconnect leaves no extra expiry timer behind', async () => {
+  // `holdBindingsForAgent` skips a taskId that already has a hold rather than
+  // arming a second timer for it. Overwriting instead would look harmless — the
+  // newer timer replaces the map entry — but the ORIGINAL timer stays pending
+  // and unreferenced, and `resumeBinding` can only cancel the one it can see.
+  // The orphan then fires on the old deadline and fails a task that was already
+  // resumed and is happily running.
+  const registry = new Registry(60);
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  const task = bindCapturing(registry, 'a1', 't-one-timer');
+
+  registry.unregisterAgent('a1', ws1, 1012);
+
+  // A second drop, comfortably inside the first hold's window.
+  await sleep(20);
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  // The client comes back for good and resumes the task.
+  registry.resumeBinding('t-one-timer', 'a1');
+
+  // Past the first hold's deadline. Nothing may fire.
+  await sleep(100);
+
+  assert.equal(task.state.finished, false, 'an orphaned expiry timer failed a resumed task');
+  assert.ok(registry.getBinding('t-one-timer'));
+});
+
+test('a foreign agent resuming a hold does not stop it from expiring', async () => {
+  // The agentId check in resumeBinding is the whole of its authorization. Held
+  // bindings stay in the map either way, so asserting presence proves nothing —
+  // only expiry does.
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-foreign');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-foreign', 'other-agent');
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, true, 'a foreign agent cancelled the hold');
+  assert.equal(registry.getBinding('t-foreign'), undefined);
+});
+
+test('the owning agent resuming a hold does stop it from expiring', async () => {
+  // Companion to the above: same shape, correct agentId, opposite outcome — so
+  // the pair pins the check rather than just the expiry.
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-owner');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-owner', 'a1');
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, false);
+  assert.ok(registry.getBinding('t-owner'));
+});
+
+test('a close code the bridge itself sent is terminal even when it comes back as 1006', () => {
+  // `disconnectClient` closes with 4014, but the code we OBSERVE is whatever
+  // our socket ends up with: a peer that never echoes the close frame leaves
+  // `ws` to time out and report 1006, which is graceable. The deleted client's
+  // tasks must still die immediately.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-deleted');
+
+  assert.equal(registry.disconnectClient('c1'), 1);
+  registry.unregisterAgent('a1', ws, 1006); // peer never acked; ws reports 1006
+
+  assert.equal(registry.getBinding('t-deleted'), undefined, 'a deleted client must not be graced');
+  assert.equal(task.state.finished, true);
+});
+
+test('close-code classification at the app-level boundaries', () => {
+  // 4000-4999 is the bridge's own range; 5000 and up is not ours and is treated
+  // like any other unexpected close.
+  const cases: Array<[number, boolean]> = [
+    [4000, false],
+    [4999, false],
+    [5000, true],
+    [3999, true],
+    [1001, true],
+    [1005, true],
+  ];
+  for (const [code, expectHold] of cases) {
+    const registry = new Registry(10_000);
+    const ws = makeWs();
+    registerFor(registry, ws);
+    bindCapturing(registry, 'a1', `t-code-${code}`);
+    registry.unregisterAgent('a1', ws, code);
+    assert.equal(
+      registry.getBinding(`t-code-${code}`) !== undefined,
+      expectHold,
+      `close code ${code} should ${expectHold ? 'hold' : 'fail immediately'}`,
+    );
+  }
+});
+
+test('unregisterAgent with no close code holds (the #364 reconcile path)', () => {
+  // ws.ts reconciles a socket that died during async auth by calling
+  // unregisterAgent with no code. Absence of a code is not evidence the client
+  // is gone for good, so it is graceable — and in that path there are no
+  // bindings anyway, since registration never completed.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-nocode');
+
+  registry.unregisterAgent('a1', ws);
+
+  assert.ok(registry.getBinding('t-nocode'));
+  assert.equal(task.state.finished, false);
 });

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -98,15 +98,51 @@ export type AgentChangeListener = (agentId: string) => void;
 // inactivity backstop is what governs.
 //
 // `0` disables the hold and restores the previous fail-immediately behavior.
+export const FALLBACK_DISCONNECT_GRACE_MS = 30_000;
+// Node's setTimeout silently clamps anything past the signed-32-bit ceiling to
+// 1ms, so an operator who typed a very large number to mean "hold a long time"
+// would get the opposite — holds that expire immediately. Cap instead, so the
+// value can only ever mean what it says.
+export const MAX_DISCONNECT_GRACE_MS = 2_147_483_647;
+
+/**
+ * Parse `BRIDGE_DISCONNECT_GRACE_MS`. Exported so the production configuration
+ * path — the one `new Registry()` actually takes — is reachable from tests;
+ * every grace test injects its value through the constructor, so without this
+ * a typo'd default or broken parse would ship green.
+ *
+ * Returns the effective grace plus why, so the caller can say so out loud
+ * rather than silently coercing. A negative value is rejected rather than
+ * treated as "off": `0` is the documented disable switch, and `-1` is a common
+ * enough idiom for it that silently re-enabling a 30s hold would be the exact
+ * opposite of what the operator asked for.
+ */
+export function resolveDisconnectGraceMs(raw: string | undefined): {
+  ms: number;
+  source: 'default' | 'env' | 'clamped' | 'invalid';
+} {
+  if (raw === undefined || raw === '') return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' };
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) {
+    return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'invalid' };
+  }
+  if (n > MAX_DISCONNECT_GRACE_MS) return { ms: MAX_DISCONNECT_GRACE_MS, source: 'clamped' };
+  return { ms: n, source: 'env' };
+}
+
 const DEFAULT_DISCONNECT_GRACE_MS = (() => {
-  const raw = process.env.BRIDGE_DISCONNECT_GRACE_MS;
-  const n = raw ? Number(raw) : Number.NaN;
-  if (!Number.isFinite(n) || n < 0) return 30_000;
-  // Node's setTimeout silently clamps anything past the signed-32-bit ceiling
-  // to 1ms, so an operator who typed a very large number to mean "hold a long
-  // time" would get the opposite — holds that expire immediately. Cap instead,
-  // so the value can only ever mean what it says.
-  return Math.min(n, 2_147_483_647);
+  const resolved = resolveDisconnectGraceMs(process.env.BRIDGE_DISCONNECT_GRACE_MS);
+  // Emitted once at module load. The grace decides whether a task survives a
+  // drop, and `0` is the rollback lever, so an operator must never have to read
+  // the source to find out which one is in effect.
+  logEvent('disconnect_grace_configured', {
+    graceMs: resolved.ms,
+    source: resolved.source,
+    ...(resolved.source === 'invalid' || resolved.source === 'clamped'
+      ? { requested: truncate(String(process.env.BRIDGE_DISCONNECT_GRACE_MS), 64) }
+      : {}),
+  });
+  return resolved.ms;
 })();
 
 /**
@@ -163,6 +199,12 @@ interface GraceHold {
   // held may be failed by its own timer. A rebind of the same taskId while the
   // hold is pending must never be collateral damage.
   binding: TaskBinding;
+  // Diagnostics carried from the hold to whichever event ends it. `heldForMs`
+  // on a resume is the one number that answers "is T long enough?" — the
+  // distribution of how long real recoveries actually take.
+  heldAt: number;
+  via: 'disconnect' | 'reconnect';
+  closeCode: number | undefined;
 }
 
 export class Registry {
@@ -207,13 +249,10 @@ export class Registry {
           clientId: conn.clientId,
           previousConnectedAt: existing.connectedAt,
         });
-        // Read the liveness of the displaced socket BEFORE closing it. `ws`
-        // sets `_readyState = CLOSING` synchronously inside `close()`, so
-        // asking afterwards would report not-OPEN unconditionally and collapse
-        // the two cases below into one — the fail-fast branch would be
-        // unreachable in production while still passing against a stub whose
-        // `close()` leaves readyState alone.
-        const displacedWasLive = existing.ws.readyState === existing.ws.OPEN;
+        // Whether this connection was already condemned has to be read BEFORE
+        // closing it: `ws` flips `_readyState` to CLOSING synchronously inside
+        // `close()`, so any liveness question asked afterwards answers itself.
+        const displacedWasCondemned = this.serverClosed.has(existing.ws);
         // The close `reason` is what the client surfaces in its disconnect
         // log line. Spelling out the cause here means an operator reading
         // the foreground log can recognize the duplicate-token scenario
@@ -227,29 +266,38 @@ export class Registry {
         // point that sees them. The new conn hasn't bound any tasks yet, so
         // this only touches the superseded ones.
         //
-        // Whether we kill or hold them turns on whether the old socket is still
-        // alive (issue #474). Which of the two paths a recovered drop takes is a
-        // pure race — the server may see the old socket's close first (→
-        // unregisterAgent) or the new hello first (→ here) — so both have to
-        // reach the same verdict, otherwise the fix works only when the events
-        // happen to arrive in the lucky order.
+        // These get the SAME grace hold the disconnect path gives them, and
+        // that uniformity is the point (issue #474). Which path a recovered drop
+        // takes is a pure race — the server may see the old socket's close first
+        // (→ unregisterAgent) or the new hello first (→ here) — so both must
+        // reach the same verdict, or the fix works only in the lucky ordering.
         //
-        // An already-dead old socket means the transport is gone and this hello
-        // is the same client coming back: hold, exactly as the disconnect path
-        // would. There is no close code to consult (the close event hasn't been
-        // delivered yet), but a socket that died without one of our own 4xxx
-        // closes is by definition in the graceable category.
+        // An earlier revision tried to keep the old fail-fast behavior for the
+        // "two live daemons share a CLIENT_TOKEN" case by testing
+        // `readyState === OPEN` here. That is not a liveness test: it only says
+        // the server has not OBSERVED a close. The server runs no keepalive of
+        // its own, and the client is built to notice first — it pings every 30s
+        // and terminates on a missed pong, which on a dead path never reaches
+        // us. So the common client-detected drop arrives here with the old
+        // socket still nominally OPEN and would be killed instantly: exactly the
+        // bug #474 exists to fix, relabeled `superseded`.
         //
-        // A still-live old socket is the genuine collision this path was written
-        // for: two live daemons sharing a CLIENT_TOKEN. That is not a recovered
-        // drop and there is nothing to wait for, so it keeps failing instantly.
+        // Holding a genuine collision instead is cheap: the second daemon does
+        // not know the first one's taskIds, so it never sends frames for them
+        // and the holds simply expire. We trade a more precise error code and T
+        // seconds of latency for not misclassifying the case that actually
+        // happens.
+        //
+        // The one exception is a connection this server already condemned (the
+        // owner deleted the client). Its tasks are dead regardless of who
+        // reconnects, so it keeps failing immediately.
         const supersededError = {
           code: 'superseded',
           message: 'superseded by a reconnect from the same client token',
           messageIdSuffix: 'superseded',
         };
-        if (displacedWasLive) {
-          this.failBindingsForAgent(conn.agentId, supersededError);
+        if (displacedWasCondemned) {
+          this.failBindingsForAgent(conn.agentId, DISCONNECTED_ERROR);
         } else {
           this.holdBindingsForAgent(conn.agentId, undefined, 'reconnect', supersededError);
         }
@@ -308,6 +356,17 @@ export class Registry {
   // whether the in-flight tasks die now or get a grace hold. The agent itself
   // leaves the `agents` map either way — it is offline until it says hello
   // again, so routing and agent-card consumers see no change from this.
+  /**
+   * Record that THIS server is closing `ws` with an app-level verdict, before
+   * calling `ws.close(4xxx)`. Callers outside the registry (ws.ts's handshake
+   * and protocol rejections) use this so their intent survives the round trip
+   * — see `serverClosed`, which explains why the observed close code cannot be
+   * trusted for that decision.
+   */
+  noteServerClose(ws: WebSocket): void {
+    this.serverClosed.add(ws);
+  }
+
   unregisterAgent(agentId: string, ws: WebSocket, closeCode?: number): void {
     const existing = this.agents.get(agentId);
     if (!existing || existing.ws !== ws) return;
@@ -329,21 +388,26 @@ export class Registry {
   // nothing about a TaskBinding is connection-scoped (no `ws` field; outbound
   // sends re-resolve the connection by agentId at send time), which is what
   // makes a hold this cheap.
-  // `disabledFallback` is the terminal to emit if the grace is switched off
-  // (`BRIDGE_DISCONNECT_GRACE_MS=0`). It differs per caller so that disabling
-  // the feature reproduces the pre-#474 behavior exactly — including the
-  // `superseded` wording the reconnect path has always used — rather than
-  // leaking this path's own error onto it. Expiry, by contrast, is always
-  // `disconnected`: a hold that runs out means the client never came back for
-  // the task, whichever path started the hold.
+  // `terminalError` is what this hold resolves to if it is never resumed —
+  // both when it expires and, immediately, when the grace is switched off
+  // (`BRIDGE_DISCONNECT_GRACE_MS=0`). It is the caller's own terminal, so each
+  // path's unresumed outcome is byte-identical to what it produced before the
+  // grace existed, just T later: `disconnected` for a drop, `superseded` for a
+  // same-token reconnect that never reclaimed the task.
+  //
+  // Keeping them distinct matters downstream: `disconnected` is the code the
+  // router's cooldown amplifier keys on, and a client that demonstrably came
+  // back (we saw its hello) but did not reclaim an old task is not a
+  // disconnected agent — reporting it as one would manufacture exactly the
+  // false failure signal issue #474 exists to remove.
   private holdBindingsForAgent(
     agentId: string,
     closeCode: number | undefined,
     via: 'disconnect' | 'reconnect',
-    disabledFallback: TerminalError,
+    terminalError: TerminalError,
   ): void {
     if (this.disconnectGraceMs <= 0) {
-      this.failBindingsForAgent(agentId, disabledFallback);
+      this.failBindingsForAgent(agentId, terminalError);
       return;
     }
     for (const binding of [...this.bindings.values()]) {
@@ -352,25 +416,31 @@ export class Registry {
       // binding whose hold is still pending). Leave the original deadline in
       // place rather than sliding it forward on every event.
       if (this.graceHolds.has(binding.taskId)) continue;
+      const heldAt = Date.now();
       const timer = setTimeout(() => {
         this.graceHolds.delete(binding.taskId);
-        // The client never came back for this task. Fail it exactly the way an
-        // ungraced disconnect always has — same code, same message, same
-        // messageId suffix — so nothing downstream has to learn a new shape.
-        // The only difference is that it happens `disconnectGraceMs` later.
+        // Never resumed. Fail it exactly the way this path always has — same
+        // code, same message, same messageId suffix — so nothing downstream has
+        // to learn a new shape. The only difference is that it happens
+        // `disconnectGraceMs` later.
         if (this.bindings.get(binding.taskId) !== binding) return;
+        // Carries the same `via`/`closeCode` as the hold that armed it, so the
+        // expiry line alone answers "which drop killed this task" without a
+        // timestamp join back to binding_grace_held.
         logEvent('binding_grace_expired', {
           agentId: binding.agentId,
           taskId: binding.taskId,
           graceMs: this.disconnectGraceMs,
+          via,
+          ...(closeCode !== undefined ? { closeCode } : {}),
           ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
         });
-        this.failBinding(binding, DISCONNECTED_ERROR);
+        this.failBinding(binding, terminalError);
         this.bindings.delete(binding.taskId);
       }, this.disconnectGraceMs);
       // Never let a pending hold keep the process alive on its own.
       timer.unref?.();
-      this.graceHolds.set(binding.taskId, { timer, binding });
+      this.graceHolds.set(binding.taskId, { timer, binding, heldAt, via, closeCode });
       logEvent('binding_grace_held', {
         agentId: binding.agentId,
         taskId: binding.taskId,
@@ -407,6 +477,10 @@ export class Registry {
     logEvent('binding_grace_resumed', {
       agentId,
       taskId,
+      heldForMs: Date.now() - hold.heldAt,
+      graceMs: this.disconnectGraceMs,
+      via: hold.via,
+      ...(hold.closeCode !== undefined ? { closeCode: hold.closeCode } : {}),
       ...(hold.binding.principalId !== undefined
         ? { principalId: hold.binding.principalId }
         : {}),

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -84,11 +84,89 @@ export type CallerChangeListener = (agentId: string, callers: string[]) => void;
 // before an unclean shutdown) is cleared unconditionally.
 export type AgentChangeListener = (agentId: string) => void;
 
+// Reconnect grace hold (issue #474). A WS drop that the client recovers from
+// used to fail every in-flight task instantly, and the results the client sent
+// after reconnecting were discarded as `dropped_terminal_frame` — a 3s infra
+// blip became a minute-long outage downstream. Instead we keep the binding
+// alive for this long and let the reconnected client's frames land on it.
+//
+// Sized off the incident: the terminal frames arrived +9s / +10s / +15s after
+// the drop, so the hold has to cover TASK COMPLETION, not just reconnect time
+// (3.2s). 30s gives 2x margin over the worst observed frame. It is not a cap on
+// task duration — a single frame (heartbeat included) on the new connection
+// resumes the binding outright, after which the executor's own 10-minute
+// inactivity backstop is what governs.
+//
+// `0` disables the hold and restores the previous fail-immediately behavior.
+const DEFAULT_DISCONNECT_GRACE_MS = (() => {
+  const raw = process.env.BRIDGE_DISCONNECT_GRACE_MS;
+  const n = raw ? Number(raw) : Number.NaN;
+  return Number.isFinite(n) && n >= 0 ? n : 30_000;
+})();
+
+/**
+ * Is this close code one we should wait out, rather than treat as proof the
+ * client is gone?
+ *
+ * Deliberately a DENY-list, not an allow-list of "transient" codes. The server
+ * has never recorded close codes (`client_disconnected` didn't carry one until
+ * this change), so we have no data on which code its socket actually observes
+ * when a proxy tears the connection down — the client saw `1012` in the
+ * incident, but the server end may well see `1006`/`1005`. Enumerating
+ * transient codes would be building on that guess. What we DO know exactly is
+ * the set of terminal closes, because the bridge itself sends them:
+ *
+ *   - 4000-4999: this server's own app-level rejections (bad token, duplicate
+ *     hello, client deleted, superseded, …). Every one is a decision that the
+ *     connection must not continue, so the task is genuinely dead.
+ *   - 1000: a clean, intentional close. Nothing to wait for.
+ *
+ * Everything else — abnormal closure, proxy restart, no code at all — gets the
+ * hold. This also makes `disconnectClient()`'s 4014 and the 4009 duplicate-token
+ * close fail fast for free, with no special-casing.
+ */
+function isGraceableCloseCode(code: number | undefined): boolean {
+  if (code === undefined) return true;
+  if (code === 1000) return false;
+  return code < 4000 || code > 4999;
+}
+
+// Shape of the terminal a binding is failed with. Named so the disconnect
+// terminal can be declared once and reused by every path that emits it.
+interface TerminalError {
+  code: string;
+  message: string;
+  messageIdSuffix: string;
+}
+
+// The mid-task disconnect terminal, unchanged since before the grace hold: a
+// task that outlives its hold must be indistinguishable downstream from one
+// that failed instantly, so the router needs no new case.
+const DISCONNECTED_ERROR: TerminalError = {
+  code: 'disconnected',
+  message: 'client disconnected mid-task',
+  messageIdSuffix: 'disc',
+};
+
+interface GraceHold {
+  timer: ReturnType<typeof setTimeout>;
+  // Identity guard, same discipline as unbindTask: only the binding that was
+  // held may be failed by its own timer. A rebind of the same taskId while the
+  // hold is pending must never be collateral damage.
+  binding: TaskBinding;
+}
+
 export class Registry {
   private agents = new Map<string, ClientConnection>();
   private bindings = new Map<string, TaskBinding>();
+  // taskId -> pending grace hold. A binding in here is still present in
+  // `bindings` and still fully serviceable; the entry only means "if nothing
+  // arrives for this task before the timer fires, declare the client dead".
+  private graceHolds = new Map<string, GraceHold>();
   private callerChangeListeners: CallerChangeListener[] = [];
   private agentChangeListeners: AgentChangeListener[] = [];
+
+  constructor(private readonly disconnectGraceMs: number = DEFAULT_DISCONNECT_GRACE_MS) {}
 
   registerAgent(conn: ClientConnection): { ok: true } | { ok: false; reason: string } {
     const existing = this.agents.get(conn.agentId);
@@ -113,18 +191,40 @@ export class Registry {
         // the foreground log can recognize the duplicate-token scenario
         // without cross-referencing close codes.
         existing.ws.close(4009, 'another client with the same token connected');
-        // Fail the displaced connection's in-flight tasks *before* swapping the
-        // map. The old socket's close fires asynchronously and, by the time its
-        // unregisterAgent runs, the map already points at `conn` — so the
+        // Deal with the displaced connection's in-flight tasks *before* swapping
+        // the map. The old socket's close fires asynchronously and, by the time
+        // its unregisterAgent runs, the map already points at `conn` — so the
         // ws-identity guard makes it a no-op and it can't clean these up. Doing
         // it here (while the bindings still belong to the old conn) is the only
         // point that sees them. The new conn hasn't bound any tasks yet, so
-        // this only terminates the superseded ones.
-        this.failBindingsForAgent(conn.agentId, {
+        // this only touches the superseded ones.
+        //
+        // Whether we kill or hold them turns on whether the old socket is still
+        // alive (issue #474). Which of the two paths a recovered drop takes is a
+        // pure race — the server may see the old socket's close first (→
+        // unregisterAgent) or the new hello first (→ here) — so both have to
+        // reach the same verdict, otherwise the fix works only when the events
+        // happen to arrive in the lucky order.
+        //
+        // A NOT-OPEN old socket means the transport is already gone and this
+        // hello is the same client coming back: hold, exactly as the disconnect
+        // path would. There is no close code to consult (the close event hasn't
+        // been delivered yet), but a socket that died without one of our own
+        // 4xxx closes is by definition in the graceable category.
+        //
+        // A still-OPEN old socket is the genuine collision this path was written
+        // for: two live daemons sharing a CLIENT_TOKEN. That is not a recovered
+        // drop and there is nothing to wait for, so it keeps failing instantly.
+        const supersededError = {
           code: 'superseded',
           message: 'superseded by a reconnect from the same client token',
           messageIdSuffix: 'superseded',
-        });
+        };
+        if (existing.ws.readyState === existing.ws.OPEN) {
+          this.failBindingsForAgent(conn.agentId, supersededError);
+        } else {
+          this.holdBindingsForAgent(conn.agentId, undefined, 'reconnect', supersededError);
+        }
         this.agents.set(conn.agentId, conn);
         this.notifyAgentChange(conn.agentId);
         return { ok: true };
@@ -171,16 +271,126 @@ export class Registry {
     return closed;
   }
 
-  unregisterAgent(agentId: string, ws: WebSocket): void {
+  // `closeCode` is the WS close code this socket reported, or undefined when
+  // the caller has none (the #364 reconcile path, which unregisters a socket
+  // that went away before registration finished). It decides only one thing:
+  // whether the in-flight tasks die now or get a grace hold. The agent itself
+  // leaves the `agents` map either way — it is offline until it says hello
+  // again, so routing and agent-card consumers see no change from this.
+  unregisterAgent(agentId: string, ws: WebSocket, closeCode?: number): void {
     const existing = this.agents.get(agentId);
     if (!existing || existing.ws !== ws) return;
     this.agents.delete(agentId);
     this.notifyAgentChange(agentId);
-    this.failBindingsForAgent(agentId, {
-      code: 'disconnected',
-      message: 'client disconnected mid-task',
-      messageIdSuffix: 'disc',
+    if (isGraceableCloseCode(closeCode)) {
+      // holdBindingsForAgent handles a disabled grace itself, falling back to
+      // the same immediate failure, so there is one decision point rather than
+      // two conditions that could drift apart.
+      this.holdBindingsForAgent(agentId, closeCode, 'disconnect', DISCONNECTED_ERROR);
+      return;
+    }
+    this.failBindingsForAgent(agentId, DISCONNECTED_ERROR);
+  }
+
+  // Start a grace hold on every in-flight task bound to this agent instead of
+  // failing it. The binding stays in `bindings` and its sink stays open, so a
+  // frame arriving on the client's next connection lands on it untouched —
+  // nothing about a TaskBinding is connection-scoped (no `ws` field; outbound
+  // sends re-resolve the connection by agentId at send time), which is what
+  // makes a hold this cheap.
+  // `disabledFallback` is the terminal to emit if the grace is switched off
+  // (`BRIDGE_DISCONNECT_GRACE_MS=0`). It differs per caller so that disabling
+  // the feature reproduces the pre-#474 behavior exactly — including the
+  // `superseded` wording the reconnect path has always used — rather than
+  // leaking this path's own error onto it. Expiry, by contrast, is always
+  // `disconnected`: a hold that runs out means the client never came back for
+  // the task, whichever path started the hold.
+  private holdBindingsForAgent(
+    agentId: string,
+    closeCode: number | undefined,
+    via: 'disconnect' | 'reconnect',
+    disabledFallback: TerminalError,
+  ): void {
+    if (this.disconnectGraceMs <= 0) {
+      this.failBindingsForAgent(agentId, disabledFallback);
+      return;
+    }
+    for (const binding of [...this.bindings.values()]) {
+      if (binding.agentId !== agentId) continue;
+      // Already holding this one (e.g. a second disconnect arriving for a
+      // binding whose hold is still pending). Leave the original deadline in
+      // place rather than sliding it forward on every event.
+      if (this.graceHolds.has(binding.taskId)) continue;
+      const timer = setTimeout(() => {
+        this.graceHolds.delete(binding.taskId);
+        // The client never came back for this task. Fail it exactly the way an
+        // ungraced disconnect always has — same code, same message, same
+        // messageId suffix — so nothing downstream has to learn a new shape.
+        // The only difference is that it happens `disconnectGraceMs` later.
+        if (this.bindings.get(binding.taskId) !== binding) return;
+        logEvent('binding_grace_expired', {
+          agentId: binding.agentId,
+          taskId: binding.taskId,
+          graceMs: this.disconnectGraceMs,
+          ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
+        });
+        this.failBinding(binding, DISCONNECTED_ERROR);
+        this.bindings.delete(binding.taskId);
+      }, this.disconnectGraceMs);
+      // Never let a pending hold keep the process alive on its own.
+      timer.unref?.();
+      this.graceHolds.set(binding.taskId, { timer, binding });
+      logEvent('binding_grace_held', {
+        agentId: binding.agentId,
+        taskId: binding.taskId,
+        graceMs: this.disconnectGraceMs,
+        via,
+        ...(closeCode !== undefined ? { closeCode } : {}),
+        ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
+      });
+    }
+  }
+
+  /**
+   * Cancel the grace hold on a task because the client just proved it is alive
+   * and still working on it.
+   *
+   * Called for every task-scoped frame from an authenticated connection — a
+   * heartbeat `task.status` is enough, and that matters: it means even a
+   * multi-minute task resumes the instant the reconnected client's next beat
+   * lands, long before the hold would have expired. No-op for the overwhelming
+   * majority of frames, where no hold is pending.
+   *
+   * `agentId` is checked so a frame cannot resume a hold belonging to some
+   * other agent's task, even if it somehow guessed the taskId.
+   */
+  resumeBinding(taskId: string, agentId: string): void {
+    const hold = this.graceHolds.get(taskId);
+    if (!hold) return;
+    if (hold.binding.agentId !== agentId) return;
+    // Identity guard: a hold whose binding has since been replaced belongs to
+    // the old binding. Leave it for the timer, which re-checks the same thing.
+    if (this.bindings.get(taskId) !== hold.binding) return;
+    clearTimeout(hold.timer);
+    this.graceHolds.delete(taskId);
+    logEvent('binding_grace_resumed', {
+      agentId,
+      taskId,
+      ...(hold.binding.principalId !== undefined
+        ? { principalId: hold.binding.principalId }
+        : {}),
     });
+  }
+
+  // Drop a pending hold without failing anything — used wherever a binding
+  // leaves the map through a path that has already decided its fate (normal
+  // terminal, rebind, explicit fail), so a stale timer can't fire against it.
+  private clearGraceHold(taskId: string, binding?: TaskBinding): void {
+    const hold = this.graceHolds.get(taskId);
+    if (!hold) return;
+    if (binding !== undefined && hold.binding !== binding) return;
+    clearTimeout(hold.timer);
+    this.graceHolds.delete(taskId);
   }
 
   // Push a terminal `failed` status to every in-flight task bound to this
@@ -193,12 +403,12 @@ export class Registry {
   // explicitly before swapping the agents map: once the map points at the new
   // conn, the old socket's late close handler hits the ws-identity guard in
   // unregisterAgent and early-returns, so it can no longer fail these bindings.
-  private failBindingsForAgent(
-    agentId: string,
-    error: { code: string; message: string; messageIdSuffix: string },
-  ): void {
+  private failBindingsForAgent(agentId: string, error: TerminalError): void {
     for (const binding of [...this.bindings.values()]) {
       if (binding.agentId !== agentId) continue;
+      // This binding's fate is being decided right now; a pending hold on it is
+      // moot and its timer must not outlive it.
+      this.clearGraceHold(binding.taskId, binding);
       this.failBinding(binding, error);
       // Identity-guarded: only drop the entry if it is still THIS binding, so a
       // concurrent rebind of the same taskId is never clobbered.
@@ -213,10 +423,7 @@ export class Registry {
   // executeStream() generator returns (closing the SSE stream) instead of
   // hanging forever on AsyncEventQueue.iterate(). Does NOT touch the bindings
   // map — callers decide whether to delete (disconnect) or overwrite (rebind).
-  private failBinding(
-    binding: TaskBinding,
-    error: { code: string; message: string; messageIdSuffix: string },
-  ): void {
+  private failBinding(binding: TaskBinding, error: TerminalError): void {
     binding.sink.pushStatus({
       taskId: binding.taskId,
       contextId: binding.contextId,
@@ -285,6 +492,11 @@ export class Registry {
         taskId: binding.taskId,
         ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
       });
+      // The displaced binding is being terminated here and now, so any hold it
+      // was under is decided — drop the timer before the new binding takes over
+      // the taskId. (The timer is identity-guarded too, so this is belt and
+      // braces, but leaving live timers around for dead bindings is a trap.)
+      this.clearGraceHold(binding.taskId, existing);
       this.failBinding(existing, {
         code: 'task_superseded',
         message: 'task superseded by a newer request for the same task id',
@@ -307,6 +519,12 @@ export class Registry {
   // guard already applied to the agents map in unregisterAgent (issue #365).
   unbindTask(taskId: string, binding: TaskBinding): void {
     if (this.bindings.get(taskId) !== binding) return;
+    // A task that reaches its terminal while a hold is pending — the exact case
+    // this feature exists to rescue, where the reconnected client's
+    // `task.complete` lands during the grace window — must take its timer with
+    // it. Otherwise the timer would fire later and try to fail an already
+    // completed task.
+    this.clearGraceHold(taskId, binding);
     this.bindings.delete(taskId);
   }
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -121,8 +121,14 @@ export function resolveDisconnectGraceMs(raw: string | undefined): {
   ms: number;
   source: 'default' | 'env' | 'clamped' | 'invalid';
 } {
-  if (raw === undefined || raw === '') return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' };
-  const n = Number(raw);
+  // Trim first: `Number(' ')` is 0, so a whitespace-only value would otherwise
+  // read as a deliberate `0` and silently disable recovery, when only a literal
+  // `0` is documented as the kill switch.
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === '') {
+    return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' };
+  }
+  const n = Number(trimmed);
   if (!Number.isFinite(n) || n < 0) {
     return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'invalid' };
   }

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -101,7 +101,12 @@ export type AgentChangeListener = (agentId: string) => void;
 const DEFAULT_DISCONNECT_GRACE_MS = (() => {
   const raw = process.env.BRIDGE_DISCONNECT_GRACE_MS;
   const n = raw ? Number(raw) : Number.NaN;
-  return Number.isFinite(n) && n >= 0 ? n : 30_000;
+  if (!Number.isFinite(n) || n < 0) return 30_000;
+  // Node's setTimeout silently clamps anything past the signed-32-bit ceiling
+  // to 1ms, so an operator who typed a very large number to mean "hold a long
+  // time" would get the opposite — holds that expire immediately. Cap instead,
+  // so the value can only ever mean what it says.
+  return Math.min(n, 2_147_483_647);
 })();
 
 /**
@@ -122,8 +127,12 @@ const DEFAULT_DISCONNECT_GRACE_MS = (() => {
  *   - 1000: a clean, intentional close. Nothing to wait for.
  *
  * Everything else — abnormal closure, proxy restart, no code at all — gets the
- * hold. This also makes `disconnectClient()`'s 4014 and the 4009 duplicate-token
- * close fail fast for free, with no special-casing.
+ * hold.
+ *
+ * This test alone is not sufficient for closes WE initiate, because the code we
+ * observe is the one our socket ends up with, not the one we sent: a peer that
+ * never echoes the close frame leaves `ws` to time out and report `1006`. The
+ * `serverClosed` WeakSet carries that intent separately; see its declaration.
  */
 function isGraceableCloseCode(code: number | undefined): boolean {
   if (code === undefined) return true;
@@ -163,6 +172,18 @@ export class Registry {
   // `bindings` and still fully serviceable; the entry only means "if nothing
   // arrives for this task before the timer fires, declare the client dead".
   private graceHolds = new Map<string, GraceHold>();
+  // Sockets this server closed with a terminal verdict of its own. The close
+  // CODE we later observe is not trustworthy for that decision: when we send
+  // `close(4014)` and the peer never echoes the close frame — dead TCP, wedged
+  // process, or a client that simply declines to — `ws` gives up after its
+  // close timeout and emits the default `1006`, which is graceable. Without
+  // this the deny-list would be advisory: a client could earn itself a grace
+  // hold just by refusing to acknowledge being kicked. Recording the intent at
+  // the moment we form it is the only reliable signal.
+  //
+  // A WeakSet so a socket that never reaches unregisterAgent (identity-guard
+  // no-op, connection dropped before registration) cannot pin an entry.
+  private serverClosed = new WeakSet<WebSocket>();
   private callerChangeListeners: CallerChangeListener[] = [];
   private agentChangeListeners: AgentChangeListener[] = [];
 
@@ -186,6 +207,13 @@ export class Registry {
           clientId: conn.clientId,
           previousConnectedAt: existing.connectedAt,
         });
+        // Read the liveness of the displaced socket BEFORE closing it. `ws`
+        // sets `_readyState = CLOSING` synchronously inside `close()`, so
+        // asking afterwards would report not-OPEN unconditionally and collapse
+        // the two cases below into one — the fail-fast branch would be
+        // unreachable in production while still passing against a stub whose
+        // `close()` leaves readyState alone.
+        const displacedWasLive = existing.ws.readyState === existing.ws.OPEN;
         // The close `reason` is what the client surfaces in its disconnect
         // log line. Spelling out the cause here means an operator reading
         // the foreground log can recognize the duplicate-token scenario
@@ -206,13 +234,13 @@ export class Registry {
         // reach the same verdict, otherwise the fix works only when the events
         // happen to arrive in the lucky order.
         //
-        // A NOT-OPEN old socket means the transport is already gone and this
-        // hello is the same client coming back: hold, exactly as the disconnect
-        // path would. There is no close code to consult (the close event hasn't
-        // been delivered yet), but a socket that died without one of our own
-        // 4xxx closes is by definition in the graceable category.
+        // An already-dead old socket means the transport is gone and this hello
+        // is the same client coming back: hold, exactly as the disconnect path
+        // would. There is no close code to consult (the close event hasn't been
+        // delivered yet), but a socket that died without one of our own 4xxx
+        // closes is by definition in the graceable category.
         //
-        // A still-OPEN old socket is the genuine collision this path was written
+        // A still-live old socket is the genuine collision this path was written
         // for: two live daemons sharing a CLIENT_TOKEN. That is not a recovered
         // drop and there is nothing to wait for, so it keeps failing instantly.
         const supersededError = {
@@ -220,7 +248,7 @@ export class Registry {
           message: 'superseded by a reconnect from the same client token',
           messageIdSuffix: 'superseded',
         };
-        if (existing.ws.readyState === existing.ws.OPEN) {
+        if (displacedWasLive) {
           this.failBindingsForAgent(conn.agentId, supersededError);
         } else {
           this.holdBindingsForAgent(conn.agentId, undefined, 'reconnect', supersededError);
@@ -265,6 +293,9 @@ export class Registry {
     let closed = 0;
     for (const conn of this.agents.values()) {
       if (conn.clientId !== clientId) continue;
+      // The owner deleted this client; its tasks are dead whatever close code
+      // comes back to us. See `serverClosed`.
+      this.serverClosed.add(conn.ws);
       conn.ws.close(4014, 'client deleted');
       closed++;
     }
@@ -282,7 +313,7 @@ export class Registry {
     if (!existing || existing.ws !== ws) return;
     this.agents.delete(agentId);
     this.notifyAgentChange(agentId);
-    if (isGraceableCloseCode(closeCode)) {
+    if (isGraceableCloseCode(closeCode) && !this.serverClosed.has(ws)) {
       // holdBindingsForAgent handles a disabled grace itself, falling back to
       // the same immediate failure, so there is one decision point rather than
       // two conditions that could drift apart.

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -587,6 +587,7 @@ export class Registry {
         agentId: binding.agentId,
         ownerAgentId: existing.agentId,
         taskId: binding.taskId,
+        operation: 'bind',
         ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
       });
       return false;

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -80,6 +80,23 @@ function makeSink(): TaskSink & {
   };
 }
 
+// `await sink.finished` on its own turns any regression that stops producing a
+// terminal into an infinite hang: the runner reports nothing, and CI only goes
+// red on job timeout. Bound every such wait.
+async function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms waiting for ${what}`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 async function waitForAgent(registry: Registry, agentId: string): Promise<void> {
   const deadline = Date.now() + 1_000;
   while (!registry.getAgent(agentId)) {
@@ -132,7 +149,7 @@ test('task.fail preserves backend error code and message on status message metad
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     assert.equal(sink.statuses.length, 1);
     const event = sink.statuses[0]!;
@@ -534,7 +551,7 @@ test('task.fail omits terminal error metadata when openai-compat extension was n
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     const event = sink.statuses[0]!;
     assert.equal(event.status.state, 'failed');
@@ -621,7 +638,7 @@ test('a task survives a proxy-style disconnect and completes on the reconnected 
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     const terminal = sink.statuses.at(-1)!;
     assert.equal(terminal.final, true);
@@ -641,7 +658,12 @@ test('a task survives a proxy-style disconnect and completes on the reconnected 
 
 test('an app-level close code fails in-flight tasks immediately, with no grace hold', async () => {
   const server = createServer();
-  const registry = new Registry(10_000);
+  // An hour, deliberately: the point of this test is that the close code
+  // reaches unregisterAgent at all. With a short grace the assertions below
+  // pass either way — a severed code argument just means the hold expires into
+  // a byte-identical terminal a few seconds later, and the only trace is the
+  // test's own duration. Nothing here may be rescued by expiry.
+  const registry = new Registry(60 * 60_000);
   attachWsServer(server, { db: mockSql(), registry });
   const port = await listen(server);
   const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
@@ -661,7 +683,7 @@ test('an app-level close code fails in-flight tasks immediately, with no grace h
 
     registry.getAgent('agent-1')!.ws.close(4014, 'client deleted');
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the immediate app-level-close terminal');
 
     const terminal = sink.statuses.at(-1)!;
     assert.equal(terminal.final, true);
@@ -763,7 +785,7 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     const terminal = sink.statuses.at(-1)!;
     assert.equal(terminal.status.state, 'completed');
@@ -846,7 +868,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
           message: { role: 'agent', messageId: 'm-ok', parts: [{ kind: 'text', text: 'real answer' }] },
         },
       }));
-      await sink.finished;
+      await withTimeout(sink.finished, 5_000, 'the task terminal');
       // Re-read through the typed alias: the `deepEqual(…, [])` above narrows
       // `sink.statuses` to never[] for the rest of this block.
       const delivered: TaskStatusUpdateEvent[] = sink.statuses;
@@ -863,14 +885,19 @@ test('an agent cannot push frames into another agent\'s task', async () => {
   }
 });
 
-test('a live duplicate-token collision supersedes immediately, against real sockets', async () => {
-  // This one deliberately uses real WebSockets rather than the registry stub.
-  // The branch it covers reads `readyState` around a `close()` call, and `ws`
+test('a live duplicate-token collision is held against real sockets, then expires as superseded', async () => {
+  // Deliberately real WebSockets rather than the registry stub. The collision
+  // branch used to read `readyState` around its own `close()` call, and `ws`
   // mutates readyState synchronously inside close() — a hand-rolled stub can
   // model that wrongly and certify a branch production never takes, which is
-  // exactly what happened before this test existed.
+  // exactly what happened once already.
+  //
+  // The contract now: a same-token reconnect is HELD even when the displaced
+  // socket is unmistakably live, because "looks live" cannot distinguish a
+  // rival daemon from the very client that is reconnecting. An unreclaimed hold
+  // then expires into this path's own `superseded` terminal.
   const server = createServer();
-  const registry = new Registry(10_000);
+  const registry = new Registry(60);
   attachWsServer(server, { db: mockSql(), registry });
   const port = await listen(server);
   const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
@@ -882,12 +909,11 @@ test('a live duplicate-token collision supersedes immediately, against real sock
     first.send(helloFrame());
     await waitForAgent(registry, 'agent-1');
     const firstConn = registry.getAgent('agent-1');
+    assert.equal(firstConn!.ws.readyState, firstConn!.ws.OPEN, 'precondition: displaced socket live');
 
     const sink = makeSink();
     registry.bindTask({ agentId: 'agent-1', taskId: 'task-4', contextId: 'ctx-4', sink });
 
-    // A second live daemon with the same token registers while the first is
-    // still connected — a genuine collision, not a recovered drop.
     second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
     await once(second, 'open');
     second.send(helloFrameFor('agent-1', 'token'));
@@ -897,15 +923,20 @@ test('a live duplicate-token collision supersedes immediately, against real sock
       await wsSleep(5);
     }
 
-    await sink.finished;
+    // Not killed on the spot — this is the whole point.
+    assert.ok(registry.getBinding('task-4'), 'a live-looking collision must still be held');
+    assert.deepEqual(sink.statuses, [], 'no premature terminal');
 
-    const terminal = sink.statuses.at(-1)!;
-    assert.equal(terminal.final, true);
-    assert.equal(terminal.status.state, 'failed');
-    assert.deepEqual(terminal.status.message?.parts, [
+    await withTimeout(sink.finished, 5_000, 'the collision hold to expire');
+
+    const terminal: TaskStatusUpdateEvent[] = sink.statuses;
+    const last = terminal.at(-1)!;
+    assert.equal(last.final, true);
+    assert.equal(last.status.state, 'failed');
+    assert.deepEqual(last.status.message?.parts, [
       { text: 'superseded by a reconnect from the same client token' },
     ]);
-    assert.equal(registry.getBinding('task-4'), undefined, 'a live collision must not be graced');
+    assert.equal(registry.getBinding('task-4'), undefined);
   } finally {
     first.close();
     second?.close();

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1012,3 +1012,26 @@ test('an oversized unauthenticated message is refused before it is parsed', asyn
     await closeServer(server);
   }
 });
+
+test('a message past the ingress cap is refused by the transport, never assembled', async () => {
+  // The pre-auth byte budget can only be charged once `ws` has already built
+  // the message, so without an ingress cap the library's 100 MiB default is
+  // what an unauthenticated peer can make each connection hold before we ever
+  // look. This asserts the transport itself refuses it: close 1009, the
+  // WebSocket "message too big" code, rather than our own 4002.
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`, { maxPayload: 0 });
+
+  try {
+    await once(ws, 'open');
+    ws.send('{"pad":"' + 'z'.repeat(17 * 1024 * 1024) + '"}');
+    const [code] = (await once(ws, 'close')) as [number, Buffer];
+    assert.equal(code, 1009, 'the transport must reject an over-cap payload');
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -11,6 +11,7 @@ import {
   PROTOCOL_VERSION,
 } from '@vicoop-bridge/protocol';
 import { Registry, type TaskSink } from './registry.js';
+import { hashToken } from './token.js';
 import { attachWsServer } from './ws.js';
 import type { Sql } from './db.js';
 
@@ -669,6 +670,245 @@ test('an app-level close code fails in-flight tasks immediately, with no grace h
     assert.equal(registry.getBinding('task-2'), undefined);
   } finally {
     ws.close();
+    await closeServer(server);
+  }
+});
+
+const wsSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Two distinct agents, each with its own token — needed to prove that one
+// agent cannot act on another's task.
+function twoAgentSql(): Sql {
+  const rows: Record<string, unknown> = {
+    [hashToken('token-1')]: {
+      id: 'agent-1',
+      client_id: 'client-1',
+      owner_principal: 'eth:0x1',
+      owner_email: null,
+      allowed_callers: [],
+    },
+    [hashToken('token-2')]: {
+      id: 'agent-2',
+      client_id: 'client-2',
+      owner_principal: 'eth:0x2',
+      owner_email: null,
+      allowed_callers: [],
+    },
+  };
+  const fn = async (_strings: TemplateStringsArray, hash: string) => {
+    const row = rows[hash];
+    return row ? [row] : [];
+  };
+  return fn as unknown as Sql;
+}
+
+function helloFrameFor(agentId: string, token: string): string {
+  return encodeFrame({
+    type: 'hello',
+    version: PROTOCOL_VERSION,
+    agentId,
+    token,
+    agentCard: { name: agentId, version: '0.0.0', protocolVersion: '0.3.0' },
+  });
+}
+
+test('a heartbeat on the reconnected socket keeps a task alive past the original grace deadline', async () => {
+  // The reason resume exists at all. Without it the hold would expire on its
+  // original deadline no matter how obviously alive the client is, which would
+  // cap every task at the grace window rather than merely deciding how long to
+  // wait for a client that may be dead. A short grace here stands in for a task
+  // that outruns whatever the deadline happens to be.
+  const server = createServer();
+  const registry = new Registry(60);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({ agentId: 'agent-1', taskId: 'task-3', contextId: 'ctx-3', sink });
+
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    // One beat, well inside the window — this is what must cancel the hold.
+    second.send(encodeFrame({
+      type: 'task.status',
+      taskId: 'task-3',
+      status: { state: 'working', timestamp: new Date().toISOString() },
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
+    }));
+
+    // Now work well past the original deadline before answering.
+    await wsSleep(150);
+    assert.ok(registry.getBinding('task-3'), 'the resumed task expired anyway');
+
+    second.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-3',
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: { role: 'agent', messageId: 'm-3', parts: [{ kind: 'text', text: 'late answer' }] },
+      },
+    }));
+
+    await sink.finished;
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.status.state, 'completed');
+    assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'late answer' }]);
+  } finally {
+    first.close();
+    second?.close();
+    await closeServer(server);
+  }
+});
+
+test('an agent cannot push frames into another agent\'s task', async () => {
+  // `getBinding` keys on taskId alone, so the handlers must check ownership
+  // themselves. The grace hold makes this load-bearing: a held binding stays
+  // resolvable for the whole window while its owner is offline and cannot
+  // contradict a forged terminal written in its name.
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: twoAgentSql(), registry });
+  const port = await listen(server);
+  const victim = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  // Connect one at a time. Opening both up front and awaiting them in sequence
+  // deadlocks: the second socket fires 'open' while we are awaiting the first,
+  // and `once()` then waits forever for a second 'open' that never comes.
+  let attacker: WebSocket | undefined;
+
+  try {
+    await once(victim, 'open');
+    victim.send(helloFrameFor('agent-1', 'token-1'));
+    await waitForAgent(registry, 'agent-1');
+
+    attacker = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(attacker, 'open');
+    attacker.send(helloFrameFor('agent-2', 'token-2'));
+    await waitForAgent(registry, 'agent-2');
+
+    const sink = makeSink();
+    registry.bindTask({ agentId: 'agent-1', taskId: 'victim-task', contextId: 'ctx-v', sink });
+
+    // The victim drops mid-task; its binding is now held and still resolvable.
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    // agent-2 forges a terminal — and reported usage — for agent-1's task.
+    attacker.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'victim-task',
+      usage: { promptTokens: 999_999, completionTokens: 999_999 },
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: { role: 'agent', messageId: 'm-x', parts: [{ kind: 'text', text: 'forged' }] },
+      },
+    }));
+    attacker.send(encodeFrame({
+      type: 'task.fail',
+      taskId: 'victim-task',
+      error: { code: 'forged', message: 'forged' },
+    }));
+
+    // Give both frames time to be processed and rejected.
+    await wsSleep(60);
+
+    assert.deepEqual(sink.statuses, [], 'a foreign agent wrote into the victim task');
+    assert.deepEqual(sink.artifacts, []);
+    assert.ok(registry.getBinding('victim-task'), 'the victim task must still be held');
+
+    // The rightful owner comes back and completes it normally.
+    const recovered = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    try {
+      await once(recovered, 'open');
+      recovered.send(helloFrameFor('agent-1', 'token-1'));
+      await waitForAgent(registry, 'agent-1');
+      recovered.send(encodeFrame({
+        type: 'task.complete',
+        taskId: 'victim-task',
+        status: {
+          state: 'completed',
+          timestamp: new Date().toISOString(),
+          message: { role: 'agent', messageId: 'm-ok', parts: [{ kind: 'text', text: 'real answer' }] },
+        },
+      }));
+      await sink.finished;
+      // Re-read through the typed alias: the `deepEqual(…, [])` above narrows
+      // `sink.statuses` to never[] for the rest of this block.
+      const delivered: TaskStatusUpdateEvent[] = sink.statuses;
+      const terminal = delivered.at(-1)!;
+      assert.equal(terminal.status.state, 'completed');
+      assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'real answer' }]);
+    } finally {
+      recovered.close();
+    }
+  } finally {
+    victim.close();
+    attacker?.close();
+    await closeServer(server);
+  }
+});
+
+test('a live duplicate-token collision supersedes immediately, against real sockets', async () => {
+  // This one deliberately uses real WebSockets rather than the registry stub.
+  // The branch it covers reads `readyState` around a `close()` call, and `ws`
+  // mutates readyState synchronously inside close() — a hand-rolled stub can
+  // model that wrongly and certify a branch production never takes, which is
+  // exactly what happened before this test existed.
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  // Connect one at a time; see the note in the ownership test above.
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+    const firstConn = registry.getAgent('agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({ agentId: 'agent-1', taskId: 'task-4', contextId: 'ctx-4', sink });
+
+    // A second live daemon with the same token registers while the first is
+    // still connected — a genuine collision, not a recovered drop.
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrameFor('agent-1', 'token'));
+    const deadline = Date.now() + 1_000;
+    while (registry.getAgent('agent-1') === firstConn) {
+      assert.ok(Date.now() < deadline, 'timed out waiting for the collision swap');
+      await wsSleep(5);
+    }
+
+    await sink.finished;
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.final, true);
+    assert.equal(terminal.status.state, 'failed');
+    assert.deepEqual(terminal.status.message?.parts, [
+      { text: 'superseded by a reconnect from the same client token' },
+    ]);
+    assert.equal(registry.getBinding('task-4'), undefined, 'a live collision must not be graced');
+  } finally {
+    first.close();
+    second?.close();
     await closeServer(server);
   }
 });

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -943,3 +943,72 @@ test('a live duplicate-token collision is held against real sockets, then expire
     await closeServer(server);
   }
 });
+test('a replay larger than the client default buffer survives the pre-auth queue', async () => {
+  const server = createServer();
+  const registry = new Registry(60 * 60_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  const REPLAY_FRAMES = 2_100;
+
+  try {
+    await once(ws, 'open');
+
+    const sink = makeSink();
+    registry.bindTask({ agentId: 'agent-1', taskId: 'task-replay', contextId: 'ctx-r', sink });
+
+    ws.send(helloFrame());
+    for (let i = 0; i < REPLAY_FRAMES; i++) {
+      ws.send(encodeFrame({
+        type: 'task.artifact',
+        taskId: 'task-replay',
+        artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: `chunk-${i}` }] },
+        append: true,
+        lastChunk: false,
+      }));
+    }
+    ws.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-replay',
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: { role: 'agent', messageId: 'm-r', parts: [{ kind: 'text', text: 'done' }] },
+      },
+    }));
+
+    await withTimeout(sink.finished, 5_000, 'the pipelined replay to complete');
+
+    assert.equal(ws.readyState, ws.OPEN, 'the connection must survive a normal-sized replay');
+    assert.equal(sink.artifacts.length, REPLAY_FRAMES, 'every replayed artifact must be delivered');
+    assert.deepEqual(sink.artifacts[0]?.artifact.parts, [{ kind: 'text', text: 'chunk-0' }]);
+    assert.deepEqual(sink.artifacts.at(-1)?.artifact.parts, [
+      { kind: 'text', text: `chunk-${REPLAY_FRAMES - 1}` },
+    ]);
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.status.state, 'completed');
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('an oversized unauthenticated message is refused before it is parsed', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send('{"type":"task.status","garbage":"' + 'z'.repeat(9 * 1024 * 1024));
+    const [code, reason] = (await once(ws, 'close')) as [number, Buffer];
+    assert.equal(code, 4002);
+    assert.match(reason.toString('utf8'), /too much data before authentication/);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -545,3 +545,130 @@ test('task.fail omits terminal error metadata when openai-compat extension was n
     await closeServer(server);
   }
 });
+async function waitForAgentGone(registry: Registry, agentId: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (registry.getAgent(agentId)) {
+    assert.ok(Date.now() < deadline, `timed out waiting for ${agentId} to unregister`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function helloFrame(): string {
+  return encodeFrame({
+    type: 'hello',
+    version: PROTOCOL_VERSION,
+    agentId: 'agent-1',
+    token: 'token',
+    agentCard: {
+      name: 'agent',
+      version: '0.0.0',
+      protocolVersion: '0.3.0',
+    },
+  });
+}
+
+test('a task survives a proxy-style disconnect and completes on the reconnected socket', async () => {
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      contextId: 'ctx-1',
+      sink,
+    });
+
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    assert.ok(registry.getBinding('task-1'), 'task must be held across the disconnect');
+    assert.equal(sink.statuses.length, 0, 'no premature failure may be emitted');
+
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    second.send(encodeFrame({
+      type: 'task.status',
+      taskId: 'task-1',
+      status: { state: 'working', timestamp: new Date().toISOString() },
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
+    }));
+
+    second.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-1',
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: {
+          role: 'agent',
+          messageId: 'm-1',
+          parts: [{ kind: 'text', text: 'the answer' }],
+        },
+      },
+    }));
+
+    await sink.finished;
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.final, true);
+    assert.equal(terminal.status.state, 'completed');
+    assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'the answer' }]);
+    assert.ok(
+      !sink.statuses.some((s) => s.status.state === 'failed'),
+      'the task must never have been marked failed',
+    );
+    assert.equal(registry.getBinding('task-1'), undefined, 'the completed task is unbound');
+  } finally {
+    first.close();
+    second?.close();
+    await closeServer(server);
+  }
+});
+
+test('an app-level close code fails in-flight tasks immediately, with no grace hold', async () => {
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-2',
+      contextId: 'ctx-2',
+      sink,
+    });
+
+    registry.getAgent('agent-1')!.ws.close(4014, 'client deleted');
+
+    await sink.finished;
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.final, true);
+    assert.equal(terminal.status.state, 'failed');
+    assert.deepEqual(terminal.status.message?.parts, [{ text: 'client disconnected mid-task' }]);
+    assert.equal(registry.getBinding('task-2'), undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -7,6 +7,7 @@ import {
   type Part,
   type TaskStatus as WireTaskStatus,
   type Message as WireMessage,
+  type UpFrame,
 } from '@vicoop-bridge/protocol';
 import type { Message, TaskStatus } from '@a2x/sdk';
 import { TaskState } from '@a2x/sdk';
@@ -231,9 +232,12 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     const b = opts.registry.getBinding(taskId);
     if (!b) return undefined;
     if (b.agentId !== agentId) {
+      // `taskId` comes straight off the frame, so a client can make this line
+      // as long as it likes — and it can emit one per frame. Truncate like
+      // every other client-controlled string we log.
       logEvent('binding_owner_mismatch', {
         agentId: agentId ?? undefined,
-        taskId,
+        taskId: truncate(taskId, 128),
         ownerAgentId: b.agentId,
       });
       return undefined;
@@ -245,18 +249,45 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     if (!authed) ws.close(4001, 'hello timeout');
   }, 10_000);
 
+  // Frames that arrived after `hello` but before its async authentication
+  // settled. A client replaying buffered work on reconnect pipelines them
+  // immediately behind the hello, and the DB token lookup takes long enough
+  // that they nearly always win the race — rejecting them would turn every
+  // replay into a 4003 close and a reconnect loop. Bounded, and discarded
+  // untouched if authentication fails.
+  let preAuthQueue: UpFrame[] = [];
+  const MAX_PRE_AUTH_FRAMES = 256;
+
   ws.on('message', (raw) => {
     let frame;
     try {
       frame = parseUpFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
     } catch (err) {
+      // A protocol violation is our verdict on this connection, so its
+      // in-flight tasks must not earn a reconnect grace hold no matter what
+      // close code we end up observing (see Registry.noteServerClose).
+      opts.registry.noteServerClose(ws);
       ws.close(4002, `invalid frame: ${(err as Error).message}`);
       return;
     }
 
     if (!authed) {
       if (frame.type !== 'hello') {
-        ws.close(4003, 'expected hello');
+        // The first frame must still be a hello — that guard is what keeps
+        // unannounced peers out. Once a hello IS in flight, though, the
+        // connection is claimed and further frames are just early, not
+        // illegal.
+        if (!helloProcessing) {
+          ws.close(4003, 'expected hello');
+          return;
+        }
+        if (preAuthQueue.length >= MAX_PRE_AUTH_FRAMES) {
+          logEvent('pre_auth_overflow', { frames: preAuthQueue.length });
+          opts.registry.noteServerClose(ws);
+          ws.close(4002, 'too many frames before authentication');
+          return;
+        }
+        preAuthQueue.push(frame);
         return;
       }
       if (frame.version !== PROTOCOL_VERSION) {
@@ -298,6 +329,16 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           name: result.cardName,
           cardSource: result.cardSource,
         });
+        // Deliver anything the client pipelined behind its hello, in arrival
+        // order, before any later frame is processed. This is what makes a
+        // reconnecting client's replay land on the tasks its grace hold is
+        // keeping alive (issue #474).
+        const queued = preAuthQueue;
+        preAuthQueue = [];
+        if (queued.length > 0) {
+          logEvent('pre_auth_replayed', { agentId, frames: queued.length });
+          for (const queuedFrame of queued) processAuthedFrame(queuedFrame);
+        }
       }).catch((err) => {
         console.error('[server] auth error:', err);
         ws.close(1011, 'internal error');
@@ -305,6 +346,10 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       return;
     }
 
+    processAuthedFrame(frame);
+  });
+
+  function processAuthedFrame(frame: UpFrame): void {
     // Any task-scoped frame on an authenticated connection is proof that the
     // client is alive and still working this task, which is exactly the signal
     // that cancels a reconnect grace hold (issue #474). Doing it here rather
@@ -373,7 +418,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           // wedged SSE stream, and this path is otherwise silent.
           logEvent('dropped_terminal_frame', {
             agentId: agentId ?? undefined,
-            taskId: frame.taskId,
+            taskId: truncate(frame.taskId, 128),
             kind: 'task.complete',
             state: frame.status.state,
           });
@@ -408,7 +453,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         if (!b) {
           logEvent('dropped_terminal_frame', {
             agentId: agentId ?? undefined,
-            taskId: frame.taskId,
+            taskId: truncate(frame.taskId, 128),
             kind: 'task.fail',
             errorCode: frame.error.code,
           });
@@ -452,10 +497,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       case 'pong':
         break;
       case 'hello':
+        opts.registry.noteServerClose(ws);
         ws.close(4007, 'duplicate hello');
         break;
     }
-  });
+  }
 
   ws.on('close', (code: number, reason: Buffer) => {
     clearTimeout(helloTimeout);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -58,8 +58,22 @@ export interface ServerWsOptions {
   registry: Registry;
 }
 
+// Largest WebSocket message the bridge will assemble at all, authenticated or
+// not. See the `maxPayload` note in attachWsServer.
+const MAX_INGRESS_BYTES = 16 * 1024 * 1024;
+
 export function attachWsServer(server: Server, opts: ServerWsOptions): void {
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({
+    noServer: true,
+    // Ingress cap, enforced by `ws` while it assembles the frame rather than by
+    // us once it already exists. Without it the library's 100 MiB default is
+    // what an unauthenticated peer can make each connection hold before our own
+    // pre-auth budget is ever consulted — several connections would be enough
+    // to exhaust the deployment. Set well above any legitimate frame (the
+    // client refuses to buffer one this large) and comfortably above the
+    // pre-auth budget, so it bounds abuse without truncating real traffic.
+    maxPayload: MAX_INGRESS_BYTES,
+  });
 
   server.on('upgrade', (req, socket, head) => {
     const url = new URL(req.url ?? '/', 'http://localhost');

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -279,6 +279,21 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       return;
     }
 
+    // Any task-scoped frame on an authenticated connection is proof that the
+    // client is alive and still working this task, which is exactly the signal
+    // that cancels a reconnect grace hold (issue #474). Doing it here rather
+    // than in each handler means every task frame counts — including a bare
+    // liveness heartbeat, and including any frame type added later — and that
+    // resumption happens before the frame is processed, so a `task.complete`
+    // arriving mid-hold resumes the binding and then completes it normally
+    // instead of being discarded as a `dropped_terminal_frame`.
+    //
+    // No-op unless a hold is actually pending, which is the case for
+    // essentially every frame the server ever sees.
+    if (agentId !== null && 'taskId' in frame) {
+      opts.registry.resumeBinding(frame.taskId, agentId);
+    }
+
     switch (frame.type) {
       case 'task.status': {
         const b = opts.registry.getBinding(frame.taskId);
@@ -416,7 +431,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     }
   });
 
-  ws.on('close', () => {
+  ws.on('close', (code: number, reason: Buffer) => {
     clearTimeout(helloTimeout);
     if (agentId) {
       // Look up the live connection BEFORE unregistering so the disconnect log
@@ -424,6 +439,16 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       const conn = opts.registry.getAgent(agentId);
       logEvent('client_disconnected', {
         agentId,
+        // The close code decides whether in-flight tasks get a reconnect grace
+        // hold (issue #474), so it belongs in the log the operator reads when
+        // asking why a task did or didn't survive a drop. It was previously
+        // discarded outright, which is why the 2026-08-20 incident left no
+        // record of what the SERVER's socket saw — the 1012 in that report is
+        // what the CLIENT observed, and the two ends need not agree.
+        // `reason` is remote-supplied, so truncate it like every other
+        // client-controlled string we log.
+        closeCode: code,
+        ...(reason.length > 0 ? { closeReason: truncate(reason.toString('utf8'), 128) } : {}),
         ...(conn
           ? {
               clientId: conn.clientId,
@@ -434,7 +459,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
             }
           : {}),
       });
-      opts.registry.unregisterAgent(agentId, ws);
+      opts.registry.unregisterAgent(agentId, ws, code);
     }
   });
 

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -260,9 +260,29 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   // replay into a 4003 close and a reconnect loop. Bounded, and discarded
   // untouched if authentication fails.
   let preAuthQueue: UpFrame[] = [];
+  let preAuthBytes = 0;
   const MAX_PRE_AUTH_FRAMES = 256;
+  // Byte budget alongside the frame count, measured on the RAW message rather
+  // than the parsed object: the protocol puts no size limit on artifact or
+  // status payloads, so a frame count alone bounds nothing. Without this an
+  // unauthenticated peer could park hundreds of megabytes per connection for
+  // the duration of the token lookup, across as many connections as it likes.
+  //
+  // Sized above the client's own replay budget (DEFAULT_MAX_PENDING_BYTES in
+  // packages/client/src/client.ts) so a legitimate replay always fits; a client
+  // that overshoots is closed rather than silently truncated.
+  const MAX_PRE_AUTH_BYTES = 8 * 1024 * 1024;
 
   ws.on('message', (raw) => {
+    // `RawData` is Buffer | ArrayBuffer | Buffer[] depending on how the socket
+    // was configured; measure all three rather than assume one.
+    const rawBytes = Buffer.isBuffer(raw)
+      ? raw.length
+      : Array.isArray(raw)
+        ? raw.reduce((n, chunk) => n + chunk.length, 0)
+        : raw instanceof ArrayBuffer
+          ? raw.byteLength
+          : Buffer.byteLength(String(raw), 'utf8');
     let frame;
     try {
       frame = parseUpFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
@@ -285,13 +305,21 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           ws.close(4003, 'expected hello');
           return;
         }
-        if (preAuthQueue.length >= MAX_PRE_AUTH_FRAMES) {
-          logEvent('pre_auth_overflow', { frames: preAuthQueue.length });
+        if (
+          preAuthQueue.length >= MAX_PRE_AUTH_FRAMES ||
+          preAuthBytes + rawBytes > MAX_PRE_AUTH_BYTES
+        ) {
+          logEvent('pre_auth_overflow', {
+            frames: preAuthQueue.length,
+            bytes: preAuthBytes,
+            frameBytes: rawBytes,
+          });
           opts.registry.noteServerClose(ws);
-          ws.close(4002, 'too many frames before authentication');
+          ws.close(4002, 'too much data before authentication');
           return;
         }
         preAuthQueue.push(frame);
+        preAuthBytes += rawBytes;
         return;
       }
       if (frame.version !== PROTOCOL_VERSION) {
@@ -339,6 +367,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         // keeping alive (issue #474).
         const queued = preAuthQueue;
         preAuthQueue = [];
+        preAuthBytes = 0;
         if (queued.length > 0) {
           logEvent('pre_auth_replayed', { agentId, frames: queued.length });
           for (const queuedFrame of queued) processAuthedFrame(queuedFrame);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -261,7 +261,14 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   // untouched if authentication fails.
   let preAuthQueue: UpFrame[] = [];
   let preAuthBytes = 0;
-  const MAX_PRE_AUTH_FRAMES = 256;
+  // Must exceed the client's own replay buffer cap (DEFAULT_MAX_PENDING_FRAMES,
+  // 2000, in packages/client/src/client.ts). The client flushes its whole
+  // buffer immediately behind `hello` and clears it as it goes, so a server cap
+  // BELOW that would close a perfectly normal replay with 4002 and destroy the
+  // very frames this feature exists to preserve — and the client would
+  // reconnect into a loop. Same relationship as the byte budget below; both
+  // caps are deliberately the larger side of that pair.
+  const MAX_PRE_AUTH_FRAMES = 4_096;
   // Byte budget alongside the frame count, measured on the RAW message rather
   // than the parsed object: the protocol puts no size limit on artifact or
   // status payloads, so a frame count alone bounds nothing. Without this an
@@ -271,6 +278,10 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   // Sized above the client's own replay budget (DEFAULT_MAX_PENDING_BYTES in
   // packages/client/src/client.ts) so a legitimate replay always fits; a client
   // that overshoots is closed rather than silently truncated.
+  //
+  // Enforced BEFORE parsing (see below): checking after `parseUpFrame` would
+  // let a peer make us materialize an oversized payload through JSON and Zod
+  // and only then reject it, which is most of the cost the cap exists to deny.
   const MAX_PRE_AUTH_BYTES = 8 * 1024 * 1024;
 
   ws.on('message', (raw) => {
@@ -283,6 +294,27 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         : raw instanceof ArrayBuffer
           ? raw.byteLength
           : Buffer.byteLength(String(raw), 'utf8');
+
+    // Everything an unauthenticated peer sends — the hello itself included —
+    // counts against one budget, and it is charged here, before the bytes are
+    // handed to the parser. There is no separate allowance for the hello: a
+    // legitimate one is a few hundred bytes, so the shared budget is orders of
+    // magnitude more than it needs while still capping what a peer can make us
+    // allocate before it has proved anything.
+    if (!authed) {
+      if (preAuthBytes + rawBytes > MAX_PRE_AUTH_BYTES) {
+        logEvent('pre_auth_overflow', {
+          frames: preAuthQueue.length,
+          bytes: preAuthBytes,
+          frameBytes: rawBytes,
+        });
+        opts.registry.noteServerClose(ws);
+        ws.close(4002, 'too much data before authentication');
+        return;
+      }
+      preAuthBytes += rawBytes;
+    }
+
     let frame;
     try {
       frame = parseUpFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
@@ -305,21 +337,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           ws.close(4003, 'expected hello');
           return;
         }
-        if (
-          preAuthQueue.length >= MAX_PRE_AUTH_FRAMES ||
-          preAuthBytes + rawBytes > MAX_PRE_AUTH_BYTES
-        ) {
-          logEvent('pre_auth_overflow', {
-            frames: preAuthQueue.length,
-            bytes: preAuthBytes,
-            frameBytes: rawBytes,
-          });
+        if (preAuthQueue.length >= MAX_PRE_AUTH_FRAMES) {
+          logEvent('pre_auth_overflow', { frames: preAuthQueue.length, bytes: preAuthBytes });
           opts.registry.noteServerClose(ws);
-          ws.close(4002, 'too much data before authentication');
+          ws.close(4002, 'too many frames before authentication');
           return;
         }
         preAuthQueue.push(frame);
-        preAuthBytes += rawBytes;
         return;
       }
       if (frame.version !== PROTOCOL_VERSION) {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -239,6 +239,10 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         agentId: agentId ?? undefined,
         taskId: truncate(taskId, 128),
         ownerAgentId: b.agentId,
+        // Same event name as the executor's cancel guard and bindTask's
+        // (issue #476), so all cross-agent attempts aggregate together;
+        // `operation` is what tells an operator which door was tried.
+        operation: 'frame',
       });
       return undefined;
     }

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -10,7 +10,7 @@ import {
 } from '@vicoop-bridge/protocol';
 import type { Message, TaskStatus } from '@a2x/sdk';
 import { TaskState } from '@a2x/sdk';
-import type { Registry } from './registry.js';
+import type { Registry, TaskBinding } from './registry.js';
 import type { Sql } from './db.js';
 import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
@@ -215,6 +215,32 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   let authed = false;
   let helloProcessing = false;
 
+  // Resolve the binding a task frame targets, but only if this connection's
+  // authenticated agent is the one that owns it. `getBinding` keys on taskId
+  // alone, so without this check any authenticated client that learned another
+  // agent's taskId could push status, artifacts, reported `usage`, or a forged
+  // terminal into that agent's caller's stream.
+  //
+  // The reconnect grace hold (issue #474) is what makes the check load-bearing.
+  // Before it, a binding vanished the instant its agent dropped; now it stays
+  // resolvable for the whole grace window while its owner is offline and in no
+  // position to contradict anything written in its name. Closing the gap here
+  // rather than in the registry keeps `getBinding` a pure lookup and puts the
+  // authorization next to the authenticated identity it is checked against.
+  const ownedBinding = (taskId: string): TaskBinding | undefined => {
+    const b = opts.registry.getBinding(taskId);
+    if (!b) return undefined;
+    if (b.agentId !== agentId) {
+      logEvent('binding_owner_mismatch', {
+        agentId: agentId ?? undefined,
+        taskId,
+        ownerAgentId: b.agentId,
+      });
+      return undefined;
+    }
+    return b;
+  };
+
   const helloTimeout = setTimeout(() => {
     if (!authed) ws.close(4001, 'hello timeout');
   }, 10_000);
@@ -296,7 +322,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
 
     switch (frame.type) {
       case 'task.status': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const b = ownedBinding(frame.taskId);
         if (!b) return;
         // Diagnostic (issue #414): count liveness-heartbeat beats forwarded for
         // this task (hop 2). A heartbeat is a non-terminal working status tagged
@@ -320,7 +346,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         break;
       }
       case 'task.artifact': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const b = ownedBinding(frame.taskId);
         if (!b) return;
         b.sink.pushArtifact({
           taskId: frame.taskId,
@@ -339,7 +365,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         break;
       }
       case 'task.complete': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const b = ownedBinding(frame.taskId);
         if (!b) {
           // No live binding for this taskId — the terminal frame cannot be
           // delivered and the corresponding stream (if any) will not close via
@@ -378,7 +404,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         break;
       }
       case 'task.fail': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const b = ownedBinding(frame.taskId);
         if (!b) {
           logEvent('dropped_terminal_frame', {
             agentId: agentId ?? undefined,


### PR DESCRIPTION
Fixes #474.

A WS drop failed every task bound to that client immediately. The client
reconnected ~3s later, finished those tasks, and sent their terminal frames —
which we discarded as `dropped_terminal_frame` because the binding was already
gone. **The answer came back and we threw it away**, so the router cooled the
agent down for a failure that never happened: a 3.2s proxy blip became a 69s
outage (vicoop-router#158).

Fixing that on the server exposed a second half of the same bug on the client,
so this PR touches both packages.

> **Scope note.** This PR was originally server-only. Adversarial review found
> that the server-side hold alone converts some clean failures into silently
> truncated successes, so it now also changes `@vicoop-bridge/client` and
> carries a changeset for it. See "Client: stop losing the output" below.

## Server: hold the binding instead of killing it

`unregisterAgent` takes the close code and, for a recoverable one, starts a
**per-binding** timer rather than failing the binding. Any task-scoped frame
from the reconnected client — a bare liveness heartbeat is enough — cancels the
timer and the task continues down the existing path. An unresumed hold expires
into the terminal that path always produced (`disconnected` for a drop,
`superseded` for a same-token reconnect), so nothing downstream needs a new case.

Binding-scoped rather than connection-scoped is what keeps this cheap.
`TaskBinding` has never held a `ws` (`sendToAgent` re-resolves by `agentId` at
send time), so a reconnected client's frames land on it with **no protocol
change** and no change to how long a task may run.

**Which close codes get grace → a deny-list, not an allow-list.** The server
never recorded close codes before this PR, so we have no data on what its socket
sees when a proxy tears a connection down — the `1012` in the incident is what
the *client* observed, and the two ends need not agree. What we do know exactly
is the terminal set, because the bridge sends it: its own `4000`–`4999`
rejections, plus `1000`. Since a peer that never echoes our close makes `4014`
come back as `1006`, server-initiated closes are recorded at the moment they are
issued and take precedence over the observed code.

**Both orderings hold.** Whether the server sees the old socket's close first or
the new hello first is a race, so the same-token reconnect path holds too. An
earlier revision tried to keep fail-fast for "two live daemons share a token" by
testing `readyState === OPEN`; that is not a liveness test — it only means the
server has not *observed* a close, and the client (which pings every 30s and
terminates on a missed pong) normally notices first. That discriminator was
therefore killing the common recovered drop, and is gone.

**T = 30s**, sized off the incident's terminal frames arriving at **+9s / +10s /
+15s** — the hold has to cover *task completion*, not the 3.2s reconnect. It is
not a cap on task duration: one frame resumes the binding outright, after which
the executor's 10-minute inactivity backstop governs as before.
`BRIDGE_DISCONNECT_GRACE_MS=0` restores the previous behavior exactly and is the
rollback lever; documented in `fly.toml` and `docs/design.md`.

## Client: stop losing the output (`@vicoop-bridge/client`, patch)

`send()` silently dropped any frame written while the socket was not OPEN. The
server-side hold keeps the task alive, but that only helps if the output
actually arrives:

- **Streamed deltas vanished** while the backend's own bookkeeping advanced past
  them, so the end-of-turn catch-up re-sent nothing and the task **completed
  with a hole**. `codex.ts` has the identical bug.
- A backend that **finished during the outage** lost its terminal outright and
  never re-emitted it, so a fully successful task was reported failed once the
  grace expired.

Frames are now buffered in arrival order and replayed on the next connection,
pipelined behind `hello` (the server queues frames arriving while its async auth
settles, so no ack round-trip is needed). Buffers are bounded by both count and
encoded bytes; a task that loses frames to either bound fails with
`client_buffer_overflow` rather than replaying a partial stream — an honest
failure the caller can retry beats a silently truncated answer.

Two other designs were rejected on review first. Re-emitting the full text as a
fresh `append:false` artifact does not replace anything (`appendArtifactChunk`
pushes unconditionally, so the prefix would be duplicated, and no wire signal
can retract bytes an SSE consumer already received). A delivered-prefix cursor
inside `claude.ts` fixes only assistant text, only for claude, and does nothing
for a lost terminal.

## Known limits, stated plainly

- A socket that is `OPEN` but half-dead still swallows frames — they are neither
  delivered nor buffered. No design closes this without app-level acks; worst
  case is bounded by the client's ping interval.
- A genuinely dead client's task now fails T seconds later, which eats into the
  router's failover budget in the worst-timed case. This is the trade-off #474
  accepted explicitly, and `=0` reverses it.

## Tests

Server 328/328, client 904/904. **18/18 mutations fail the suite** — including
the close-code wiring, both agent-scoping filters, every `clearGraceHold` site,
and the production config path (`new Registry()` with no argument, which is what
ships and which no test previously reached). The client buffer was verified the
same way: reverting it fails its tests.

The incident is reproduced end to end in `ws.test.ts` — bind a task, close the
server socket with `1012`, reconnect, complete on the new socket — and that test
fails without the fix.

Related: #476 (cross-agent A2A ownership, found during review here) was fixed
separately in #477, which this branch is rebased on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3SwVrGFrR5cQnZBZMGztz
