### PR TITLE
fix(server): enforce per-agent task ownership

### DIFF
--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -629,9 +629,18 @@ CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
   state           TEXT NOT NULL,
   task_json       JSONB NOT NULL,
   owner_principal TEXT,
+  owner_agent     TEXT,
   created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+-- Existing installations predate per-agent task ownership. Leave legacy rows
+-- unowned (and therefore invisible to every scoped A2A handler); their owning
+-- agent cannot be recovered reliably from task_json.
+ALTER TABLE infra.a2a_tasks ADD COLUMN IF NOT EXISTS owner_agent TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_a2a_tasks_agent_context_principal
+  ON infra.a2a_tasks (owner_agent, context_id, owner_principal, created_at);
 
 CREATE INDEX IF NOT EXISTS idx_a2a_tasks_context_principal
   ON infra.a2a_tasks (context_id, owner_principal, created_at);

--- a/packages/server/schema.sql
+++ b/packages/server/schema.sql
@@ -629,7 +629,6 @@ CREATE TABLE IF NOT EXISTS infra.a2a_tasks (
   state           TEXT NOT NULL,
   task_json       JSONB NOT NULL,
   owner_principal TEXT,
-  owner_agent     TEXT,
   created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/packages/server/src/admin.ts
+++ b/packages/server/src/admin.ts
@@ -491,12 +491,15 @@ export function createAdminA2XServer(opts: AdminAgentOptions): {
   // is truthy, retain the full inbound request envelope on persisted task rows
   // instead of stripping it (the lean post-#409 default). Left on it re-creates
   // the #408 growth, so it is an on-demand debugging toggle, not a steady state.
-  // This store is shared by the admin agent and every WS-forwarding agent (see
-  // buildAgentA2XServer in http.tsx), so the flag governs all persisted tasks.
   const persistRequestEnvelope = parsePersistRequestEnvelope(
     process.env.A2A_PERSIST_REQUEST_ENVELOPE,
   );
-  const taskStore = new PostgresTaskStore(opts.db, { persistRequestEnvelope });
+  const taskStore = new PostgresTaskStore(opts.db, {
+    persistRequestEnvelope,
+    // "admin" is reserved by the bridge and cannot be registered by an
+    // operator, so it is also a collision-free task-owner scope.
+    ownerAgent: 'admin',
+  });
   const executor = new AdminA2XExecutor(opts.db, opts.registry, taskStore);
 
   const a2xServer = new A2XServer({

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -22,8 +22,8 @@ export interface AgentA2XOptions {
 
 /**
  * Build the A2XServer for a WS-connected client. Each per-agent A2XServer
- * owns a `WSForwardingExecutor` bound to that agent's id and the
- * shared task store.
+ * owns a `WSForwardingExecutor` bound to that agent's id and an
+ * agent-scoped task store.
  *
  * The card surface is derived from the wire `AgentCard` the client sent
  * in its hello frame, plus security schemes synthesised from the

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -452,6 +452,14 @@ test('executeStream cannot displace a live task binding owned by another agent',
   assert.equal(victimFinished, false, 'the victim stream must remain open');
   assert.equal(victimStatuses.length, 0, 'the victim must not receive a forged failed event');
   assert.equal(sent.length, 0, 'the attacker agent must not receive a task.assign frame');
+  const abortControllers = (
+    executor as unknown as { abortControllers: Map<string, AbortController> }
+  ).abortControllers;
+  assert.equal(
+    abortControllers.has(task.id),
+    false,
+    'a rejected binding must not leave a stale AbortController behind',
+  );
 });
 
 test('executor omits message.metadata entirely when the only entry was _principalId', async () => {

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -390,7 +390,11 @@ test('cancel rejects a task bound to a different agent without touching its stre
     status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
   } as unknown as Task;
 
-  await assert.rejects(executor.cancel(task), TaskNotCancelableError);
+  await assert.rejects(executor.cancel(task), (err: unknown) => {
+    assert.ok(err instanceof TaskNotCancelableError);
+    assert.equal(err.message, 'Task cannot be canceled');
+    return true;
+  });
   assert.equal(task.status.state, TaskState.WORKING, 'the task must not be marked canceled');
   assert.equal(victimFinished, false, 'the victim stream must remain open');
   assert.equal(victimStatuses.length, 0, 'the victim must not receive a forged canceled event');

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
 import {
+  TaskNotCancelableError,
   TaskState,
   type Artifact,
   type Message,
@@ -352,6 +353,105 @@ test('cancel delivers a CANCELED terminal event through the stream before aborti
   assert.equal(ev.status.state, TaskState.CANCELED);
   for await (const _event of gen) void _event; // drain to completion
   assert.equal(registry.getBinding('t-cancel'), undefined, 'binding released');
+});
+
+test('cancel rejects a task bound to a different agent without touching its stream', async () => {
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'attacker',
+    clientId: 'c-attacker',
+    ownerPrincipal: 'eth:0xattacker',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+
+  const victimStatuses: TaskStatusUpdateEvent[] = [];
+  let victimFinished = false;
+  registry.bindTask({
+    agentId: 'victim',
+    taskId: 't-cross-cancel',
+    contextId: 'ctx-cross-cancel',
+    sink: {
+      pushStatus: (event) => victimStatuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        victimFinished = true;
+      },
+    },
+  });
+
+  const executor = new WSForwardingExecutor('attacker', registry, noopTaskStore());
+  const task = {
+    id: 't-cross-cancel',
+    contextId: 'ctx-cross-cancel',
+    status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+
+  await assert.rejects(executor.cancel(task), TaskNotCancelableError);
+  assert.equal(task.status.state, TaskState.WORKING, 'the task must not be marked canceled');
+  assert.equal(victimFinished, false, 'the victim stream must remain open');
+  assert.equal(victimStatuses.length, 0, 'the victim must not receive a forged canceled event');
+  assert.equal(sent.length, 0, 'no cancel frame may be sent through the attacker agent');
+});
+
+test('executeStream cannot displace a live task binding owned by another agent', async () => {
+  const { ws, sent } = makeWsCapture();
+  const registry = new Registry();
+  registry.registerAgent({
+    agentId: 'attacker',
+    clientId: 'c-attacker',
+    ownerPrincipal: 'eth:0xattacker',
+    agentCard: makeAgentCard(),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+
+  const victimStatuses: TaskStatusUpdateEvent[] = [];
+  let victimFinished = false;
+  const victimBinding = {
+    agentId: 'victim',
+    taskId: 't-cross-bind',
+    contextId: 'ctx-cross-bind',
+    sink: {
+      pushStatus: (event: TaskStatusUpdateEvent) => victimStatuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        victimFinished = true;
+      },
+    },
+  };
+  registry.bindTask(victimBinding);
+
+  const executor = new WSForwardingExecutor('attacker', registry, noopTaskStore());
+  const task = {
+    id: 't-cross-bind',
+    contextId: 'ctx-cross-bind',
+    status: { state: TaskState.WORKING, timestamp: new Date().toISOString() },
+  } as unknown as Task;
+  const message = {
+    role: 'user',
+    parts: [{ kind: 'text', text: 'hijack' }],
+    messageId: 'm-cross-bind',
+    taskId: task.id,
+    contextId: task.contextId,
+  } as unknown as Message;
+
+  const events: TaskStatusUpdateEvent[] = [];
+  for await (const event of executor.executeStream(task, message)) {
+    events.push(event as TaskStatusUpdateEvent);
+  }
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.final, true);
+  assert.equal(events[0]?.status.state, TaskState.FAILED);
+  assert.equal(registry.getBinding(task.id), victimBinding, 'the victim binding must remain installed');
+  assert.equal(victimFinished, false, 'the victim stream must remain open');
+  assert.equal(victimStatuses.length, 0, 'the victim must not receive a forged failed event');
+  assert.equal(sent.length, 0, 'the attacker agent must not receive a task.assign frame');
 });
 
 test('executor omits message.metadata entirely when the only entry was _principalId', async () => {

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -362,7 +362,6 @@ export class WSForwardingExecutor extends AgentExecutor {
 
     const queue = new AsyncEventQueue<TaskStatusUpdateEvent | TaskArtifactUpdateEvent>();
     const ac = new AbortController();
-    this.abortControllers.set(taskId, ac);
 
     const sink: TaskSink = {
       pushStatus: (event) => queue.push(event),
@@ -409,6 +408,9 @@ export class WSForwardingExecutor extends AgentExecutor {
       ...(requestedExtensions !== undefined ? { requestedExtensions } : {}),
     };
     if (!this.registry.bindTask(binding)) {
+      // This queue will never be consumed because the binding was rejected.
+      // Close it now, and do not publish the AbortController into the task map.
+      queue.end();
       const failEvent: TaskStatusUpdateEvent = {
         taskId,
         contextId,
@@ -452,6 +454,7 @@ export class WSForwardingExecutor extends AgentExecutor {
       }
       return;
     }
+    this.abortControllers.set(taskId, ac);
 
     let history = appendHistoryMessage(task.history ?? [], message);
     task.history = history;

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -689,7 +689,7 @@ export class WSForwardingExecutor extends AgentExecutor {
         taskId,
         operation: 'cancel',
       });
-      throw new TaskNotCancelableError(`Task '${taskId}' is not owned by this agent`);
+      throw new TaskNotCancelableError('Task cannot be canceled');
     }
 
     // Notify the connected client so it can abort in-flight work and

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -3,6 +3,7 @@ import {
   BaseAgent,
   InMemoryRunner,
   StreamingMode,
+  TaskNotCancelableError,
   TaskState,
   TERMINAL_STATES,
   type Artifact,
@@ -407,7 +408,50 @@ export class WSForwardingExecutor extends AgentExecutor {
       ...(principalId !== undefined ? { principalId } : {}),
       ...(requestedExtensions !== undefined ? { requestedExtensions } : {}),
     };
-    this.registry.bindTask(binding);
+    if (!this.registry.bindTask(binding)) {
+      const failEvent: TaskStatusUpdateEvent = {
+        taskId,
+        contextId,
+        final: true,
+        status: {
+          state: TaskState.FAILED,
+          timestamp: new Date().toISOString(),
+          message: {
+            messageId: `${taskId}-owner-mismatch`,
+            role: 'agent',
+            parts: [{ text: 'task ownership validation failed' }],
+            ...terminalErrorMessageFields(
+              {
+                code: 'task_owner_mismatch',
+                message: 'task ownership validation failed',
+              },
+              requestedExtensions,
+            ),
+            taskId,
+            contextId,
+          },
+        },
+      };
+      const terminal =
+        gate && settlement
+          ? await this.settleTerminal(gate, settlement, failEvent, binding, taskId, contextId)
+          : failEvent;
+      task.status = terminal.status;
+      task.history = appendHistoryMessage(
+        appendHistoryMessage(task.history ?? [], message),
+        terminal.status.message,
+      );
+      yield terminal;
+      try {
+        await this.taskStore.updateTask(taskId, {
+          status: task.status,
+          history: task.history,
+        });
+      } catch (err) {
+        logEvent('task_persist_error', { taskId, error: String(err) });
+      }
+      return;
+    }
 
     let history = appendHistoryMessage(task.history ?? [], message);
     task.history = history;
@@ -633,6 +677,17 @@ export class WSForwardingExecutor extends AgentExecutor {
     const taskId = task.id;
     const contextId = task.contextId ?? taskId;
     const ac = this.abortControllers.get(taskId);
+    const binding = this.registry.getBinding(taskId);
+
+    if (binding && binding.agentId !== this.agentId) {
+      logEvent('binding_owner_mismatch', {
+        agentId: this.agentId,
+        ownerAgentId: binding.agentId,
+        taskId,
+        operation: 'cancel',
+      });
+      throw new TaskNotCancelableError(`Task '${taskId}' is not owned by this agent`);
+    }
 
     // Notify the connected client so it can abort in-flight work and
     // emit its own task.fail / task.complete frame.
@@ -645,7 +700,6 @@ export class WSForwardingExecutor extends AgentExecutor {
     // buffered-but-unyielded — the stream would close without ever delivering
     // the terminal frame. The ac.abort() below is then only a fallback to
     // unblock a parked executor when there was no binding to deliver through.
-    const binding = this.registry.getBinding(taskId);
     if (binding) {
       const cancelStatus: TaskStatusUpdateEvent = {
         taskId,

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -52,6 +52,10 @@ import { Landing } from './landing.js';
 import { logEvent } from './log.js';
 import { buildAgentA2XServer, type AgentA2XOptions } from './agent-card.js';
 import {
+  PostgresTaskStore,
+  parsePersistRequestEnvelope,
+} from './postgres-task-store.js';
+import {
   buildLandingDirectory,
   mountWellKnown,
   type ConnectionPair,
@@ -131,17 +135,18 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     }),
   );
 
-  // Built-in admin agent at root. The admin agent owns its own taskStore
-  // (Postgres-backed) for context-aware history loading; client agents
-  // share a separate taskStore so their state isn't entangled with the
-  // admin's persistence model.
-  const { handler: adminHandler, a2xServer: adminA2X, taskStore: adminTaskStore } =
-    createAdminA2XServer({
-      db: opts.db,
-      registry: opts.registry,
-      publicUrl: opts.publicUrl,
-    });
+  // The built-in admin agent and every connected client agent get distinct
+  // owner-scoped views of the same Postgres table. A handler can therefore
+  // never resolve another agent's task by taskId.
+  const { handler: adminHandler, a2xServer: adminA2X } = createAdminA2XServer({
+    db: opts.db,
+    registry: opts.registry,
+    publicUrl: opts.publicUrl,
+  });
   const adminCard = adminA2X.getAgentCard() as AgentCardV03;
+  const persistRequestEnvelope = parsePersistRequestEnvelope(
+    process.env.A2A_PERSIST_REQUEST_ENVELOPE,
+  );
 
   // Per-agent A2XServer cache. Rebuilds on caller-/agent-change so the
   // card reflects the latest connection state.
@@ -162,7 +167,11 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   function getAgentForConn(conn: ClientConnection): A2XServer {
     const cached = agentCache.get(conn.agentId);
     if (cached) return cached;
-    const a2x = buildAgentA2XServer(conn, adminTaskStore, opts.registry, agentCardOpts);
+    const taskStore = new PostgresTaskStore(opts.db, {
+      persistRequestEnvelope,
+      ownerAgent: conn.agentId,
+    });
+    const a2x = buildAgentA2XServer(conn, taskStore, opts.registry, agentCardOpts);
     agentCache.set(conn.agentId, a2x);
     return a2x;
   }

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -217,6 +217,42 @@ test('stripSensitiveMetadata with preserveEnvelope still scrubs bearer/principal
 // ── updateTask concurrency (issue #366) ─────────────────────────────────────
 
 test(
+  'owner-scoped stores cannot read, update, or delete another agent task',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    try {
+      await ensureSchema(sql);
+      const victimStore = new PostgresTaskStore(sql, { ownerAgent: 'scope-victim' });
+      const attackerStore = new PostgresTaskStore(sql, { ownerAgent: 'scope-attacker' });
+      const maintenanceStore = new PostgresTaskStore(sql);
+      const task = await victimStore.createTask({});
+
+      try {
+        const rows = await sql<{ owner_agent: string | null }[]>`
+          SELECT owner_agent FROM infra.a2a_tasks WHERE task_id = ${task.id}
+        `;
+        assert.equal(rows[0]?.owner_agent, 'scope-victim');
+        assert.equal(await attackerStore.getTask(task.id), null);
+        await assert.rejects(
+          attackerStore.updateTask(task.id, {
+            status: { state: TaskState.CANCELED, timestamp: new Date().toISOString() },
+          }),
+          /Task not found/,
+        );
+
+        await attackerStore.deleteTask(task.id);
+        assert.ok(await victimStore.getTask(task.id), 'cross-agent delete must be a no-op');
+      } finally {
+        await maintenanceStore.deleteTask(task.id);
+      }
+    } finally {
+      await sql.end();
+    }
+  },
+);
+
+test(
   'updateTask: concurrent updates touching different fields do not lose either write (issue #366)',
   { skip: !hasDb },
   async () => {

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -132,6 +132,12 @@ export interface PostgresTaskStoreOptions {
   // #408 growth for as long as it is on, so it is NOT meant to be left on.
   // (Reads still strip on the hot replay path regardless — see loadByContextId.)
   persistRequestEnvelope?: boolean;
+
+  // Restrict every task read and mutation to one owning A2A agent (issue #476).
+  // Runtime request handlers must always set this; leaving it undefined is
+  // reserved for maintenance jobs and low-level store tests that intentionally
+  // operate across all agents.
+  ownerAgent?: string;
 }
 
 // Parse the A2A_PERSIST_REQUEST_ENVELOPE env value into the store flag. Accepts
@@ -145,12 +151,14 @@ export function parsePersistRequestEnvelope(raw: string | undefined): boolean {
 
 export class PostgresTaskStore implements ContextAwareTaskStore {
   private readonly persistRequestEnvelope: boolean;
+  private readonly ownerAgent: string | undefined;
 
   constructor(
     private readonly sql: Sql,
     options?: PostgresTaskStoreOptions,
   ) {
     this.persistRequestEnvelope = options?.persistRequestEnvelope ?? false;
+    this.ownerAgent = options?.ownerAgent;
   }
 
   async createTask(params: CreateTaskParams): Promise<Task> {
@@ -167,9 +175,15 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
   }
 
   async getTask(taskId: string): Promise<Task | null> {
-    const rows = await this.sql<{ task_json: Task }[]>`
-      SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} LIMIT 1
-    `;
+    const rows = this.ownerAgent === undefined
+      ? await this.sql<{ task_json: Task }[]>`
+          SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} LIMIT 1
+        `
+      : await this.sql<{ task_json: Task }[]>`
+          SELECT task_json FROM infra.a2a_tasks
+          WHERE task_id = ${taskId} AND owner_agent = ${this.ownerAgent}
+          LIMIT 1
+        `;
     // Returns the stored row verbatim — including the request envelope when
     // persistRequestEnvelope is on (issue #419); this is the forensic read path.
     // Unlike loadByContextId (hot per-turn replay), this is a single on-demand
@@ -207,9 +221,15 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     let retentionMs = 0;
     try {
       const merged = await this.sql.begin(async (sql) => {
-        const rows = await sql<{ task_json: Task }[]>`
-          SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} FOR UPDATE
-        `;
+        const rows = this.ownerAgent === undefined
+          ? await sql<{ task_json: Task }[]>`
+              SELECT task_json FROM infra.a2a_tasks WHERE task_id = ${taskId} FOR UPDATE
+            `
+          : await sql<{ task_json: Task }[]>`
+              SELECT task_json FROM infra.a2a_tasks
+              WHERE task_id = ${taskId} AND owner_agent = ${this.ownerAgent}
+              FOR UPDATE
+            `;
         const existing = rows[0]?.task_json ?? null;
         if (!existing) {
           throw new Error(`Task not found: ${taskId}`);
@@ -271,7 +291,14 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
   }
 
   async deleteTask(taskId: string): Promise<void> {
-    await this.sql`DELETE FROM infra.a2a_tasks WHERE task_id = ${taskId}`;
+    if (this.ownerAgent === undefined) {
+      await this.sql`DELETE FROM infra.a2a_tasks WHERE task_id = ${taskId}`;
+      return;
+    }
+    await this.sql`
+      DELETE FROM infra.a2a_tasks
+      WHERE task_id = ${taskId} AND owner_agent = ${this.ownerAgent}
+    `;
   }
 
   async loadByContextId(
@@ -279,22 +306,41 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     principalId: string,
     excludeTaskId?: string,
   ): Promise<Task[]> {
-    const rows = excludeTaskId
-      ? await this.sql<{ task_json: Task }[]>`
-          SELECT task_json FROM infra.a2a_tasks
-          WHERE context_id = ${contextId}
-            AND owner_principal = ${principalId}
-            AND task_id != ${excludeTaskId}
-          ORDER BY created_at DESC, task_id DESC
-          LIMIT ${MAX_CONTEXT_TASKS}
-        `
-      : await this.sql<{ task_json: Task }[]>`
-          SELECT task_json FROM infra.a2a_tasks
-          WHERE context_id = ${contextId}
-            AND owner_principal = ${principalId}
-          ORDER BY created_at DESC, task_id DESC
-          LIMIT ${MAX_CONTEXT_TASKS}
-        `;
+    const rows = this.ownerAgent === undefined
+      ? excludeTaskId
+        ? await this.sql<{ task_json: Task }[]>`
+            SELECT task_json FROM infra.a2a_tasks
+            WHERE context_id = ${contextId}
+              AND owner_principal = ${principalId}
+              AND task_id != ${excludeTaskId}
+            ORDER BY created_at DESC, task_id DESC
+            LIMIT ${MAX_CONTEXT_TASKS}
+          `
+        : await this.sql<{ task_json: Task }[]>`
+            SELECT task_json FROM infra.a2a_tasks
+            WHERE context_id = ${contextId}
+              AND owner_principal = ${principalId}
+            ORDER BY created_at DESC, task_id DESC
+            LIMIT ${MAX_CONTEXT_TASKS}
+          `
+      : excludeTaskId
+        ? await this.sql<{ task_json: Task }[]>`
+            SELECT task_json FROM infra.a2a_tasks
+            WHERE owner_agent = ${this.ownerAgent}
+              AND context_id = ${contextId}
+              AND owner_principal = ${principalId}
+              AND task_id != ${excludeTaskId}
+            ORDER BY created_at DESC, task_id DESC
+            LIMIT ${MAX_CONTEXT_TASKS}
+          `
+        : await this.sql<{ task_json: Task }[]>`
+            SELECT task_json FROM infra.a2a_tasks
+            WHERE owner_agent = ${this.ownerAgent}
+              AND context_id = ${contextId}
+              AND owner_principal = ${principalId}
+            ORDER BY created_at DESC, task_id DESC
+            LIMIT ${MAX_CONTEXT_TASKS}
+          `;
     // Strip the request envelope from replayed tasks unconditionally — even
     // when persistRequestEnvelope is on and the stored rows carry it (issue
     // #419). The per-turn context replay must stay lean: re-reading a large
@@ -306,19 +352,20 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
   }
 
   /**
-   * Time-based retention. Deletes every task belonging to a context that has
-   * been idle (no task created or updated) for longer than `retentionDays`
-   * AND has no in-flight (non-terminal) task.
+   * Time-based retention. Deletes every task belonging to an agent/context
+   * pair that has been idle (no task created or updated) for longer than
+   * `retentionDays` AND has no in-flight (non-terminal) task.
    *
-   * Pruning is context-scoped rather than per-row on purpose: an actively-used
-   * long-running context keeps ALL its turns (its newest task's updated_at is
-   * recent, so the whole context is spared), and only contexts with no recent
-   * activity are reclaimed. This is the orthogonal axis to the count-based cap
-   * in enforceRetention() (which bounds a single context to MAX_CONTEXT_TASKS):
-   * the count cap stops one context from bloating, this stops the table from
-   * growing monotonically with the number of stale contexts over time (the root
-   * cause in #385). It also reclaims old terminal contexts whose rows have no
-   * owner_principal, which the count-based path skips.
+   * Pruning is agent/context-scoped rather than per-row on purpose: an
+   * actively-used long-running context keeps ALL its turns for that agent (its
+   * newest task's updated_at is recent, so the pair is spared), and only pairs
+   * with no recent activity are reclaimed. This is the orthogonal axis to the
+   * count-based cap in enforceRetention() (which bounds one agent/context pair
+   * to MAX_CONTEXT_TASKS): the count cap stops one context from bloating, this
+   * stops the table from growing monotonically with the number of stale
+   * contexts over time (the root cause in #385). It also reclaims old terminal
+   * contexts whose rows have no owner_principal, which the count-based path
+   * skips.
    *
    * Any context that still holds a non-terminal task is spared regardless of
    * age: the executor only persists a task at terminal/stream-end (no
@@ -334,15 +381,17 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
    */
   async pruneStaleContexts(retentionDays: number): Promise<number> {
     const res = await this.sql`
-      DELETE FROM infra.a2a_tasks
-      WHERE context_id IN (
-        SELECT context_id FROM infra.a2a_tasks
-        GROUP BY context_id
+      DELETE FROM infra.a2a_tasks AS task
+      USING (
+        SELECT owner_agent, context_id FROM infra.a2a_tasks
+        GROUP BY owner_agent, context_id
         HAVING max(updated_at) < now() - ${retentionDays} * interval '1 day'
            AND count(*) FILTER (
                  WHERE state NOT IN ('completed', 'failed', 'canceled', 'rejected')
                ) = 0
-      )
+      ) AS stale
+      WHERE task.context_id = stale.context_id
+        AND task.owner_agent IS NOT DISTINCT FROM stale.owner_agent
     `;
     return res.count;
   }
@@ -357,14 +406,30 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     });
     const contextId = task.contextId ?? task.id;
 
+    const persisted = sql.json(JSON.parse(JSON.stringify(sanitized)));
+    if (this.ownerAgent === undefined) {
+      await sql`
+        INSERT INTO infra.a2a_tasks
+          (task_id, context_id, state, task_json, owner_principal, owner_agent)
+        VALUES (
+          ${task.id}, ${contextId}, ${task.status.state}, ${persisted},
+          ${ownerPrincipal ?? null}, NULL
+        )
+        ON CONFLICT (task_id) DO UPDATE SET
+          context_id = EXCLUDED.context_id,
+          state = EXCLUDED.state,
+          task_json = EXCLUDED.task_json,
+          owner_principal = COALESCE(infra.a2a_tasks.owner_principal, EXCLUDED.owner_principal),
+          updated_at = now()
+      `;
+      return;
+    }
     await sql`
-      INSERT INTO infra.a2a_tasks (task_id, context_id, state, task_json, owner_principal)
+      INSERT INTO infra.a2a_tasks
+        (task_id, context_id, state, task_json, owner_principal, owner_agent)
       VALUES (
-        ${task.id},
-        ${contextId},
-        ${task.status.state},
-        ${sql.json(JSON.parse(JSON.stringify(sanitized)))},
-        ${ownerPrincipal ?? null}
+        ${task.id}, ${contextId}, ${task.status.state}, ${persisted},
+        ${ownerPrincipal ?? null}, ${this.ownerAgent}
       )
       ON CONFLICT (task_id) DO UPDATE SET
         context_id = EXCLUDED.context_id,
@@ -372,6 +437,7 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
         task_json = EXCLUDED.task_json,
         owner_principal = COALESCE(infra.a2a_tasks.owner_principal, EXCLUDED.owner_principal),
         updated_at = now()
+      WHERE infra.a2a_tasks.owner_agent = EXCLUDED.owner_agent
     `;
   }
 
@@ -393,11 +459,26 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     if (!ownerPrincipal || !TERMINAL_STATES.has(task.status.state)) return;
     const contextId = task.contextId ?? task.id;
 
+    if (this.ownerAgent === undefined) {
+      await this.sql`
+        DELETE FROM infra.a2a_tasks
+        WHERE task_id IN (
+          SELECT task_id FROM infra.a2a_tasks
+          WHERE context_id = ${contextId}
+            AND owner_principal = ${ownerPrincipal}
+            AND state IN ('completed', 'failed', 'canceled', 'rejected')
+          ORDER BY created_at DESC, task_id DESC
+          OFFSET ${MAX_CONTEXT_TASKS}
+        )
+      `;
+      return;
+    }
     await this.sql`
       DELETE FROM infra.a2a_tasks
       WHERE task_id IN (
         SELECT task_id FROM infra.a2a_tasks
-        WHERE context_id = ${contextId}
+        WHERE owner_agent = ${this.ownerAgent}
+          AND context_id = ${contextId}
           AND owner_principal = ${ownerPrincipal}
           AND state IN ('completed', 'failed', 'canceled', 'rejected')
         ORDER BY created_at DESC, task_id DESC

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -574,6 +574,24 @@ test('bindTask leaves a self-rebind untouched (same object is not a displacement
   assert.equal(registry.getBinding('t-self'), only.binding);
 });
 
+test('bindTask rejects a different agent without displacing the owner binding', () => {
+  const registry = new Registry();
+  const victim = recordingBinding('victim', 't-owned');
+  const attacker = recordingBinding('attacker', 't-owned');
+
+  assert.equal(registry.bindTask(victim.binding), true);
+  assert.equal(registry.bindTask(attacker.binding), false);
+
+  assert.equal(
+    registry.getBinding('t-owned'),
+    victim.binding,
+    'the victim must retain ownership of the live task id',
+  );
+  assert.equal(victim.state.finished, false, 'the victim stream must remain open');
+  assert.equal(victim.statuses.length, 0, 'the victim must not receive a forged terminal status');
+  assert.equal(attacker.state.finished, false, 'the rejected binding was never installed');
+});
+
 test('bindTask displacing a live binding emits a superseded terminal on the old sink', () => {
   const registry = new Registry();
   const first = recordingBinding('a1', 't-sup');

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -256,7 +256,7 @@ export class Registry {
     return [...this.agents.values()];
   }
 
-  bindTask(binding: TaskBinding): void {
+  bindTask(binding: TaskBinding): boolean {
     // A taskId can be reused across turns (A2A keeps the same taskId for an
     // `input-required` continuation) or arrive on a duplicate/retried request
     // while the prior run is still in flight. If a DIFFERENT live binding
@@ -266,6 +266,19 @@ export class Registry {
     // binding). Terminating it emits a `failed` terminal so that stream closes
     // cleanly instead of orphaning.
     const existing = this.bindings.get(binding.taskId);
+    if (existing && existing.agentId !== binding.agentId) {
+      // A task id is owned by exactly one agent (issue #476). Never let a
+      // request routed through another agent fail or displace the legitimate
+      // caller's live stream, even if an upstream task-store scoping regression
+      // hands the wrong task to that executor.
+      logEvent('binding_owner_mismatch', {
+        agentId: binding.agentId,
+        ownerAgentId: existing.agentId,
+        taskId: binding.taskId,
+        ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
+      });
+      return false;
+    }
     if (existing && existing !== binding) {
       logEvent('binding_displaced', {
         agentId: binding.agentId,
@@ -279,6 +292,7 @@ export class Registry {
       });
     }
     this.bindings.set(binding.taskId, binding);
+    return true;
   }
 
   getBinding(taskId: string): TaskBinding | undefined {


### PR DESCRIPTION
## Summary

- persist an `owner_agent` scope on A2A task rows and enforce it across task reads, updates, deletes, and context-history loading
- give the admin agent and every connected client agent distinct scoped task-store views
- reject cross-agent live-binding replacement and cancellation as a second defense layer
- add regressions for cross-agent task access, cancellation, and binding hijacking

## Security impact

This closes the shared-`taskStore` paths that allowed an operator who knew another agent's live task ID to read, cancel, fail, or hijack that task through their own A2A endpoint.

Existing rows have no reliably recoverable owning agent, so the migration leaves them with `owner_agent = NULL`. Scoped A2A handlers intentionally cannot access those legacy rows.

## Verification

- `pnpm --filter @vicoop-bridge/server test` — 295 passed, 0 failed, 71 DB-gated tests skipped because `DATABASE_URL` is unset
- `pnpm -r typecheck`
- `pnpm --filter @vicoop-bridge/server build`
- `git diff --check`

No changeset: this PR only changes the ignored, server-deployed package.

Closes #476