### PR TITLE
fix: make reconnect replay generation-safe

### DIFF
--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -1,0 +1,8 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Preserve in-flight task output across transient bridge reconnects with an
+acknowledged, generation-scoped replay protocol. Unacknowledged frames retain
+their original binding ID and sequence when resent, while bounded retention and
+legacy-server fallback fail closed instead of risking partial or stale output.

--- a/.changeset/eighty-cameras-repeat.md
+++ b/.changeset/eighty-cameras-repeat.md
@@ -4,5 +4,5 @@
 
 Preserve in-flight task output across transient bridge reconnects with an
 acknowledged, generation-scoped replay protocol. Unacknowledged frames retain
-their original binding ID and sequence when resent, while bounded retention and
+their original execution ID and sequence when resent, while bounded retention and
 legacy-server fallback fail closed instead of risking partial or stale output.

--- a/docs/design.md
+++ b/docs/design.md
@@ -65,6 +65,62 @@ vicoop-bridge/
 - `task.cancel`   — `{ taskId }`
 - `ping`
 
+### 4.1 Disconnect handling (acknowledged task replay)
+
+A `TaskBinding` is not tied to the connection that created it — it holds only
+`agentId`, and outbound sends re-resolve the live socket at send time. So a
+dropped WebSocket does not by itself invalidate an in-flight task.
+
+Clients opt in by advertising `task-replay-v1` in `hello`. After authentication,
+the server answers with `hello.ack`, then gives every `task.assign` a unique
+`bindingId`. The client adds that ID and a consecutive `seq` to each task frame,
+retains the encoded frame until `task.ack`, and resends the same ID and sequence
+after reconnecting. The server deduplicates acknowledged prefixes and fails the
+task on a sequence gap. This generation key is required because A2A can reuse a
+`taskId` across turns; output from an old turn must never complete a newer one.
+
+When a negotiated client's socket closes, the server keeps the binding alive
+for `BRIDGE_DISCONNECT_GRACE_MS` (default 30s) instead of failing the task at
+once. Only a generation-correct, gap-free frame on the next authenticated
+connection resumes the binding. An unresumed hold expires into exactly the
+terminal that path always produced: `disconnected` for a drop, `superseded` for
+a same-token reconnect.
+
+Legacy clients do not receive `hello.ack`, binding IDs, or grace holds. They
+retain the previous fail-immediately behavior, which keeps rolling server-first
+deploys safe. A new client connected to an older server recognizes a legacy
+`task.assign` and also uses the old fail-fast path.
+
+The grace is therefore *how long to wait before declaring a client dead*, not a
+cap on task duration; a long task is governed by
+`BRIDGE_TASK_INACTIVITY_TIMEOUT_MS` as before.
+
+Closes that are this server's own verdict rather than a transport failure skip
+the hold: the app-level codes it issues (`4000`–`4999`) and a clean `1000`.
+Since the code the server *observes* is not always the one it *sent* (a peer
+that never echoes the close frame surfaces as `1006`), the intent is recorded
+when the close is issued and takes precedence.
+
+One app-level close is deliberately excepted. `4009` — a second daemon
+authenticating with the same `CLIENT_TOKEN` — is *usually* the same client
+coming back rather than a rival, and the server cannot tell the two apart
+(`readyState` reports only what it has observed, and the client's own heartbeat
+normally detects a dead path first). So a `4009` collision holds like any other
+reconnect and expires as `superseded` if the task is never reclaimed. Operators
+reading a delayed collision failure should expect that delay.
+
+Setting `BRIDGE_DISCONNECT_GRACE_MS=0` disables the hold and restores the
+previous fail-immediately behavior exactly — the rollback lever if holds ever
+delay failover more than they save.
+
+The client bounds unacknowledged output by frame count, encoded bytes, and age.
+Exceeding a bound aborts and suppresses that run so the server fails it closed;
+it never replays a suffix after dropping a prefix. The server keeps short-lived
+terminal receipts so a terminal whose acknowledgement was lost can be
+acknowledged again without reopening or completing a reused task ID.
+
+Background: issue #474.
+
 ## 5. Client Backends
 
 ```bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -73,7 +73,7 @@ dropped WebSocket does not by itself invalidate an in-flight task.
 
 Clients opt in by advertising `task-replay-v1` in `hello`. After authentication,
 the server answers with `hello.ack`, then gives every `task.assign` a unique
-`bindingId`. The client adds that ID and a consecutive `seq` to each task frame,
+`executionId`. The client adds that ID and a consecutive `seq` to each task frame,
 retains the encoded frame until `task.ack`, and resends the same ID and sequence
 after reconnecting. The server deduplicates acknowledged prefixes and fails the
 task on a sequence gap. This generation key is required because A2A can reuse a
@@ -86,7 +86,7 @@ connection resumes the binding. An unresumed hold expires into exactly the
 terminal that path always produced: `disconnected` for a drop, `superseded` for
 a same-token reconnect.
 
-Legacy clients do not receive `hello.ack`, binding IDs, or grace holds. They
+Legacy clients do not receive `hello.ack`, execution IDs, or grace holds. They
 retain the previous fail-immediately behavior, which keeps rolling server-first
 deploys safe. A new client connected to an older server recognizes a legacy
 `task.assign` and also uses the old fail-fast path.

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -10,6 +10,7 @@ import {
   encodeFrame,
   parseUpFrame,
   OPENAI_COMPAT_EXTENSION_URI,
+  TASK_REPLAY_CAPABILITY,
   type Part,
   type TaskAssignFrame,
   type UpFrame,
@@ -345,7 +346,7 @@ test('Client reconnects after WebSocket close and sends hello again', async () =
       if (frame.type === 'hello') {
         assert.equal(frame.agentId, 'agent-1');
         assert.equal(frame.token, 'client-token');
-        assert.deepEqual(frame.protocolCapabilities, ['caller-context-v1']);
+        assert.deepEqual(frame.protocolCapabilities, ['caller-context-v1', TASK_REPLAY_CAPABILITY]);
       }
     }
   } finally {
@@ -1265,4 +1266,241 @@ test('usage.request: a throwing backend.usage() replies ok:false / usage_failed'
   assert.equal(resp.ok, false);
   assert.equal(resp.error?.code, 'usage_failed');
   assert.match(resp.error?.message ?? '', /serve down/);
+});
+
+// ── acknowledged reconnect replay ───────────────────────────────────────────
+
+test('reliable task frames carry one binding generation and consecutive sequences', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const received: UpFrame[] = [];
+  wss.on('connection', (ws) => {
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack',
+          protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        ws.send(encodeFrame({ ...makeAssign('t-seq'), bindingId: 'binding-seq' }));
+        return;
+      }
+      received.push(frame);
+      if ('bindingId' in frame && frame.bindingId && 'seq' in frame && frame.seq !== undefined) {
+        ws.send(encodeFrame({
+          type: 'task.ack',
+          taskId: frame.taskId,
+          bindingId: frame.bindingId,
+          acceptedSeq: frame.seq,
+        }));
+      }
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      emit({
+        type: 'task.artifact',
+        taskId: task.taskId,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'hello' }] },
+      });
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  try {
+    client.start();
+    await waitFor(() => received.filter((frame) => 'taskId' in frame).length === 2, 'task frames');
+    const taskFrames = received.filter((frame) => 'taskId' in frame);
+    assert.deepEqual(taskFrames.map((frame) => frame.type), ['task.artifact', 'task.complete']);
+    assert.deepEqual(
+      taskFrames.map((frame) => 'bindingId' in frame ? [frame.bindingId, frame.seq] : []),
+      [['binding-seq', 0], ['binding-seq', 1]],
+    );
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('an unacknowledged frame is replayed with the same binding id and sequence', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const artifacts: Array<{ bindingId?: string; seq?: number }> = [];
+  let connections = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  wss.on('connection', (ws) => {
+    const connection = ++connections;
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack',
+          protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        if (connection === 1) {
+          ws.send(encodeFrame({ ...makeAssign('t-replay'), bindingId: 'binding-replay' }));
+        }
+        return;
+      }
+      if (frame.type === 'task.artifact') {
+        artifacts.push({ bindingId: frame.bindingId, seq: frame.seq });
+        if (connection === 1) ws.close(1012, 'restart before ack');
+        else if (frame.bindingId && frame.seq !== undefined) {
+          ws.send(encodeFrame({
+            type: 'task.ack', taskId: frame.taskId,
+            bindingId: frame.bindingId, acceptedSeq: frame.seq,
+          }));
+          release();
+        }
+      }
+      if (frame.type === 'task.complete' && frame.bindingId && frame.seq !== undefined) {
+        ws.send(encodeFrame({
+          type: 'task.ack', taskId: frame.taskId,
+          bindingId: frame.bindingId, acceptedSeq: frame.seq,
+        }));
+      }
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      emit({
+        type: 'task.artifact', taskId: task.taskId,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'once' }] },
+      });
+      await gate;
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  try {
+    client.start();
+    await waitFor(() => artifacts.length === 2, 'replayed artifact');
+    assert.deepEqual(artifacts, [
+      { bindingId: 'binding-replay', seq: 0 },
+      { bindingId: 'binding-replay', seq: 0 },
+    ]);
+  } finally {
+    release();
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('an unacknowledged frame expires even while the socket stays open', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  let socketClosed = false;
+  let backendAborted = false;
+  wss.on('connection', (ws) => {
+    ws.on('close', () => { socketClosed = true; });
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type !== 'hello') return;
+      ws.send(encodeFrame({
+        type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+        disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
+      }));
+      ws.send(encodeFrame({ ...makeAssign('t-expire'), bindingId: 'binding-expire' }));
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit, signal) => {
+      emit({
+        type: 'task.artifact', taskId: task.taskId,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'unacked' }] },
+      });
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => {
+          backendAborted = true;
+          resolve();
+        }, { once: true });
+      });
+    }),
+    maxPendingAgeMs: 20,
+    reconnectDelayMs: 1_000,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  try {
+    client.start();
+    await waitFor(() => socketClosed, 'socket closed after acknowledgement timeout');
+    assert.equal(backendAborted, true);
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
+test('a replacement assignment suppresses the older run with the same taskId', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const completes: Array<{ bindingId?: string; seq?: number }> = [];
+  let releaseOld!: () => void;
+  const oldGate = new Promise<void>((resolve) => { releaseOld = resolve; });
+  wss.on('connection', (ws) => {
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        ws.send(encodeFrame({ ...makeAssign('t-reuse'), bindingId: 'binding-old' }));
+        setTimeout(() => {
+          ws.send(encodeFrame({ ...makeAssign('t-reuse'), bindingId: 'binding-new' }));
+        }, 10);
+        return;
+      }
+      if (frame.type === 'task.complete') completes.push(frame);
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      if (task.bindingId === 'binding-old') await oldGate;
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  try {
+    client.start();
+    await waitFor(() => completes.some((frame) => frame.bindingId === 'binding-new'), 'new run');
+    releaseOld();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.deepEqual(completes.map((frame) => frame.bindingId), ['binding-new']);
+  } finally {
+    releaseOld();
+    client.stop();
+    await closeServer(server, wss);
+  }
 });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1270,7 +1270,7 @@ test('usage.request: a throwing backend.usage() replies ok:false / usage_failed'
 
 // ── acknowledged reconnect replay ───────────────────────────────────────────
 
-test('reliable task frames carry one binding generation and consecutive sequences', async () => {
+test('reliable task frames carry one execution ID and consecutive sequences', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });
   const serverUrl = await listen(server);
@@ -1285,15 +1285,15 @@ test('reliable task frames carry one binding generation and consecutive sequence
           disconnectGraceMs: 30_000,
           maxFrameBytes: 16 * 1024 * 1024,
         }));
-        ws.send(encodeFrame({ ...makeAssign('t-seq'), bindingId: 'binding-seq' }));
+        ws.send(encodeFrame({ ...makeAssign('t-seq'), executionId: 'execution-seq' }));
         return;
       }
       received.push(frame);
-      if ('bindingId' in frame && frame.bindingId && 'seq' in frame && frame.seq !== undefined) {
+      if ('executionId' in frame && frame.executionId && 'seq' in frame && frame.seq !== undefined) {
         ws.send(encodeFrame({
           type: 'task.ack',
           taskId: frame.taskId,
-          bindingId: frame.bindingId,
+          executionId: frame.executionId,
           acceptedSeq: frame.seq,
         }));
       }
@@ -1321,8 +1321,8 @@ test('reliable task frames carry one binding generation and consecutive sequence
     const taskFrames = received.filter((frame) => 'taskId' in frame);
     assert.deepEqual(taskFrames.map((frame) => frame.type), ['task.artifact', 'task.complete']);
     assert.deepEqual(
-      taskFrames.map((frame) => 'bindingId' in frame ? [frame.bindingId, frame.seq] : []),
-      [['binding-seq', 0], ['binding-seq', 1]],
+      taskFrames.map((frame) => 'executionId' in frame ? [frame.executionId, frame.seq] : []),
+      [['execution-seq', 0], ['execution-seq', 1]],
     );
   } finally {
     client.stop();
@@ -1330,11 +1330,11 @@ test('reliable task frames carry one binding generation and consecutive sequence
   }
 });
 
-test('an unacknowledged frame is replayed with the same binding id and sequence', async () => {
+test('an unacknowledged frame is replayed with the same execution ID and sequence', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });
   const serverUrl = await listen(server);
-  const artifacts: Array<{ bindingId?: string; seq?: number }> = [];
+  const artifacts: Array<{ executionId?: string; seq?: number }> = [];
   let connections = 0;
   let release!: () => void;
   const gate = new Promise<void>((resolve) => { release = resolve; });
@@ -1350,25 +1350,25 @@ test('an unacknowledged frame is replayed with the same binding id and sequence'
           maxFrameBytes: 16 * 1024 * 1024,
         }));
         if (connection === 1) {
-          ws.send(encodeFrame({ ...makeAssign('t-replay'), bindingId: 'binding-replay' }));
+          ws.send(encodeFrame({ ...makeAssign('t-replay'), executionId: 'execution-replay' }));
         }
         return;
       }
       if (frame.type === 'task.artifact') {
-        artifacts.push({ bindingId: frame.bindingId, seq: frame.seq });
+        artifacts.push({ executionId: frame.executionId, seq: frame.seq });
         if (connection === 1) ws.close(1012, 'restart before ack');
-        else if (frame.bindingId && frame.seq !== undefined) {
+        else if (frame.executionId && frame.seq !== undefined) {
           ws.send(encodeFrame({
             type: 'task.ack', taskId: frame.taskId,
-            bindingId: frame.bindingId, acceptedSeq: frame.seq,
+            executionId: frame.executionId, acceptedSeq: frame.seq,
           }));
           release();
         }
       }
-      if (frame.type === 'task.complete' && frame.bindingId && frame.seq !== undefined) {
+      if (frame.type === 'task.complete' && frame.executionId && frame.seq !== undefined) {
         ws.send(encodeFrame({
           type: 'task.ack', taskId: frame.taskId,
-          bindingId: frame.bindingId, acceptedSeq: frame.seq,
+          executionId: frame.executionId, acceptedSeq: frame.seq,
         }));
       }
     });
@@ -1396,8 +1396,8 @@ test('an unacknowledged frame is replayed with the same binding id and sequence'
     client.start();
     await waitFor(() => artifacts.length === 2, 'replayed artifact');
     assert.deepEqual(artifacts, [
-      { bindingId: 'binding-replay', seq: 0 },
-      { bindingId: 'binding-replay', seq: 0 },
+      { executionId: 'execution-replay', seq: 0 },
+      { executionId: 'execution-replay', seq: 0 },
     ]);
   } finally {
     release();
@@ -1421,7 +1421,7 @@ test('an unacknowledged frame expires even while the socket stays open', async (
         type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
         disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
       }));
-      ws.send(encodeFrame({ ...makeAssign('t-expire'), bindingId: 'binding-expire' }));
+      ws.send(encodeFrame({ ...makeAssign('t-expire'), executionId: 'execution-expire' }));
     });
   });
   const client = new Client({
@@ -1460,7 +1460,7 @@ test('a replacement assignment suppresses the older run with the same taskId', a
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });
   const serverUrl = await listen(server);
-  const completes: Array<{ bindingId?: string; seq?: number }> = [];
+  const completes: Array<{ executionId?: string; seq?: number }> = [];
   let releaseOld!: () => void;
   const oldGate = new Promise<void>((resolve) => { releaseOld = resolve; });
   wss.on('connection', (ws) => {
@@ -1471,9 +1471,9 @@ test('a replacement assignment suppresses the older run with the same taskId', a
           type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
           disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
         }));
-        ws.send(encodeFrame({ ...makeAssign('t-reuse'), bindingId: 'binding-old' }));
+        ws.send(encodeFrame({ ...makeAssign('t-reuse'), executionId: 'execution-old' }));
         setTimeout(() => {
-          ws.send(encodeFrame({ ...makeAssign('t-reuse'), bindingId: 'binding-new' }));
+          ws.send(encodeFrame({ ...makeAssign('t-reuse'), executionId: 'execution-new' }));
         }, 10);
         return;
       }
@@ -1486,7 +1486,7 @@ test('a replacement assignment suppresses the older run with the same taskId', a
     agentId: 'agent-1',
     backendKind: 'echo',
     backend: backendOf('echo', async (task, emit) => {
-      if (task.bindingId === 'binding-old') await oldGate;
+      if (task.executionId === 'execution-old') await oldGate;
       emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
     }),
     heartbeatIntervalMs: 0,
@@ -1494,10 +1494,10 @@ test('a replacement assignment suppresses the older run with the same taskId', a
   });
   try {
     client.start();
-    await waitFor(() => completes.some((frame) => frame.bindingId === 'binding-new'), 'new run');
+    await waitFor(() => completes.some((frame) => frame.executionId === 'execution-new'), 'new run');
     releaseOld();
     await new Promise((resolve) => setTimeout(resolve, 30));
-    assert.deepEqual(completes.map((frame) => frame.bindingId), ['binding-new']);
+    assert.deepEqual(completes.map((frame) => frame.executionId), ['execution-new']);
   } finally {
     releaseOld();
     client.stop();

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1509,6 +1509,56 @@ test('an unacknowledged frame expires even while the socket stays open', async (
   }
 });
 
+test('an unacknowledged terminal disconnects after its backend has returned', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  let terminalReceived = false;
+  let socketClosed = false;
+  wss.on('connection', (ws) => {
+    ws.on('close', () => { socketClosed = true; });
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        ws.send(encodeFrame({
+          ...makeAssign('t-expired-terminal'), executionId: 'execution-expired-terminal',
+        }));
+      } else if (frame.type === 'task.complete') {
+        // Deliberately leave the terminal unacknowledged. The backend has
+        // already returned, so expiry must still disconnect and wake the
+        // server-side task lifecycle.
+        terminalReceived = true;
+      }
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    maxPendingAgeMs: 20,
+    reconnectDelayMs: 5_000,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(() => terminalReceived, 'unacknowledged terminal');
+    await waitFor(() => socketClosed, 'socket close after terminal acknowledgement timeout');
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('a pending-frame overflow reports client_buffer_overflow before disconnecting', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1456,6 +1456,63 @@ test('an unacknowledged frame expires even while the socket stays open', async (
   }
 });
 
+for (const [bound, options] of [
+  ['byte', { maxPendingBytes: 0 }],
+  ['age', { maxPendingAgeMs: 0 }],
+] as const) {
+  test(`a zero ${bound} retention bound aborts a reliable run on disconnect`, async () => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server, path: '/connect' });
+    const serverUrl = await listen(server);
+    let backendAborted = false;
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => {
+        const frame = parseUpFrame(raw.toString('utf8'));
+        if (frame.type === 'hello') {
+          ws.send(encodeFrame({
+            type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+            disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
+          }));
+          ws.send(encodeFrame({
+            ...makeAssign(`t-zero-${bound}`), executionId: `execution-zero-${bound}`,
+          }));
+        } else if (frame.type === 'task.artifact') {
+          ws.close(1012, 'disconnect with retention disabled');
+        }
+      });
+    });
+    const client = new Client({
+      serverUrl,
+      token: 'token',
+      agentId: 'agent-1',
+      backendKind: 'echo',
+      backend: backendOf('echo', async (task, emit, signal) => {
+        emit({
+          type: 'task.artifact', taskId: task.taskId,
+          artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'one shot' }] },
+        });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => {
+            backendAborted = true;
+            resolve();
+          }, { once: true });
+        });
+      }),
+      ...options,
+      reconnectDelayMs: 5_000,
+      heartbeatIntervalMs: 0,
+      logLevel: 'silent',
+    });
+    try {
+      client.start();
+      await waitFor(() => backendAborted, `zero ${bound} bound did not abort the run`);
+    } finally {
+      client.stop();
+      await closeServer(server, wss);
+    }
+  });
+}
+
 test('a replacement assignment suppresses the older run with the same taskId', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1270,6 +1270,59 @@ test('usage.request: a throwing backend.usage() replies ok:false / usage_failed'
 
 // ── acknowledged reconnect replay ───────────────────────────────────────────
 
+test('frames queued on a replaced socket cannot start or mutate current runs', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const sockets: WebSocket[] = [];
+  let hellos = 0;
+  const handled: string[] = [];
+  wss.on('connection', (ws) => {
+    sockets.push(ws);
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type !== 'hello') return;
+      hellos++;
+      ws.send(encodeFrame({
+        type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+        disconnectGraceMs: 30_000, maxFrameBytes: 16 * 1024 * 1024,
+      }));
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      handled.push(task.taskId);
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  try {
+    client.start();
+    await waitFor(() => hellos === 1, 'first hello');
+    (client as unknown as { connect(): void }).connect();
+    await waitFor(() => hellos === 2, 'replacement hello');
+
+    sockets[0]!.send(encodeFrame({
+      ...makeAssign('stale-task'), executionId: 'stale-execution',
+    }));
+    sockets[1]!.send(encodeFrame({
+      ...makeAssign('current-task'), executionId: 'current-execution',
+    }));
+
+    await waitFor(() => handled.length === 1, 'current task dispatch');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(handled, ['current-task']);
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('reliable task frames carry one execution ID and consecutive sequences', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1383,6 +1383,94 @@ test('reliable task frames carry one execution ID and consecutive sequences', as
   }
 });
 
+test('acknowledged frames are removed and not replayed after reconnect', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const framesByConnection: UpFrame[][] = [[], []];
+  const sockets: WebSocket[] = [];
+  let hellos = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  wss.on('connection', (ws) => {
+    const connection = sockets.push(ws) - 1;
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        hellos++;
+        ws.send(encodeFrame({
+          type: 'hello.ack',
+          protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        if (connection === 0) {
+          ws.send(encodeFrame({ ...makeAssign('t-acked'), executionId: 'execution-acked' }));
+        }
+        return;
+      }
+      framesByConnection[connection]!.push(frame);
+      if ('executionId' in frame && frame.executionId && 'seq' in frame && frame.seq !== undefined) {
+        ws.send(encodeFrame({
+          type: 'task.ack',
+          taskId: frame.taskId,
+          executionId: frame.executionId,
+          acceptedSeq: frame.seq,
+        }));
+      }
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      emit({
+        type: 'task.artifact',
+        taskId: task.taskId,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'accepted' }] },
+      });
+      await gate;
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+  const pendingCount = () =>
+    (client as unknown as { pendingFrames: unknown[] }).pendingFrames.length;
+  try {
+    client.start();
+    await waitFor(
+      () => framesByConnection[0]!.some((frame) => frame.type === 'task.artifact'),
+      'first artifact',
+    );
+    await waitFor(() => pendingCount() === 0, 'acknowledged artifact removal');
+
+    sockets[0]!.close(1012, 'restart after ack');
+    await waitFor(() => hellos === 2, 'reconnect hello');
+    release();
+    await waitFor(
+      () => framesByConnection[1]!.some((frame) => frame.type === 'task.complete'),
+      'completion after reconnect',
+    );
+
+    assert.deepEqual(
+      framesByConnection[1]!.filter((frame) => 'taskId' in frame).map((frame) => frame.type),
+      ['task.complete'],
+      'the acknowledged artifact must not be replayed on the new connection',
+    );
+    await waitFor(() => pendingCount() === 0, 'acknowledged completion removal');
+  } finally {
+    release();
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('an unacknowledged frame is replayed with the same execution ID and sequence', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1509,6 +1509,69 @@ test('an unacknowledged frame expires even while the socket stays open', async (
   }
 });
 
+test('a pending-frame overflow reports client_buffer_overflow before disconnecting', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const taskFrames: UpFrame[] = [];
+  wss.on('connection', (ws) => {
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack',
+          protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: 16 * 1024 * 1024,
+        }));
+        ws.send(encodeFrame({ ...makeAssign('t-overflow'), executionId: 'execution-overflow' }));
+        return;
+      }
+      taskFrames.push(frame);
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit) => {
+      emit({
+        type: 'task.artifact', taskId: task.taskId,
+        artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'fills the buffer' }] },
+      });
+      emit({ type: 'task.complete', taskId: task.taskId, status: { state: 'completed' } });
+    }),
+    maxPendingFrames: 1,
+    reconnectDelayMs: 5_000,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(
+      () => taskFrames.some((frame) => frame.type === 'task.fail'),
+      'client_buffer_overflow terminal',
+    );
+    assert.equal(taskFrames[0]?.type, 'task.artifact');
+    const failure = taskFrames.find((frame) => frame.type === 'task.fail');
+    assert.deepEqual(failure, {
+      type: 'task.fail',
+      taskId: 't-overflow',
+      executionId: 'execution-overflow',
+      seq: 1,
+      error: {
+        code: 'client_buffer_overflow',
+        message: 'client unacknowledged frame buffer limit exceeded',
+      },
+    });
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 for (const [bound, options] of [
   ['byte', { maxPendingBytes: 0 }],
   ['age', { maxPendingAgeMs: 0 }],

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1459,6 +1459,90 @@ test('an unacknowledged frame is replayed with the same execution ID and sequenc
   }
 });
 
+test('replay replaces a frame above the newly negotiated size limit with a failure', async () => {
+  const server = createServer();
+  const wss = new WebSocketServer({ server, path: '/connect' });
+  const serverUrl = await listen(server);
+  const replayed: UpFrame[] = [];
+  let connections = 0;
+  let backendAborted = false;
+  wss.on('connection', (ws) => {
+    const connection = ++connections;
+    ws.on('message', (raw) => {
+      const frame = parseUpFrame(raw.toString('utf8'));
+      if (frame.type === 'hello') {
+        ws.send(encodeFrame({
+          type: 'hello.ack',
+          protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: connection === 1 ? 16 * 1024 * 1024 : 512,
+        }));
+        if (connection === 1) {
+          ws.send(encodeFrame({
+            ...makeAssign('t-smaller-limit'), executionId: 'execution-smaller-limit',
+          }));
+        }
+        return;
+      }
+      if (connection === 1 && frame.type === 'task.artifact') {
+        ws.close(1012, 'reconnect with a smaller frame limit');
+      } else if (connection === 2) {
+        replayed.push(frame);
+      }
+    });
+  });
+  const client = new Client({
+    serverUrl,
+    token: 'token',
+    agentId: 'agent-1',
+    backendKind: 'echo',
+    backend: backendOf('echo', async (task, emit, signal) => {
+      emit({
+        type: 'task.artifact', taskId: task.taskId,
+        artifact: { artifactId: 'large', parts: [{ kind: 'text', text: 'x'.repeat(2_000) }] },
+      });
+      await new Promise<void>((resolve) => {
+        signal.addEventListener('abort', () => {
+          backendAborted = true;
+          resolve();
+        }, { once: true });
+      });
+    }),
+    reconnectDelayMs: 10,
+    reconnectMaxDelayMs: 10,
+    reconnectJitterRatio: 0,
+    heartbeatIntervalMs: 0,
+    logLevel: 'silent',
+  });
+
+  try {
+    client.start();
+    await waitFor(
+      () => replayed.some((frame) => frame.type === 'task.fail'),
+      'bounded replay failure',
+    );
+    assert.equal(backendAborted, true);
+    assert.equal(
+      replayed.some((frame) => frame.type === 'task.artifact'),
+      false,
+      'the oversized retained artifact must not be replayed',
+    );
+    assert.deepEqual(replayed.find((frame) => frame.type === 'task.fail'), {
+      type: 'task.fail',
+      taskId: 't-smaller-limit',
+      executionId: 'execution-smaller-limit',
+      seq: 0,
+      error: {
+        code: 'client_buffer_overflow',
+        message: 'retained client frame exceeds the negotiated server limit',
+      },
+    });
+  } finally {
+    client.stop();
+    await closeServer(server, wss);
+  }
+});
+
 test('an unacknowledged frame expires even while the socket stays open', async () => {
   const server = createServer();
   const wss = new WebSocketServer({ server, path: '/connect' });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -682,11 +682,22 @@ export class Client {
       (retentionEnabled && this.pendingFrames.length >= frameLimit) ||
       (retentionEnabled && this.pendingBytes + bytes > byteLimit)
     ) {
+      const why =
+        `unacknowledged frame buffer limit exceeded for task ${safeToken(frame.taskId)}`;
       this.failReliableRun(
         run,
-        `unacknowledged frame buffer limit exceeded for task ${safeToken(frame.taskId)}`,
-        true,
+        why,
+        false,
       );
+      // Replace the frame that could not be retained with a small terminal at
+      // the same sequence. On a healthy-looking socket this gives the bridge a
+      // precise failure instead of making it wait for reconnect grace and then
+      // report a generic disconnect. The send callback terminates only after
+      // `ws` has flushed the best-effort terminal to the transport.
+      this.sendReliableFailureAndDisconnect(run, frame.taskId, seq, {
+        code: 'client_buffer_overflow',
+        message: 'client unacknowledged frame buffer limit exceeded',
+      });
       return;
     }
 
@@ -750,6 +761,52 @@ export class Client {
     if (run.executionId !== undefined) this.removePendingExecution(run.executionId);
     this.logger.error(`${why}; suppressing the run so the bridge fails it closed`);
     if (disconnect && this.ws?.readyState === WebSocket.OPEN) this.ws.terminate();
+  }
+
+  private sendReliableFailureAndDisconnect(
+    run: ClientRun,
+    taskId: string,
+    seq: number,
+    error: { code: string; message: string },
+  ): void {
+    const ws = this.ws;
+    const executionId = run.executionId;
+    if (!this.replayReady || !ws || ws.readyState !== WebSocket.OPEN || executionId === undefined) {
+      if (ws?.readyState === WebSocket.OPEN) ws.terminate();
+      return;
+    }
+
+    const encoded = encodeFrame({
+      type: 'task.fail',
+      taskId,
+      executionId,
+      seq,
+      error,
+    });
+    if (
+      this.negotiatedMaxFrameBytes !== null &&
+      Buffer.byteLength(encoded, 'utf8') > this.negotiatedMaxFrameBytes
+    ) {
+      ws.terminate();
+      return;
+    }
+
+    try {
+      ws.send(encoded, (err) => {
+        if (err) {
+          this.logger.warn(
+            `best-effort task failure send failed (${safeToken(err.message)}); reconnecting`,
+          );
+        }
+        if (this.ws === ws) ws.terminate();
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `best-effort task failure send threw (${safeToken(message)}); reconnecting`,
+      );
+      if (this.ws === ws) ws.terminate();
+    }
   }
 
   private removePendingExecution(executionId: string): void {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -390,10 +390,14 @@ export class Client {
         return;
       }
 
+      // A replaced socket may still have already-queued message callbacks.
+      // Once another connection owns `this.ws`, no frame from this socket may
+      // mutate task generations, acknowledgements, or in-flight runs.
+      if (this.ws !== ws) return;
+
       switch (frame.type) {
         case 'hello.ack':
           if (!frame.protocolCapabilities.includes(TASK_REPLAY_CAPABILITY)) return;
-          if (this.ws !== ws) return;
           this.replayReady = true;
           this.negotiatedMaxFrameBytes = frame.maxFrameBytes;
           this.flushPendingFrames(ws);

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -48,7 +48,7 @@ export interface ClientOptions {
   maxPendingFrames?: number;
   // Companion byte budget for the encoded unacknowledged frames.
   maxPendingBytes?: number;
-  // Maximum age of an unacknowledged frame. Binding ids make stale frames safe
+  // Maximum age of an unacknowledged frame. Execution IDs make stale frames safe
   // to drop independently of the server's configured grace.
   maxPendingAgeMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
@@ -124,12 +124,12 @@ type TaskUpFrame = Extract<UpFrame, { taskId: string }>;
 interface ClientRun {
   controller: AbortController;
   suppressed: boolean;
-  bindingId?: string;
+  executionId?: string;
   nextSeq: number;
 }
 interface PendingFrame {
   taskId: string;
-  bindingId: string;
+  executionId: string;
   seq: number;
   encoded: string;
   bytes: number;
@@ -156,7 +156,7 @@ export class Client {
   // doesn't change mid-process.
   private effectiveCardPromise: Promise<AgentCard | undefined> | null = null;
   // Reliable frames stay here until the bridge cumulatively acknowledges their
-  // binding-local sequence. Reconnect simply resends the same generations and
+  // execution-local sequence. Reconnect simply resends the same generations and
   // sequences; the bridge deduplicates them and detects gaps.
   private pendingFrames: PendingFrame[] = [];
   private pendingBytes = 0;
@@ -396,13 +396,13 @@ export class Client {
           this.flushPendingFrames(ws);
           break;
         case 'task.ack':
-          this.acknowledgeFrames(frame.bindingId, frame.acceptedSeq);
+          this.acknowledgeFrames(frame.executionId, frame.acceptedSeq);
           break;
         case 'task.assign':
-          // A task assignment without a binding id came from a legacy bridge.
+          // A task assignment without an execution ID came from a legacy bridge.
           // It is proof that authentication finished, but reconnect replay is
           // intentionally unavailable on that connection.
-          if (frame.bindingId === undefined) this.replayReady = false;
+          if (frame.executionId === undefined) this.replayReady = false;
           // `summarizeParts` already sanitizes each MIME via safeToken, so
           // the `parts=` token here intentionally does NOT wrap the whole
           // summary again — that would double-escape backslashes (a `\n`
@@ -420,14 +420,14 @@ export class Client {
           this.logger.info(`task.cancel taskId=${safeToken(frame.taskId)}`);
           {
             const run = this.inflight.get(frame.taskId);
-            if (run && (frame.bindingId === undefined || frame.bindingId === run.bindingId)) {
+            if (run && (frame.executionId === undefined || frame.executionId === run.executionId)) {
               // A generation-scoped cancel is also the server's fail-closed
               // signal (for example after detecting a sequence gap). No later
               // frame from this generation can be accepted, so release its
               // retained prefix and suppress the backend's abort terminal.
-              if (frame.bindingId !== undefined) {
+              if (frame.executionId !== undefined) {
                 run.suppressed = true;
-                this.removePendingBinding(frame.bindingId);
+                this.removePendingExecution(frame.executionId);
               }
               run.controller.abort();
             }
@@ -461,7 +461,7 @@ export class Client {
       // safe, so stop those runs. Reliable runs retain their unacknowledged
       // frames and resume after the next hello.ack.
       for (const run of this.inflight.values()) {
-        if (run.bindingId !== undefined) continue;
+        if (run.executionId !== undefined) continue;
         run.suppressed = true;
         run.controller.abort();
       }
@@ -654,13 +654,13 @@ export class Client {
 
   private sendTaskFrame(run: ClientRun, frame: TaskUpFrame): void {
     if (run.suppressed) return;
-    if (run.bindingId === undefined) {
+    if (run.executionId === undefined) {
       this.send(frame);
       return;
     }
 
     const seq = run.nextSeq++;
-    const reliableFrame = { ...frame, bindingId: run.bindingId, seq } as TaskUpFrame;
+    const reliableFrame = { ...frame, executionId: run.executionId, seq } as TaskUpFrame;
     const encoded = encodeFrame(reliableFrame);
     const bytes = Buffer.byteLength(encoded, 'utf8');
     const frameLimit = this.pendingFrameLimit();
@@ -685,7 +685,7 @@ export class Client {
     if (frameLimit > 0 && byteLimit > 0 && ageLimit > 0) {
       this.pendingFrames.push({
         taskId: frame.taskId,
-        bindingId: run.bindingId,
+        executionId: run.executionId,
         seq,
         encoded,
         bytes,
@@ -723,10 +723,10 @@ export class Client {
     }
   }
 
-  private acknowledgeFrames(bindingId: string, acceptedSeq: number): void {
+  private acknowledgeFrames(executionId: string, acceptedSeq: number): void {
     let removed = 0;
     this.pendingFrames = this.pendingFrames.filter((entry) => {
-      if (entry.bindingId !== bindingId || entry.seq > acceptedSeq) return true;
+      if (entry.executionId !== executionId || entry.seq > acceptedSeq) return true;
       this.pendingBytes -= entry.bytes;
       removed++;
       return false;
@@ -739,14 +739,14 @@ export class Client {
     if (run.suppressed) return;
     run.suppressed = true;
     run.controller.abort();
-    if (run.bindingId !== undefined) this.removePendingBinding(run.bindingId);
+    if (run.executionId !== undefined) this.removePendingExecution(run.executionId);
     this.logger.error(`${why}; suppressing the run so the bridge fails it closed`);
     if (disconnect && this.ws?.readyState === WebSocket.OPEN) this.ws.terminate();
   }
 
-  private removePendingBinding(bindingId: string): void {
+  private removePendingExecution(executionId: string): void {
     this.pendingFrames = this.pendingFrames.filter((entry) => {
-      if (entry.bindingId !== bindingId) return true;
+      if (entry.executionId !== executionId) return true;
       this.pendingBytes -= entry.bytes;
       return false;
     });
@@ -788,13 +788,13 @@ export class Client {
     const ageLimit = this.pendingAgeLimit();
     if (ageLimit <= 0 || this.pendingFrames.length === 0) return;
     const cutoff = Date.now() - ageLimit;
-    const expiredBindings = new Set(
+    const expiredExecutions = new Set(
       this.pendingFrames
         .filter((entry) => entry.createdAt <= cutoff)
-        .map((entry) => entry.bindingId),
+        .map((entry) => entry.executionId),
     );
-    for (const bindingId of expiredBindings) {
-      const run = [...this.inflight.values()].find((candidate) => candidate.bindingId === bindingId);
+    for (const executionId of expiredExecutions) {
+      const run = [...this.inflight.values()].find((candidate) => candidate.executionId === executionId);
       if (run) {
         this.failReliableRun(
           run,
@@ -802,7 +802,7 @@ export class Client {
           this.ws?.readyState === WebSocket.OPEN,
         );
       } else {
-        this.removePendingBinding(bindingId);
+        this.removePendingExecution(executionId);
       }
     }
     this.schedulePendingExpiry();
@@ -860,13 +860,13 @@ export class Client {
     if (previous) {
       previous.suppressed = true;
       previous.controller.abort();
-      if (previous.bindingId !== undefined) this.removePendingBinding(previous.bindingId);
+      if (previous.executionId !== undefined) this.removePendingExecution(previous.executionId);
     }
     const controller = new AbortController();
     const run: ClientRun = {
       controller,
       suppressed: false,
-      ...(frame.bindingId !== undefined ? { bindingId: frame.bindingId } : {}),
+      ...(frame.executionId !== undefined ? { executionId: frame.executionId } : {}),
       nextSeq: 0,
     };
     this.inflight.set(frame.taskId, run);

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -44,12 +44,15 @@ export interface ClientOptions {
   reconnectJitterRatio?: number;
   reconnectStableMs?: number;
   // Maximum number of unacknowledged task frames retained across reconnects.
-  // `0` keeps sequencing/gap detection but disables retry retention.
+  // Setting any retention bound to `0` keeps sequencing/gap detection but
+  // disables retry retention and aborts reliable runs when their socket drops.
   maxPendingFrames?: number;
   // Companion byte budget for the encoded unacknowledged frames.
+  // `0` has the retention-disable behavior described above.
   maxPendingBytes?: number;
   // Maximum age of an unacknowledged frame. Execution IDs make stale frames safe
   // to drop independently of the server's configured grace.
+  // `0` has the retention-disable behavior described above.
   maxPendingAgeMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
@@ -456,12 +459,12 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
-      // Legacy task frames have no generation or sequence. Once their socket is
-      // gone, allowing a late backend terminal to target a reused taskId is not
-      // safe, so stop those runs. Reliable runs retain their unacknowledged
-      // frames and resume after the next hello.ack.
+      // Legacy frames, and reliable runs whose retention was explicitly
+      // disabled, cannot safely continue after losing their socket. Stop them
+      // so output produced during the outage is never silently discarded.
+      // Retained reliable runs resume after the next hello.ack.
       for (const run of this.inflight.values()) {
-        if (run.executionId !== undefined) continue;
+        if (run.executionId !== undefined && this.pendingRetentionEnabled()) continue;
         run.suppressed = true;
         run.controller.abort();
       }
@@ -666,13 +669,14 @@ export class Client {
     const frameLimit = this.pendingFrameLimit();
     const byteLimit = this.pendingByteLimit();
     const ageLimit = this.pendingAgeLimit();
+    const retentionEnabled = frameLimit > 0 && byteLimit > 0 && ageLimit > 0;
     const maxFrameBytes = this.negotiatedMaxFrameBytes;
 
     if (
       (maxFrameBytes !== null && bytes > maxFrameBytes) ||
-      (byteLimit > 0 && bytes > byteLimit) ||
-      (frameLimit > 0 && this.pendingFrames.length >= frameLimit) ||
-      (byteLimit > 0 && this.pendingBytes + bytes > byteLimit)
+      (retentionEnabled && bytes > byteLimit) ||
+      (retentionEnabled && this.pendingFrames.length >= frameLimit) ||
+      (retentionEnabled && this.pendingBytes + bytes > byteLimit)
     ) {
       this.failReliableRun(
         run,
@@ -682,7 +686,7 @@ export class Client {
       return;
     }
 
-    if (frameLimit > 0 && byteLimit > 0 && ageLimit > 0) {
+    if (retentionEnabled) {
       this.pendingFrames.push({
         taskId: frame.taskId,
         executionId: run.executionId,
@@ -766,6 +770,14 @@ export class Client {
   private pendingAgeLimit(): number {
     const value = this.opts.maxPendingAgeMs ?? DEFAULT_MAX_PENDING_AGE_MS;
     return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : DEFAULT_MAX_PENDING_AGE_MS;
+  }
+
+  private pendingRetentionEnabled(): boolean {
+    return (
+      this.pendingFrameLimit() > 0 &&
+      this.pendingByteLimit() > 0 &&
+      this.pendingAgeLimit() > 0
+    );
   }
 
   private schedulePendingExpiry(): void {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -3,6 +3,7 @@ import {
   CALLER_CONTEXT_CAPABILITY,
   PROTOCOL_VERSION,
   OPENAI_COMPAT_EXTENSION_URI,
+  TASK_REPLAY_CAPABILITY,
   encodeFrame,
   parseDownFrame,
   withOpenAICompatModelsAdvertise,
@@ -42,6 +43,14 @@ export interface ClientOptions {
   reconnectMaxDelayMs?: number;
   reconnectJitterRatio?: number;
   reconnectStableMs?: number;
+  // Maximum number of unacknowledged task frames retained across reconnects.
+  // `0` keeps sequencing/gap detection but disables retry retention.
+  maxPendingFrames?: number;
+  // Companion byte budget for the encoded unacknowledged frames.
+  maxPendingBytes?: number;
+  // Maximum age of an unacknowledged frame. Binding ids make stale frames safe
+  // to drop independently of the server's configured grace.
+  maxPendingAgeMs?: number;
   // Minimum reconnect delay after a 4009 "another client with the same
   // token connected" close — i.e. two daemons authenticated with the
   // same CLIENT_TOKEN colliding at the registry's clientId check. The
@@ -101,9 +110,31 @@ const DEFAULT_PROBE_DEADLINE_MS = 12_000;
 const DEFAULT_RECONNECT_DELAY_MS = 3000;
 const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
 const DEFAULT_RECONNECT_JITTER_RATIO = 0.2;
+// Bounds apply to unacknowledged frames, not merely frames produced while the
+// socket is visibly down. WebSocket OPEN/send success is not proof of server
+// acceptance; task.ack is.
+const DEFAULT_MAX_PENDING_FRAMES = 2_000;
+const DEFAULT_MAX_PENDING_BYTES = 4 * 1024 * 1024;
+const DEFAULT_MAX_PENDING_AGE_MS = 60_000;
 const DEFAULT_RECONNECT_STABLE_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_COLLISION_BACKOFF_MS = 300_000;
+
+type TaskUpFrame = Extract<UpFrame, { taskId: string }>;
+interface ClientRun {
+  controller: AbortController;
+  suppressed: boolean;
+  bindingId?: string;
+  nextSeq: number;
+}
+interface PendingFrame {
+  taskId: string;
+  bindingId: string;
+  seq: number;
+  encoded: string;
+  bytes: number;
+  createdAt: number;
+}
 
 export class Client {
   private ws: WebSocket | null = null;
@@ -117,13 +148,23 @@ export class Client {
   // is logged exactly once on first successful connect — same data on every
   // reconnect would just be noise, and we don't want to wait for whoami.
   private identityLogged = false;
-  private inflight = new Map<string, AbortController>();
+  private inflight = new Map<string, ClientRun>();
   // Resolved once per process via backend.resolveCapabilities(); the bridge
   // hello frame is held until this settles so the advertised card matches the
   // backend's actual upstream capability. Cached across reconnects so we
   // don't re-probe on every bridge WS reconnect — the underlying upstream
   // doesn't change mid-process.
   private effectiveCardPromise: Promise<AgentCard | undefined> | null = null;
+  // Reliable frames stay here until the bridge cumulatively acknowledges their
+  // binding-local sequence. Reconnect simply resends the same generations and
+  // sequences; the bridge deduplicates them and detects gaps.
+  private pendingFrames: PendingFrame[] = [];
+  private pendingBytes = 0;
+  private pendingExpiryTimer: ReturnType<typeof setTimeout> | null = null;
+  // False until the authenticated server replies with hello.ack on each
+  // connection. This prevents replay from racing asynchronous authentication.
+  private replayReady = false;
+  private negotiatedMaxFrameBytes: number | null = null;
   private readonly logger: Logger;
 
   constructor(private readonly opts: ClientOptions) {
@@ -148,7 +189,12 @@ export class Client {
     this.clearHeartbeat();
     // Abort all inflight tasks so backends can unwind cleanly instead of
     // running to completion after the WS is gone.
-    for (const controller of this.inflight.values()) controller.abort();
+    for (const run of this.inflight.values()) {
+      run.suppressed = true;
+      run.controller.abort();
+    }
+    // Nothing will replay these — the process is going away.
+    this.dropPendingFrames();
     this.ws?.close();
     // Tear down long-lived backend resources (e.g. codex app-server child).
     // Per-task abort above covers per-handle subprocesses; this hook is for
@@ -276,6 +322,8 @@ export class Client {
 
   private connect(): void {
     if (this.stopped) return;
+    this.replayReady = false;
+    this.negotiatedMaxFrameBytes = null;
     const ws = new WebSocket(`${this.opts.serverUrl.replace(/\/$/, '')}/connect`);
     this.ws = ws;
 
@@ -307,7 +355,7 @@ export class Client {
             backendKind: this.opts.backendKind,
             version: PROTOCOL_VERSION,
             token: this.opts.token,
-            protocolCapabilities: [CALLER_CONTEXT_CAPABILITY],
+            protocolCapabilities: [CALLER_CONTEXT_CAPABILITY, TASK_REPLAY_CAPABILITY],
           }),
         );
       };
@@ -340,7 +388,21 @@ export class Client {
       }
 
       switch (frame.type) {
+        case 'hello.ack':
+          if (!frame.protocolCapabilities.includes(TASK_REPLAY_CAPABILITY)) return;
+          if (this.ws !== ws) return;
+          this.replayReady = true;
+          this.negotiatedMaxFrameBytes = frame.maxFrameBytes;
+          this.flushPendingFrames(ws);
+          break;
+        case 'task.ack':
+          this.acknowledgeFrames(frame.bindingId, frame.acceptedSeq);
+          break;
         case 'task.assign':
+          // A task assignment without a binding id came from a legacy bridge.
+          // It is proof that authentication finished, but reconnect replay is
+          // intentionally unavailable on that connection.
+          if (frame.bindingId === undefined) this.replayReady = false;
           // `summarizeParts` already sanitizes each MIME via safeToken, so
           // the `parts=` token here intentionally does NOT wrap the whole
           // summary again — that would double-escape backslashes (a `\n`
@@ -356,7 +418,20 @@ export class Client {
           break;
         case 'task.cancel':
           this.logger.info(`task.cancel taskId=${safeToken(frame.taskId)}`);
-          this.inflight.get(frame.taskId)?.abort();
+          {
+            const run = this.inflight.get(frame.taskId);
+            if (run && (frame.bindingId === undefined || frame.bindingId === run.bindingId)) {
+              // A generation-scoped cancel is also the server's fail-closed
+              // signal (for example after detecting a sequence gap). No later
+              // frame from this generation can be accepted, so release its
+              // retained prefix and suppress the backend's abort terminal.
+              if (frame.bindingId !== undefined) {
+                run.suppressed = true;
+                this.removePendingBinding(frame.bindingId);
+              }
+              run.controller.abort();
+            }
+          }
           break;
         case 'ping':
           this.send({ type: 'pong' });
@@ -381,6 +456,15 @@ export class Client {
       this.logger.info(`disconnected: ${code} ${safeToken(reason.toString())}`);
       if (!current) return;
       this.ws = null;
+      // Legacy task frames have no generation or sequence. Once their socket is
+      // gone, allowing a late backend terminal to target a reused taskId is not
+      // safe, so stop those runs. Reliable runs retain their unacknowledged
+      // frames and resume after the next hello.ack.
+      for (const run of this.inflight.values()) {
+        if (run.bindingId !== undefined) continue;
+        run.suppressed = true;
+        run.controller.abort();
+      }
       // Terminal auth failures the daemon cannot recover from by waiting:
       //
       //   - **4014 "client deleted"** (issue #166). The DB row was just
@@ -411,7 +495,15 @@ export class Client {
         this.logger.error(`${label}; stopping (code=${code})`);
         this.stopped = true;
         this.clearReconnectTimer();
-        for (const controller of this.inflight.values()) controller.abort();
+        for (const run of this.inflight.values()) {
+          run.suppressed = true;
+          run.controller.abort();
+        }
+        // Nothing will ever replay these — this daemon is not reconnecting. The
+        // host process may keep running (onFatal owns that decision), so
+        // release the buffer rather than hold it for a reconnect that is not
+        // coming.
+        this.dropPendingFrames();
         this.opts.onFatal?.({ code, reason: reason.toString() });
         return;
       }
@@ -560,6 +652,169 @@ export class Client {
     this.ws.send(encodeFrame(frame));
   }
 
+  private sendTaskFrame(run: ClientRun, frame: TaskUpFrame): void {
+    if (run.suppressed) return;
+    if (run.bindingId === undefined) {
+      this.send(frame);
+      return;
+    }
+
+    const seq = run.nextSeq++;
+    const reliableFrame = { ...frame, bindingId: run.bindingId, seq } as TaskUpFrame;
+    const encoded = encodeFrame(reliableFrame);
+    const bytes = Buffer.byteLength(encoded, 'utf8');
+    const frameLimit = this.pendingFrameLimit();
+    const byteLimit = this.pendingByteLimit();
+    const ageLimit = this.pendingAgeLimit();
+    const maxFrameBytes = this.negotiatedMaxFrameBytes;
+
+    if (
+      (maxFrameBytes !== null && bytes > maxFrameBytes) ||
+      (byteLimit > 0 && bytes > byteLimit) ||
+      (frameLimit > 0 && this.pendingFrames.length >= frameLimit) ||
+      (byteLimit > 0 && this.pendingBytes + bytes > byteLimit)
+    ) {
+      this.failReliableRun(
+        run,
+        `unacknowledged frame buffer limit exceeded for task ${safeToken(frame.taskId)}`,
+        true,
+      );
+      return;
+    }
+
+    if (frameLimit > 0 && byteLimit > 0 && ageLimit > 0) {
+      this.pendingFrames.push({
+        taskId: frame.taskId,
+        bindingId: run.bindingId,
+        seq,
+        encoded,
+        bytes,
+        createdAt: Date.now(),
+      });
+      this.pendingBytes += bytes;
+      this.schedulePendingExpiry();
+    }
+    if (this.replayReady && this.ws?.readyState === WebSocket.OPEN) {
+      this.sendEncoded(this.ws, encoded);
+    }
+  }
+
+  private flushPendingFrames(ws: WebSocket): void {
+    if (!this.replayReady || ws.readyState !== WebSocket.OPEN) return;
+    this.expirePendingFrames();
+    if (!this.replayReady || ws.readyState !== WebSocket.OPEN) return;
+    for (const entry of this.pendingFrames) this.sendEncoded(ws, entry.encoded);
+    if (this.pendingFrames.length > 0) {
+      this.logger.info(`replayed ${this.pendingFrames.length} unacknowledged frame(s) after reconnect`);
+    }
+  }
+
+  private sendEncoded(ws: WebSocket, encoded: string): void {
+    try {
+      ws.send(encoded, (err) => {
+        if (!err || this.ws !== ws) return;
+        this.logger.warn(`task frame send failed (${safeToken(err.message)}); reconnecting`);
+        ws.terminate();
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`task frame send threw (${safeToken(message)}); reconnecting`);
+      if (this.ws === ws) ws.terminate();
+    }
+  }
+
+  private acknowledgeFrames(bindingId: string, acceptedSeq: number): void {
+    let removed = 0;
+    this.pendingFrames = this.pendingFrames.filter((entry) => {
+      if (entry.bindingId !== bindingId || entry.seq > acceptedSeq) return true;
+      this.pendingBytes -= entry.bytes;
+      removed++;
+      return false;
+    });
+    this.schedulePendingExpiry();
+    if (removed > 0) this.logger.debug(`acknowledged ${removed} task frame(s)`);
+  }
+
+  private failReliableRun(run: ClientRun, why: string, disconnect: boolean): void {
+    if (run.suppressed) return;
+    run.suppressed = true;
+    run.controller.abort();
+    if (run.bindingId !== undefined) this.removePendingBinding(run.bindingId);
+    this.logger.error(`${why}; suppressing the run so the bridge fails it closed`);
+    if (disconnect && this.ws?.readyState === WebSocket.OPEN) this.ws.terminate();
+  }
+
+  private removePendingBinding(bindingId: string): void {
+    this.pendingFrames = this.pendingFrames.filter((entry) => {
+      if (entry.bindingId !== bindingId) return true;
+      this.pendingBytes -= entry.bytes;
+      return false;
+    });
+    this.schedulePendingExpiry();
+  }
+
+  private pendingFrameLimit(): number {
+    const value = this.opts.maxPendingFrames ?? DEFAULT_MAX_PENDING_FRAMES;
+    return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : DEFAULT_MAX_PENDING_FRAMES;
+  }
+
+  private pendingByteLimit(): number {
+    const value = this.opts.maxPendingBytes ?? DEFAULT_MAX_PENDING_BYTES;
+    return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : DEFAULT_MAX_PENDING_BYTES;
+  }
+
+  private pendingAgeLimit(): number {
+    const value = this.opts.maxPendingAgeMs ?? DEFAULT_MAX_PENDING_AGE_MS;
+    return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : DEFAULT_MAX_PENDING_AGE_MS;
+  }
+
+  private schedulePendingExpiry(): void {
+    if (this.pendingExpiryTimer !== null) {
+      clearTimeout(this.pendingExpiryTimer);
+      this.pendingExpiryTimer = null;
+    }
+    const ageLimit = this.pendingAgeLimit();
+    const oldest = this.pendingFrames[0];
+    if (!oldest || ageLimit <= 0) return;
+    const delay = Math.max(0, oldest.createdAt + ageLimit - Date.now());
+    this.pendingExpiryTimer = setTimeout(() => {
+      this.pendingExpiryTimer = null;
+      this.expirePendingFrames();
+    }, delay);
+    this.pendingExpiryTimer.unref?.();
+  }
+
+  private expirePendingFrames(): void {
+    const ageLimit = this.pendingAgeLimit();
+    if (ageLimit <= 0 || this.pendingFrames.length === 0) return;
+    const cutoff = Date.now() - ageLimit;
+    const expiredBindings = new Set(
+      this.pendingFrames
+        .filter((entry) => entry.createdAt <= cutoff)
+        .map((entry) => entry.bindingId),
+    );
+    for (const bindingId of expiredBindings) {
+      const run = [...this.inflight.values()].find((candidate) => candidate.bindingId === bindingId);
+      if (run) {
+        this.failReliableRun(
+          run,
+          `unacknowledged replay expired after ${ageLimit}ms`,
+          this.ws?.readyState === WebSocket.OPEN,
+        );
+      } else {
+        this.removePendingBinding(bindingId);
+      }
+    }
+    this.schedulePendingExpiry();
+  }
+
+  private dropPendingFrames(): void {
+    if (this.pendingExpiryTimer !== null) clearTimeout(this.pendingExpiryTimer);
+    this.pendingExpiryTimer = null;
+    this.pendingFrames = [];
+    this.pendingBytes = 0;
+  }
+
   // Answer a server-initiated usage.request by querying the backend's optional
   // usage() capability. Fire-and-forget (errors surface as usage.response with
   // ok:false rather than throwing) so it never stalls the message loop.
@@ -601,16 +856,34 @@ export class Client {
 
   private async runTask(frame: import('@vicoop-bridge/protocol').DownFrame): Promise<void> {
     if (frame.type !== 'task.assign') return;
+    const previous = this.inflight.get(frame.taskId);
+    if (previous) {
+      previous.suppressed = true;
+      previous.controller.abort();
+      if (previous.bindingId !== undefined) this.removePendingBinding(previous.bindingId);
+    }
     const controller = new AbortController();
-    this.inflight.set(frame.taskId, controller);
+    const run: ClientRun = {
+      controller,
+      suppressed: false,
+      ...(frame.bindingId !== undefined ? { bindingId: frame.bindingId } : {}),
+      nextSeq: 0,
+    };
+    this.inflight.set(frame.taskId, run);
     try {
       await processTask(frame, controller.signal, {
         backend: this.opts.backend,
-        send: (f) => this.send(f),
+        // A suppressed run is over as far as the bridge is concerned; anything
+        // still trickling out of the backend must not reach a taskId that may
+        // now belong to someone else.
+        send: (f) => {
+          if (run.suppressed) return;
+          this.sendTaskFrame(run, f as TaskUpFrame);
+        },
         logger: this.logger,
       });
     } finally {
-      this.inflight.delete(frame.taskId);
+      if (this.inflight.get(frame.taskId) === run) this.inflight.delete(frame.taskId);
     }
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -694,7 +694,7 @@ export class Client {
       // precise failure instead of making it wait for reconnect grace and then
       // report a generic disconnect. The send callback terminates only after
       // `ws` has flushed the best-effort terminal to the transport.
-      this.sendReliableFailureAndDisconnect(run, frame.taskId, seq, {
+      this.sendReliableFailureAndDisconnect(run.executionId, frame.taskId, seq, {
         code: 'client_buffer_overflow',
         message: 'client unacknowledged frame buffer limit exceeded',
       });
@@ -722,7 +722,32 @@ export class Client {
     if (!this.replayReady || ws.readyState !== WebSocket.OPEN) return;
     this.expirePendingFrames();
     if (!this.replayReady || ws.readyState !== WebSocket.OPEN) return;
-    for (const entry of this.pendingFrames) this.sendEncoded(ws, entry.encoded);
+    for (const entry of this.pendingFrames) {
+      if (
+        this.negotiatedMaxFrameBytes !== null &&
+        entry.bytes > this.negotiatedMaxFrameBytes
+      ) {
+        const why =
+          `retained frame exceeds the negotiated limit for task ${safeToken(entry.taskId)}`;
+        const run = [...this.inflight.values()].find(
+          (candidate) => candidate.executionId === entry.executionId,
+        );
+        if (run) this.failReliableRun(run, why, false);
+        else {
+          this.removePendingExecution(entry.executionId);
+          this.logger.error(`${why}; suppressing the execution so the bridge fails it closed`);
+        }
+        // Entries earlier in this loop have already been queued in sequence.
+        // Replace the first oversized one at its own sequence with a bounded
+        // terminal, then reconnect so other executions can replay cleanly.
+        this.sendReliableFailureAndDisconnect(entry.executionId, entry.taskId, entry.seq, {
+          code: 'client_buffer_overflow',
+          message: 'retained client frame exceeds the negotiated server limit',
+        });
+        return;
+      }
+      this.sendEncoded(ws, entry.encoded);
+    }
     if (this.pendingFrames.length > 0) {
       this.logger.info(`replayed ${this.pendingFrames.length} unacknowledged frame(s) after reconnect`);
     }
@@ -764,14 +789,13 @@ export class Client {
   }
 
   private sendReliableFailureAndDisconnect(
-    run: ClientRun,
+    executionId: string,
     taskId: string,
     seq: number,
     error: { code: string; message: string },
   ): void {
     const ws = this.ws;
-    const executionId = run.executionId;
-    if (!this.replayReady || !ws || ws.readyState !== WebSocket.OPEN || executionId === undefined) {
+    if (!this.replayReady || !ws || ws.readyState !== WebSocket.OPEN) {
       if (ws?.readyState === WebSocket.OPEN) ws.terminate();
       return;
     }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -876,6 +876,15 @@ export class Client {
         );
       } else {
         this.removePendingExecution(executionId);
+        // A backend may already have returned after emitting its terminal, so
+        // its run is no longer in `inflight` even though that terminal remains
+        // unacknowledged. Dropping it while keeping a half-dead socket open can
+        // strand the server binding forever: there is nothing left to replay
+        // or abort. Force the normal disconnect/grace path to settle it.
+        this.logger.error(
+          `unacknowledged replay expired after ${ageLimit}ms; disconnecting so the bridge fails it closed`,
+        );
+        if (this.ws?.readyState === WebSocket.OPEN) this.ws.terminate();
       }
     }
     this.schedulePendingExpiry();

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const PROTOCOL_VERSION = '0.1';
 // Additive capability layered onto protocol 0.1. Clients advertising this
 // capability wait for `hello.ack`, tag every task frame with the server-issued
-// binding id and a per-binding sequence number, and retain frames until the
+// execution ID and a per-execution sequence number, and retain frames until the
 // server acknowledges them. Legacy clients and servers continue to use the
 // original taskId-only frames.
 export const TASK_REPLAY_CAPABILITY = 'task-replay-v1';
@@ -273,7 +273,7 @@ export const HelloFrame = z.object({
 export const TaskStatusFrame = z.object({
   type: z.literal('task.status'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
   seq: z.number().int().nonnegative().optional(),
   status: TaskStatus,
   // Optional, passed through verbatim onto the A2A
@@ -302,7 +302,7 @@ export const TaskStatusFrame = z.object({
 export const TaskArtifactFrame = z.object({
   type: z.literal('task.artifact'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
   seq: z.number().int().nonnegative().optional(),
   artifact: Artifact,
   append: z.boolean().optional(),
@@ -342,7 +342,7 @@ export type TaskUsage = z.infer<typeof TaskUsage>;
 export const TaskCompleteFrame = z.object({
   type: z.literal('task.complete'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
   seq: z.number().int().nonnegative().optional(),
   status: TaskStatus,
   usage: TaskUsage.optional(),
@@ -351,7 +351,7 @@ export const TaskCompleteFrame = z.object({
 export const TaskFailFrame = z.object({
   type: z.literal('task.fail'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
   seq: z.number().int().nonnegative().optional(),
   error: z.object({
     code: z.string(),
@@ -462,7 +462,7 @@ export type UpFrame = z.infer<typeof UpFrame>;
 export const TaskAssignFrame = z.object({
   type: z.literal('task.assign'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
   contextId: z.string(),
   message: Message,
   requestedExtensions: z.array(z.string()).optional(),
@@ -472,7 +472,7 @@ export const TaskAssignFrame = z.object({
 export const TaskCancelFrame = z.object({
   type: z.literal('task.cancel'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128).optional(),
+  executionId: z.string().min(1).max(128).optional(),
 });
 
 export const HelloAckFrame = z.object({
@@ -485,7 +485,7 @@ export const HelloAckFrame = z.object({
 export const TaskAckFrame = z.object({
   type: z.literal('task.ack'),
   taskId: z.string(),
-  bindingId: z.string().min(1).max(128),
+  executionId: z.string().min(1).max(128),
   acceptedSeq: z.number().int().nonnegative(),
 });
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
 export const PROTOCOL_VERSION = '0.1';
+// Additive capability layered onto protocol 0.1. Clients advertising this
+// capability wait for `hello.ack`, tag every task frame with the server-issued
+// binding id and a per-binding sequence number, and retain frames until the
+// server acknowledges them. Legacy clients and servers continue to use the
+// original taskId-only frames.
+export const TASK_REPLAY_CAPABILITY = 'task-replay-v1';
 export const TRACEABILITY_EXTENSION_URI =
   'https://github.com/a2aproject/a2a-samples/extensions/traceability/v1';
 export const SIWE_BEARER_AUTH_EXTENSION_URI =
@@ -267,6 +273,8 @@ export const HelloFrame = z.object({
 export const TaskStatusFrame = z.object({
   type: z.literal('task.status'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
+  seq: z.number().int().nonnegative().optional(),
   status: TaskStatus,
   // Optional, passed through verbatim onto the A2A
   // `TaskStatusUpdateEvent.metadata` (top-level) by the server. Used by the
@@ -294,6 +302,8 @@ export const TaskStatusFrame = z.object({
 export const TaskArtifactFrame = z.object({
   type: z.literal('task.artifact'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
+  seq: z.number().int().nonnegative().optional(),
   artifact: Artifact,
   append: z.boolean().optional(),
   lastChunk: z.boolean().optional(),
@@ -332,6 +342,8 @@ export type TaskUsage = z.infer<typeof TaskUsage>;
 export const TaskCompleteFrame = z.object({
   type: z.literal('task.complete'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
+  seq: z.number().int().nonnegative().optional(),
   status: TaskStatus,
   usage: TaskUsage.optional(),
 });
@@ -339,6 +351,8 @@ export const TaskCompleteFrame = z.object({
 export const TaskFailFrame = z.object({
   type: z.literal('task.fail'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
+  seq: z.number().int().nonnegative().optional(),
   error: z.object({
     code: z.string(),
     message: z.string(),
@@ -448,6 +462,7 @@ export type UpFrame = z.infer<typeof UpFrame>;
 export const TaskAssignFrame = z.object({
   type: z.literal('task.assign'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
   contextId: z.string(),
   message: Message,
   requestedExtensions: z.array(z.string()).optional(),
@@ -457,6 +472,21 @@ export const TaskAssignFrame = z.object({
 export const TaskCancelFrame = z.object({
   type: z.literal('task.cancel'),
   taskId: z.string(),
+  bindingId: z.string().min(1).max(128).optional(),
+});
+
+export const HelloAckFrame = z.object({
+  type: z.literal('hello.ack'),
+  protocolCapabilities: z.array(z.string().min(1).max(128)).max(32),
+  disconnectGraceMs: z.number().int().nonnegative(),
+  maxFrameBytes: z.number().int().positive(),
+});
+
+export const TaskAckFrame = z.object({
+  type: z.literal('task.ack'),
+  taskId: z.string(),
+  bindingId: z.string().min(1).max(128),
+  acceptedSeq: z.number().int().nonnegative(),
 });
 
 export const PingFrame = z.object({ type: z.literal('ping') });
@@ -471,9 +501,13 @@ export const UsageRequestFrame = z.object({
 
 export type TaskAssignFrame = z.infer<typeof TaskAssignFrame>;
 export type TaskCancelFrame = z.infer<typeof TaskCancelFrame>;
+export type HelloAckFrame = z.infer<typeof HelloAckFrame>;
+export type TaskAckFrame = z.infer<typeof TaskAckFrame>;
 export type UsageRequestFrame = z.infer<typeof UsageRequestFrame>;
 
 export const DownFrame = z.discriminatedUnion('type', [
+  HelloAckFrame,
+  TaskAckFrame,
   TaskAssignFrame,
   TaskCancelFrame,
   PingFrame,

--- a/packages/server/fly.toml
+++ b/packages/server/fly.toml
@@ -38,6 +38,20 @@ primary_region = "nrt"
   # healthily-heartbeating long task is never reaped. "0" disables it. Must sit
   # above the longest legitimate silent gap for non-heartbeating backends.
   BRIDGE_TASK_INACTIVITY_TIMEOUT_MS = "600000"
+  # Reconnect grace hold (ms) for an in-flight task whose replay-capable
+  # client's WebSocket drops (issue #474). Rather than failing the task the
+  # instant the socket goes, the bridge keeps its binding alive so the client
+  # can replay unacknowledged output. A generation-correct, gap-free frame on
+  # the authenticated replacement connection resumes the task. Legacy clients
+  # still fail immediately.
+  #
+  # Sized off the 2026-08-20 fly-proxy incident, where the recovered clients'
+  # terminal frames arrived +9s/+10s/+15s after the drop — so it has to cover
+  # task completion, not the 3.2s reconnect.
+  #
+  # "0" disables it and restores the previous fail-immediately behavior exactly:
+  # this is the rollback lever if holds ever delay failover more than they save.
+  BRIDGE_DISCONNECT_GRACE_MS = "30000"
 
 [http_service]
   internal_port = 8787

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -14,6 +14,7 @@ import {
   CALLER_CONTEXT_CAPABILITY,
   OPENAI_COMPAT_EXTENSION_URI,
   parseDownFrame,
+  TASK_REPLAY_CAPABILITY,
   type AgentCard,
 } from '@vicoop-bridge/protocol';
 import { Registry, type ClientConnection } from './registry.js';
@@ -155,6 +156,7 @@ test('executor records principalId in binding and strips _principalId from outgo
     ownerPrincipal: 'eth:0x0',
     agentCard: makeAgentCard(),
     allowedCallers: [],
+    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
     ws,
     connectedAt: 0,
   };
@@ -182,6 +184,8 @@ test('executor records principalId in binding and strips _principalId from outgo
   assert.ok(binding, 'expected binding to be registered before first yield');
   assert.equal(binding.principalId, 'eth:0xabc');
   assert.equal(binding.agentId, 'a1');
+  assert.match(binding.bindingId ?? '', /^[0-9a-f-]{36}$/);
+  assert.equal(binding.nextClientSeq, 0);
 
   // The WS frame must NOT carry server-internal `_*` keys — the connected
   // client should only see caller-supplied metadata.
@@ -198,6 +202,7 @@ test('executor records principalId in binding and strips _principalId from outgo
     );
     assert.equal((md as Record<string, unknown>).userField, 'keep');
     assert.equal(frame.caller, undefined, 'old clients receive no caller field fallback');
+    assert.equal(frame.bindingId, binding.bindingId);
   }
 
   // Push a terminal status so the generator returns without hanging.

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -184,7 +184,7 @@ test('executor records principalId in binding and strips _principalId from outgo
   assert.ok(binding, 'expected binding to be registered before first yield');
   assert.equal(binding.principalId, 'eth:0xabc');
   assert.equal(binding.agentId, 'a1');
-  assert.match(binding.bindingId ?? '', /^[0-9a-f-]{36}$/);
+  assert.match(binding.executionId ?? '', /^[0-9a-f-]{36}$/);
   assert.equal(binding.nextClientSeq, 0);
 
   // The WS frame must NOT carry server-internal `_*` keys — the connected
@@ -202,7 +202,7 @@ test('executor records principalId in binding and strips _principalId from outgo
     );
     assert.equal((md as Record<string, unknown>).userField, 'keep');
     assert.equal(frame.caller, undefined, 'old clients receive no caller field fallback');
-    assert.equal(frame.bindingId, binding.bindingId);
+    assert.equal(frame.executionId, binding.executionId);
   }
 
   // Push a terminal status so the generator returns without hanging.

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -14,6 +14,7 @@ import {
   type TaskStatusUpdateEvent,
   type TaskStore,
 } from '@a2x/sdk';
+import { randomUUID } from 'node:crypto';
 import type { Registry, TaskBinding, TaskSink } from './registry.js';
 import { AsyncEventQueue } from './event-queue.js';
 import { logEvent } from './log.js';
@@ -21,7 +22,11 @@ import { terminalErrorMessageFields } from './terminal-error.js';
 import { X402Gate, createPostgresX402Context, type X402Settlement } from './x402/gate.js';
 import { readTaskUsage } from './x402/usage.js';
 import type { Sql } from './db.js';
-import { CALLER_CONTEXT_CAPABILITY, CallerContextV1 } from '@vicoop-bridge/protocol';
+import {
+  CALLER_CONTEXT_CAPABILITY,
+  CallerContextV1,
+  TASK_REPLAY_CAPABILITY,
+} from '@vicoop-bridge/protocol';
 
 /**
  * What the executor needs to run the x402 payment gate: a DB handle for the
@@ -399,11 +404,17 @@ export class WSForwardingExecutor extends AgentExecutor {
       });
     }
 
+    const replayCapable =
+      this.registry
+        .getAgent(this.agentId)
+        ?.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY) === true;
+    const bindingId = replayCapable ? randomUUID() : undefined;
     const binding: TaskBinding = {
       agentId: this.agentId,
       taskId,
       contextId,
       sink,
+      ...(bindingId !== undefined ? { bindingId, nextClientSeq: 0 } : {}),
       ...(principalId !== undefined ? { principalId } : {}),
       ...(requestedExtensions !== undefined ? { requestedExtensions } : {}),
     };
@@ -462,6 +473,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     const sent = this.registry.sendToAgent(this.agentId, {
       type: 'task.assign',
       taskId,
+      ...(bindingId !== undefined ? { bindingId } : {}),
       contextId,
       message: {
         role: message.role,
@@ -694,7 +706,11 @@ export class WSForwardingExecutor extends AgentExecutor {
 
     // Notify the connected client so it can abort in-flight work and
     // emit its own task.fail / task.complete frame.
-    this.registry.sendToAgent(this.agentId, { type: 'task.cancel', taskId });
+    this.registry.sendToAgent(this.agentId, {
+      type: 'task.cancel',
+      taskId,
+      ...(binding?.bindingId !== undefined ? { bindingId: binding.bindingId } : {}),
+    });
 
     // Deliver the CANCELED terminal through the sink FIRST, then finish the
     // queue: the executor's iterate() consumes the terminal event (breaking on

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -408,13 +408,13 @@ export class WSForwardingExecutor extends AgentExecutor {
       this.registry
         .getAgent(this.agentId)
         ?.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY) === true;
-    const bindingId = replayCapable ? randomUUID() : undefined;
+    const executionId = replayCapable ? randomUUID() : undefined;
     const binding: TaskBinding = {
       agentId: this.agentId,
       taskId,
       contextId,
       sink,
-      ...(bindingId !== undefined ? { bindingId, nextClientSeq: 0 } : {}),
+      ...(executionId !== undefined ? { executionId, nextClientSeq: 0 } : {}),
       ...(principalId !== undefined ? { principalId } : {}),
       ...(requestedExtensions !== undefined ? { requestedExtensions } : {}),
     };
@@ -473,7 +473,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     const sent = this.registry.sendToAgent(this.agentId, {
       type: 'task.assign',
       taskId,
-      ...(bindingId !== undefined ? { bindingId } : {}),
+      ...(executionId !== undefined ? { executionId } : {}),
       contextId,
       message: {
         role: message.role,
@@ -709,7 +709,7 @@ export class WSForwardingExecutor extends AgentExecutor {
     this.registry.sendToAgent(this.agentId, {
       type: 'task.cancel',
       taskId,
-      ...(binding?.bindingId !== undefined ? { bindingId: binding.bindingId } : {}),
+      ...(binding?.executionId !== undefined ? { executionId: binding.executionId } : {}),
     });
 
     // Deliver the CANCELED terminal through the sink FIRST, then finish the

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -1,14 +1,45 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { WebSocket } from 'ws';
-import { OPENAI_COMPAT_EXTENSION_URI, type AgentCard } from '@vicoop-bridge/protocol';
-import { Registry } from './registry.js';
+import {
+  OPENAI_COMPAT_EXTENSION_URI,
+  TASK_REPLAY_CAPABILITY,
+  type AgentCard,
+} from '@vicoop-bridge/protocol';
+import {
+  FALLBACK_DISCONNECT_GRACE_MS,
+  MAX_DISCONNECT_GRACE_MS,
+  Registry,
+  resolveDisconnectGraceMs,
+  type TaskBinding,
+} from './registry.js';
 
-// Minimal WebSocket stub — Registry only uses `.close()` on replacement and
-// equality (`existing.ws !== ws`) on unregister. Nothing else on the real ws
-// interface is exercised here.
-function makeWs(): WebSocket {
-  return { close: () => undefined } as unknown as WebSocket;
+// Mirrors the `ws` library's ReadyState constants; the stubs below are typed as
+// WebSocket, so these have to agree with the real values.
+const WS_OPEN = 1;
+const WS_CLOSING = 2;
+const WS_CLOSED = 3;
+
+// Minimal WebSocket stub — Registry uses `.close()` on replacement, equality
+// (`existing.ws !== ws`) on unregister, and `readyState` to tell a live
+// duplicate-token collision from a client that is merely reconnecting after its
+// socket already died (issue #474). Defaults to OPEN, which is what every
+// pre-#474 test implicitly assumed.
+//
+// `close()` MUST move readyState to CLOSING, because the real `ws` library does
+// so synchronously inside close() — and a stub that froze readyState instead
+// would let `registry.ts` read it *after* closing the socket and still appear
+// to work, certifying a branch that real sockets can never take. That is not
+// hypothetical: it is exactly the bug this stub previously hid.
+function makeWs(readyState: number = WS_OPEN): WebSocket {
+  const ws = {
+    readyState,
+    OPEN: WS_OPEN,
+    close: () => {
+      ws.readyState = WS_CLOSING;
+    },
+  };
+  return ws as unknown as WebSocket;
 }
 
 interface RecordingWs extends WebSocket {
@@ -19,10 +50,14 @@ function makeRecordingWs(): RecordingWs {
   const closeArgs: Array<{ code: number; reason: string }> = [];
   const ws = {
     closeArgs,
+    readyState: WS_OPEN,
+    OPEN: WS_OPEN,
     close(code: number, reason: string) {
       closeArgs.push({ code, reason });
+      // Same fidelity requirement as makeWs().
+      ws.readyState = WS_CLOSING;
     },
-  } as unknown as RecordingWs;
+  } as unknown as RecordingWs & { readyState: number };
   return ws;
 }
 
@@ -126,6 +161,11 @@ test('onAgentChange fires on disconnect (unregister) so stale transports do not 
   assert.deepEqual(seen, ['a1']);
 });
 
+// 4009 (duplicate CLIENT_TOKEN) stands in for any app-level close: the bridge
+// only sends 4xxx when it has decided the connection must not continue, so
+// those skip the reconnect grace hold and fail in-flight tasks immediately
+// (issue #474). The terminal shape asserted here is the one a graced task also
+// ends up with once its hold expires — see the grace tests below.
 test('unregisterAgent reports mid-task disconnect with structured error metadata', () => {
   const registry = new Registry();
   const ws = makeWs();
@@ -155,7 +195,7 @@ test('unregisterAgent reports mid-task disconnect with structured error metadata
     },
   });
 
-  registry.unregisterAgent('a1', ws);
+  registry.unregisterAgent('a1', ws, 4009);
 
   assert.equal(finished, true);
   assert.equal(registry.getBinding('t-disc'), undefined);
@@ -199,8 +239,11 @@ test('unregisterAgent omits terminal error metadata when openai-compat extension
     },
   });
 
-  registry.unregisterAgent('a1', ws);
+  registry.unregisterAgent('a1', ws, 4009);
 
+  // Assert a terminal was actually pushed before asserting what it omits —
+  // without this the two checks below pass vacuously on an empty array.
+  assert.equal(statuses.length, 1);
   assert.equal(statuses[0]?.status.message?.metadata, undefined);
   assert.equal(statuses[0]?.status.message?.extensions, undefined);
 });
@@ -401,13 +444,19 @@ test('registerAgent emits client_collision and closes the prior ws with the desc
   assert.equal(parsed.previousConnectedAt, 1000);
 });
 
-test('same-token reconnect fails the displaced connection in-flight bindings (issue #365)', () => {
+test('same-token reconnect eventually fails the displaced connection in-flight bindings (issue #365)', () => {
   // A second daemon authenticating with the same CLIENT_TOKEN replaces the
   // incumbent. The old connection's in-flight task must receive a terminal
   // `failed` status and have its sink finished + binding dropped — otherwise
-  // the task's HTTP stream hangs forever (the new daemon is a separate process
-  // that never knew the old taskId, so it can't complete it either).
-  const registry = new Registry();
+  // the task's HTTP stream hangs forever (if the new daemon is a separate
+  // process that never knew the old taskId, it can't complete it either).
+  //
+  // Since #474 that outcome is delayed by the reconnect grace, which exists
+  // because the new daemon is USUALLY the same client coming back and can
+  // finish the task. Grace 0 keeps this test on its original subject — that a
+  // displaced binding is never orphaned, and that this path's terminal is
+  // `superseded` — while the graced variants are covered separately below.
+  const registry = new Registry(0);
   const oldWs = makeWs();
   const base = {
     agentId: 'a1',
@@ -415,6 +464,7 @@ test('same-token reconnect fails the displaced connection in-flight bindings (is
     ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
+    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
     connectedAt: 0,
   };
   registry.registerAgent({ ...base, ws: oldWs });
@@ -607,4 +657,698 @@ test('bindTask displacing a live binding emits a superseded terminal on the old 
   assert.equal(terminal?.final, true);
   assert.equal(terminal?.status?.state, 'failed');
   assert.match(terminal?.status?.message?.parts?.[0]?.text ?? '', /superseded/);
+});
+interface CapturedTask {
+  statuses: unknown[];
+  state: { finished: boolean };
+}
+
+// Terminal-status reader, matching recordingBinding's `unknown[]` idiom above:
+// the sink receives full TaskStatusUpdateEvents, and these tests only care
+// about the human-readable reason on the first one.
+function terminalText(task: CapturedTask): string {
+  const first = task.statuses[0] as
+    | { status?: { message?: { parts?: Array<{ text?: string }> } } }
+    | undefined;
+  return first?.status?.message?.parts?.[0]?.text ?? '';
+}
+
+function bindCapturing(registry: Registry, agentId: string, taskId: string): CapturedTask {
+  const statuses: unknown[] = [];
+  const state = { finished: false };
+  registry.bindTask({
+    agentId,
+    taskId,
+    contextId: `ctx-${taskId}`,
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        state.finished = true;
+      },
+    },
+  });
+  return { statuses, state };
+}
+
+function registerFor(registry: Registry, ws: WebSocket, agentId = 'a1', clientId = 'c1'): void {
+  registry.registerAgent({
+    agentId,
+    clientId,
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+    ws,
+    connectedAt: 0,
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+test('grace hold keeps the binding alive across a recoverable disconnect instead of failing it', () => {
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-grace');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.ok(registry.getBinding('t-grace'), 'binding must survive the disconnect');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, [], 'no terminal may be emitted during the hold');
+  assert.equal(registry.getAgent('a1'), undefined);
+});
+
+test('a legacy client that did not negotiate replay still fails immediately', () => {
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registry.registerAgent({
+    agentId: 'a1',
+    clientId: 'c1',
+    ownerPrincipal: 'eth:0x0',
+    agentCard: makeCard(false),
+    allowedCallers: [],
+    ws,
+    connectedAt: 0,
+  });
+  const task = bindCapturing(registry, 'a1', 't-legacy');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.equal(registry.getBinding('t-legacy'), undefined);
+  assert.equal(task.state.finished, true);
+  assert.match(terminalText(task), /disconnected mid-task/);
+});
+
+test('a frame from the reconnected client resumes a held binding and cancels its expiry', async () => {
+  const registry = new Registry(25);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-resume');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-resume', 'a1');
+
+  await sleep(80);
+
+  assert.ok(registry.getBinding('t-resume'), 'resumed binding must not be reaped');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, []);
+});
+
+test('grace hold expires into the identical disconnected terminal it always produced', async () => {
+  const registry = new Registry(15);
+  const ws = makeWs();
+  registerFor(registry, ws);
+
+  const statuses: Array<{ status: { message?: { metadata?: unknown } } }> = [];
+  let finished = false;
+  registry.bindTask({
+    agentId: 'a1',
+    taskId: 't-expire',
+    contextId: 'ctx-expire',
+    requestedExtensions: [OPENAI_COMPAT_EXTENSION_URI],
+    sink: {
+      pushStatus: (event) => statuses.push(event),
+      pushArtifact: () => undefined,
+      finish: () => {
+        finished = true;
+      },
+    },
+  });
+
+  registry.unregisterAgent('a1', ws, 1012);
+  await sleep(80);
+
+  assert.equal(finished, true);
+  assert.equal(registry.getBinding('t-expire'), undefined);
+  assert.deepEqual(statuses[0]?.status.message?.metadata, {
+    [OPENAI_COMPAT_EXTENSION_URI]: {
+      terminal_error: {
+        code: 'disconnected',
+        message: 'client disconnected mid-task',
+      },
+    },
+    error: {
+      code: 'disconnected',
+      message: 'client disconnected mid-task',
+    },
+  });
+});
+
+test('a task completing during the hold is not failed by the expiry timer afterwards', async () => {
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-late-complete');
+  const binding = registry.getBinding('t-late-complete');
+  assert.ok(binding);
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-late-complete', 'a1');
+  registry.unbindTask('t-late-complete', binding);
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, false, 'a completed task must not be failed later');
+  assert.deepEqual(task.statuses, []);
+});
+
+test('app-level close codes skip the hold entirely and fail in-flight tasks at once', () => {
+  for (const code of [4014, 4009, 1000]) {
+    const registry = new Registry(10_000);
+    const ws = makeWs();
+    registerFor(registry, ws);
+    const task = bindCapturing(registry, 'a1', `t-terminal-${code}`);
+
+    registry.unregisterAgent('a1', ws, code);
+
+    assert.equal(
+      registry.getBinding(`t-terminal-${code}`),
+      undefined,
+      `close code ${code} must not be graced`,
+    );
+    assert.equal(task.state.finished, true);
+    assert.match(terminalText(task), /disconnected mid-task/);
+  }
+});
+
+test('a grace of 0 restores the pre-#474 fail-immediately behavior', () => {
+  const registry = new Registry(0);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-nograce');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.equal(registry.getBinding('t-nograce'), undefined);
+  assert.equal(task.state.finished, true);
+});
+
+test('reconnect arriving BEFORE the old socket close holds the task instead of superseding it', () => {
+  const registry = new Registry(10_000);
+  const deadWs = makeWs(WS_CLOSED);
+  registerFor(registry, deadWs);
+  const task = bindCapturing(registry, 'a1', 't-race');
+
+  registerFor(registry, makeWs());
+
+  assert.ok(registry.getBinding('t-race'), 'a reconnect must not supersede its own in-flight task');
+  assert.equal(task.state.finished, false);
+  assert.deepEqual(task.statuses, []);
+
+});
+
+test('a hold armed by the reconnect branch really is a hold: it resumes and it expires', async () => {
+  // Presence of the binding right after the reconnect proves nothing — a
+  // binding simply left alone, with no timer at all, looks identical at that
+  // instant and would then hang until the executor's 10-minute backstop. Drive
+  // both ends of the lifecycle instead.
+  const armed = new Registry(20);
+  registerFor(armed, makeWs(WS_CLOSED));
+  const abandoned = bindCapturing(armed, 'a1', 't-race-expire');
+  registerFor(armed, makeWs());
+  await sleep(80);
+  assert.equal(abandoned.state.finished, true, 'the reconnect branch armed no expiry');
+  assert.equal(armed.getBinding('t-race-expire'), undefined);
+
+  const resumed = new Registry(20);
+  registerFor(resumed, makeWs(WS_CLOSED));
+  const reclaimed = bindCapturing(resumed, 'a1', 't-race-resume');
+  registerFor(resumed, makeWs());
+  resumed.resumeBinding('t-race-resume', 'a1');
+  await sleep(80);
+  assert.equal(reclaimed.state.finished, false, 'a resumed hold must not expire');
+  assert.ok(resumed.getBinding('t-race-resume'));
+});
+
+test('a same-token reconnect is held whether or not the old socket looks live', async () => {
+  // `readyState === OPEN` is NOT a liveness test — it only means the server has
+  // not observed a close. The server runs no keepalive, and the client pings
+  // every 30s and terminates on a missed pong, so on a dead path the client
+  // notices first and its next hello arrives here with the old socket still
+  // nominally OPEN. Killing on "looks live" would kill the common recovered
+  // drop — the exact bug #474 exists to fix, relabeled `superseded`.
+  //
+  // So both socket states take the hold, and an unresumed hold expires into the
+  // `superseded` terminal this path has always produced.
+  for (const [label, state] of [
+    ['live-looking', WS_OPEN],
+    ['dead', WS_CLOSED],
+  ] as const) {
+    const registry = new Registry(20);
+    registerFor(registry, makeWs(state));
+    const task = bindCapturing(registry, 'a1', `t-collision-${label}`);
+
+    registerFor(registry, makeWs());
+
+    assert.ok(registry.getBinding(`t-collision-${label}`), `${label}: must be held, not killed`);
+    assert.equal(task.state.finished, false, `${label}: no premature terminal`);
+
+    await sleep(80);
+
+    assert.equal(task.state.finished, true, `${label}: an unresumed hold must expire`);
+    assert.equal(registry.getBinding(`t-collision-${label}`), undefined);
+    assert.match(terminalText(task), /superseded/, `${label}: expiry keeps this path's terminal`);
+  }
+});
+
+test('a reconnect reclaiming its task survives, even when the old socket still looked live', async () => {
+  // The payoff of the above: the client that reconnected is normally the SAME
+  // client, and one frame on the new connection rescues its in-flight work.
+  const registry = new Registry(20);
+  registerFor(registry, makeWs(WS_OPEN));
+  const task = bindCapturing(registry, 'a1', 't-collision-reclaim');
+
+  registerFor(registry, makeWs());
+  registry.resumeBinding('t-collision-reclaim', 'a1');
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, false, 'a reclaimed task must not be failed');
+  assert.ok(registry.getBinding('t-collision-reclaim'));
+});
+
+test('a connection this server condemned is never rescued by a reconnect', () => {
+  // disconnectClient() closes with 4014 because the owner deleted the client.
+  // A hello arriving on that token before the close event lands must not
+  // resurrect its tasks through the reconnect branch.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-condemned');
+
+  assert.equal(registry.disconnectClient('c1'), 1);
+  registerFor(registry, makeWs(), 'a1', 'c1'); // the racing reconnect
+
+  assert.equal(
+    registry.getBinding('t-condemned'),
+    undefined,
+    'a deleted client must not be graced',
+  );
+  assert.equal(task.state.finished, true);
+  assert.match(terminalText(task), /disconnected mid-task/);
+});
+
+test('the late close of an already-replaced socket does not re-hold or double-fail', () => {
+  const registry = new Registry(10_000);
+  const deadWs = makeWs(WS_CLOSED);
+  registerFor(registry, deadWs);
+  const task = bindCapturing(registry, 'a1', 't-late-close');
+
+  registerFor(registry, makeWs()); // holds t-late-close
+  registry.resumeBinding('t-late-close', 'a1'); // client's first frame resumes it
+
+  registry.unregisterAgent('a1', deadWs, 1006);
+
+  assert.ok(registry.getBinding('t-late-close'));
+  assert.equal(task.state.finished, false);
+});
+
+test("resumeBinding cannot be used by one agent to rescue another agent's held task", () => {
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  bindCapturing(registry, 'a1', 't-owned');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-owned', 'other-agent');
+
+  assert.ok(registry.getBinding('t-owned'));
+});
+test('with the grace disabled, the reconnect race keeps its original superseded terminal', () => {
+  const registry = new Registry(0);
+  registerFor(registry, makeWs(WS_CLOSED));
+  const task = bindCapturing(registry, 'a1', 't-nograce-race');
+
+  registerFor(registry, makeWs());
+
+  assert.equal(registry.getBinding('t-nograce-race'), undefined);
+  assert.equal(task.state.finished, true);
+  assert.match(terminalText(task), /superseded/);
+});
+
+// ---------------------------------------------------------------------------
+// Guard coverage.
+//
+// The three `clearGraceHold` call sites and the "don't slide the deadline" skip
+// are individually invisible to a test that only checks the binding right after
+// the event: the timer's own identity guard independently suppresses a stale
+// fire, so deleting either half of that pair changes nothing observable at that
+// moment. What DOES expose a missing clear is the *next* hold for the same
+// taskId — `holdBindingsForAgent` skips a taskId that already has an entry, so
+// a hold left behind by a finished binding silently denies its successor a
+// hold, and that successor then never expires. Each test below drives exactly
+// that sequence through one of the clear sites.
+//
+// Not covered, deliberately: the identity guards inside `resumeBinding` and the
+// expiry timer. With every clear site intact, `graceHolds` can only ever hold
+// an entry for the binding currently occupying that taskId, so those guards are
+// unreachable defense-in-depth against a future missing clear — no behavioral
+// test can distinguish them. They are kept precisely because the tests here
+// cannot speak for them.
+// ---------------------------------------------------------------------------
+
+// Re-hold a taskId after its previous binding is gone, and prove the new
+// binding still gets a working hold of its own (i.e. that the old one's entry
+// was cleared). `settle` performs whatever terminated the previous binding.
+async function assertSuccessorIsHeld(
+  registry: Registry,
+  settle: (binding: TaskBinding) => void,
+  taskId: string,
+): Promise<void> {
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  bindCapturing(registry, 'a1', taskId);
+  const first = registry.getBinding(taskId);
+  assert.ok(first);
+
+  registry.unregisterAgent('a1', ws1, 1012); // first binding is now held
+  settle(first);
+
+  // A new run claims the same taskId, then its client drops too.
+  const successor = bindCapturing(registry, 'a1', taskId);
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  await sleep(80);
+
+  // The successor must have been held and then expired. A stale entry from the
+  // first binding would have made `holdBindingsForAgent` skip it, leaving it
+  // bound and unfinished forever.
+  assert.equal(successor.state.finished, true, 'successor was never held, so it never expired');
+  assert.equal(registry.getBinding(taskId), undefined);
+  assert.match(terminalText(successor), /disconnected mid-task/);
+}
+
+test('unbindTask clears the hold, so the next binding for that taskId can be held', async () => {
+  const registry = new Registry(20);
+  await assertSuccessorIsHeld(
+    registry,
+    (binding) => registry.unbindTask(binding.taskId, binding),
+    't-clear-unbind',
+  );
+});
+
+test('a displacing bindTask clears the hold, so the displacing binding can be held', async () => {
+  const registry = new Registry(20);
+  // bindCapturing inside the helper is what displaces the held binding here.
+  await assertSuccessorIsHeld(registry, () => undefined, 't-clear-rebind');
+});
+
+test('failBindingsForAgent clears the hold, so the next binding for that taskId can be held', async () => {
+  const registry = new Registry(20);
+  await assertSuccessorIsHeld(
+    registry,
+    () => {
+      // Reconnect and take an app-level close: fails the held binding outright.
+      const ws = makeWs();
+      registerFor(registry, ws);
+      registry.unregisterAgent('a1', ws, 4009);
+    },
+    't-clear-fail',
+  );
+});
+
+test('a second disconnect leaves no extra expiry timer behind', async () => {
+  // `holdBindingsForAgent` skips a taskId that already has a hold rather than
+  // arming a second timer for it. Overwriting instead would look harmless — the
+  // newer timer replaces the map entry — but the ORIGINAL timer stays pending
+  // and unreferenced, and `resumeBinding` can only cancel the one it can see.
+  // The orphan then fires on the old deadline and fails a task that was already
+  // resumed and is happily running.
+  const registry = new Registry(60);
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  const task = bindCapturing(registry, 'a1', 't-one-timer');
+
+  registry.unregisterAgent('a1', ws1, 1012);
+
+  // A second drop, comfortably inside the first hold's window.
+  await sleep(20);
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  // The client comes back for good and resumes the task.
+  registry.resumeBinding('t-one-timer', 'a1');
+
+  // Past the first hold's deadline. Nothing may fire.
+  await sleep(100);
+
+  assert.equal(task.state.finished, false, 'an orphaned expiry timer failed a resumed task');
+  assert.ok(registry.getBinding('t-one-timer'));
+});
+
+test('a foreign agent resuming a hold does not stop it from expiring', async () => {
+  // The agentId check in resumeBinding is the whole of its authorization. Held
+  // bindings stay in the map either way, so asserting presence proves nothing —
+  // only expiry does.
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-foreign');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-foreign', 'other-agent');
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, true, 'a foreign agent cancelled the hold');
+  assert.equal(registry.getBinding('t-foreign'), undefined);
+});
+
+test('the owning agent resuming a hold does stop it from expiring', async () => {
+  // Companion to the above: same shape, correct agentId, opposite outcome — so
+  // the pair pins the check rather than just the expiry.
+  const registry = new Registry(20);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-owner');
+
+  registry.unregisterAgent('a1', ws, 1012);
+  registry.resumeBinding('t-owner', 'a1');
+
+  await sleep(80);
+
+  assert.equal(task.state.finished, false);
+  assert.ok(registry.getBinding('t-owner'));
+});
+
+test('a close code the bridge itself sent is terminal even when it comes back as 1006', () => {
+  // `disconnectClient` closes with 4014, but the code we OBSERVE is whatever
+  // our socket ends up with: a peer that never echoes the close frame leaves
+  // `ws` to time out and report 1006, which is graceable. The deleted client's
+  // tasks must still die immediately.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws, 'a1', 'c1');
+  const task = bindCapturing(registry, 'a1', 't-deleted');
+
+  assert.equal(registry.disconnectClient('c1'), 1);
+  registry.unregisterAgent('a1', ws, 1006); // peer never acked; ws reports 1006
+
+  assert.equal(registry.getBinding('t-deleted'), undefined, 'a deleted client must not be graced');
+  assert.equal(task.state.finished, true);
+});
+
+test('close-code classification at the app-level boundaries', () => {
+  // 4000-4999 is the bridge's own range; 5000 and up is not ours and is treated
+  // like any other unexpected close.
+  const cases: Array<[number, boolean]> = [
+    [4000, false],
+    [4999, false],
+    [5000, true],
+    [3999, true],
+    [1001, true],
+    [1005, true],
+  ];
+  for (const [code, expectHold] of cases) {
+    const registry = new Registry(10_000);
+    const ws = makeWs();
+    registerFor(registry, ws);
+    bindCapturing(registry, 'a1', `t-code-${code}`);
+    registry.unregisterAgent('a1', ws, code);
+    assert.equal(
+      registry.getBinding(`t-code-${code}`) !== undefined,
+      expectHold,
+      `close code ${code} should ${expectHold ? 'hold' : 'fail immediately'}`,
+    );
+  }
+});
+
+test('unregisterAgent with no close code holds (the #364 reconcile path)', () => {
+  // ws.ts reconciles a socket that died during async auth by calling
+  // unregisterAgent with no code. Absence of a code is not evidence the client
+  // is gone for good, so it is graceable — and in that path there are no
+  // bindings anyway, since registration never completed.
+  const registry = new Registry(10_000);
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-nocode');
+
+  registry.unregisterAgent('a1', ws);
+
+  assert.ok(registry.getBinding('t-nocode'));
+  assert.equal(task.state.finished, false);
+});
+
+// ---------------------------------------------------------------------------
+// Blast radius: a hold or a failure must touch ONE agent's tasks.
+//
+// The agent filters in failBindingsForAgent/holdBindingsForAgent were entirely
+// unconstrained — deleting either left the suite green, because no test had two
+// agents holding bindings at the same time. Without them a single client's
+// disconnect fails (or, 30s later, kills) every other client's in-flight work.
+// ---------------------------------------------------------------------------
+
+test('one agent disconnecting does not fail another agent\'s in-flight task', () => {
+  const registry = new Registry(0); // grace off: the immediate-fail path
+  const wsA = makeWs();
+  const wsB = makeWs();
+  registerFor(registry, wsA, 'a1', 'c1');
+  registerFor(registry, wsB, 'a2', 'c2');
+  const mine = bindCapturing(registry, 'a1', 't-mine');
+  const theirs = bindCapturing(registry, 'a2', 't-theirs');
+
+  registry.unregisterAgent('a1', wsA, 1012);
+
+  assert.equal(mine.state.finished, true);
+  assert.equal(theirs.state.finished, false, "another agent's task was failed");
+  assert.ok(registry.getBinding('t-theirs'));
+  assert.deepEqual(theirs.statuses, []);
+});
+
+test('one agent disconnecting does not hold — or later kill — another agent\'s task', async () => {
+  const registry = new Registry(20); // grace on: the hold path
+  const wsA = makeWs();
+  const wsB = makeWs();
+  registerFor(registry, wsA, 'a1', 'c1');
+  registerFor(registry, wsB, 'a2', 'c2');
+  bindCapturing(registry, 'a1', 't-a-task');
+  const theirs = bindCapturing(registry, 'a2', 't-b-task');
+
+  registry.unregisterAgent('a1', wsA, 1012);
+
+  // Past the deadline: a1's task expires, a2's — never held — must be untouched.
+  await sleep(80);
+
+  assert.equal(registry.getBinding('t-a-task'), undefined, "the disconnecting agent's task expired");
+  assert.equal(theirs.state.finished, false, "another agent's task was swept up in the hold");
+  assert.ok(registry.getBinding('t-b-task'));
+  assert.ok(registry.getAgent('a2'), 'the other agent is still connected');
+});
+
+// ---------------------------------------------------------------------------
+// The expiry timer's own cleanup is a FOURTH clear site.
+//
+// The guard-coverage note above lists three explicit clearGraceHold calls, but
+// the timer deletes its own map entry too. Leave that out and a naturally
+// expired hold's entry outlives it, and the `has()` skip then denies the next
+// binding for that taskId a hold of its own — the same successor failure the
+// three explicit sites are tested through.
+// ---------------------------------------------------------------------------
+
+test('a naturally expired hold clears its own entry, so the taskId can be held again', async () => {
+  const registry = new Registry(20);
+  const ws1 = makeWs();
+  registerFor(registry, ws1);
+  const first = bindCapturing(registry, 'a1', 't-reexpire');
+
+  registry.unregisterAgent('a1', ws1, 1012);
+  await sleep(80);
+  assert.equal(first.state.finished, true, 'precondition: the first hold expired');
+  assert.equal(registry.getBinding('t-reexpire'), undefined);
+
+  // The same taskId comes round again (A2A reuses a taskId across turns) and
+  // its client drops too.
+  const successor = bindCapturing(registry, 'a1', 't-reexpire');
+  const ws2 = makeWs();
+  registerFor(registry, ws2);
+  registry.unregisterAgent('a1', ws2, 1012);
+
+  await sleep(80);
+
+  assert.equal(successor.state.finished, true, 'a stale entry denied the successor its hold');
+  assert.equal(registry.getBinding('t-reexpire'), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// The production configuration path.
+//
+// `index.ts` constructs `new Registry()` with no argument, so the default, the
+// env parse and the clamp are exactly the code no other test reaches — every
+// grace test injects its value through the constructor. A typo'd default or a
+// broken parse would ship with a green suite.
+// ---------------------------------------------------------------------------
+
+test('resolveDisconnectGraceMs covers default, env, clamp and rejection', () => {
+  assert.deepEqual(resolveDisconnectGraceMs(undefined), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'default',
+  });
+  assert.deepEqual(resolveDisconnectGraceMs(''), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'default',
+  });
+  // `Number(' ')` is 0, so without a trim a whitespace-only value would read as
+  // a deliberate kill switch and silently disable recovery.
+  for (const blank of [' ', '\t', '  \n ']) {
+    assert.deepEqual(
+      resolveDisconnectGraceMs(blank),
+      { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' },
+      `blank value ${JSON.stringify(blank)} must not disable the grace`,
+    );
+  }
+  // A surrounding-whitespace value is still the number the operator meant.
+  assert.deepEqual(resolveDisconnectGraceMs(' 45000 '), { ms: 45_000, source: 'env' });
+  assert.deepEqual(resolveDisconnectGraceMs('45000'), { ms: 45_000, source: 'env' });
+  // 0 is the documented kill switch and must survive as a real 0, not be
+  // mistaken for "unset".
+  assert.deepEqual(resolveDisconnectGraceMs('0'), { ms: 0, source: 'env' });
+  assert.deepEqual(resolveDisconnectGraceMs(String(MAX_DISCONNECT_GRACE_MS)), {
+    ms: MAX_DISCONNECT_GRACE_MS,
+    source: 'env',
+  });
+  // Past setTimeout's ceiling the timer would collapse to 1ms — i.e. asking for
+  // a very long hold would silently give none at all.
+  assert.deepEqual(resolveDisconnectGraceMs(String(MAX_DISCONNECT_GRACE_MS + 1)), {
+    ms: MAX_DISCONNECT_GRACE_MS,
+    source: 'clamped',
+  });
+  // `-1` is a common "disable" idiom; silently restoring the 30s default would
+  // be the opposite of the operator's intent, so it is reported as invalid.
+  assert.deepEqual(resolveDisconnectGraceMs('-1'), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'invalid',
+  });
+  assert.deepEqual(resolveDisconnectGraceMs('30s'), {
+    ms: FALLBACK_DISCONNECT_GRACE_MS,
+    source: 'invalid',
+  });
+});
+
+test('a default-constructed Registry actually grants a grace hold', async () => {
+  // The shape production runs (`new Registry()`, index.ts). Guards the default
+  // constant itself: at 0 the feature is off and this binding would be failed
+  // on the spot.
+  const registry = new Registry();
+  const ws = makeWs();
+  registerFor(registry, ws);
+  const task = bindCapturing(registry, 'a1', 't-default');
+
+  registry.unregisterAgent('a1', ws, 1012);
+
+  assert.ok(registry.getBinding('t-default'), 'the default grace is disabled');
+  assert.equal(task.state.finished, false);
+
+  // Long enough to prove it is not a near-zero timer, short enough to stay a
+  // unit test. The real deadline is minutes away in wall-clock terms.
+  await sleep(60);
+  assert.ok(registry.getBinding('t-default'), 'the default grace is far too short');
+
+  // Don't leave a live 30s hold behind for the runner to trip over.
+  registry.unbindTask('t-default', registry.getBinding('t-default')!);
 });

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -20,17 +20,11 @@ const WS_OPEN = 1;
 const WS_CLOSING = 2;
 const WS_CLOSED = 3;
 
-// Minimal WebSocket stub — Registry uses `.close()` on replacement, equality
-// (`existing.ws !== ws`) on unregister, and `readyState` to tell a live
-// duplicate-token collision from a client that is merely reconnecting after its
-// socket already died (issue #474). Defaults to OPEN, which is what every
-// pre-#474 test implicitly assumed.
-//
-// `close()` MUST move readyState to CLOSING, because the real `ws` library does
-// so synchronously inside close() — and a stub that froze readyState instead
-// would let `registry.ts` read it *after* closing the socket and still appear
-// to work, certifying a branch that real sockets can never take. That is not
-// hypothetical: it is exactly the bug this stub previously hid.
+// Minimal WebSocket stub — Registry uses `.close()` on replacement and socket
+// identity (`existing.ws !== ws`) on unregister. Tests can initialize distinct
+// readyState values to model race orderings, and `close()` mirrors the real
+// library by moving OPEN to CLOSING synchronously. Production deliberately does
+// not use readyState as a liveness signal for reconnect classification.
 function makeWs(readyState: number = WS_OPEN): WebSocket {
   const ws = {
     readyState,

--- a/packages/server/src/registry.test.ts
+++ b/packages/server/src/registry.test.ts
@@ -444,19 +444,17 @@ test('registerAgent emits client_collision and closes the prior ws with the desc
   assert.equal(parsed.previousConnectedAt, 1000);
 });
 
-test('same-token reconnect eventually fails the displaced connection in-flight bindings (issue #365)', () => {
+test('same-token reconnect immediately supersedes legacy in-flight bindings (issue #365)', () => {
   // A second daemon authenticating with the same CLIENT_TOKEN replaces the
   // incumbent. The old connection's in-flight task must receive a terminal
   // `failed` status and have its sink finished + binding dropped — otherwise
   // the task's HTTP stream hangs forever (if the new daemon is a separate
   // process that never knew the old taskId, it can't complete it either).
   //
-  // Since #474 that outcome is delayed by the reconnect grace, which exists
-  // because the new daemon is USUALLY the same client coming back and can
-  // finish the task. Grace 0 keeps this test on its original subject — that a
-  // displaced binding is never orphaned, and that this path's terminal is
-  // `superseded` — while the graced variants are covered separately below.
-  const registry = new Registry(0);
+  // A legacy client cannot safely reclaim output, so it still fails
+  // immediately even when grace is configured. The terminal remains this
+  // path's established `superseded`, not the transport-drop `disconnected`.
+  const registry = new Registry(10_000);
   const oldWs = makeWs();
   const base = {
     agentId: 'a1',
@@ -464,7 +462,6 @@ test('same-token reconnect eventually fails the displaced connection in-flight b
     ownerPrincipal: 'eth:0x0',
     agentCard: makeCard(false),
     allowedCallers: [],
-    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
     connectedAt: 0,
   };
   registry.registerAgent({ ...base, ws: oldWs });

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -1,6 +1,6 @@
 import type { WebSocket } from 'ws';
 import type { AgentCard, DownFrame, TaskUsage } from '@vicoop-bridge/protocol';
-import { encodeFrame } from '@vicoop-bridge/protocol';
+import { encodeFrame, TASK_REPLAY_CAPABILITY } from '@vicoop-bridge/protocol';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import { logEvent, truncate } from './log.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
@@ -45,6 +45,13 @@ export interface TaskSink {
 export interface TaskBinding {
   agentId: string;
   taskId: string;
+  // Unique to one dispatch/turn. A2A deliberately reuses taskId for
+  // continuations, so reconnect replay must never use taskId as its generation
+  // identity. Present only for clients that negotiated task-replay-v1.
+  bindingId?: string;
+  // Next client sequence accepted for this binding. Frames below this value
+  // are duplicates; frames above it prove a gap and must fail closed.
+  nextClientSeq?: number;
   contextId: string;
   sink: TaskSink;
   // principalId of the caller that originated this task (post-auth). Optional
@@ -84,11 +91,205 @@ export type CallerChangeListener = (agentId: string, callers: string[]) => void;
 // before an unclean shutdown) is cleared unconditionally.
 export type AgentChangeListener = (agentId: string) => void;
 
+// Reconnect grace hold (issue #474). A WS drop that the client recovers from
+// used to fail every in-flight task instantly, and the results the client sent
+// after reconnecting were discarded as `dropped_terminal_frame` — a 3s infra
+// blip became a minute-long outage downstream. Instead we keep the binding
+// alive for this long and let the reconnected client's frames land on it.
+//
+// Sized off the incident: the terminal frames arrived +9s / +10s / +15s after
+// the drop, so the hold has to cover TASK COMPLETION, not just reconnect time
+// (3.2s). 30s gives 2x margin over the worst observed frame. It is not a cap on
+// task duration — a single frame (heartbeat included) on the new connection
+// resumes the binding outright, after which the executor's own 10-minute
+// inactivity backstop is what governs.
+//
+// `0` disables the hold and restores the previous fail-immediately behavior.
+export const FALLBACK_DISCONNECT_GRACE_MS = 30_000;
+// Node's setTimeout silently clamps anything past the signed-32-bit ceiling to
+// 1ms, so an operator who typed a very large number to mean "hold a long time"
+// would get the opposite — holds that expire immediately. Cap instead, so the
+// value can only ever mean what it says.
+export const MAX_DISCONNECT_GRACE_MS = 2_147_483_647;
+
+/**
+ * Parse `BRIDGE_DISCONNECT_GRACE_MS`. Exported so the production configuration
+ * path — the one `new Registry()` actually takes — is reachable from tests;
+ * every grace test injects its value through the constructor, so without this
+ * a typo'd default or broken parse would ship green.
+ *
+ * Returns the effective grace plus why, so the caller can say so out loud
+ * rather than silently coercing. A negative value is rejected rather than
+ * treated as "off": `0` is the documented disable switch, and `-1` is a common
+ * enough idiom for it that silently re-enabling a 30s hold would be the exact
+ * opposite of what the operator asked for.
+ */
+export function resolveDisconnectGraceMs(raw: string | undefined): {
+  ms: number;
+  source: 'default' | 'env' | 'clamped' | 'invalid';
+} {
+  // Trim first: `Number(' ')` is 0, so a whitespace-only value would otherwise
+  // read as a deliberate `0` and silently disable recovery, when only a literal
+  // `0` is documented as the kill switch.
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === '') {
+    return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'default' };
+  }
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n < 0) {
+    return { ms: FALLBACK_DISCONNECT_GRACE_MS, source: 'invalid' };
+  }
+  if (n > MAX_DISCONNECT_GRACE_MS) return { ms: MAX_DISCONNECT_GRACE_MS, source: 'clamped' };
+  return { ms: n, source: 'env' };
+}
+
+const DEFAULT_DISCONNECT_GRACE_MS = (() => {
+  const resolved = resolveDisconnectGraceMs(process.env.BRIDGE_DISCONNECT_GRACE_MS);
+  // Emitted once at module load. The grace decides whether a task survives a
+  // drop, and `0` is the rollback lever, so an operator must never have to read
+  // the source to find out which one is in effect.
+  logEvent('disconnect_grace_configured', {
+    graceMs: resolved.ms,
+    source: resolved.source,
+    ...(resolved.source === 'invalid' || resolved.source === 'clamped'
+      ? { requested: truncate(String(process.env.BRIDGE_DISCONNECT_GRACE_MS), 64) }
+      : {}),
+  });
+  return resolved.ms;
+})();
+
+/**
+ * Is this close code one we should wait out, rather than treat as proof the
+ * client is gone?
+ *
+ * Deliberately a DENY-list, not an allow-list of "transient" codes. The server
+ * has never recorded close codes (`client_disconnected` didn't carry one until
+ * this change), so we have no data on which code its socket actually observes
+ * when a proxy tears the connection down — the client saw `1012` in the
+ * incident, but the server end may well see `1006`/`1005`. Enumerating
+ * transient codes would be building on that guess. What we DO know exactly is
+ * the set of terminal closes, because the bridge itself sends them:
+ *
+ *   - 4000-4999: this server's own app-level rejections (bad token, duplicate
+ *     hello, client deleted, superseded, …). Every one is a decision that the
+ *     connection must not continue, so the task is genuinely dead.
+ *   - 1000: a clean, intentional close. Nothing to wait for.
+ *
+ * Everything else — abnormal closure, proxy restart, no code at all — gets the
+ * hold.
+ *
+ * This test alone is not sufficient for closes WE initiate, because the code we
+ * observe is the one our socket ends up with, not the one we sent: a peer that
+ * never echoes the close frame leaves `ws` to time out and report `1006`. The
+ * `serverClosed` WeakSet carries that intent separately; see its declaration.
+ */
+function isGraceableCloseCode(code: number | undefined): boolean {
+  if (code === undefined) return true;
+  if (code === 1000) return false;
+  return code < 4000 || code > 4999;
+}
+
+// Shape of the terminal a binding is failed with. Named so the disconnect
+// terminal can be declared once and reused by every path that emits it.
+interface TerminalError {
+  code: string;
+  message: string;
+  messageIdSuffix: string;
+}
+
+// The mid-task disconnect terminal, unchanged since before the grace hold: a
+// task that outlives its hold must be indistinguishable downstream from one
+// that failed instantly, so the router needs no new case.
+const DISCONNECTED_ERROR: TerminalError = {
+  code: 'disconnected',
+  message: 'client disconnected mid-task',
+  messageIdSuffix: 'disc',
+};
+
+interface GraceHold {
+  timer: ReturnType<typeof setTimeout>;
+  // Identity guard, same discipline as unbindTask: only the binding that was
+  // held may be failed by its own timer. A rebind of the same taskId while the
+  // hold is pending must never be collateral damage.
+  binding: TaskBinding;
+  // Diagnostics carried from the hold to whichever event ends it. `heldForMs`
+  // on a resume is the one number that answers "is T long enough?" — the
+  // distribution of how long real recoveries actually take.
+  heldAt: number;
+  via: 'disconnect' | 'reconnect';
+  closeCode: number | undefined;
+}
+
 export class Registry {
   private agents = new Map<string, ClientConnection>();
   private bindings = new Map<string, TaskBinding>();
+  // taskId -> pending grace hold. A binding in here is still present in
+  // `bindings` and still fully serviceable; the entry only means "if nothing
+  // arrives for this task before the timer fires, declare the client dead".
+  private graceHolds = new Map<string, GraceHold>();
+  // Recently completed reliable bindings. If the terminal ack is lost with
+  // the socket, the client may replay that terminal after reconnect. Keeping a
+  // short, bounded receipt lets us acknowledge the duplicate without ever
+  // looking it up by a taskId that may now belong to another turn.
+  private terminalReceipts = new Map<
+    string,
+    { agentId: string; taskId: string; acceptedSeq: number; expiresAt: number }
+  >();
+  // Sockets this server closed with a terminal verdict of its own. The close
+  // CODE we later observe is not trustworthy for that decision: when we send
+  // `close(4014)` and the peer never echoes the close frame — dead TCP, wedged
+  // process, or a client that simply declines to — `ws` gives up after its
+  // close timeout and emits the default `1006`, which is graceable. Without
+  // this the deny-list would be advisory: a client could earn itself a grace
+  // hold just by refusing to acknowledge being kicked. Recording the intent at
+  // the moment we form it is the only reliable signal.
+  //
+  // A WeakSet so a socket that never reaches unregisterAgent (identity-guard
+  // no-op, connection dropped before registration) cannot pin an entry.
+  private serverClosed = new WeakSet<WebSocket>();
   private callerChangeListeners: CallerChangeListener[] = [];
   private agentChangeListeners: AgentChangeListener[] = [];
+
+  constructor(private readonly disconnectGraceMs: number = DEFAULT_DISCONNECT_GRACE_MS) {}
+
+  getDisconnectGraceMs(): number {
+    return this.disconnectGraceMs;
+  }
+
+  rememberTerminalReceipt(binding: TaskBinding, acceptedSeq: number): void {
+    if (!binding.bindingId) return;
+    const now = Date.now();
+    this.pruneTerminalReceipts(now);
+    this.terminalReceipts.set(binding.bindingId, {
+      agentId: binding.agentId,
+      taskId: binding.taskId,
+      acceptedSeq,
+      expiresAt: now + Math.max(this.disconnectGraceMs, 60_000),
+    });
+    while (this.terminalReceipts.size > 10_000) {
+      const oldest = this.terminalReceipts.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.terminalReceipts.delete(oldest);
+    }
+  }
+
+  getTerminalReceipt(
+    bindingId: string,
+    agentId: string,
+    taskId: string,
+  ): { acceptedSeq: number } | undefined {
+    this.pruneTerminalReceipts(Date.now());
+    const receipt = this.terminalReceipts.get(bindingId);
+    if (!receipt || receipt.agentId !== agentId || receipt.taskId !== taskId) return undefined;
+    return { acceptedSeq: receipt.acceptedSeq };
+  }
+
+  private pruneTerminalReceipts(now: number): void {
+    for (const [bindingId, receipt] of this.terminalReceipts) {
+      if (receipt.expiresAt > now) continue;
+      this.terminalReceipts.delete(bindingId);
+    }
+  }
 
   registerAgent(conn: ClientConnection): { ok: true } | { ok: false; reason: string } {
     const existing = this.agents.get(conn.agentId);
@@ -108,23 +309,60 @@ export class Registry {
           clientId: conn.clientId,
           previousConnectedAt: existing.connectedAt,
         });
+        // Whether this connection was already condemned has to be read BEFORE
+        // closing it: `ws` flips `_readyState` to CLOSING synchronously inside
+        // `close()`, so any liveness question asked afterwards answers itself.
+        const displacedWasCondemned = this.serverClosed.has(existing.ws);
         // The close `reason` is what the client surfaces in its disconnect
         // log line. Spelling out the cause here means an operator reading
         // the foreground log can recognize the duplicate-token scenario
         // without cross-referencing close codes.
         existing.ws.close(4009, 'another client with the same token connected');
-        // Fail the displaced connection's in-flight tasks *before* swapping the
-        // map. The old socket's close fires asynchronously and, by the time its
-        // unregisterAgent runs, the map already points at `conn` — so the
+        // Deal with the displaced connection's in-flight tasks *before* swapping
+        // the map. The old socket's close fires asynchronously and, by the time
+        // its unregisterAgent runs, the map already points at `conn` — so the
         // ws-identity guard makes it a no-op and it can't clean these up. Doing
         // it here (while the bindings still belong to the old conn) is the only
         // point that sees them. The new conn hasn't bound any tasks yet, so
-        // this only terminates the superseded ones.
-        this.failBindingsForAgent(conn.agentId, {
+        // this only touches the superseded ones.
+        //
+        // These get the SAME grace hold the disconnect path gives them, and
+        // that uniformity is the point (issue #474). Which path a recovered drop
+        // takes is a pure race — the server may see the old socket's close first
+        // (→ unregisterAgent) or the new hello first (→ here) — so both must
+        // reach the same verdict, or the fix works only in the lucky ordering.
+        //
+        // An earlier revision tried to keep the old fail-fast behavior for the
+        // "two live daemons share a CLIENT_TOKEN" case by testing
+        // `readyState === OPEN` here. That is not a liveness test: it only says
+        // the server has not OBSERVED a close. The server runs no keepalive of
+        // its own, and the client is built to notice first — it pings every 30s
+        // and terminates on a missed pong, which on a dead path never reaches
+        // us. So the common client-detected drop arrives here with the old
+        // socket still nominally OPEN and would be killed instantly: exactly the
+        // bug #474 exists to fix, relabeled `superseded`.
+        //
+        // Holding a genuine collision instead is cheap: the second daemon does
+        // not know the first one's taskIds, so it never sends frames for them
+        // and the holds simply expire. We trade a more precise error code and T
+        // seconds of latency for not misclassifying the case that actually
+        // happens.
+        //
+        // The one exception is a connection this server already condemned (the
+        // owner deleted the client). Its tasks are dead regardless of who
+        // reconnects, so it keeps failing immediately.
+        const supersededError = {
           code: 'superseded',
           message: 'superseded by a reconnect from the same client token',
           messageIdSuffix: 'superseded',
-        });
+        };
+        const displacedSupportsReplay =
+          existing.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY) === true;
+        if (displacedWasCondemned || !displacedSupportsReplay) {
+          this.failBindingsForAgent(conn.agentId, DISCONNECTED_ERROR);
+        } else {
+          this.holdBindingsForAgent(conn.agentId, undefined, 'reconnect', supersededError);
+        }
         this.agents.set(conn.agentId, conn);
         this.notifyAgentChange(conn.agentId);
         return { ok: true };
@@ -165,22 +403,163 @@ export class Registry {
     let closed = 0;
     for (const conn of this.agents.values()) {
       if (conn.clientId !== clientId) continue;
+      // The owner deleted this client; its tasks are dead whatever close code
+      // comes back to us. See `serverClosed`.
+      this.serverClosed.add(conn.ws);
       conn.ws.close(4014, 'client deleted');
       closed++;
     }
     return closed;
   }
 
-  unregisterAgent(agentId: string, ws: WebSocket): void {
+  // `closeCode` is the WS close code this socket reported, or undefined when
+  // the caller has none (the #364 reconcile path, which unregisters a socket
+  // that went away before registration finished). It decides only one thing:
+  // whether the in-flight tasks die now or get a grace hold. The agent itself
+  // leaves the `agents` map either way — it is offline until it says hello
+  // again, so routing and agent-card consumers see no change from this.
+  /**
+   * Record that THIS server is closing `ws` with an app-level verdict, before
+   * calling `ws.close(4xxx)`. Callers outside the registry (ws.ts's handshake
+   * and protocol rejections) use this so their intent survives the round trip
+   * — see `serverClosed`, which explains why the observed close code cannot be
+   * trusted for that decision.
+   */
+  noteServerClose(ws: WebSocket): void {
+    this.serverClosed.add(ws);
+  }
+
+  unregisterAgent(agentId: string, ws: WebSocket, closeCode?: number): void {
     const existing = this.agents.get(agentId);
     if (!existing || existing.ws !== ws) return;
     this.agents.delete(agentId);
     this.notifyAgentChange(agentId);
-    this.failBindingsForAgent(agentId, {
-      code: 'disconnected',
-      message: 'client disconnected mid-task',
-      messageIdSuffix: 'disc',
+    const supportsReplay =
+      existing.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY) === true;
+    if (supportsReplay && isGraceableCloseCode(closeCode) && !this.serverClosed.has(ws)) {
+      // holdBindingsForAgent handles a disabled grace itself, falling back to
+      // the same immediate failure, so there is one decision point rather than
+      // two conditions that could drift apart.
+      this.holdBindingsForAgent(agentId, closeCode, 'disconnect', DISCONNECTED_ERROR);
+      return;
+    }
+    this.failBindingsForAgent(agentId, DISCONNECTED_ERROR);
+  }
+
+  // Start a grace hold on every in-flight task bound to this agent instead of
+  // failing it. The binding stays in `bindings` and its sink stays open, so a
+  // frame arriving on the client's next connection lands on it untouched —
+  // nothing about a TaskBinding is connection-scoped (no `ws` field; outbound
+  // sends re-resolve the connection by agentId at send time), which is what
+  // makes a hold this cheap.
+  // `terminalError` is what this hold resolves to if it is never resumed —
+  // both when it expires and, immediately, when the grace is switched off
+  // (`BRIDGE_DISCONNECT_GRACE_MS=0`). It is the caller's own terminal, so each
+  // path's unresumed outcome is byte-identical to what it produced before the
+  // grace existed, just T later: `disconnected` for a drop, `superseded` for a
+  // same-token reconnect that never reclaimed the task.
+  //
+  // Keeping them distinct matters downstream: `disconnected` is the code the
+  // router's cooldown amplifier keys on, and a client that demonstrably came
+  // back (we saw its hello) but did not reclaim an old task is not a
+  // disconnected agent — reporting it as one would manufacture exactly the
+  // false failure signal issue #474 exists to remove.
+  private holdBindingsForAgent(
+    agentId: string,
+    closeCode: number | undefined,
+    via: 'disconnect' | 'reconnect',
+    terminalError: TerminalError,
+  ): void {
+    if (this.disconnectGraceMs <= 0) {
+      this.failBindingsForAgent(agentId, terminalError);
+      return;
+    }
+    for (const binding of [...this.bindings.values()]) {
+      if (binding.agentId !== agentId) continue;
+      // Already holding this one (e.g. a second disconnect arriving for a
+      // binding whose hold is still pending). Leave the original deadline in
+      // place rather than sliding it forward on every event.
+      if (this.graceHolds.has(binding.taskId)) continue;
+      const heldAt = Date.now();
+      const timer = setTimeout(() => {
+        this.graceHolds.delete(binding.taskId);
+        // Never resumed. Fail it exactly the way this path always has — same
+        // code, same message, same messageId suffix — so nothing downstream has
+        // to learn a new shape. The only difference is that it happens
+        // `disconnectGraceMs` later.
+        if (this.bindings.get(binding.taskId) !== binding) return;
+        // Carries the same `via`/`closeCode` as the hold that armed it, so the
+        // expiry line alone answers "which drop killed this task" without a
+        // timestamp join back to binding_grace_held.
+        logEvent('binding_grace_expired', {
+          agentId: binding.agentId,
+          taskId: binding.taskId,
+          graceMs: this.disconnectGraceMs,
+          via,
+          ...(closeCode !== undefined ? { closeCode } : {}),
+          ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
+        });
+        this.failBinding(binding, terminalError);
+        this.bindings.delete(binding.taskId);
+      }, this.disconnectGraceMs);
+      // Never let a pending hold keep the process alive on its own.
+      timer.unref?.();
+      this.graceHolds.set(binding.taskId, { timer, binding, heldAt, via, closeCode });
+      logEvent('binding_grace_held', {
+        agentId: binding.agentId,
+        taskId: binding.taskId,
+        graceMs: this.disconnectGraceMs,
+        via,
+        ...(closeCode !== undefined ? { closeCode } : {}),
+        ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
+      });
+    }
+  }
+
+  /**
+   * Cancel the grace hold on a task because the client just proved it is alive
+   * and still working on it.
+   *
+   * Called for every task-scoped frame from an authenticated connection — a
+   * heartbeat `task.status` is enough, and that matters: it means even a
+   * multi-minute task resumes the instant the reconnected client's next beat
+   * lands, long before the hold would have expired. No-op for the overwhelming
+   * majority of frames, where no hold is pending.
+   *
+   * `agentId` is checked so a frame cannot resume a hold belonging to some
+   * other agent's task, even if it somehow guessed the taskId.
+   */
+  resumeBinding(taskId: string, agentId: string): void {
+    const hold = this.graceHolds.get(taskId);
+    if (!hold) return;
+    if (hold.binding.agentId !== agentId) return;
+    // Identity guard: a hold whose binding has since been replaced belongs to
+    // the old binding. Leave it for the timer, which re-checks the same thing.
+    if (this.bindings.get(taskId) !== hold.binding) return;
+    clearTimeout(hold.timer);
+    this.graceHolds.delete(taskId);
+    logEvent('binding_grace_resumed', {
+      agentId,
+      taskId,
+      heldForMs: Date.now() - hold.heldAt,
+      graceMs: this.disconnectGraceMs,
+      via: hold.via,
+      ...(hold.closeCode !== undefined ? { closeCode: hold.closeCode } : {}),
+      ...(hold.binding.principalId !== undefined
+        ? { principalId: hold.binding.principalId }
+        : {}),
     });
+  }
+
+  // Drop a pending hold without failing anything — used wherever a binding
+  // leaves the map through a path that has already decided its fate (normal
+  // terminal, rebind, explicit fail), so a stale timer can't fire against it.
+  private clearGraceHold(taskId: string, binding?: TaskBinding): void {
+    const hold = this.graceHolds.get(taskId);
+    if (!hold) return;
+    if (binding !== undefined && hold.binding !== binding) return;
+    clearTimeout(hold.timer);
+    this.graceHolds.delete(taskId);
   }
 
   // Push a terminal `failed` status to every in-flight task bound to this
@@ -193,12 +572,12 @@ export class Registry {
   // explicitly before swapping the agents map: once the map points at the new
   // conn, the old socket's late close handler hits the ws-identity guard in
   // unregisterAgent and early-returns, so it can no longer fail these bindings.
-  private failBindingsForAgent(
-    agentId: string,
-    error: { code: string; message: string; messageIdSuffix: string },
-  ): void {
+  private failBindingsForAgent(agentId: string, error: TerminalError): void {
     for (const binding of [...this.bindings.values()]) {
       if (binding.agentId !== agentId) continue;
+      // This binding's fate is being decided right now; a pending hold on it is
+      // moot and its timer must not outlive it.
+      this.clearGraceHold(binding.taskId, binding);
       this.failBinding(binding, error);
       // Identity-guarded: only drop the entry if it is still THIS binding, so a
       // concurrent rebind of the same taskId is never clobbered.
@@ -213,10 +592,7 @@ export class Registry {
   // executeStream() generator returns (closing the SSE stream) instead of
   // hanging forever on AsyncEventQueue.iterate(). Does NOT touch the bindings
   // map — callers decide whether to delete (disconnect) or overwrite (rebind).
-  private failBinding(
-    binding: TaskBinding,
-    error: { code: string; message: string; messageIdSuffix: string },
-  ): void {
+  private failBinding(binding: TaskBinding, error: TerminalError): void {
     binding.sink.pushStatus({
       taskId: binding.taskId,
       contextId: binding.contextId,
@@ -275,6 +651,7 @@ export class Registry {
         agentId: binding.agentId,
         ownerAgentId: existing.agentId,
         taskId: binding.taskId,
+        operation: 'bind',
         ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
       });
       return false;
@@ -285,6 +662,11 @@ export class Registry {
         taskId: binding.taskId,
         ...(binding.principalId !== undefined ? { principalId: binding.principalId } : {}),
       });
+      // The displaced binding is being terminated here and now, so any hold it
+      // was under is decided — drop the timer before the new binding takes over
+      // the taskId. (The timer is identity-guarded too, so this is belt and
+      // braces, but leaving live timers around for dead bindings is a trap.)
+      this.clearGraceHold(binding.taskId, existing);
       this.failBinding(existing, {
         code: 'task_superseded',
         message: 'task superseded by a newer request for the same task id',
@@ -299,6 +681,17 @@ export class Registry {
     return this.bindings.get(taskId);
   }
 
+  failTaskBinding(binding: TaskBinding, code: string, message: string): void {
+    if (this.bindings.get(binding.taskId) !== binding) return;
+    this.clearGraceHold(binding.taskId, binding);
+    this.failBinding(binding, {
+      code,
+      message,
+      messageIdSuffix: code,
+    });
+    this.bindings.delete(binding.taskId);
+  }
+
   // Identity-scoped: only remove the entry when it is still the SAME binding
   // this caller installed. A stale executor tearing down (after its awaited
   // taskStore.updateTask) must never delete a newer binding that has since
@@ -307,6 +700,12 @@ export class Registry {
   // guard already applied to the agents map in unregisterAgent (issue #365).
   unbindTask(taskId: string, binding: TaskBinding): void {
     if (this.bindings.get(taskId) !== binding) return;
+    // A task that reaches its terminal while a hold is pending — the exact case
+    // this feature exists to rescue, where the reconnected client's
+    // `task.complete` lands during the grace window — must take its timer with
+    // it. Otherwise the timer would fire later and try to fail an already
+    // completed task.
+    this.clearGraceHold(taskId, binding);
     this.bindings.delete(taskId);
   }
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -500,7 +500,7 @@ export class Registry {
         // timestamp join back to binding_grace_held.
         logEvent('binding_grace_expired', {
           agentId: binding.agentId,
-          taskId: binding.taskId,
+          taskId: truncate(binding.taskId, 128),
           graceMs: this.disconnectGraceMs,
           via,
           ...(closeCode !== undefined ? { closeCode } : {}),
@@ -514,7 +514,7 @@ export class Registry {
       this.graceHolds.set(binding.taskId, { timer, binding, heldAt, via, closeCode });
       logEvent('binding_grace_held', {
         agentId: binding.agentId,
-        taskId: binding.taskId,
+        taskId: truncate(binding.taskId, 128),
         graceMs: this.disconnectGraceMs,
         via,
         ...(closeCode !== undefined ? { closeCode } : {}),
@@ -547,7 +547,7 @@ export class Registry {
     this.graceHolds.delete(taskId);
     logEvent('binding_grace_resumed', {
       agentId,
-      taskId,
+      taskId: truncate(taskId, 128),
       heldForMs: Date.now() - hold.heldAt,
       graceMs: this.disconnectGraceMs,
       via: hold.via,

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -48,7 +48,7 @@ export interface TaskBinding {
   // Unique to one dispatch/turn. A2A deliberately reuses taskId for
   // continuations, so reconnect replay must never use taskId as its generation
   // identity. Present only for clients that negotiated task-replay-v1.
-  bindingId?: string;
+  executionId?: string;
   // Next client sequence accepted for this binding. Frames below this value
   // are duplicates; frames above it prove a gap and must fail closed.
   nextClientSeq?: number;
@@ -257,10 +257,10 @@ export class Registry {
   }
 
   rememberTerminalReceipt(binding: TaskBinding, acceptedSeq: number): void {
-    if (!binding.bindingId) return;
+    if (!binding.executionId) return;
     const now = Date.now();
     this.pruneTerminalReceipts(now);
-    this.terminalReceipts.set(binding.bindingId, {
+    this.terminalReceipts.set(binding.executionId, {
       agentId: binding.agentId,
       taskId: binding.taskId,
       acceptedSeq,
@@ -274,20 +274,20 @@ export class Registry {
   }
 
   getTerminalReceipt(
-    bindingId: string,
+    executionId: string,
     agentId: string,
     taskId: string,
   ): { acceptedSeq: number } | undefined {
     this.pruneTerminalReceipts(Date.now());
-    const receipt = this.terminalReceipts.get(bindingId);
+    const receipt = this.terminalReceipts.get(executionId);
     if (!receipt || receipt.agentId !== agentId || receipt.taskId !== taskId) return undefined;
     return { acceptedSeq: receipt.acceptedSeq };
   }
 
   private pruneTerminalReceipts(now: number): void {
-    for (const [bindingId, receipt] of this.terminalReceipts) {
+    for (const [executionId, receipt] of this.terminalReceipts) {
       if (receipt.expiresAt > now) continue;
-      this.terminalReceipts.delete(bindingId);
+      this.terminalReceipts.delete(executionId);
     }
   }
 

--- a/packages/server/src/registry.ts
+++ b/packages/server/src/registry.ts
@@ -309,9 +309,10 @@ export class Registry {
           clientId: conn.clientId,
           previousConnectedAt: existing.connectedAt,
         });
-        // Whether this connection was already condemned has to be read BEFORE
-        // closing it: `ws` flips `_readyState` to CLOSING synchronously inside
-        // `close()`, so any liveness question asked afterwards answers itself.
+        // Preserve a terminal verdict this server already made about the old
+        // socket. It is policy intent, independent of the close code the peer
+        // eventually echoes (or fails to echo), and a reconnect must not turn
+        // a condemned connection back into a recoverable one.
         const displacedWasCondemned = this.serverClosed.has(existing.ws);
         // The close `reason` is what the client surfaces in its disconnect
         // log line. Spelling out the cause here means an operator reading
@@ -358,10 +359,16 @@ export class Registry {
         };
         const displacedSupportsReplay =
           existing.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY) === true;
-        if (displacedWasCondemned || !displacedSupportsReplay) {
+        if (displacedWasCondemned) {
           this.failBindingsForAgent(conn.agentId, DISCONNECTED_ERROR);
-        } else {
+        } else if (displacedSupportsReplay) {
           this.holdBindingsForAgent(conn.agentId, undefined, 'reconnect', supersededError);
+        } else {
+          // Legacy clients cannot reclaim output safely, but this is still a
+          // same-token replacement rather than a transport disconnect. Keep
+          // the path's established terminal classification while failing it
+          // immediately.
+          this.failBindingsForAgent(conn.agentId, supersededError);
         }
         this.agents.set(conn.agentId, conn);
         this.notifyAgentChange(conn.agentId);

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -972,6 +972,29 @@ test('a live duplicate-token collision is held against real sockets, then expire
     await closeServer(server);
   }
 });
+
+test('a pre-auth task frame is rejected with an actionable hello-first reason', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'task.fail', taskId: 'pre-auth-task',
+      error: { code: 'too_early', message: 'too early' },
+    }));
+    const [code, reason] = (await once(ws, 'close')) as [number, Buffer];
+    assert.equal(code, 4003);
+    assert.equal(reason.toString('utf8'), 'expected hello before task frames');
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('a message past the ingress cap is refused by the transport, never assembled', async () => {
   // The pre-auth byte budget can only be charged once `ws` has already built
   // the message, so without an ingress cap the library's 100 MiB default is

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1299,32 +1299,52 @@ test('a terminal replay from an old execution cannot complete a reused taskId', 
   const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
   try {
     await once(ws, 'open');
+    const helloAck = once(ws, 'message');
     ws.send(encodeFrame({
       type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
       protocolCapabilities: [TASK_REPLAY_CAPABILITY],
       agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
     }));
+    await withTimeout(helloAck, 5_000, 'hello acknowledgement');
     await waitForAgent(registry, 'agent-1');
     const first = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-1', sink: first,
       executionId: 'execution-old', nextClientSeq: 0,
     });
+    const firstTerminalAck = once(ws, 'message');
     ws.send(encodeFrame({
       type: 'task.complete', taskId: 'task-reuse', executionId: 'execution-old', seq: 0,
       status: { state: 'completed' },
     }));
     await withTimeout(first.finished, 5_000, 'first terminal');
+    const [firstAckRaw] = await withTimeout(
+      firstTerminalAck,
+      5_000,
+      'first terminal acknowledgement',
+    ) as [Buffer];
+    assert.deepEqual(parseDownFrame(firstAckRaw.toString('utf8')), {
+      type: 'task.ack', taskId: 'task-reuse', executionId: 'execution-old', acceptedSeq: 0,
+    });
 
     const second = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-2', sink: second,
       executionId: 'execution-new', nextClientSeq: 0,
     });
+    const replayAck = once(ws, 'message');
     ws.send(encodeFrame({
       type: 'task.complete', taskId: 'task-reuse', executionId: 'execution-old', seq: 0,
       status: { state: 'completed' },
     }));
+    const [replayAckRaw] = await withTimeout(
+      replayAck,
+      5_000,
+      'terminal receipt acknowledgement',
+    ) as [Buffer];
+    assert.deepEqual(parseDownFrame(replayAckRaw.toString('utf8')), {
+      type: 'task.ack', taskId: 'task-reuse', executionId: 'execution-old', acceptedSeq: 0,
+    });
     await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(second.statuses.length, 0, 'old terminal must not touch the new binding');
     ws.send(encodeFrame({

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -230,6 +230,69 @@ test('a socket closing during async auth does not leave a zombie registration', 
   }
 });
 
+test('hello timeout remains a server verdict when async auth completes after close', async () => {
+  const server = createServer();
+  const registry = new Registry(60_000);
+  let releaseAuth!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    releaseAuth = resolve;
+  });
+  attachWsServer(server, { db: gatedSql(gate), registry, helloTimeoutMs: 20 });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  const sink = makeSink();
+
+  try {
+    // Bind before the deliberately delayed registration so the late-auth
+    // reconciliation has a replay-capable task whose fate exposes whether the
+    // server's timeout intent survived the close event.
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'late-auth-task',
+      contextId: 'late-auth-context',
+      sink,
+      executionId: 'late-auth-execution',
+      nextClientSeq: 0,
+    });
+
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello',
+      version: PROTOCOL_VERSION,
+      agentId: 'agent-1',
+      token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: {
+        name: 'agent',
+        version: '0.0.0',
+        protocolVersion: '0.3.0',
+      },
+    }));
+
+    const [code, reason] = (await once(ws, 'close')) as [number, Buffer];
+    assert.equal(code, 4001);
+    assert.equal(reason.toString('utf8'), 'hello timeout');
+
+    // registerAgent now briefly installs this already-closed socket, then the
+    // post-auth reconciliation unregisters it without a close code. That must
+    // retain the timeout verdict and fail the task rather than granting the
+    // replay grace period.
+    releaseAuth();
+    await withTimeout(sink.finished, 1_000, 'the late-auth task terminal');
+
+    assert.equal(registry.getAgent('agent-1'), undefined);
+    assert.equal(registry.getBinding('late-auth-task'), undefined);
+    assert.equal(sink.statuses.at(-1)?.status.state, 'failed');
+    assert.deepEqual(sink.statuses.at(-1)?.status.message?.parts, [
+      { text: 'client disconnected mid-task' },
+    ]);
+  } finally {
+    releaseAuth();
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('task.status propagates frame metadata onto the top-level TaskStatusUpdateEvent.metadata (liveness heartbeat marker)', async () => {
   const server = createServer();
   const registry = new Registry();

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -822,12 +822,13 @@ function helloFrameFor(agentId: string, token: string): string {
   });
 }
 
-test('a heartbeat on the reconnected socket keeps a task alive past the original grace deadline', async () => {
+test('a duplicate replay on the reconnected socket keeps a task alive past grace', async () => {
   // The reason resume exists at all. Without it the hold would expire on its
   // original deadline no matter how obviously alive the client is, which would
   // cap every task at the grace window rather than merely deciding how long to
-  // wait for a client that may be dead. A short grace here stands in for a task
-  // that outruns whatever the deadline happens to be.
+  // wait for a client that may be dead. An ack can be lost after the server
+  // accepts a frame, so the first replay on the new socket may be a duplicate;
+  // that still proves the execution recovered and must cancel the hold.
   const server = createServer();
   const registry = new Registry(60);
   attachWsServer(server, { db: mockSql(), registry });
@@ -843,7 +844,9 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-3', contextId: 'ctx-3', sink,
-      executionId: 'execution-3', nextClientSeq: 0,
+      // Model seq=0 as already accepted on the lost socket, with only its ack
+      // lost. The reconnect therefore replays seq=0 while the server expects 1.
+      executionId: 'execution-3', nextClientSeq: 1,
     });
 
     registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
@@ -854,7 +857,7 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
     second.send(helloFrame());
     await waitForAgent(registry, 'agent-1');
 
-    // One beat, well inside the window — this is what must cancel the hold.
+    // Duplicate seq=0, well inside the window — this must still cancel the hold.
     second.send(encodeFrame({
       type: 'task.status',
       taskId: 'task-3',

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1140,6 +1140,41 @@ test('a sequence gap fails closed without forwarding the suffix', async () => {
   }
 });
 
+test('a replay-capable frame without a sequence fails closed with a distinct error', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-no-seq', contextId: 'ctx', sink,
+      executionId: 'execution-no-seq', nextClientSeq: 0,
+    });
+    ws.send(encodeFrame({
+      type: 'task.artifact', taskId: 'task-no-seq', executionId: 'execution-no-seq',
+      artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'unsequenced' }] },
+    }));
+    await withTimeout(sink.finished, 5_000, 'missing sequence failure');
+    assert.equal(sink.artifacts.length, 0);
+    assert.equal(sink.statuses.at(-1)?.status.state, 'failed');
+    assert.deepEqual(sink.statuses.at(-1)?.status.message?.parts, [
+      { text: 'client frame sequence is required for a replay-capable execution' },
+    ]);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('a terminal replay from an old execution cannot complete a reused taskId', async () => {
   const server = createServer();
   const registry = new Registry();

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -607,7 +607,7 @@ test('a task survives a proxy-style disconnect and completes on the reconnected 
       taskId: 'task-1',
       contextId: 'ctx-1',
       sink,
-      bindingId: 'binding-1',
+      executionId: 'execution-1',
       nextClientSeq: 0,
     });
 
@@ -625,7 +625,7 @@ test('a task survives a proxy-style disconnect and completes on the reconnected 
     second.send(encodeFrame({
       type: 'task.status',
       taskId: 'task-1',
-      bindingId: 'binding-1',
+      executionId: 'execution-1',
       seq: 0,
       status: { state: 'working', timestamp: new Date().toISOString() },
       metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
@@ -634,7 +634,7 @@ test('a task survives a proxy-style disconnect and completes on the reconnected 
     second.send(encodeFrame({
       type: 'task.complete',
       taskId: 'task-1',
-      bindingId: 'binding-1',
+      executionId: 'execution-1',
       seq: 1,
       status: {
         state: 'completed',
@@ -765,7 +765,7 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-3', contextId: 'ctx-3', sink,
-      bindingId: 'binding-3', nextClientSeq: 0,
+      executionId: 'execution-3', nextClientSeq: 0,
     });
 
     registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
@@ -780,7 +780,7 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
     second.send(encodeFrame({
       type: 'task.status',
       taskId: 'task-3',
-      bindingId: 'binding-3',
+      executionId: 'execution-3',
       seq: 0,
       status: { state: 'working', timestamp: new Date().toISOString() },
       metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
@@ -793,7 +793,7 @@ test('a heartbeat on the reconnected socket keeps a task alive past the original
     second.send(encodeFrame({
       type: 'task.complete',
       taskId: 'task-3',
-      bindingId: 'binding-3',
+      executionId: 'execution-3',
       seq: 1,
       status: {
         state: 'completed',
@@ -842,7 +842,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'victim-task', contextId: 'ctx-v', sink,
-      bindingId: 'binding-victim', nextClientSeq: 0,
+      executionId: 'execution-victim', nextClientSeq: 0,
     });
 
     // The victim drops mid-task; its binding is now held and still resolvable.
@@ -853,7 +853,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
     attacker.send(encodeFrame({
       type: 'task.complete',
       taskId: 'victim-task',
-      bindingId: 'binding-victim',
+      executionId: 'execution-victim',
       seq: 0,
       usage: { promptTokens: 999_999, completionTokens: 999_999 },
       status: {
@@ -865,7 +865,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
     attacker.send(encodeFrame({
       type: 'task.fail',
       taskId: 'victim-task',
-      bindingId: 'binding-victim',
+      executionId: 'execution-victim',
       seq: 0,
       error: { code: 'forged', message: 'forged' },
     }));
@@ -886,7 +886,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
       recovered.send(encodeFrame({
         type: 'task.complete',
         taskId: 'victim-task',
-        bindingId: 'binding-victim',
+        executionId: 'execution-victim',
         seq: 0,
         status: {
           state: 'completed',
@@ -940,7 +940,7 @@ test('a live duplicate-token collision is held against real sockets, then expire
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-4', contextId: 'ctx-4', sink,
-      bindingId: 'binding-4', nextClientSeq: 0,
+      executionId: 'execution-4', nextClientSeq: 0,
     });
 
     second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
@@ -1041,16 +1041,16 @@ test('sequenced task frames are acknowledged, deduplicated, and completed once',
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-seq', contextId: 'ctx', sink,
-      bindingId: 'binding-seq', nextClientSeq: 0,
+      executionId: 'execution-seq', nextClientSeq: 0,
     });
     const artifact = encodeFrame({
-      type: 'task.artifact', taskId: 'task-seq', bindingId: 'binding-seq', seq: 0,
+      type: 'task.artifact', taskId: 'task-seq', executionId: 'execution-seq', seq: 0,
       artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'once' }] },
     });
     ws.send(artifact);
     ws.send(artifact);
     ws.send(encodeFrame({
-      type: 'task.complete', taskId: 'task-seq', bindingId: 'binding-seq', seq: 1,
+      type: 'task.complete', taskId: 'task-seq', executionId: 'execution-seq', seq: 1,
       status: { state: 'completed' },
     }));
     await withTimeout(sink.finished, 5_000, 'sequenced terminal');
@@ -1085,10 +1085,10 @@ test('a sequence gap fails closed without forwarding the suffix', async () => {
     const sink = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-gap', contextId: 'ctx', sink,
-      bindingId: 'binding-gap', nextClientSeq: 0,
+      executionId: 'execution-gap', nextClientSeq: 0,
     });
     ws.send(encodeFrame({
-      type: 'task.artifact', taskId: 'task-gap', bindingId: 'binding-gap', seq: 1,
+      type: 'task.artifact', taskId: 'task-gap', executionId: 'execution-gap', seq: 1,
       artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'suffix' }] },
     }));
     await withTimeout(sink.finished, 5_000, 'gap failure');
@@ -1103,7 +1103,7 @@ test('a sequence gap fails closed without forwarding the suffix', async () => {
   }
 });
 
-test('a terminal replay from an old binding generation cannot complete a reused taskId', async () => {
+test('a terminal replay from an old execution cannot complete a reused taskId', async () => {
   const server = createServer();
   const registry = new Registry();
   attachWsServer(server, { db: mockSql(), registry });
@@ -1120,10 +1120,10 @@ test('a terminal replay from an old binding generation cannot complete a reused 
     const first = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-1', sink: first,
-      bindingId: 'binding-old', nextClientSeq: 0,
+      executionId: 'execution-old', nextClientSeq: 0,
     });
     ws.send(encodeFrame({
-      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-old', seq: 0,
+      type: 'task.complete', taskId: 'task-reuse', executionId: 'execution-old', seq: 0,
       status: { state: 'completed' },
     }));
     await withTimeout(first.finished, 5_000, 'first terminal');
@@ -1131,16 +1131,16 @@ test('a terminal replay from an old binding generation cannot complete a reused 
     const second = makeSink();
     registry.bindTask({
       agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-2', sink: second,
-      bindingId: 'binding-new', nextClientSeq: 0,
+      executionId: 'execution-new', nextClientSeq: 0,
     });
     ws.send(encodeFrame({
-      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-old', seq: 0,
+      type: 'task.complete', taskId: 'task-reuse', executionId: 'execution-old', seq: 0,
       status: { state: 'completed' },
     }));
     await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(second.statuses.length, 0, 'old terminal must not touch the new binding');
     ws.send(encodeFrame({
-      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-new', seq: 0,
+      type: 'task.complete', taskId: 'task-reuse', executionId: 'execution-new', seq: 0,
       status: { state: 'completed' },
     }));
     await withTimeout(second.finished, 5_000, 'new terminal');

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -8,9 +8,12 @@ import {
   CALLER_CONTEXT_CAPABILITY,
   encodeFrame,
   OPENAI_COMPAT_EXTENSION_URI,
+  parseDownFrame,
   PROTOCOL_VERSION,
+  TASK_REPLAY_CAPABILITY,
 } from '@vicoop-bridge/protocol';
 import { Registry, type TaskSink } from './registry.js';
+import { hashToken } from './token.js';
 import { attachWsServer } from './ws.js';
 import type { Sql } from './db.js';
 
@@ -79,6 +82,23 @@ function makeSink(): TaskSink & {
   };
 }
 
+// `await sink.finished` on its own turns any regression that stops producing a
+// terminal into an infinite hang: the runner reports nothing, and CI only goes
+// red on job timeout. Bound every such wait.
+async function withTimeout<T>(promise: Promise<T>, ms: number, what: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms waiting for ${what}`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 async function waitForAgent(registry: Registry, agentId: string): Promise<void> {
   const deadline = Date.now() + 1_000;
   while (!registry.getAgent(agentId)) {
@@ -131,7 +151,7 @@ test('task.fail preserves backend error code and message on status message metad
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     assert.equal(sink.statuses.length, 1);
     const event = sink.statuses[0]!;
@@ -533,13 +553,598 @@ test('task.fail omits terminal error metadata when openai-compat extension was n
       },
     }));
 
-    await sink.finished;
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
 
     const event = sink.statuses[0]!;
     assert.equal(event.status.state, 'failed');
     assert.deepEqual(event.status.message?.parts, [{ text: 'rate_limited: slow down' }]);
     assert.equal(event.status.message?.metadata, undefined);
     assert.equal(event.status.message?.extensions, undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+async function waitForAgentGone(registry: Registry, agentId: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (registry.getAgent(agentId)) {
+    assert.ok(Date.now() < deadline, `timed out waiting for ${agentId} to unregister`);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function helloFrame(): string {
+  return encodeFrame({
+    type: 'hello',
+    version: PROTOCOL_VERSION,
+    agentId: 'agent-1',
+    token: 'token',
+    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+    agentCard: {
+      name: 'agent',
+      version: '0.0.0',
+      protocolVersion: '0.3.0',
+    },
+  });
+}
+
+test('a task survives a proxy-style disconnect and completes on the reconnected socket', async () => {
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      contextId: 'ctx-1',
+      sink,
+      bindingId: 'binding-1',
+      nextClientSeq: 0,
+    });
+
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    assert.ok(registry.getBinding('task-1'), 'task must be held across the disconnect');
+    assert.equal(sink.statuses.length, 0, 'no premature failure may be emitted');
+
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    second.send(encodeFrame({
+      type: 'task.status',
+      taskId: 'task-1',
+      bindingId: 'binding-1',
+      seq: 0,
+      status: { state: 'working', timestamp: new Date().toISOString() },
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
+    }));
+
+    second.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-1',
+      bindingId: 'binding-1',
+      seq: 1,
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: {
+          role: 'agent',
+          messageId: 'm-1',
+          parts: [{ kind: 'text', text: 'the answer' }],
+        },
+      },
+    }));
+
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.final, true);
+    assert.equal(terminal.status.state, 'completed');
+    assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'the answer' }]);
+    assert.ok(
+      !sink.statuses.some((s) => s.status.state === 'failed'),
+      'the task must never have been marked failed',
+    );
+    assert.equal(registry.getBinding('task-1'), undefined, 'the completed task is unbound');
+  } finally {
+    first.close();
+    second?.close();
+    await closeServer(server);
+  }
+});
+
+test('an app-level close code fails in-flight tasks immediately, with no grace hold', async () => {
+  const server = createServer();
+  // An hour, deliberately: the point of this test is that the close code
+  // reaches unregisterAgent at all. With a short grace the assertions below
+  // pass either way — a severed code argument just means the hold expires into
+  // a byte-identical terminal a few seconds later, and the only trace is the
+  // test's own duration. Nothing here may be rescued by expiry.
+  const registry = new Registry(60 * 60_000);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+
+  try {
+    await once(ws, 'open');
+    ws.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'task-2',
+      contextId: 'ctx-2',
+      sink,
+    });
+
+    registry.getAgent('agent-1')!.ws.close(4014, 'client deleted');
+
+    await withTimeout(sink.finished, 5_000, 'the immediate app-level-close terminal');
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.final, true);
+    assert.equal(terminal.status.state, 'failed');
+    assert.deepEqual(terminal.status.message?.parts, [{ text: 'client disconnected mid-task' }]);
+    assert.equal(registry.getBinding('task-2'), undefined);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+const wsSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Two distinct agents, each with its own token — needed to prove that one
+// agent cannot act on another's task.
+function twoAgentSql(): Sql {
+  const rows: Record<string, unknown> = {
+    [hashToken('token-1')]: {
+      id: 'agent-1',
+      client_id: 'client-1',
+      owner_principal: 'eth:0x1',
+      owner_email: null,
+      allowed_callers: [],
+    },
+    [hashToken('token-2')]: {
+      id: 'agent-2',
+      client_id: 'client-2',
+      owner_principal: 'eth:0x2',
+      owner_email: null,
+      allowed_callers: [],
+    },
+  };
+  const fn = async (_strings: TemplateStringsArray, hash: string) => {
+    const row = rows[hash];
+    return row ? [row] : [];
+  };
+  return fn as unknown as Sql;
+}
+
+function helloFrameFor(agentId: string, token: string): string {
+  return encodeFrame({
+    type: 'hello',
+    version: PROTOCOL_VERSION,
+    agentId,
+    token,
+    protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+    agentCard: { name: agentId, version: '0.0.0', protocolVersion: '0.3.0' },
+  });
+}
+
+test('a heartbeat on the reconnected socket keeps a task alive past the original grace deadline', async () => {
+  // The reason resume exists at all. Without it the hold would expire on its
+  // original deadline no matter how obviously alive the client is, which would
+  // cap every task at the grace window rather than merely deciding how long to
+  // wait for a client that may be dead. A short grace here stands in for a task
+  // that outruns whatever the deadline happens to be.
+  const server = createServer();
+  const registry = new Registry(60);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-3', contextId: 'ctx-3', sink,
+      bindingId: 'binding-3', nextClientSeq: 0,
+    });
+
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+
+    // One beat, well inside the window — this is what must cancel the hold.
+    second.send(encodeFrame({
+      type: 'task.status',
+      taskId: 'task-3',
+      bindingId: 'binding-3',
+      seq: 0,
+      status: { state: 'working', timestamp: new Date().toISOString() },
+      metadata: { [OPENAI_COMPAT_EXTENSION_URI]: { heartbeat: true } },
+    }));
+
+    // Now work well past the original deadline before answering.
+    await wsSleep(150);
+    assert.ok(registry.getBinding('task-3'), 'the resumed task expired anyway');
+
+    second.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'task-3',
+      bindingId: 'binding-3',
+      seq: 1,
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: { role: 'agent', messageId: 'm-3', parts: [{ kind: 'text', text: 'late answer' }] },
+      },
+    }));
+
+    await withTimeout(sink.finished, 5_000, 'the task terminal');
+
+    const terminal = sink.statuses.at(-1)!;
+    assert.equal(terminal.status.state, 'completed');
+    assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'late answer' }]);
+  } finally {
+    first.close();
+    second?.close();
+    await closeServer(server);
+  }
+});
+
+test('an agent cannot push frames into another agent\'s task', async () => {
+  // `getBinding` keys on taskId alone, so the handlers must check ownership
+  // themselves. The grace hold makes this load-bearing: a held binding stays
+  // resolvable for the whole window while its owner is offline and cannot
+  // contradict a forged terminal written in its name.
+  const server = createServer();
+  const registry = new Registry(10_000);
+  attachWsServer(server, { db: twoAgentSql(), registry });
+  const port = await listen(server);
+  const victim = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  // Connect one at a time. Opening both up front and awaiting them in sequence
+  // deadlocks: the second socket fires 'open' while we are awaiting the first,
+  // and `once()` then waits forever for a second 'open' that never comes.
+  let attacker: WebSocket | undefined;
+
+  try {
+    await once(victim, 'open');
+    victim.send(helloFrameFor('agent-1', 'token-1'));
+    await waitForAgent(registry, 'agent-1');
+
+    attacker = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(attacker, 'open');
+    attacker.send(helloFrameFor('agent-2', 'token-2'));
+    await waitForAgent(registry, 'agent-2');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'victim-task', contextId: 'ctx-v', sink,
+      bindingId: 'binding-victim', nextClientSeq: 0,
+    });
+
+    // The victim drops mid-task; its binding is now held and still resolvable.
+    registry.getAgent('agent-1')!.ws.close(1012, 'restarting');
+    await waitForAgentGone(registry, 'agent-1');
+
+    // agent-2 forges a terminal — and reported usage — for agent-1's task.
+    attacker.send(encodeFrame({
+      type: 'task.complete',
+      taskId: 'victim-task',
+      bindingId: 'binding-victim',
+      seq: 0,
+      usage: { promptTokens: 999_999, completionTokens: 999_999 },
+      status: {
+        state: 'completed',
+        timestamp: new Date().toISOString(),
+        message: { role: 'agent', messageId: 'm-x', parts: [{ kind: 'text', text: 'forged' }] },
+      },
+    }));
+    attacker.send(encodeFrame({
+      type: 'task.fail',
+      taskId: 'victim-task',
+      bindingId: 'binding-victim',
+      seq: 0,
+      error: { code: 'forged', message: 'forged' },
+    }));
+
+    // Give both frames time to be processed and rejected.
+    await wsSleep(60);
+
+    assert.deepEqual(sink.statuses, [], 'a foreign agent wrote into the victim task');
+    assert.deepEqual(sink.artifacts, []);
+    assert.ok(registry.getBinding('victim-task'), 'the victim task must still be held');
+
+    // The rightful owner comes back and completes it normally.
+    const recovered = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    try {
+      await once(recovered, 'open');
+      recovered.send(helloFrameFor('agent-1', 'token-1'));
+      await waitForAgent(registry, 'agent-1');
+      recovered.send(encodeFrame({
+        type: 'task.complete',
+        taskId: 'victim-task',
+        bindingId: 'binding-victim',
+        seq: 0,
+        status: {
+          state: 'completed',
+          timestamp: new Date().toISOString(),
+          message: { role: 'agent', messageId: 'm-ok', parts: [{ kind: 'text', text: 'real answer' }] },
+        },
+      }));
+      await withTimeout(sink.finished, 5_000, 'the task terminal');
+      // Re-read through the typed alias: the `deepEqual(…, [])` above narrows
+      // `sink.statuses` to never[] for the rest of this block.
+      const delivered: TaskStatusUpdateEvent[] = sink.statuses;
+      const terminal = delivered.at(-1)!;
+      assert.equal(terminal.status.state, 'completed');
+      assert.deepEqual(terminal.status.message?.parts, [{ kind: 'text', text: 'real answer' }]);
+    } finally {
+      recovered.close();
+    }
+  } finally {
+    victim.close();
+    attacker?.close();
+    await closeServer(server);
+  }
+});
+
+test('a live duplicate-token collision is held against real sockets, then expires as superseded', async () => {
+  // Deliberately real WebSockets rather than the registry stub. The collision
+  // branch used to read `readyState` around its own `close()` call, and `ws`
+  // mutates readyState synchronously inside close() — a hand-rolled stub can
+  // model that wrongly and certify a branch production never takes, which is
+  // exactly what happened once already.
+  //
+  // The contract now: a same-token reconnect is HELD even when the displaced
+  // socket is unmistakably live, because "looks live" cannot distinguish a
+  // rival daemon from the very client that is reconnecting. An unreclaimed hold
+  // then expires into this path's own `superseded` terminal.
+  const server = createServer();
+  const registry = new Registry(60);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const first = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  // Connect one at a time; see the note in the ownership test above.
+  let second: WebSocket | undefined;
+
+  try {
+    await once(first, 'open');
+    first.send(helloFrame());
+    await waitForAgent(registry, 'agent-1');
+    const firstConn = registry.getAgent('agent-1');
+    assert.equal(firstConn!.ws.readyState, firstConn!.ws.OPEN, 'precondition: displaced socket live');
+
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-4', contextId: 'ctx-4', sink,
+      bindingId: 'binding-4', nextClientSeq: 0,
+    });
+
+    second = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    await once(second, 'open');
+    second.send(helloFrameFor('agent-1', 'token'));
+    const deadline = Date.now() + 1_000;
+    while (registry.getAgent('agent-1') === firstConn) {
+      assert.ok(Date.now() < deadline, 'timed out waiting for the collision swap');
+      await wsSleep(5);
+    }
+
+    // Not killed on the spot — this is the whole point.
+    assert.ok(registry.getBinding('task-4'), 'a live-looking collision must still be held');
+    assert.deepEqual(sink.statuses, [], 'no premature terminal');
+
+    await withTimeout(sink.finished, 5_000, 'the collision hold to expire');
+
+    const terminal: TaskStatusUpdateEvent[] = sink.statuses;
+    const last = terminal.at(-1)!;
+    assert.equal(last.final, true);
+    assert.equal(last.status.state, 'failed');
+    assert.deepEqual(last.status.message?.parts, [
+      { text: 'superseded by a reconnect from the same client token' },
+    ]);
+    assert.equal(registry.getBinding('task-4'), undefined);
+  } finally {
+    first.close();
+    second?.close();
+    await closeServer(server);
+  }
+});
+test('a message past the ingress cap is refused by the transport, never assembled', async () => {
+  // The pre-auth byte budget can only be charged once `ws` has already built
+  // the message, so without an ingress cap the library's 100 MiB default is
+  // what an unauthenticated peer can make each connection hold before we ever
+  // look. This asserts the transport itself refuses it: close 1009, the
+  // WebSocket "message too big" code, rather than our own 4002.
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`, { maxPayload: 0 });
+
+  try {
+    await once(ws, 'open');
+    ws.send('{"pad":"' + 'z'.repeat(17 * 1024 * 1024) + '"}');
+    const [code] = (await once(ws, 'close')) as [number, Buffer];
+    assert.equal(code, 1009, 'the transport must reject an over-cap payload');
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('task-replay-v1 is acknowledged only after authentication', async () => {
+  const server = createServer();
+  const registry = new Registry(12_345);
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    const ack = once(ws, 'message');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    const [raw] = (await ack) as [Buffer];
+    const frame = parseDownFrame(raw.toString('utf8'));
+    assert.equal(frame.type, 'hello.ack');
+    if (frame.type === 'hello.ack') {
+      assert.deepEqual(frame.protocolCapabilities, [TASK_REPLAY_CAPABILITY]);
+      assert.equal(frame.disconnectGraceMs, 12_345);
+    }
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('sequenced task frames are acknowledged, deduplicated, and completed once', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  const down: ReturnType<typeof parseDownFrame>[] = [];
+  ws.on('message', (raw) => down.push(parseDownFrame(raw.toString('utf8'))));
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-seq', contextId: 'ctx', sink,
+      bindingId: 'binding-seq', nextClientSeq: 0,
+    });
+    const artifact = encodeFrame({
+      type: 'task.artifact', taskId: 'task-seq', bindingId: 'binding-seq', seq: 0,
+      artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'once' }] },
+    });
+    ws.send(artifact);
+    ws.send(artifact);
+    ws.send(encodeFrame({
+      type: 'task.complete', taskId: 'task-seq', bindingId: 'binding-seq', seq: 1,
+      status: { state: 'completed' },
+    }));
+    await withTimeout(sink.finished, 5_000, 'sequenced terminal');
+    assert.equal(sink.artifacts.length, 1);
+    assert.equal(sink.statuses.filter((status) => status.final).length, 1);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(
+      down.filter((frame) => frame.type === 'task.ack').map((frame) =>
+        frame.type === 'task.ack' ? frame.acceptedSeq : -1),
+      [0, 0, 1],
+    );
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('a sequence gap fails closed without forwarding the suffix', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-gap', contextId: 'ctx', sink,
+      bindingId: 'binding-gap', nextClientSeq: 0,
+    });
+    ws.send(encodeFrame({
+      type: 'task.artifact', taskId: 'task-gap', bindingId: 'binding-gap', seq: 1,
+      artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'suffix' }] },
+    }));
+    await withTimeout(sink.finished, 5_000, 'gap failure');
+    assert.equal(sink.artifacts.length, 0);
+    assert.equal(sink.statuses.at(-1)?.status.state, 'failed');
+    assert.deepEqual(sink.statuses.at(-1)?.status.message?.parts, [
+      { text: 'client frame sequence gap: expected 0, received 1' },
+    ]);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
+test('a terminal replay from an old binding generation cannot complete a reused taskId', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+    const first = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-1', sink: first,
+      bindingId: 'binding-old', nextClientSeq: 0,
+    });
+    ws.send(encodeFrame({
+      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-old', seq: 0,
+      status: { state: 'completed' },
+    }));
+    await withTimeout(first.finished, 5_000, 'first terminal');
+
+    const second = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-reuse', contextId: 'ctx-2', sink: second,
+      bindingId: 'binding-new', nextClientSeq: 0,
+    });
+    ws.send(encodeFrame({
+      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-old', seq: 0,
+      status: { state: 'completed' },
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(second.statuses.length, 0, 'old terminal must not touch the new binding');
+    ws.send(encodeFrame({
+      type: 'task.complete', taskId: 'task-reuse', bindingId: 'binding-new', seq: 0,
+      status: { state: 'completed' },
+    }));
+    await withTimeout(second.finished, 5_000, 'new terminal');
+    assert.equal(second.statuses.at(-1)?.status.state, 'completed');
   } finally {
     ws.close();
     await closeServer(server);

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -828,6 +828,17 @@ test('an agent cannot push frames into another agent\'s task', async () => {
   // deadlocks: the second socket fires 'open' while we are awaiting the first,
   // and `once()` then waits forever for a second 'open' that never comes.
   let attacker: WebSocket | undefined;
+  const eventNames: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: unknown[]) => {
+    if (typeof args[0] !== 'string') return;
+    try {
+      const event = (JSON.parse(args[0]) as { event?: unknown }).event;
+      if (typeof event === 'string') eventNames.push(event);
+    } catch {
+      // Ignore non-JSON console output.
+    }
+  };
 
   try {
     await once(victim, 'open');
@@ -876,6 +887,8 @@ test('an agent cannot push frames into another agent\'s task', async () => {
     assert.deepEqual(sink.statuses, [], 'a foreign agent wrote into the victim task');
     assert.deepEqual(sink.artifacts, []);
     assert.ok(registry.getBinding('victim-task'), 'the victim task must still be held');
+    assert.equal(eventNames.filter((name) => name === 'binding_owner_mismatch').length, 2);
+    assert.equal(eventNames.filter((name) => name === 'dropped_terminal_frame').length, 0);
 
     // The rightful owner comes back and completes it normally.
     const recovered = new WebSocket(`ws://127.0.0.1:${port}/connect`);
@@ -905,6 +918,7 @@ test('an agent cannot push frames into another agent\'s task', async () => {
       recovered.close();
     }
   } finally {
+    console.log = origLog;
     victim.close();
     attacker?.close();
     await closeServer(server);

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1253,6 +1253,41 @@ test('a replay-capable frame without a sequence fails closed with a distinct err
   }
 });
 
+test('a replay-capable frame without an execution ID fails closed', async () => {
+  const server = createServer();
+  const registry = new Registry();
+  attachWsServer(server, { db: mockSql(), registry });
+  const port = await listen(server);
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  try {
+    await once(ws, 'open');
+    ws.send(encodeFrame({
+      type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+      agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+    }));
+    await waitForAgent(registry, 'agent-1');
+    const sink = makeSink();
+    registry.bindTask({
+      agentId: 'agent-1', taskId: 'task-no-execution', contextId: 'ctx', sink,
+      executionId: 'execution-required', nextClientSeq: 0,
+    });
+    ws.send(encodeFrame({
+      type: 'task.artifact', taskId: 'task-no-execution',
+      artifact: { artifactId: 'a', parts: [{ kind: 'text', text: 'unscoped' }] },
+    }));
+    await withTimeout(sink.finished, 5_000, 'missing execution ID failure');
+    assert.equal(sink.artifacts.length, 0);
+    assert.equal(sink.statuses.at(-1)?.status.state, 'failed');
+    assert.deepEqual(sink.statuses.at(-1)?.status.message?.parts, [
+      { text: 'client frame execution id is required for a replay-capable execution' },
+    ]);
+  } finally {
+    ws.close();
+    await closeServer(server);
+  }
+});
+
 test('a terminal replay from an old execution cannot complete a reused taskId', async () => {
   const server = createServer();
   const registry = new Registry();

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -180,9 +180,9 @@ test('task.fail preserves backend error code and message on status message metad
   }
 });
 
-test('a socket closing during async auth does not leave a zombie registration', async () => {
+test('a clean close during async auth leaves no zombie registration or replay grace', async () => {
   const server = createServer();
-  const registry = new Registry();
+  const registry = new Registry(60_000);
   let releaseAuth!: () => void;
   const gate = new Promise<void>((resolve) => {
     releaseAuth = resolve;
@@ -190,14 +190,24 @@ test('a socket closing during async auth does not leave a zombie registration', 
   attachWsServer(server, { db: gatedSql(gate), registry });
   const port = await listen(server);
   const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+  const sink = makeSink();
 
   try {
+    registry.bindTask({
+      agentId: 'agent-1',
+      taskId: 'clean-close-task',
+      contextId: 'clean-close-context',
+      sink,
+      executionId: 'clean-close-execution',
+      nextClientSeq: 0,
+    });
     await once(ws, 'open');
     ws.send(encodeFrame({
       type: 'hello',
       version: PROTOCOL_VERSION,
       agentId: 'agent-1',
       token: 'token',
+      protocolCapabilities: [TASK_REPLAY_CAPABILITY],
       agentCard: {
         name: 'agent',
         version: '0.0.0',
@@ -208,7 +218,7 @@ test('a socket closing during async auth does not leave a zombie registration', 
     // Let the server enter authenticateAndRegister and block on the gated
     // token lookup, then close the socket while auth is still in flight.
     await new Promise((resolve) => setTimeout(resolve, 20));
-    ws.close();
+    ws.close(1000, 'client shutdown');
     await once(ws, 'close');
 
     // Wait for the *server-side* close handler to run — it fires shortly after
@@ -220,12 +230,17 @@ test('a socket closing during async auth does not leave a zombie registration', 
     await new Promise((resolve) => setTimeout(resolve, 40));
 
     // Release auth: registerAgent now runs against the already-dead socket.
-    // The post-auth reconciliation must tear that entry back out.
+    // The post-auth reconciliation must tear that entry back out and retain
+    // the observed clean-close policy rather than treating a missing code as a
+    // graceable network failure.
     releaseAuth();
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await withTimeout(sink.finished, 1_000, 'the clean-close task terminal');
 
     assert.equal(registry.getAgent('agent-1'), undefined);
+    assert.equal(registry.getBinding('clean-close-task'), undefined);
+    assert.equal(sink.statuses.at(-1)?.status.state, 'failed');
   } finally {
+    releaseAuth();
     await closeServer(server);
   }
 });

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -293,7 +293,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         // task output while authentication is pending is unnecessary and would
         // reopen an unauthenticated buffering surface.
         opts.registry.noteServerClose(ws);
-        ws.close(4003, 'expected hello acknowledgement before task frames');
+        ws.close(4003, 'expected hello before task frames');
         return;
       }
       if (frame.version !== PROTOCOL_VERSION) {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -328,7 +328,15 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         // (no-ops unless the stored ws is this one), so racing a later close
         // event is safe. (#364)
         if (ws.readyState !== ws.OPEN) {
-          opts.registry.unregisterAgent(frame.agentId, ws, observedCloseCode);
+          if (observedCloseCode === undefined) {
+            // `close()` has moved the socket to CLOSING, but its close event
+            // has not supplied the policy-bearing code yet. Hand the identity
+            // to that handler instead of converting "not observed yet" into
+            // Registry's deliberately graceable "no code available" case.
+            agentId = frame.agentId;
+          } else {
+            opts.registry.unregisterAgent(frame.agentId, ws, observedCloseCode);
+          }
           return;
         }
         agentId = frame.agentId;
@@ -566,6 +574,24 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     if (!binding) return { kind: 'handled' };
 
     if (binding.executionId !== undefined) {
+      if (frame.executionId === undefined) {
+        logEvent('task_frame_execution_id_missing', {
+          agentId: binding.agentId,
+          taskId: truncate(binding.taskId, 128),
+          ownerExecutionId: binding.executionId,
+        });
+        opts.registry.failTaskBinding(
+          binding,
+          'client_frame_execution_id_missing',
+          'client frame execution id is required for a replay-capable execution',
+        );
+        opts.registry.sendToAgent(binding.agentId, {
+          type: 'task.cancel',
+          taskId: binding.taskId,
+          executionId: binding.executionId,
+        });
+        return { kind: 'handled' };
+      }
       if (frame.executionId !== binding.executionId) {
         // A stale generation must never affect the current turn.
         if (!acknowledgeReceipt(frame)) {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -548,7 +548,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;
     }
     const binding = ownedBinding(frame.taskId);
-    if (!binding) return undefined;
+    // `current` proved the task exists, so undefined here means the ownership
+    // guard already rejected and logged a foreign-agent frame. Treat that as
+    // fully handled; terminal callers must not add a misleading
+    // dropped_terminal_frame event for a binding that was never missing.
+    if (!binding) return { kind: 'duplicate' };
 
     if (binding.executionId !== undefined) {
       if (frame.executionId !== binding.executionId || frame.seq === undefined) {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -1,16 +1,19 @@
 import { WebSocketServer, type WebSocket } from 'ws';
 import type { IncomingMessage, Server } from 'node:http';
 import {
+  encodeFrame,
   parseUpFrame,
   PROTOCOL_VERSION,
   OPENAI_COMPAT_EXTENSION_URI,
+  TASK_REPLAY_CAPABILITY,
   type Part,
   type TaskStatus as WireTaskStatus,
   type Message as WireMessage,
+  type UpFrame,
 } from '@vicoop-bridge/protocol';
 import type { Message, TaskStatus } from '@a2x/sdk';
 import { TaskState } from '@a2x/sdk';
-import type { Registry } from './registry.js';
+import type { Registry, TaskBinding } from './registry.js';
 import type { Sql } from './db.js';
 import { hashToken } from './token.js';
 import { logEvent, truncate } from './log.js';
@@ -19,6 +22,11 @@ import { resolveHelloAgentCard } from './card-resolver.js';
 import { terminalErrorMessageFields } from './terminal-error.js';
 import { resolveUsageResponse } from './usage-rpc.js';
 import { parseX402Pricing } from './x402/pricing.js';
+
+type TaskUpFrame = Extract<UpFrame, { taskId: string }>;
+type TaskFrameAcceptance =
+  | { kind: 'binding'; binding: TaskBinding }
+  | { kind: 'duplicate' };
 
 // Diagnostic (issue #414): is this `task.status` frame a tagged liveness
 // heartbeat (non-terminal working status carrying
@@ -57,8 +65,22 @@ export interface ServerWsOptions {
   registry: Registry;
 }
 
+// Largest WebSocket message the bridge will assemble at all, authenticated or
+// not. See the `maxPayload` note in attachWsServer.
+const MAX_INGRESS_BYTES = 16 * 1024 * 1024;
+
 export function attachWsServer(server: Server, opts: ServerWsOptions): void {
-  const wss = new WebSocketServer({ noServer: true });
+  const wss = new WebSocketServer({
+    noServer: true,
+    // Ingress cap, enforced by `ws` while it assembles the frame rather than by
+    // us once it already exists. Without it the library's 100 MiB default is
+    // what an unauthenticated peer can make each connection hold before our own
+    // pre-auth budget is ever consulted — several connections would be enough
+    // to exhaust the deployment. Set well above any legitimate frame (the
+    // client refuses to buffer one this large) and comfortably above the
+    // pre-auth budget, so it bounds abuse without truncating real traffic.
+    maxPayload: MAX_INGRESS_BYTES,
+  });
 
   server.on('upgrade', (req, socket, head) => {
     const url = new URL(req.url ?? '/', 'http://localhost');
@@ -215,6 +237,39 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   let authed = false;
   let helloProcessing = false;
 
+  // Resolve the binding a task frame targets, but only if this connection's
+  // authenticated agent is the one that owns it. `getBinding` keys on taskId
+  // alone, so without this check any authenticated client that learned another
+  // agent's taskId could push status, artifacts, reported `usage`, or a forged
+  // terminal into that agent's caller's stream.
+  //
+  // The reconnect grace hold (issue #474) is what makes the check load-bearing.
+  // Before it, a binding vanished the instant its agent dropped; now it stays
+  // resolvable for the whole grace window while its owner is offline and in no
+  // position to contradict anything written in its name. Closing the gap here
+  // rather than in the registry keeps `getBinding` a pure lookup and puts the
+  // authorization next to the authenticated identity it is checked against.
+  const ownedBinding = (taskId: string): TaskBinding | undefined => {
+    const b = opts.registry.getBinding(taskId);
+    if (!b) return undefined;
+    if (b.agentId !== agentId) {
+      // `taskId` comes straight off the frame, so a client can make this line
+      // as long as it likes — and it can emit one per frame. Truncate like
+      // every other client-controlled string we log.
+      logEvent('binding_owner_mismatch', {
+        agentId: agentId ?? undefined,
+        taskId: truncate(taskId, 128),
+        ownerAgentId: b.agentId,
+        // Same event name as the executor's cancel guard and bindTask's
+        // (issue #476), so all cross-agent attempts aggregate together;
+        // `operation` is what tells an operator which door was tried.
+        operation: 'frame',
+      });
+      return undefined;
+    }
+    return b;
+  };
+
   const helloTimeout = setTimeout(() => {
     if (!authed) ws.close(4001, 'hello timeout');
   }, 10_000);
@@ -224,13 +279,21 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     try {
       frame = parseUpFrame(typeof raw === 'string' ? raw : raw.toString('utf8'));
     } catch (err) {
+      // A protocol violation is our verdict on this connection, so its
+      // in-flight tasks must not earn a reconnect grace hold no matter what
+      // close code we end up observing (see Registry.noteServerClose).
+      opts.registry.noteServerClose(ws);
       ws.close(4002, `invalid frame: ${(err as Error).message}`);
       return;
     }
 
     if (!authed) {
       if (frame.type !== 'hello') {
-        ws.close(4003, 'expected hello');
+        // Reliable clients wait for hello.ack before replaying, so accepting
+        // task output while authentication is pending is unnecessary and would
+        // reopen an unauthenticated buffering surface.
+        opts.registry.noteServerClose(ws);
+        ws.close(4003, 'expected hello acknowledgement before task frames');
         return;
       }
       if (frame.version !== PROTOCOL_VERSION) {
@@ -260,6 +323,16 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         agentId = frame.agentId;
         authed = true;
         clearTimeout(helloTimeout);
+        if (frame.protocolCapabilities?.includes(TASK_REPLAY_CAPABILITY)) {
+          ws.send(
+            encodeFrame({
+              type: 'hello.ack',
+              protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+              disconnectGraceMs: opts.registry.getDisconnectGraceMs(),
+              maxFrameBytes: MAX_INGRESS_BYTES,
+            }),
+          );
+        }
         logEvent('client_connected', {
           agentId,
           clientId: result.clientId,
@@ -279,10 +352,15 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       return;
     }
 
+    processAuthedFrame(frame);
+  });
+
+  function processAuthedFrame(frame: UpFrame): void {
     switch (frame.type) {
       case 'task.status': {
-        const b = opts.registry.getBinding(frame.taskId);
-        if (!b) return;
+        const accepted = acceptTaskFrame(frame);
+        if (!accepted || accepted.kind === 'duplicate') return;
+        const { binding: b } = accepted;
         // Diagnostic (issue #414): count liveness-heartbeat beats forwarded for
         // this task (hop 2). A heartbeat is a non-terminal working status tagged
         // `metadata[<URI>].heartbeat === true`; other `task.status` frames don't
@@ -302,11 +380,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           // (planetarium/a2x-internal-router#95).
           ...(frame.metadata !== undefined ? { metadata: frame.metadata } : {}),
         });
+        acknowledge(b);
         break;
       }
       case 'task.artifact': {
-        const b = opts.registry.getBinding(frame.taskId);
-        if (!b) return;
+        const accepted = acceptTaskFrame(frame);
+        if (!accepted || accepted.kind === 'duplicate') return;
+        const { binding: b } = accepted;
         b.sink.pushArtifact({
           taskId: frame.taskId,
           contextId: b.contextId,
@@ -321,10 +401,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           append: frame.append,
           lastChunk: frame.lastChunk,
         });
+        acknowledge(b);
         break;
       }
       case 'task.complete': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const accepted = acceptTaskFrame(frame);
+        if (accepted?.kind === 'duplicate') return;
+        const b = accepted?.binding;
         if (!b) {
           // No live binding for this taskId — the terminal frame cannot be
           // delivered and the corresponding stream (if any) will not close via
@@ -332,7 +415,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           // wedged SSE stream, and this path is otherwise silent.
           logEvent('dropped_terminal_frame', {
             agentId: agentId ?? undefined,
-            taskId: frame.taskId,
+            taskId: truncate(frame.taskId, 128),
             kind: 'task.complete',
             state: frame.status.state,
           });
@@ -350,7 +433,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           status: wireStatusToA2X(frame.status, frame.taskId, b.contextId),
         });
         b.sink.finish();
+        if (b.bindingId !== undefined && b.nextClientSeq !== undefined) {
+          opts.registry.rememberTerminalReceipt(b, b.nextClientSeq - 1);
+        }
         opts.registry.unbindTask(frame.taskId, b);
+        acknowledge(b);
         logEvent('task_completed', {
           agentId: b.agentId,
           backend: opts.registry.getAgent(b.agentId)?.backendKind ?? 'inline',
@@ -363,11 +450,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         break;
       }
       case 'task.fail': {
-        const b = opts.registry.getBinding(frame.taskId);
+        const accepted = acceptTaskFrame(frame);
+        if (accepted?.kind === 'duplicate') return;
+        const b = accepted?.binding;
         if (!b) {
           logEvent('dropped_terminal_frame', {
             agentId: agentId ?? undefined,
-            taskId: frame.taskId,
+            taskId: truncate(frame.taskId, 128),
             kind: 'task.fail',
             errorCode: frame.error.code,
           });
@@ -391,7 +480,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           },
         });
         b.sink.finish();
+        if (b.bindingId !== undefined && b.nextClientSeq !== undefined) {
+          opts.registry.rememberTerminalReceipt(b, b.nextClientSeq - 1);
+        }
         opts.registry.unbindTask(frame.taskId, b);
+        acknowledge(b);
         logEvent('task_failed_by_client', {
           agentId: b.agentId,
           backend: opts.registry.getAgent(b.agentId)?.backendKind ?? 'inline',
@@ -411,12 +504,106 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       case 'pong':
         break;
       case 'hello':
+        opts.registry.noteServerClose(ws);
         ws.close(4007, 'duplicate hello');
         break;
     }
-  });
+  }
 
-  ws.on('close', () => {
+  function acknowledge(binding: TaskBinding): void {
+    if (binding.bindingId === undefined || binding.nextClientSeq === undefined) return;
+    if (ws.readyState !== ws.OPEN) return;
+    ws.send(
+      encodeFrame({
+        type: 'task.ack',
+        taskId: binding.taskId,
+        bindingId: binding.bindingId,
+        acceptedSeq: binding.nextClientSeq - 1,
+      }),
+    );
+  }
+
+  function acknowledgeReceipt(frame: TaskUpFrame): boolean {
+    if (agentId === null || frame.bindingId === undefined || frame.seq === undefined) return false;
+    const receipt = opts.registry.getTerminalReceipt(frame.bindingId, agentId, frame.taskId);
+    if (!receipt || frame.seq > receipt.acceptedSeq) return false;
+    if (ws.readyState === ws.OPEN) {
+      ws.send(
+        encodeFrame({
+          type: 'task.ack',
+          taskId: frame.taskId,
+          bindingId: frame.bindingId,
+          acceptedSeq: receipt.acceptedSeq,
+        }),
+      );
+    }
+    return true;
+  }
+
+  function acceptTaskFrame(
+    frame: TaskUpFrame,
+  ): TaskFrameAcceptance | undefined {
+    const current = opts.registry.getBinding(frame.taskId);
+    if (!current) {
+      return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;
+    }
+    const binding = ownedBinding(frame.taskId);
+    if (!binding) return undefined;
+
+    if (binding.bindingId !== undefined) {
+      if (frame.bindingId !== binding.bindingId || frame.seq === undefined) {
+        // A stale generation must never affect the current turn. Missing
+        // sequencing on a negotiated binding is likewise unusable, but it is a
+        // connection protocol error rather than a gap in the current run.
+        if (!acknowledgeReceipt(frame)) {
+          logEvent('binding_generation_mismatch', {
+            agentId: agentId ?? undefined,
+            taskId: truncate(frame.taskId, 128),
+            bindingId: frame.bindingId ? truncate(frame.bindingId, 128) : undefined,
+            ownerBindingId: binding.bindingId,
+          });
+        }
+        return { kind: 'duplicate' };
+      }
+      const expected = binding.nextClientSeq ?? 0;
+      if (frame.seq < expected) {
+        acknowledge(binding);
+        return { kind: 'duplicate' };
+      }
+      if (frame.seq > expected) {
+        logEvent('task_frame_gap', {
+          agentId: binding.agentId,
+          taskId: truncate(binding.taskId, 128),
+          bindingId: binding.bindingId,
+          expectedSeq: expected,
+          receivedSeq: frame.seq,
+        });
+        opts.registry.failTaskBinding(
+          binding,
+          'client_frame_gap',
+          `client frame sequence gap: expected ${expected}, received ${frame.seq}`,
+        );
+        opts.registry.sendToAgent(binding.agentId, {
+          type: 'task.cancel',
+          taskId: binding.taskId,
+          bindingId: binding.bindingId,
+        });
+        return undefined;
+      }
+      binding.nextClientSeq = expected + 1;
+    } else if (frame.bindingId !== undefined || frame.seq !== undefined) {
+      // A reliable frame cannot be attached to a legacy binding merely because
+      // A2A reused the same taskId.
+      return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;
+    }
+
+    // Only an accepted, generation-correct, gap-free frame proves that this
+    // exact binding survived the reconnect.
+    if (agentId !== null) opts.registry.resumeBinding(frame.taskId, agentId);
+    return { kind: 'binding', binding };
+  }
+
+  ws.on('close', (code: number, reason: Buffer) => {
     clearTimeout(helloTimeout);
     if (agentId) {
       // Look up the live connection BEFORE unregistering so the disconnect log
@@ -424,6 +611,16 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       const conn = opts.registry.getAgent(agentId);
       logEvent('client_disconnected', {
         agentId,
+        // The close code decides whether in-flight tasks get a reconnect grace
+        // hold (issue #474), so it belongs in the log the operator reads when
+        // asking why a task did or didn't survive a drop. It was previously
+        // discarded outright, which is why the 2026-08-20 incident left no
+        // record of what the SERVER's socket saw — the 1012 in that report is
+        // what the CLIENT observed, and the two ends need not agree.
+        // `reason` is remote-supplied, so truncate it like every other
+        // client-controlled string we log.
+        closeCode: code,
+        ...(reason.length > 0 ? { closeReason: truncate(reason.toString('utf8'), 128) } : {}),
         ...(conn
           ? {
               clientId: conn.clientId,
@@ -434,11 +631,17 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
             }
           : {}),
       });
-      opts.registry.unregisterAgent(agentId, ws);
+      opts.registry.unregisterAgent(agentId, ws, code);
     }
   });
 
   ws.on('error', (err) => {
+    // `ws` rejects an oversized message before our message handler runs. Mark
+    // that transport-level protocol verdict explicitly so the subsequent
+    // abnormal close cannot accidentally earn a reconnect grace hold.
+    if ((err as NodeJS.ErrnoException).code === 'WS_ERR_UNSUPPORTED_MESSAGE_LENGTH') {
+      opts.registry.noteServerClose(ws);
+    }
     console.error('[server] ws error:', err);
   });
 }

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -26,7 +26,7 @@ import { parseX402Pricing } from './x402/pricing.js';
 type TaskUpFrame = Extract<UpFrame, { taskId: string }>;
 type TaskFrameAcceptance =
   | { kind: 'binding'; binding: TaskBinding }
-  | { kind: 'duplicate' };
+  | { kind: 'handled' };
 
 // Diagnostic (issue #414): is this `task.status` frame a tagged liveness
 // heartbeat (non-terminal working status carrying
@@ -359,7 +359,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     switch (frame.type) {
       case 'task.status': {
         const accepted = acceptTaskFrame(frame);
-        if (!accepted || accepted.kind === 'duplicate') return;
+        if (!accepted || accepted.kind === 'handled') return;
         const { binding: b } = accepted;
         // Diagnostic (issue #414): count liveness-heartbeat beats forwarded for
         // this task (hop 2). A heartbeat is a non-terminal working status tagged
@@ -385,7 +385,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       }
       case 'task.artifact': {
         const accepted = acceptTaskFrame(frame);
-        if (!accepted || accepted.kind === 'duplicate') return;
+        if (!accepted || accepted.kind === 'handled') return;
         const { binding: b } = accepted;
         b.sink.pushArtifact({
           taskId: frame.taskId,
@@ -406,7 +406,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       }
       case 'task.complete': {
         const accepted = acceptTaskFrame(frame);
-        if (accepted?.kind === 'duplicate') return;
+        if (accepted?.kind === 'handled') return;
         const b = accepted?.binding;
         if (!b) {
           // No live binding for this taskId — the terminal frame cannot be
@@ -451,7 +451,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       }
       case 'task.fail': {
         const accepted = acceptTaskFrame(frame);
-        if (accepted?.kind === 'duplicate') return;
+        if (accepted?.kind === 'handled') return;
         const b = accepted?.binding;
         if (!b) {
           logEvent('dropped_terminal_frame', {
@@ -545,20 +545,18 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   ): TaskFrameAcceptance | undefined {
     const current = opts.registry.getBinding(frame.taskId);
     if (!current) {
-      return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;
+      return acknowledgeReceipt(frame) ? { kind: 'handled' } : undefined;
     }
     const binding = ownedBinding(frame.taskId);
     // `current` proved the task exists, so undefined here means the ownership
     // guard already rejected and logged a foreign-agent frame. Treat that as
     // fully handled; terminal callers must not add a misleading
     // dropped_terminal_frame event for a binding that was never missing.
-    if (!binding) return { kind: 'duplicate' };
+    if (!binding) return { kind: 'handled' };
 
     if (binding.executionId !== undefined) {
-      if (frame.executionId !== binding.executionId || frame.seq === undefined) {
-        // A stale generation must never affect the current turn. Missing
-        // sequencing on a negotiated binding is likewise unusable, but it is a
-        // connection protocol error rather than a gap in the current run.
+      if (frame.executionId !== binding.executionId) {
+        // A stale generation must never affect the current turn.
         if (!acknowledgeReceipt(frame)) {
           logEvent('execution_id_mismatch', {
             agentId: agentId ?? undefined,
@@ -567,12 +565,30 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
             ownerExecutionId: binding.executionId,
           });
         }
-        return { kind: 'duplicate' };
+        return { kind: 'handled' };
+      }
+      if (frame.seq === undefined) {
+        logEvent('task_frame_sequence_missing', {
+          agentId: binding.agentId,
+          taskId: truncate(binding.taskId, 128),
+          executionId: binding.executionId,
+        });
+        opts.registry.failTaskBinding(
+          binding,
+          'client_frame_sequence_missing',
+          'client frame sequence is required for a replay-capable execution',
+        );
+        opts.registry.sendToAgent(binding.agentId, {
+          type: 'task.cancel',
+          taskId: binding.taskId,
+          executionId: binding.executionId,
+        });
+        return { kind: 'handled' };
       }
       const expected = binding.nextClientSeq ?? 0;
       if (frame.seq < expected) {
         acknowledge(binding);
-        return { kind: 'duplicate' };
+        return { kind: 'handled' };
       }
       if (frame.seq > expected) {
         logEvent('task_frame_gap', {
@@ -592,13 +608,13 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           taskId: binding.taskId,
           executionId: binding.executionId,
         });
-        return undefined;
+        return { kind: 'handled' };
       }
       binding.nextClientSeq = expected + 1;
     } else if (frame.executionId !== undefined || frame.seq !== undefined) {
       // A reliable frame cannot be attached to a legacy binding merely because
       // A2A reused the same taskId.
-      return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;
+      return acknowledgeReceipt(frame) ? { kind: 'handled' } : undefined;
     }
 
     // Only an accepted, generation-correct, gap-free frame proves that this

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -625,6 +625,11 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
       const expected = binding.nextClientSeq ?? 0;
       if (frame.seq < expected) {
         acknowledge(binding);
+        // A duplicate is the normal replay shape when the server accepted a
+        // frame but its ack was lost with the old socket. It proves this exact
+        // execution is alive just as strongly as a new frame does, so cancel
+        // the disconnect hold before its original deadline can fire.
+        opts.registry.resumeBinding(frame.taskId, binding.agentId);
         return { kind: 'handled' };
       }
       if (frame.seq > expected) {

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -433,7 +433,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           status: wireStatusToA2X(frame.status, frame.taskId, b.contextId),
         });
         b.sink.finish();
-        if (b.bindingId !== undefined && b.nextClientSeq !== undefined) {
+        if (b.executionId !== undefined && b.nextClientSeq !== undefined) {
           opts.registry.rememberTerminalReceipt(b, b.nextClientSeq - 1);
         }
         opts.registry.unbindTask(frame.taskId, b);
@@ -480,7 +480,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           },
         });
         b.sink.finish();
-        if (b.bindingId !== undefined && b.nextClientSeq !== undefined) {
+        if (b.executionId !== undefined && b.nextClientSeq !== undefined) {
           opts.registry.rememberTerminalReceipt(b, b.nextClientSeq - 1);
         }
         opts.registry.unbindTask(frame.taskId, b);
@@ -511,28 +511,28 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   }
 
   function acknowledge(binding: TaskBinding): void {
-    if (binding.bindingId === undefined || binding.nextClientSeq === undefined) return;
+    if (binding.executionId === undefined || binding.nextClientSeq === undefined) return;
     if (ws.readyState !== ws.OPEN) return;
     ws.send(
       encodeFrame({
         type: 'task.ack',
         taskId: binding.taskId,
-        bindingId: binding.bindingId,
+        executionId: binding.executionId,
         acceptedSeq: binding.nextClientSeq - 1,
       }),
     );
   }
 
   function acknowledgeReceipt(frame: TaskUpFrame): boolean {
-    if (agentId === null || frame.bindingId === undefined || frame.seq === undefined) return false;
-    const receipt = opts.registry.getTerminalReceipt(frame.bindingId, agentId, frame.taskId);
+    if (agentId === null || frame.executionId === undefined || frame.seq === undefined) return false;
+    const receipt = opts.registry.getTerminalReceipt(frame.executionId, agentId, frame.taskId);
     if (!receipt || frame.seq > receipt.acceptedSeq) return false;
     if (ws.readyState === ws.OPEN) {
       ws.send(
         encodeFrame({
           type: 'task.ack',
           taskId: frame.taskId,
-          bindingId: frame.bindingId,
+          executionId: frame.executionId,
           acceptedSeq: receipt.acceptedSeq,
         }),
       );
@@ -550,17 +550,17 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
     const binding = ownedBinding(frame.taskId);
     if (!binding) return undefined;
 
-    if (binding.bindingId !== undefined) {
-      if (frame.bindingId !== binding.bindingId || frame.seq === undefined) {
+    if (binding.executionId !== undefined) {
+      if (frame.executionId !== binding.executionId || frame.seq === undefined) {
         // A stale generation must never affect the current turn. Missing
         // sequencing on a negotiated binding is likewise unusable, but it is a
         // connection protocol error rather than a gap in the current run.
         if (!acknowledgeReceipt(frame)) {
-          logEvent('binding_generation_mismatch', {
+          logEvent('execution_id_mismatch', {
             agentId: agentId ?? undefined,
             taskId: truncate(frame.taskId, 128),
-            bindingId: frame.bindingId ? truncate(frame.bindingId, 128) : undefined,
-            ownerBindingId: binding.bindingId,
+            executionId: frame.executionId ? truncate(frame.executionId, 128) : undefined,
+            ownerExecutionId: binding.executionId,
           });
         }
         return { kind: 'duplicate' };
@@ -574,7 +574,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         logEvent('task_frame_gap', {
           agentId: binding.agentId,
           taskId: truncate(binding.taskId, 128),
-          bindingId: binding.bindingId,
+          executionId: binding.executionId,
           expectedSeq: expected,
           receivedSeq: frame.seq,
         });
@@ -586,12 +586,12 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         opts.registry.sendToAgent(binding.agentId, {
           type: 'task.cancel',
           taskId: binding.taskId,
-          bindingId: binding.bindingId,
+          executionId: binding.executionId,
         });
         return undefined;
       }
       binding.nextClientSeq = expected + 1;
-    } else if (frame.bindingId !== undefined || frame.seq !== undefined) {
+    } else if (frame.executionId !== undefined || frame.seq !== undefined) {
       // A reliable frame cannot be attached to a legacy binding merely because
       // A2A reused the same taskId.
       return acknowledgeReceipt(frame) ? { kind: 'duplicate' } : undefined;

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -237,6 +237,10 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   let agentId: string | null = null;
   let authed = false;
   let helloProcessing = false;
+  // Authentication can finish after the close handler. Preserve the code even
+  // before `agentId` is known so the late-auth reconciliation applies the same
+  // grace policy as an ordinary authenticated disconnect.
+  let observedCloseCode: number | undefined;
 
   // Resolve the binding a task frame targets, but only if this connection's
   // authenticated agent is the one that owns it. `getBinding` keys on taskId
@@ -324,7 +328,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
         // (no-ops unless the stored ws is this one), so racing a later close
         // event is safe. (#364)
         if (ws.readyState !== ws.OPEN) {
-          opts.registry.unregisterAgent(frame.agentId, ws);
+          opts.registry.unregisterAgent(frame.agentId, ws, observedCloseCode);
           return;
         }
         agentId = frame.agentId;
@@ -632,6 +636,7 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
 
   ws.on('close', (code: number, reason: Buffer) => {
     clearTimeout(helloTimeout);
+    observedCloseCode = code;
     if (agentId) {
       // Look up the live connection BEFORE unregistering so the disconnect log
       // carries the same identifying detail as client_connected.

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -63,6 +63,7 @@ async function lookupByTokenHash(sql: Sql, hash: string): Promise<ClientRow | nu
 export interface ServerWsOptions {
   db: Sql;
   registry: Registry;
+  helloTimeoutMs?: number;
 }
 
 // Largest WebSocket message the bridge will assemble at all, authenticated or
@@ -271,8 +272,14 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
   };
 
   const helloTimeout = setTimeout(() => {
-    if (!authed) ws.close(4001, 'hello timeout');
-  }, 10_000);
+    if (!authed) {
+      // Authentication may still be awaiting the token lookup. Preserve this
+      // server verdict so the post-auth reconciliation below cannot mistake
+      // its code-less unregister for a graceable network disconnect.
+      opts.registry.noteServerClose(ws);
+      ws.close(4001, 'hello timeout');
+    }
+  }, opts.helloTimeoutMs ?? 10_000);
 
   ws.on('message', (raw) => {
     let frame;


### PR DESCRIPTION
## Summary

- negotiate task-replay-v1 only after WebSocket authentication
- scope every replayable run with a server-issued executionId and consecutive client sequence numbers
- retain task output until cumulative task.ack, then deduplicate retries and fail closed on gaps
- preserve short terminal receipts so a lost terminal acknowledgement cannot complete a reused taskId
- apply reconnect grace only to capable clients; legacy client/server combinations keep fail-fast behavior
- bound retained output by frame count, encoded bytes, and age

## Why a new PR

The replay queue in #475 had no server acceptance signal and keyed safety primarily by taskId. That cannot distinguish a lost send from an accepted send, and A2A taskId reuse means a stale replay can target a later turn. This PR keeps the useful grace-hold work but adds the missing generation and acknowledgement protocol.

Supersedes #475.
Fixes #474.

## Rollout compatibility

Deploying the server first is safe: clients that do not advertise task-replay-v1 receive no hello acknowledgement, no execution IDs, and no grace hold. A new client talking to an older server recognizes legacy task assignments and aborts in-flight legacy work on disconnect instead of attempting replay.

## Verification

- pnpm -r typecheck
- pnpm -r build
- pnpm --filter @vicoop-bridge/client test (903 passed)
- pnpm --filter @vicoop-bridge/server test (334 passed, 71 skipped)