### PR TITLE
feat: expose A2A v1 transports and bump @a2x/sdk

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -163,13 +163,21 @@ interface Backend {
 
 ## 6. External A2A Surface
 
-Server는 `@a2aproject/a2a-js` v0.3.x 스펙을 따른다.
+Server는 기존 A2A v0.3 호출을 유지하면서 각 연결된 에이전트에 A2A v1을
+별도 base URL로 함께 노출한다.
 
-- `GET /.well-known/agent.json` — Server 메타
-- `GET /agents/{id}/agent.json` — 연결된 특정 에이전트의 AgentCard
-- `POST /agents/{id}/messages/send` — A2A task 생성
-- `POST /agents/{id}/messages/stream` — SSE 스트리밍
-- `POST /agents/{id}/tasks/{taskId}/cancel`
+- `GET /.well-known/agent-card.json` — bridge admin agent의 v0.3 AgentCard
+- `GET /agents/{id}/.well-known/agent-card.json` — 연결된 에이전트의 v0.3 AgentCard
+- `POST /agents/{id}` — v0.3 JSON-RPC
+- `GET /agents/{id}/v1/.well-known/agent-card.json` — 연결된 에이전트의 v1 AgentCard
+- `POST /agents/{id}/v1` — v1 JSON-RPC
+- `/agents/{id}/v1/*` — 같은 base URL을 쓰는 v1 HTTP+JSON operation
+  (`message:send`, `message:stream`, `tasks`, `tasks/{taskId}`, cancel,
+  subscribe, push-notification config, extended card)
+
+v1 AgentCard의 `supportedInterfaces`는 `/agents/{id}/v1`을 JSONRPC와
+HTTP+JSON 두 binding으로 광고한다. HTTP+JSON의 operation 이름은 고정된
+`/v1` prefix가 아니라 이 owner-defined base URL에 상대적으로 붙는다.
 
 ## 7. Auth (미결)
 

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -3,9 +3,10 @@
 Onboarding guide for connecting a local A2A backend (OpenClaw, Claude Code, or
 Codex CLI; `echo` is available for testing) to a deployed vicoop-bridge server. The
 first target is a verified foreground `vicoop-client` process on your host
-that bridges inbound A2A traffic at `POST <bridge>/agents/<your-agent-id>` to
-your local backend. Persistent service setup is optional once the foreground
-run works.
+that bridges inbound A2A traffic at the v0.3 base URL
+`<bridge>/agents/<your-agent-id>` or the v1 base URL
+`<bridge>/agents/<your-agent-id>/v1` to your local backend. Persistent service
+setup is optional once the foreground run works.
 
 Custom backends are described in `docs/design.md` §5. The released client
 currently registers `echo`, `openclaw`, `claude`, and `codex`.
@@ -488,6 +489,11 @@ server publishes the canonical card for that backend at
 metadata/capability fixes on the faster server deploy path instead of
 requiring every operator to upgrade their client bundle.
 
+The versioned A2A v1 card is available at
+`GET <bridge>/agents/<agent_id>/v1/.well-known/agent-card.json`. It advertises
+both JSON-RPC and HTTP+JSON on the same `<bridge>/agents/<agent_id>/v1` base
+URL. The unversioned card and endpoint remain A2A v0.3 for existing callers.
+
 Starter cards for the built-in backends (`openclaw.json`, `claude.json`,
 `codex.json`, `echo.json`) live in the source tree under
 [`packages/client/cards/`](https://github.com/planetarium/vicoop-bridge/tree/main/packages/client/cards) —
@@ -579,8 +585,15 @@ After that:
   place; otherwise `agent register` auto-minted an API key (printed once) and
   added its `apikey:<key-id>` principal to `allowed_callers`, so the agent is
   restricted to that key rather than being publicly callable.
-- `POST $BRIDGE_URL/agents/$AGENT_ID` with a JSON-RPC `message/send` payload
-  reaches your backend and the reply is returned inline.
+- A2A v0.3 remains available at `POST
+  $BRIDGE_URL/agents/$AGENT_ID` with JSON-RPC `message/send`.
+- A2A v1 JSON-RPC is available at `POST
+  $BRIDGE_URL/agents/$AGENT_ID/v1` with the v1 method names and wire shapes.
+- A2A v1 HTTP+JSON uses operation paths relative to that same base, including
+  `POST .../v1/message:send`, `POST .../v1/message:stream`, `GET
+  .../v1/tasks`, `GET .../v1/tasks/<task-id>`, and `POST
+  .../v1/tasks/<task-id>:cancel`. Send `A2A-Version: 1.0`; POST bodies use
+  `Content-Type: application/a2a+json` (or `application/json`).
 
 ## Step 6b — Run unattended (`--detach`)
 
@@ -776,6 +789,10 @@ vicoop-client auth whoami
 ```
 
 Typical follow-ups from this output:
+
+The current `whoami` output names the backwards-compatible v0.3 URLs. Derive
+the v1 equivalents by appending `/v1` to `a2a`, and
+`/v1/.well-known/agent-card.json` after the agent id for the card.
 
 1. **Hand the mention to another agent.** Copy the `mention:` line and paste
    it into the other agent's `allowed_callers` (via `agent callers add` or

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -64,44 +64,73 @@ pnpm --filter @vicoop-bridge/server dev
 
 ## Bring up an echo client
 
-Creates a `clients` row directly via SQL (bypasses SIWE admin UI), then runs
-`vicoop-client` with the `echo` backend so we have a real connected agent to
-route requests to.
+Creates the runtime `agents` row and its compatibility `clients` row directly
+via SQL (bypasses SIWE admin UI), then runs `vicoop-client` with the `echo`
+backend so we have a real connected agent to route requests to.
 
 ```bash
-# 1. Pick a raw token and insert the hashed form into clients.
+# 1. Pick a raw token and insert the hashed form into agents + clients.
 TOKEN=dev-client-token-raw-12345
 psql vicoop_bridge_dev <<SQL
-INSERT INTO clients (owner_principal, client_name, token_hash, allowed_agent_ids)
-VALUES (
-  'eth:0x0000000000000000000000000000000000000001',
-  'dev-echo-client',
-  encode(digest('$TOKEN', 'sha256'), 'hex'),
-  ARRAY['echo-agent']
-) ON CONFLICT (token_hash) DO NOTHING;
+WITH registered AS (
+  INSERT INTO agents (id, owner_principal, name, token_hash)
+  VALUES (
+    'echo-agent',
+    'eth:0x0000000000000000000000000000000000000001',
+    'dev-echo-client',
+    encode(digest('$TOKEN', 'sha256'), 'hex')
+  )
+  RETURNING client_id, owner_principal, name, token_hash
+)
+INSERT INTO clients (id, owner_principal, client_name, token_hash, allowed_agent_ids)
+SELECT client_id, owner_principal, name, token_hash, ARRAY['echo-agent']
+FROM registered;
 SQL
 
 # 2. Run the client. NOTE: --server is the base URL WITHOUT /connect — the
 # client appends /connect itself (client.ts:39). Pass ws:// not http://.
-cd packages/client
-../../node_modules/.bin/tsx src/cli.ts \
+pnpm -s cli:client start \
   --server ws://localhost:8787 \
   --token dev-client-token-raw-12345 \
-  --agentId echo-agent \
-  --backend echo
+  --agentId echo-agent --backend echo
 # logs: [client] connected, sending hello
 ```
 
-The WS registration auto-creates an `agent_policies` row with
-`allowed_callers = '{}'` (public). Two ways to populate it:
+The `agents.allowed_callers` default is `'{}'` (public). Two ways to populate
+it:
 
 - **`vicoop-client agent callers add`** (Paths B/C below) — hot-reloads via
   `registry.updateAllowedCallers`, no restart needed. Requires an
   owner-session bearer (issued via SIWE exchange or Google device flow).
-- **Raw SQL `UPDATE agent_policies SET allowed_callers = …`** (Path A
+- **Raw SQL `UPDATE agents SET allowed_callers = …`** (Path A
   below) — bypasses the registry, so the connected client must be killed
   and rerun to pick up the new list. Useful when you want to skip the
   auth flow entirely for the smoke test.
+
+## A2A v1 dual-transport smoke client
+
+With the local server and echo client running, execute the repository's
+dependency-free v1 client:
+
+```bash
+pnpm e2e:a2a-v1 \
+  http://localhost:8787/agents/echo-agent/v1/.well-known/agent-card.json
+```
+
+It discovers the v1 AgentCard, confirms that JSON-RPC and HTTP+JSON share the
+same base URL, then checks both directions across the transports:
+
+1. JSON-RPC `SendMessage` → HTTP+JSON `GET tasks/{id}`
+2. HTTP+JSON `POST message:send` → JSON-RPC `GetTask`
+3. HTTP+JSON `GET tasks` contains both completed echo tasks
+
+For an independent SDK-backed check with the installed `a2x` CLI:
+
+```bash
+CARD=http://localhost:8787/agents/echo-agent/v1/.well-known/agent-card.json
+a2x a2a agent-card "$CARD" --json
+a2x a2a send "$CARD" 'a2x v1 smoke' --no-x402 --json
+```
 
 ## Path A — opaque token via direct DB insert
 
@@ -114,19 +143,19 @@ psql vicoop_bridge_dev <<SQL
 INSERT INTO callers (token_hash, principal_id, provider, email, expires_at)
 VALUES (
   encode(digest('$CALLER_TOKEN', 'sha256'), 'hex'),
-  'google:1234567890',
+  'google:sub:1234567890',
   'google',
   'alice@example.com',
   now() + interval '1 day'
 );
-UPDATE agent_policies
+UPDATE agents
 SET allowed_callers = ARRAY['google:sub:1234567890']
-WHERE agent_id = 'echo-agent';
+WHERE id = 'echo-agent';
 SQL
 
 # 2. Restart the echo client so registry picks up the new allowed_callers
 pkill -f 'tsx.*cli.ts.*echo-agent'
-# ...rerun the client command from "Bring up an echo client" step 3...
+# ...rerun the client command from "Bring up an echo client" step 2...
 
 # 3. Auth matrix
 BODY='{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"m1","role":"user","kind":"message","parts":[{"kind":"text","text":"hello"}]}}}'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:client": "pnpm --filter @vicoop-bridge/client dev",
     "cli:client": "pnpm --filter @vicoop-bridge/client cli",
     "dev:admin-ui": "pnpm --filter @vicoop-bridge/admin-ui dev",
+    "e2e:a2a-v1": "node scripts/a2a-v1-smoke.mjs",
     "deploy:server": "fly deploy -c packages/server/fly.toml .",
     "changeset": "changeset"
   },

--- a/packages/admin-ui/package.json
+++ b/packages/admin-ui/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@a2x/sdk": "^0.23.0",
+    "@a2x/sdk": "^0.24.0",
     "@rainbow-me/rainbowkit": "^2",
     "@tanstack/react-query": "^5",
     "lucide-react": "^0.468",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
     "test": "tsx --test \"src/**/*.test.ts\""
   },
   "dependencies": {
-    "@a2x/sdk": "^0.23.0",
+    "@a2x/sdk": "^0.24.0",
     "@ai-sdk/anthropic": "^3.0.69",
     "@hono/node-server": "^1.13.7",
     "@sentry/hono": "^10.57.0",

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -133,6 +133,7 @@ function setWWWAuthenticate(
 export interface AgentAuthOptions {
   sql: Sql;
   deviceFlowEnabled?: boolean;
+  responseFormat?: 'jsonrpc' | 'http-json';
   // SIWE domain for the bridge — used to validate raw SIWE bearer tokens
   // (siwe-bearer-auth/v0.1). When undefined, the SIWE bearer fast-path is
   // disabled and only opaque vbc_caller_* tokens are accepted.
@@ -160,6 +161,43 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     ? `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}* or SIWE bearer)`
     : `Authentication required (Bearer ${CALLER_TOKEN_PREFIX}*)`;
 
+  function reject(
+    c: Context,
+    status: 401 | 403 | 404 | 503,
+    jsonRpcCode: number,
+    message: string,
+    rejectionId: string,
+  ) {
+    if (opts.responseFormat !== 'http-json') {
+      return c.json(rejectionErrorBody(jsonRpcCode, message, rejectionId), status);
+    }
+    const statusName = {
+      401: 'UNAUTHENTICATED',
+      403: 'PERMISSION_DENIED',
+      404: 'NOT_FOUND',
+      503: 'UNAVAILABLE',
+    }[status];
+    return c.body(
+      JSON.stringify({
+        error: {
+          code: status,
+          status: statusName,
+          message,
+          details: [
+            {
+              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+              reason: statusName,
+              domain: 'vicoop-bridge',
+              metadata: { rejectionId },
+            },
+          ],
+        },
+      }),
+      status,
+      { 'Content-Type': 'application/a2a+json' },
+    );
+  }
+
   return async (c: Context, next: Next) => {
     const agentId = c.req.param('id')!;
     const conn = registry.getAgent(agentId);
@@ -172,13 +210,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           rejectionId,
         });
         c.header('Retry-After', String(AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS));
-        return c.json(
-          rejectionErrorBody(
-            -32000,
-            'Agent temporarily unavailable (registered but not connected)',
-            rejectionId,
-          ),
+        return reject(
+          c,
           503,
+          -32000,
+          'Agent temporarily unavailable (registered but not connected)',
+          rejectionId,
         );
       }
       logEvent('agent_request_rejected', {
@@ -186,7 +223,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         reason: 'agent_not_connected',
         rejectionId,
       });
-      return c.json(rejectionErrorBody(-32000, 'Agent not connected', rejectionId), 404);
+      return reject(c, 404, -32000, 'Agent not connected', rejectionId);
     }
 
     c.set('agentConn', conn);
@@ -207,7 +244,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
       // Per RFC 6750 §3.1, no error code when the request lacks any
       // authentication information — only the challenge realm.
       setWWWAuthenticate(c);
-      return c.json(rejectionErrorBody(-32001, missingBearerMessage, rejectionId), 401);
+      return reject(c, 401, -32001, missingBearerMessage, rejectionId);
     }
 
     let caller: VerifiedCaller;
@@ -231,13 +268,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           error: 'invalid_token',
           description: 'invalid bearer token',
         });
-        return c.json(
-          rejectionErrorBody(
-            -32001,
-            `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
-            rejectionId,
-          ),
+        return reject(
+          c,
           401,
+          -32001,
+          `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
+          rejectionId,
         );
       }
     } else if (bearerToken.startsWith(OWNER_SESSION_PREFIX)) {
@@ -257,13 +293,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         error: 'invalid_token',
         description: `${OWNER_SESSION_PREFIX}* tokens are not accepted on /agents/:id`,
       });
-      return c.json(
-        rejectionErrorBody(
-          -32001,
-          `Invalid bearer token: ${OWNER_SESSION_PREFIX}* (owner-session) tokens are not accepted on /agents/:id. Acquire one via ${acquisitionHint}.`,
-          rejectionId,
-        ),
+      return reject(
+        c,
         401,
+        -32001,
+        `Invalid bearer token: ${OWNER_SESSION_PREFIX}* (owner-session) tokens are not accepted on /agents/:id. Acquire one via ${acquisitionHint}.`,
+        rejectionId,
       );
     } else if (opts.siweDomain) {
       // Stateless SIWE bearer per siwe-bearer-auth/v0.1. No callers row is
@@ -289,13 +324,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
           error: 'invalid_token',
           description: 'invalid SIWE bearer',
         });
-        return c.json(
-          rejectionErrorBody(
-            -32001,
-            `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
-            rejectionId,
-          ),
+        return reject(
+          c,
           401,
+          -32001,
+          `Invalid bearer token. Acquire one via ${acquisitionHint}.`,
+          rejectionId,
         );
       }
     } else {
@@ -309,13 +343,12 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         error: 'invalid_token',
         description: `expected ${CALLER_TOKEN_PREFIX}* prefix`,
       });
-      return c.json(
-        rejectionErrorBody(
-          -32001,
-          `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
-          rejectionId,
-        ),
+      return reject(
+        c,
         401,
+        -32001,
+        `Invalid bearer token: expected ${CALLER_TOKEN_PREFIX}* prefix. Acquire one via ${acquisitionHint}.`,
+        rejectionId,
       );
     }
 
@@ -332,10 +365,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
         error: 'insufficient_scope',
         description: 'caller not in allowed list',
       });
-      return c.json(
-        rejectionErrorBody(-32001, 'Caller not authorized for this agent', rejectionId),
-        403,
-      );
+      return reject(c, 403, -32001, 'Caller not authorized for this agent', rejectionId);
     }
 
     c.set('caller', caller);

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { InMemoryTaskStore, type AgentCardV03 } from '@a2x/sdk';
+import { InMemoryTaskStore, type AgentCardV03, type AgentCardV10 } from '@a2x/sdk';
 import {
   SIWE_BEARER_AUTH_EXTENSION_URI,
   TRACEABILITY_EXTENSION_URI,
@@ -23,6 +23,41 @@ function fakeConn(card: AgentCard, overrides: Partial<ClientConnection> = {}): C
     ...overrides,
   };
 }
+
+test('buildAgentA2XServer publishes v1 JSON-RPC and HTTP+JSON on one versioned base URL', () => {
+  const agent = buildAgentA2XServer(
+    fakeConn({
+      name: 'claude',
+      description: 'Claude Code',
+      version: '0.0.1',
+      protocolVersion: '0.3.0',
+      capabilities: { streaming: true },
+      skills: [],
+    }),
+    new InMemoryTaskStore(),
+    new Registry(),
+    {
+      publicUrl: 'https://bridge.example',
+      deviceFlowEnabled: false,
+      protocolVersion: '1.0',
+    },
+  );
+
+  const card = agent.getAgentCard() as AgentCardV10;
+  assert.deepEqual(card.supportedInterfaces, [
+    {
+      url: 'https://bridge.example/agents/claude/v1',
+      protocolBinding: 'JSONRPC',
+      protocolVersion: '1.0',
+    },
+    {
+      url: 'https://bridge.example/agents/claude/v1',
+      protocolBinding: 'HTTP+JSON',
+      protocolVersion: '1.0',
+    },
+  ]);
+  assert.equal((card as AgentCardV10 & { protocolVersion?: string }).protocolVersion, undefined);
+});
 
 test('buildAgentA2XServer preserves advertised optional extensions', () => {
   const agent = buildAgentA2XServer(

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -1,7 +1,9 @@
 import {
+  A2A_TRANSPORTS,
   A2XServer,
   HttpBearerAuthorization,
   OAuth2DeviceCodeAuthorization,
+  type ProtocolVersion,
   type TaskStore,
 } from '@a2x/sdk';
 import { SIWE_BEARER_AUTH_EXTENSION_URI } from '@vicoop-bridge/protocol';
@@ -15,6 +17,7 @@ import type { Sql } from './db.js';
 export interface AgentA2XOptions {
   publicUrl: string | undefined;
   deviceFlowEnabled: boolean;
+  protocolVersion?: ProtocolVersion;
   // DB handle for the x402 offering store. Absent on deployments assembled
   // without a payment path; the executor then never installs the gate.
   db?: Sql;
@@ -39,9 +42,11 @@ export function buildAgentA2XServer(
   opts: AgentA2XOptions,
 ): A2XServer {
   const wire = conn.agentCard;
+  const protocolVersion = opts.protocolVersion ?? '0.3';
+  const versionPath = protocolVersion === '1.0' ? '/v1' : '';
   const url = opts.publicUrl
-    ? `${opts.publicUrl}/agents/${conn.agentId}`
-    : `/agents/${conn.agentId}`;
+    ? `${opts.publicUrl}/agents/${conn.agentId}${versionPath}`
+    : `/agents/${conn.agentId}${versionPath}`;
 
   // x402 `resource` must be an absolute URL — strict facilitators reject
   // anything else, so without `publicUrl` a paid agent would publish offerings
@@ -68,7 +73,7 @@ export function buildAgentA2XServer(
   const a2xServer = new A2XServer({
     taskStore,
     executor,
-    protocolVersion: '0.3',
+    protocolVersion,
   })
     .setName(wire.name)
     .setDescription(wire.description ?? '')
@@ -84,6 +89,20 @@ export function buildAgentA2XServer(
       streaming: wire.capabilities?.streaming ?? false,
       pushNotifications: wire.capabilities?.pushNotifications ?? false,
     });
+
+  // A2A v1 decouples the protocol version from the HTTP binding. Publish both
+  // bindings on the same owner-defined base URL: POSTing JSON-RPC to the base
+  // remains available, while the HTTP+JSON operation paths (message:send,
+  // tasks/{id}, etc.) are resolved relative to it.
+  if (protocolVersion === '1.0') {
+    a2xServer
+      .setDefaultTransport(A2A_TRANSPORTS.JSONRPC)
+      .addInterface({
+        url,
+        protocol: A2A_TRANSPORTS.HTTP_JSON,
+        protocolVersion: '1.0',
+      });
+  }
 
   // Advertise SIWE bearer-auth (siwe-bearer-auth/v0.1) when this agent is
   // restricted to a non-empty allowed_callers set. Mentionable / A2A clients
@@ -152,7 +171,7 @@ export function buildAgentA2XServer(
         domainBinding: true,
         usageHint: {
           mintToken: `a2a-wallet siwe auth --domain ${siweDomain} --uri ${opts.publicUrl} --ttl 1h --json | jq -r '.token'`,
-          sendMessage: `a2a-wallet a2a send --bearer "$TOKEN" ${opts.publicUrl}/agents/${conn.agentId}/.well-known/agent-card.json "Hello"`,
+          sendMessage: `a2a-wallet a2a send --bearer "$TOKEN" ${url}/.well-known/agent-card.json "Hello"`,
         },
       },
     });

--- a/packages/server/src/agent-v1.test.ts
+++ b/packages/server/src/agent-v1.test.ts
@@ -1,0 +1,159 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { WebSocket } from 'ws';
+import type { AgentCard } from '@vicoop-bridge/protocol';
+import { createHttpApp } from './http.js';
+import { Registry, type ClientConnection } from './registry.js';
+import type { Sql } from './db.js';
+
+function fakeSql(): Sql {
+  return (async () => []) as unknown as Sql;
+}
+
+function registerAgent(registry: Registry, allowedCallers: string[] = []): void {
+  const agentCard: AgentCard = {
+    name: 'v1-test-agent',
+    description: 'A2A v1 route test',
+    version: '0.0.1',
+    protocolVersion: '0.3.0',
+    capabilities: { streaming: true },
+    skills: [],
+  };
+  const conn: ClientConnection = {
+    agentId: 'v1-test-agent',
+    clientId: 'client-1',
+    ownerPrincipal: 'eth:0x0000000000000000000000000000000000000001',
+    agentCard,
+    allowedCallers,
+    ws: { close() {} } as unknown as WebSocket,
+    connectedAt: Date.now(),
+  };
+  assert.deepEqual(registry.registerAgent(conn), { ok: true });
+}
+
+function buildApp(allowedCallers: string[] = []) {
+  const registry = new Registry();
+  registerAgent(registry, allowedCallers);
+  return createHttpApp({
+    registry,
+    db: fakeSql(),
+    publicUrl: 'https://bridge.example',
+  });
+}
+
+test('versioned discovery exposes a v1 dual-transport card without changing v0.3', async () => {
+  const app = buildApp();
+
+  const v1Response = await app.request(
+    '/agents/v1-test-agent/v1/.well-known/agent-card.json',
+  );
+  assert.equal(v1Response.status, 200);
+  const v1Card = await v1Response.json() as {
+    protocolVersion?: string;
+    supportedInterfaces: Array<{
+      url: string;
+      protocolBinding: string;
+      protocolVersion: string;
+    }>;
+  };
+  assert.equal(v1Card.protocolVersion, undefined);
+  assert.deepEqual(v1Card.supportedInterfaces, [
+    {
+      url: 'https://bridge.example/agents/v1-test-agent/v1',
+      protocolBinding: 'JSONRPC',
+      protocolVersion: '1.0',
+    },
+    {
+      url: 'https://bridge.example/agents/v1-test-agent/v1',
+      protocolBinding: 'HTTP+JSON',
+      protocolVersion: '1.0',
+    },
+  ]);
+
+  const v03Response = await app.request(
+    '/agents/v1-test-agent/.well-known/agent-card.json',
+  );
+  assert.equal(v03Response.status, 200);
+  const v03Card = await v03Response.json() as { protocolVersion: string; url: string };
+  assert.equal(v03Card.protocolVersion, '0.3.0');
+  assert.equal(v03Card.url, 'https://bridge.example/agents/v1-test-agent');
+});
+
+test('v1 JSON-RPC route returns protocol parse errors with an A2A-Version header', async () => {
+  const response = await buildApp().request('/agents/v1-test-agent/v1', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{',
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('A2A-Version'), '1.0');
+  const body = await response.json() as { error: { code: number } };
+  assert.equal(body.error.code, -32700);
+});
+
+test('v1 HTTP+JSON routes use structured errors and expose task listing', async () => {
+  const app = buildApp();
+  const malformed = await app.request('/agents/v1-test-agent/v1/message:send', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/a2a+json' },
+    body: '{',
+  });
+  assert.equal(malformed.status, 400);
+  assert.match(malformed.headers.get('Content-Type') ?? '', /^application\/a2a\+json/);
+  const malformedBody = await malformed.json() as { error: { status: string } };
+  assert.equal(malformedBody.error.status, 'INVALID_ARGUMENT');
+
+  const missingTask = await app.request('/agents/v1-test-agent/v1/tasks/missing-task');
+  assert.equal(missingTask.status, 404);
+  const missingTaskBody = await missingTask.json() as { error: { status: string } };
+  assert.equal(missingTaskBody.error.status, 'NOT_FOUND');
+
+  const list = await app.request('/agents/v1-test-agent/v1/tasks?pageSize=10');
+  assert.equal(list.status, 200);
+  assert.equal(list.headers.get('A2A-Version'), '1.0');
+  const listBody = await list.json() as {
+    tasks: unknown[];
+    pageSize: number;
+    totalSize: number;
+  };
+  assert.deepEqual(listBody.tasks, []);
+  assert.equal(listBody.pageSize, 10);
+  assert.equal(listBody.totalSize, 0);
+
+  const wrongVersion = await app.request(
+    '/agents/v1-test-agent/v1/tasks?A2A-Version=99.0',
+  );
+  assert.equal(wrongVersion.status, 400);
+  const wrongVersionBody = await wrongVersion.json() as { error: { message: string } };
+  assert.match(wrongVersionBody.error.message, /99\.0.*not supported/);
+});
+
+test('restricted v1 HTTP+JSON routes return google.rpc.Status auth errors', async () => {
+  const response = await buildApp([
+    'eth:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  ]).request('/agents/v1-test-agent/v1/tasks/missing-task');
+
+  assert.equal(response.status, 401);
+  assert.match(response.headers.get('Content-Type') ?? '', /^application\/a2a\+json/);
+  const body = await response.json() as {
+    error: { code: number; status: string; details: Array<{ metadata: { rejectionId: string } }> };
+  };
+  assert.equal(body.error.code, 401);
+  assert.equal(body.error.status, 'UNAUTHENTICATED');
+  assert.match(body.error.details[0]!.metadata.rejectionId, /^rej_[0-9a-f]{8}$/);
+});
+
+test('CORS preflight allows the A2A-Version request header', async () => {
+  const response = await buildApp().request('/agents/v1-test-agent/v1/message:send', {
+    method: 'OPTIONS',
+    headers: {
+      Origin: 'https://client.example',
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'A2A-Version,Content-Type',
+    },
+  });
+
+  assert.equal(response.status, 204);
+  assert.match(response.headers.get('Access-Control-Allow-Headers') ?? '', /A2A-Version/i);
+});

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -21,6 +21,7 @@ import { Registry, type ClientConnection } from './registry.js';
 import {
   WSForwardingExecutor,
   appendHistoryMessage,
+  partsToWire,
   stripInternalMetadata,
 } from './executor.js';
 
@@ -145,6 +146,48 @@ test('appendHistoryMessage appends messages once by messageId', () => {
   const withSecond = appendHistoryMessage(withDuplicate, second);
 
   assert.deepEqual(withSecond.map((m) => m.messageId), ['m-1', 'm-2']);
+});
+
+test('partsToWire converts discriminator-free A2A v1 parts for the client WS protocol', () => {
+  const parts = [
+    { text: 'hello' },
+    { data: { answer: 42 } },
+    {
+      raw: 'aGVsbG8=',
+      filename: 'hello.txt',
+      mediaType: 'text/plain',
+    },
+    { url: 'https://example.com/file.bin', mediaType: 'application/octet-stream' },
+  ] as unknown as Message['parts'];
+
+  assert.deepEqual(partsToWire(parts), [
+    { kind: 'text', text: 'hello' },
+    { kind: 'data', data: { answer: 42 } },
+    {
+      kind: 'file',
+      file: {
+        name: 'hello.txt',
+        mimeType: 'text/plain',
+        bytes: 'aGVsbG8=',
+      },
+    },
+    {
+      kind: 'file',
+      file: {
+        mimeType: 'application/octet-stream',
+        uri: 'https://example.com/file.bin',
+      },
+    },
+  ]);
+});
+
+test('partsToWire preserves already-discriminated v0.3 wire parts', () => {
+  const parts = [
+    { kind: 'text', text: 'legacy' },
+    { kind: 'file', file: { name: 'legacy.txt', bytes: 'eA==' } },
+  ] as unknown as Message['parts'];
+
+  assert.deepEqual(partsToWire(parts), parts);
 });
 
 test('executor records principalId in binding and strips _principalId from outgoing WS frame', async () => {

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -26,6 +26,7 @@ import {
   CALLER_CONTEXT_CAPABILITY,
   CallerContextV1,
   TASK_REPLAY_CAPABILITY,
+  type Part as WirePart,
 } from '@vicoop-bridge/protocol';
 
 /**
@@ -150,6 +151,47 @@ export function appendHistoryMessage(history: Message[], message: Message | unde
   if (message === undefined) return history;
   if (history.some((existing) => existing.messageId === message.messageId)) return history;
   return [...history, message];
+}
+
+/**
+ * Convert the SDK's discriminator-free v1 Part shape into the bridge WS
+ * protocol's v0.3-style discriminated union. v0.3 requests already carry a
+ * `kind` and pass through unchanged; v1 requests use field presence
+ * (`{text}`, `{data}`, `{raw|url}`), which the connected client would reject
+ * if forwarded verbatim.
+ */
+export function partsToWire(parts: Message['parts']): WirePart[] {
+  return parts.map((part) => {
+    const value = part as unknown as Record<string, unknown>;
+    if (value.kind === 'text' || value.kind === 'file' || value.kind === 'data') {
+      return value as unknown as WirePart;
+    }
+    if (typeof value.text === 'string') {
+      return { kind: 'text', text: value.text };
+    }
+    if ('data' in value) {
+      if (
+        typeof value.data !== 'object' ||
+        value.data === null ||
+        Array.isArray(value.data)
+      ) {
+        throw new Error('A2A DataPart.data must be an object');
+      }
+      return { kind: 'data', data: value.data as Record<string, unknown> };
+    }
+    if (typeof value.raw === 'string' || typeof value.url === 'string') {
+      return {
+        kind: 'file',
+        file: {
+          ...(typeof value.filename === 'string' ? { name: value.filename } : {}),
+          ...(typeof value.mediaType === 'string' ? { mimeType: value.mediaType } : {}),
+          ...(typeof value.raw === 'string' ? { bytes: value.raw } : {}),
+          ...(typeof value.url === 'string' ? { uri: value.url } : {}),
+        },
+      };
+    }
+    throw new Error('Unsupported A2A message part');
+  });
 }
 
 /**
@@ -477,10 +519,7 @@ export class WSForwardingExecutor extends AgentExecutor {
       contextId,
       message: {
         role: message.role,
-        // The WS protocol uses the v0.3 wire shape (`{kind, ...}`); the
-        // request-handler hands us `message` unmodified, so we forward
-        // the parts through as-is.
-        parts: message.parts as never,
+        parts: partsToWire(message.parts),
         messageId: message.messageId,
         ...(forwardMetadata !== undefined ? { metadata: forwardMetadata } : {}),
         ...(message.extensions !== undefined ? { extensions: message.extensions } : {}),

--- a/packages/server/src/http.tsx
+++ b/packages/server/src/http.tsx
@@ -9,8 +9,15 @@ import { sentry } from '@sentry/hono/node';
 import * as Sentry from '@sentry/hono/node';
 import {
   A2XServer,
+  createSSEStream,
   DefaultRequestHandler,
+  HttpJsonRequestHandler,
+  JSONParseError,
+  toHttpJsonErrorResponse,
   type AgentCardV03,
+  type AgentCardV10,
+  type HttpJsonResponse,
+  type RequestContext,
 } from '@a2x/sdk';
 import type { ClientConnection, Registry } from './registry.js';
 import { createAdminA2XServer } from './admin.js';
@@ -123,6 +130,7 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       allowHeaders: [
         'Authorization',
         'Content-Type',
+        'A2A-Version',
         A2A_EXTENSIONS_HEADER,
         A2A_EXTENSIONS_LEGACY_HEADER,
       ],
@@ -152,6 +160,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   // card reflects the latest connection state.
   const agentCache = new Map<string, A2XServer>();
   const handlerCache = new Map<string, DefaultRequestHandler>();
+  const agentV1Cache = new Map<string, A2XServer>();
+  const handlerV1Cache = new Map<string, DefaultRequestHandler>();
+  const httpJsonV1Cache = new Map<string, HttpJsonRequestHandler>();
 
   // Device flow endpoints (/oauth/device/code, /oauth/token) are only mounted
   // when Google OAuth is fully configured. Surface this to the agent card and
@@ -184,11 +195,47 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     return handler;
   }
 
+  function getAgentV1ForConn(conn: ClientConnection): A2XServer {
+    const cached = agentV1Cache.get(conn.agentId);
+    if (cached) return cached;
+    const taskStore = new PostgresTaskStore(opts.db, {
+      persistRequestEnvelope,
+      ownerAgent: conn.agentId,
+    });
+    const a2x = buildAgentA2XServer(conn, taskStore, opts.registry, {
+      ...agentCardOpts,
+      protocolVersion: '1.0',
+    });
+    agentV1Cache.set(conn.agentId, a2x);
+    return a2x;
+  }
+
+  function getHandlerV1ForConn(conn: ClientConnection): DefaultRequestHandler {
+    const cached = handlerV1Cache.get(conn.agentId);
+    if (cached) return cached;
+    const handler = new DefaultRequestHandler(getAgentV1ForConn(conn));
+    handlerV1Cache.set(conn.agentId, handler);
+    return handler;
+  }
+
+  function getHttpJsonV1ForConn(conn: ClientConnection): HttpJsonRequestHandler {
+    const cached = httpJsonV1Cache.get(conn.agentId);
+    if (cached) return cached;
+    const handler = new HttpJsonRequestHandler(getHandlerV1ForConn(conn), {
+      basePath: `/agents/${conn.agentId}/v1`,
+    });
+    httpJsonV1Cache.set(conn.agentId, handler);
+    return handler;
+  }
+
   // Invalidate cached A2XServer + handler when allowedCallers changes so
   // the rendered card reflects the updated security fields.
   opts.registry.onCallerChange((agentId) => {
     agentCache.delete(agentId);
     handlerCache.delete(agentId);
+    agentV1Cache.delete(agentId);
+    handlerV1Cache.delete(agentId);
+    httpJsonV1Cache.delete(agentId);
   });
   // Also invalidate on (re)registration or disconnect. The handler
   // captures the agent card at construction time — including
@@ -198,6 +245,9 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
   opts.registry.onAgentChange((agentId) => {
     agentCache.delete(agentId);
     handlerCache.delete(agentId);
+    agentV1Cache.delete(agentId);
+    handlerV1Cache.delete(agentId);
+    httpJsonV1Cache.delete(agentId);
   });
 
   async function handleHandlerResult(result: unknown, c: Context) {
@@ -213,6 +263,95 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
       });
     }
     return c.json(result as Record<string, unknown>);
+  }
+
+  function handleHttpJsonResponse(response: HttpJsonResponse): Response {
+    const headers = { ...response.headers, 'A2A-Version': '1.0' };
+    if (
+      response.body &&
+      typeof response.body === 'object' &&
+      Symbol.asyncIterator in response.body
+    ) {
+      return new Response(createSSEStream(response.body as AsyncGenerator<unknown>), {
+        status: response.status,
+        headers,
+      });
+    }
+    return new Response(JSON.stringify(response.body), {
+      status: response.status,
+      headers,
+    });
+  }
+
+  function getRequestContext(c: Context): RequestContext {
+    const url = new URL(c.req.url);
+    const headers = Object.fromEntries(c.req.raw.headers.entries());
+    const queryVersion = url.searchParams.get('A2A-Version');
+    if (queryVersion !== null && !('a2a-version' in headers)) {
+      headers['a2a-version'] = queryVersion;
+    }
+    return {
+      headers,
+      query: Object.fromEntries(url.searchParams.entries()),
+    };
+  }
+
+  function prepareAgentRequestBody(
+    body: unknown,
+    c: Context,
+    caller: ReturnType<typeof getCaller>,
+  ): void {
+    if (!isRecord(body)) return;
+    const params = isRecord(body.params) ? body.params : undefined;
+    const message = isRecord(params?.message)
+      ? params.message
+      : isRecord(body.message)
+        ? body.message
+        : undefined;
+    if (!message) return;
+
+    const requestedExtensions = [
+      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_HEADER)),
+      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_LEGACY_HEADER)),
+    ];
+    if (requestedExtensions.length > 0) {
+      const existing = Array.isArray(message.extensions)
+        ? message.extensions.filter((value: unknown): value is string => typeof value === 'string')
+        : [];
+      message.extensions = [...new Set([...existing, ...requestedExtensions])];
+    }
+
+    stripCallerSuppliedInternalKeys(message);
+    if (caller !== undefined) {
+      message.metadata = {
+        ...(isRecord(message.metadata) ? message.metadata : {}),
+        _principalId: caller.principalId,
+      };
+    }
+  }
+
+  function recordAgentRequest(
+    c: Context,
+    conn: ClientConnection,
+    caller: ReturnType<typeof getCaller>,
+  ): void {
+    logEvent('agent_request', {
+      agentId: conn.agentId,
+      backend: conn.backendKind ?? 'inline',
+      ownerEmail: conn.ownerEmail ?? undefined,
+      hasAuth: !!c.req.header('Authorization'),
+      ...(caller !== undefined
+        ? {
+            principalId: caller.principalId,
+            ...(caller.email ? { callerEmail: caller.email } : {}),
+          }
+        : {}),
+    });
+    Sentry.getActiveSpan()?.setAttributes({
+      'bridge.agent': conn.agentId,
+      'bridge.backend': conn.backendKind ?? 'inline',
+      'bridge.caller': caller?.principalId ?? 'public',
+    });
   }
 
   // Derive the public hostname once. Used both for SIWE domain verification
@@ -718,11 +857,33 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     return c.json(getAgentForConn(conn).getAgentCard() as AgentCardV03);
   });
 
+  // A2A v1 card. It deliberately lives below the versioned base URL so the
+  // existing v0.3 discovery and JSON-RPC endpoint remain byte-for-byte
+  // compatible for deployed clients.
+  app.get('/agents/:id/v1/.well-known/agent-card.json', async (c) => {
+    const id = c.req.param('id');
+    const conn = opts.registry.getAgent(id);
+    if (!conn) {
+      if ((await classifyMissingAgent(opts.db, id)) === 'offline') {
+        c.header('Retry-After', String(AGENT_UNAVAILABLE_RETRY_AFTER_SECONDS));
+        return c.json({ error: 'agent temporarily unavailable' }, 503);
+      }
+      return c.json({ error: 'agent not connected' }, 404);
+    }
+    return c.json(getAgentV1ForConn(conn).getAgentCard() as AgentCardV10);
+  });
+
   // Client agent A2A endpoints (auth middleware checks allowedCallers)
   const authMw = agentAuthMiddleware(opts.registry, {
     sql: opts.db,
     deviceFlowEnabled,
     siweDomain,
+  });
+  const httpJsonAuthMw = agentAuthMiddleware(opts.registry, {
+    sql: opts.db,
+    deviceFlowEnabled,
+    siweDomain,
+    responseFormat: 'http-json',
   });
   app.post('/agents/:id', authMw, async (c) => {
     const conn = getAgentConn(c);
@@ -731,64 +892,69 @@ export function createHttpApp(opts: ServerHttpOptions): Hono {
     // For restricted agents it's always populated; otherwise the middleware
     // would have returned 401/403 before reaching this handler.
     const caller = getCaller(c);
-    logEvent('agent_request', {
-      agentId: conn.agentId,
-      backend: conn.backendKind ?? 'inline',
-      ownerEmail: conn.ownerEmail ?? undefined,
-      hasAuth: !!c.req.header('Authorization'),
-      ...(caller !== undefined
-        ? {
-            principalId: caller.principalId,
-            ...(caller.email ? { callerEmail: caller.email } : {}),
-          }
-        : {}),
-    });
-    // Tie this request session to its trace: the @sentry/hono transaction wraps
-    // the whole handler (the executor + the WS round-trip to the provider run
-    // within it), so these attributes make the session identifiable in the trace.
-    Sentry.getActiveSpan()?.setAttributes({
-      'bridge.agent': conn.agentId,
-      'bridge.backend': conn.backendKind ?? 'inline',
-      'bridge.caller': caller?.principalId ?? 'public',
-    });
-
+    recordAgentRequest(c, conn, caller);
     const rawBody = await c.req.text();
     const parsed = JSON.parse(rawBody);
-    const requestedExtensions = [
-      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_HEADER)),
-      ...parseA2AExtensionsHeader(c.req.header(A2A_EXTENSIONS_LEGACY_HEADER)),
-    ];
-    const message = parsed.params?.message;
-    if (isRecord(message)) {
-      if (requestedExtensions.length > 0) {
-        const existing = Array.isArray(message.extensions)
-          ? message.extensions.filter((v: unknown): v is string => typeof v === 'string')
-          : [];
-        message.extensions = [...new Set([...existing, ...requestedExtensions])];
-      }
-      // Drop any caller-supplied `_*` metadata BEFORE injecting the verified
-      // `_principalId`. Without this scrub, a public-agent caller (where
-      // `caller` is undefined and the injection block below is a no-op)
-      // could put `_principalId: eth:victim` in their request body and have
-      // it stamped into the binding + downstream `task_*` logs as if it had
-      // been verified. The strip runs unconditionally so it also covers the
-      // restricted-agent case for any future `_*` consumer beyond
-      // `_principalId`.
-      stripCallerSuppliedInternalKeys(message);
-      // Stash caller identity under the `_principalId` convention so the
-      // WSForwardingExecutor can thread it into the task binding for
-      // accept-path log correlation (issue #128). Stripped before the WS
-      // frame leaves the bridge — the connected client never sees `_*` keys.
-      if (caller !== undefined) {
-        message.metadata = {
-          ...(isRecord(message.metadata) ? message.metadata : {}),
-          _principalId: caller.principalId,
-        };
-      }
-    }
+    prepareAgentRequestBody(parsed, c, caller);
     const handler = getHandlerForConn(conn);
     const result = await handler.handle(parsed);
     return handleHandlerResult(result, c);
+  });
+
+  // A2A v1 JSON-RPC binding. v1 method names and wire shapes are handled by a
+  // dedicated v1 A2XServer; sharing the Postgres owner scope keeps its tasks
+  // visible through the sibling HTTP+JSON binding.
+  app.post('/agents/:id/v1', authMw, async (c) => {
+    const conn = getAgentConn(c);
+    const caller = getCaller(c);
+    recordAgentRequest(c, conn, caller);
+    const rawBody = await c.req.text();
+    let body: unknown = rawBody;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      // DefaultRequestHandler accepts a string and returns the protocol's
+      // structured JSON parse error, so don't turn malformed JSON into a 500.
+    }
+    prepareAgentRequestBody(body, c, caller);
+    c.header('A2A-Version', '1.0');
+    const result = await getHandlerV1ForConn(conn).handle(body, getRequestContext(c));
+    return handleHandlerResult(result, c);
+  });
+
+  // A2A v1 HTTP+JSON binding. Operation paths are relative to the same base
+  // URL advertised for JSON-RPC, e.g. POST message:send and GET tasks/{id}.
+  app.all('/agents/:id/v1/*', httpJsonAuthMw, async (c) => {
+    const conn = getAgentConn(c);
+    const caller = getCaller(c);
+    recordAgentRequest(c, conn, caller);
+    const context = getRequestContext(c);
+    let body: unknown;
+    if (c.req.method === 'POST') {
+      const mediaType = c.req.header('Content-Type')?.split(';', 1)[0]?.trim().toLowerCase();
+      // Let the SDK produce its canonical content-type error before attempting
+      // to parse an unsupported payload format.
+      if (mediaType === 'application/a2a+json' || mediaType === 'application/json') {
+        const rawBody = await c.req.text();
+        if (rawBody.length > 0) {
+          try {
+            body = JSON.parse(rawBody);
+          } catch {
+            return handleHttpJsonResponse(
+              toHttpJsonErrorResponse(new JSONParseError('Invalid JSON request body')),
+            );
+          }
+        }
+      }
+    }
+    prepareAgentRequestBody(body, c, caller);
+    const response = await getHttpJsonV1ForConn(conn).handle({
+      method: c.req.method,
+      url: c.req.url,
+      body,
+      context,
+    });
+    return handleHttpJsonResponse(response);
   });
 
   // Admin UI — serve static SPA from /admin

--- a/packages/server/src/postgres-task-store.test.ts
+++ b/packages/server/src/postgres-task-store.test.ts
@@ -253,6 +253,55 @@ test(
 );
 
 test(
+  'listTasks paginates and remains scoped to the owning agent',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const suffix = crypto.randomUUID();
+    const ownerA = `list-owner-a-${suffix}`;
+    const ownerB = `list-owner-b-${suffix}`;
+    const contextA = `list-context-a-${suffix}`;
+    const maintenanceStore = new PostgresTaskStore(sql);
+    const createdIds: string[] = [];
+    try {
+      await ensureSchema(sql);
+      const storeA = new PostgresTaskStore(sql, { ownerAgent: ownerA });
+      const storeB = new PostgresTaskStore(sql, { ownerAgent: ownerB });
+      createdIds.push(
+        (await storeA.createTask({ contextId: contextA })).id,
+        (await storeA.createTask({ contextId: contextA })).id,
+        (await storeB.createTask({ contextId: contextA })).id,
+      );
+
+      const firstPage = await storeA.listTasks({ pageSize: 1, contextId: contextA });
+      assert.equal(firstPage.tasks.length, 1);
+      assert.equal(firstPage.totalSize, 2);
+      assert.equal(firstPage.pageSize, 1);
+      assert.equal(firstPage.nextPageToken, '1');
+      assert.equal(firstPage.tasks[0]!.artifacts, undefined);
+
+      const secondPage = await storeA.listTasks({
+        pageSize: 1,
+        pageToken: firstPage.nextPageToken,
+        contextId: contextA,
+      });
+      assert.equal(secondPage.tasks.length, 1);
+      assert.equal(secondPage.totalSize, 2);
+      assert.equal(secondPage.nextPageToken, '');
+      assert.notEqual(secondPage.tasks[0]!.id, firstPage.tasks[0]!.id);
+
+      const otherOwner = await storeB.listTasks({ contextId: contextA });
+      assert.equal(otherOwner.tasks.length, 1);
+      assert.equal(otherOwner.totalSize, 1);
+      assert.equal(createdIds.includes(otherOwner.tasks[0]!.id), true);
+    } finally {
+      await Promise.all(createdIds.map((taskId) => maintenanceStore.deleteTask(taskId)));
+      await sql.end();
+    }
+  },
+);
+
+test(
   'updateTask: concurrent updates touching different fields do not lose either write (issue #366)',
   { skip: !hasDb },
   async () => {

--- a/packages/server/src/postgres-task-store.ts
+++ b/packages/server/src/postgres-task-store.ts
@@ -3,6 +3,8 @@ import type {
   Task,
   Message,
   CreateTaskParams,
+  ListTasksParams,
+  ListTasksResult,
   TaskUpdate,
   TaskStore,
 } from '@a2x/sdk';
@@ -191,6 +193,75 @@ export class PostgresTaskStore implements ContextAwareTaskStore {
     // is never read back for request forwarding (the gateway re-sends it every
     // turn), so returning it here changes no execution behavior.
     return rows[0]?.task_json ?? null;
+  }
+
+  async listTasks(params: ListTasksParams): Promise<ListTasksResult> {
+    const pageSize = Math.min(Math.max(params.pageSize ?? 50, 1), 100);
+    const rawOffset = Number(params.pageToken ?? 0);
+    const offset = Number.isSafeInteger(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+    const status = params.status === undefined
+      ? null
+      : String(params.status)
+          .toLowerCase()
+          .replace(/^task_state_/, '')
+          .replaceAll('_', '-');
+    const parsedAfter = params.statusTimestampAfter === undefined
+      ? null
+      : Date.parse(params.statusTimestampAfter);
+
+    // Match InMemoryTaskStore's behavior for an invalid timestamp filter: it
+    // selects no tasks rather than sending an invalid timestamptz to Postgres.
+    if (parsedAfter !== null && !Number.isFinite(parsedAfter)) {
+      return { tasks: [], nextPageToken: '', pageSize, totalSize: 0 };
+    }
+
+    const ownerAgent = this.ownerAgent ?? null;
+    const contextId = params.contextId ?? null;
+    const after = parsedAfter === null ? null : new Date(parsedAfter).toISOString();
+    const countRows = await this.sql<{ total_size: string | number }[]>`
+      SELECT count(*) AS total_size
+      FROM infra.a2a_tasks
+      WHERE (${ownerAgent}::text IS NULL OR owner_agent = ${ownerAgent})
+        AND (${contextId}::text IS NULL OR context_id = ${contextId})
+        AND (${status}::text IS NULL OR task_json->'status'->>'state' = ${status})
+        AND (
+          ${after}::timestamptz IS NULL
+          OR (task_json->'status'->>'timestamp')::timestamptz >= ${after}::timestamptz
+        )
+    `;
+    const totalSize = Number(countRows[0]?.total_size ?? 0);
+    const rows = await this.sql<{ task_json: Task }[]>`
+      SELECT task_json
+      FROM infra.a2a_tasks
+      WHERE (${ownerAgent}::text IS NULL OR owner_agent = ${ownerAgent})
+        AND (${contextId}::text IS NULL OR context_id = ${contextId})
+        AND (${status}::text IS NULL OR task_json->'status'->>'state' = ${status})
+        AND (
+          ${after}::timestamptz IS NULL
+          OR (task_json->'status'->>'timestamp')::timestamptz >= ${after}::timestamptz
+        )
+      ORDER BY updated_at DESC, task_id DESC
+      OFFSET ${offset}
+      LIMIT ${pageSize}
+    `;
+    const tasks = rows.map(({ task_json }) => ({
+      ...task_json,
+      ...(params.historyLength !== undefined
+        ? {
+            history: params.historyLength === 0
+              ? []
+              : (task_json.history ?? []).slice(-params.historyLength),
+          }
+        : {}),
+      ...(!params.includeArtifacts ? { artifacts: undefined } : {}),
+    }));
+    const nextOffset = offset + tasks.length;
+    return {
+      tasks,
+      nextPageToken: nextOffset < totalSize ? String(nextOffset) : '',
+      pageSize,
+      totalSize,
+    };
   }
 
   async updateTask(taskId: string, update: TaskUpdate): Promise<Task> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
   packages/admin-ui:
     dependencies:
       '@a2x/sdk':
-        specifier: ^0.23.0
-        version: 0.23.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.24.0
+        version: 0.24.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@rainbow-me/rainbowkit':
         specifier: ^2
         version: 2.2.10(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.99.0)(@tanstack/react-query@5.99.0(react@19.2.5))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.5)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
@@ -134,8 +134,8 @@ importers:
   packages/server:
     dependencies:
       '@a2x/sdk':
-        specifier: ^0.23.0
-        version: 0.23.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
+        specifier: ^0.24.0
+        version: 0.24.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
       '@ai-sdk/anthropic':
         specifier: ^3.0.69
         version: 3.0.69(zod@3.25.76)
@@ -209,8 +209,8 @@ importers:
 
 packages:
 
-  '@a2x/sdk@0.23.0':
-    resolution: {integrity: sha512-qsh4h/F4L4z0dghQ7nRhGsqMzDxvhzB9RjFZ3kVeUn0nMV9hKML6Q79/d1Fi8tTrqViQ278G9xOAEMM0F5ZFtQ==}
+  '@a2x/sdk@0.24.0':
+    resolution: {integrity: sha512-2F51pJNGU9fFVV/VFVcbIkAYyi1Ff4loPDPl5K1NjMFiPw3EknPJVAfQxBr7Lh7rrHrV0ElAFZnuylrTYyV13w==}
     engines: {node: '>=22.11.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.52.0'
@@ -4734,7 +4734,7 @@ packages:
 
 snapshots:
 
-  '@a2x/sdk@0.23.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
+  '@a2x/sdk@0.24.0(@x402/core@2.21.0)(@x402/evm@2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.48.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)':
     optionalDependencies:
       '@x402/core': 2.21.0
       '@x402/evm': 2.21.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)

--- a/scripts/a2a-v1-smoke.mjs
+++ b/scripts/a2a-v1-smoke.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+
+const cardUrl = process.argv[2] ?? process.env.A2A_AGENT_CARD_URL;
+if (!cardUrl) {
+  console.error(
+    'usage: node scripts/a2a-v1-smoke.mjs <v1-agent-card-url>\n' +
+      '   or: A2A_AGENT_CARD_URL=<url> pnpm e2e:a2a-v1',
+  );
+  process.exit(2);
+}
+
+const bearer = process.env.A2A_BEARER_TOKEN;
+const jsonHeaders = {
+  'A2A-Version': '1.0',
+  'Content-Type': 'application/json',
+  ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+};
+
+async function readJson(response, label) {
+  const text = await response.text();
+  let body;
+  try {
+    body = text.length > 0 ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`${label}: expected JSON, got HTTP ${response.status}: ${text.slice(0, 500)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`${label}: HTTP ${response.status}: ${JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function requestJson(url, init, label) {
+  return readJson(await fetch(url, init), label);
+}
+
+function collectText(value, output = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectText(item, output);
+  } else if (value && typeof value === 'object') {
+    if (typeof value.text === 'string') output.push(value.text);
+    for (const [key, nested] of Object.entries(value)) {
+      if (key !== 'text') collectText(nested, output);
+    }
+  }
+  return output;
+}
+
+function assertCompletedEcho(task, prompt, label) {
+  assert.ok(task && typeof task === 'object', `${label}: expected a Task`);
+  assert.equal(task.status?.state, 'TASK_STATE_COMPLETED', `${label}: task did not complete`);
+  const text = collectText(task).join('\n');
+  assert.match(text, new RegExp(`echo: ${prompt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  return task.id;
+}
+
+function message(prompt) {
+  return {
+    messageId: randomUUID(),
+    role: 'ROLE_USER',
+    parts: [{ text: prompt }],
+  };
+}
+
+const card = await requestJson(cardUrl, { headers: bearer ? { Authorization: `Bearer ${bearer}` } : {} }, 'agent card');
+assert.ok(Array.isArray(card.supportedInterfaces), 'agent card: supportedInterfaces is missing');
+
+const jsonRpcInterface = card.supportedInterfaces.find(
+  (entry) => entry.protocolVersion === '1.0' && entry.protocolBinding === 'JSONRPC',
+);
+const httpJsonInterface = card.supportedInterfaces.find(
+  (entry) => entry.protocolVersion === '1.0' && entry.protocolBinding === 'HTTP+JSON',
+);
+assert.ok(jsonRpcInterface, 'agent card: JSONRPC v1 interface is missing');
+assert.ok(httpJsonInterface, 'agent card: HTTP+JSON v1 interface is missing');
+assert.equal(
+  jsonRpcInterface.url,
+  httpJsonInterface.url,
+  'agent card: the two v1 bindings should share one base URL',
+);
+
+const requiredExtensions = (card.capabilities?.extensions ?? [])
+  .filter((extension) => extension.required)
+  .map((extension) => extension.uri);
+if (requiredExtensions.length > 0) {
+  jsonHeaders['A2A-Extensions'] = requiredExtensions.join(',');
+}
+
+let rpcSequence = 0;
+async function jsonRpc(method, params) {
+  const id = `smoke-${++rpcSequence}`;
+  const response = await requestJson(
+    jsonRpcInterface.url,
+    {
+      method: 'POST',
+      headers: jsonHeaders,
+      body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    },
+    `JSON-RPC ${method}`,
+  );
+  assert.equal(response.id, id, `JSON-RPC ${method}: response id mismatch`);
+  assert.equal(response.jsonrpc, '2.0', `JSON-RPC ${method}: invalid envelope`);
+  assert.ok(!response.error, `JSON-RPC ${method}: ${JSON.stringify(response.error)}`);
+  return response.result;
+}
+
+const rpcPrompt = `v1-rpc-${randomUUID().slice(0, 8)}`;
+const rpcTask = await jsonRpc('SendMessage', {
+  message: message(rpcPrompt),
+  configuration: { returnImmediately: false },
+});
+const rpcTaskId = assertCompletedEcho(rpcTask, rpcPrompt, 'JSON-RPC SendMessage');
+
+const restTask = await requestJson(
+  `${httpJsonInterface.url}/tasks/${encodeURIComponent(rpcTaskId)}`,
+  { headers: jsonHeaders },
+  'HTTP+JSON GetTask for JSON-RPC task',
+);
+assert.equal(restTask.id, rpcTaskId, 'HTTP+JSON GetTask: task id mismatch');
+assertCompletedEcho(restTask, rpcPrompt, 'HTTP+JSON GetTask for JSON-RPC task');
+
+const restPrompt = `v1-rest-${randomUUID().slice(0, 8)}`;
+const restSend = await requestJson(
+  `${httpJsonInterface.url}/message:send`,
+  {
+    method: 'POST',
+    headers: jsonHeaders,
+    body: JSON.stringify({
+      message: message(restPrompt),
+      configuration: { returnImmediately: false },
+    }),
+  },
+  'HTTP+JSON SendMessage',
+);
+const restTaskId = assertCompletedEcho(restSend.task, restPrompt, 'HTTP+JSON SendMessage');
+
+const rpcGet = await jsonRpc('GetTask', { id: restTaskId });
+assert.equal(rpcGet.id, restTaskId, 'JSON-RPC GetTask: task id mismatch');
+assertCompletedEcho(rpcGet, restPrompt, 'JSON-RPC GetTask for HTTP+JSON task');
+
+const listed = await requestJson(
+  `${httpJsonInterface.url}/tasks?pageSize=100&includeArtifacts=true`,
+  { headers: jsonHeaders },
+  'HTTP+JSON ListTasks',
+);
+const listedIds = new Set((listed.tasks ?? []).map((task) => task.id));
+assert.ok(listedIds.has(rpcTaskId), 'HTTP+JSON ListTasks: JSON-RPC task is missing');
+assert.ok(listedIds.has(restTaskId), 'HTTP+JSON ListTasks: HTTP+JSON task is missing');
+
+console.log(JSON.stringify({
+  ok: true,
+  cardUrl,
+  baseUrl: jsonRpcInterface.url,
+  transports: ['JSONRPC', 'HTTP+JSON'],
+  rpcTaskId,
+  restTaskId,
+  listedTasks: listed.tasks.length,
+}, null, 2));


### PR DESCRIPTION
## Summary

- bump `@a2x/sdk` from 0.23.0 to 0.24.0 in the private server/admin-ui packages
- preserve the existing per-agent A2A v0.3 card and JSON-RPC endpoint
- add a versioned A2A v1 card at `/agents/:id/v1/.well-known/agent-card.json`
- advertise and serve both v1 JSON-RPC and HTTP+JSON on the shared `/agents/:id/v1` base URL
- expose the v1 HTTP+JSON operation surface, including owner-scoped, paginated task listing
- return `google.rpc.Status`-shaped auth failures for HTTP+JSON while retaining JSON-RPC auth envelopes
- normalize discriminator-free A2A v1 message parts into the bridge WebSocket wire format
- add a dependency-free local v1 smoke client that cross-checks tasks between JSON-RPC and HTTP+JSON
- document the local echo-agent E2E flow and omit a changeset because only root tooling/docs and ignored private packages are affected

## Verification

- `pnpm install --frozen-lockfile --offline`
- `pnpm -r build`
- `pnpm -r typecheck`
- `pnpm --filter @vicoop-bridge/server test` (346 passed, 72 skipped, 0 failed)
- focused executor and v1 card/JSON-RPC/HTTP+JSON/auth/CORS tests (26 passed, 0 failed)
- real local PostgreSQL + server + WebSocket echo-client E2E with `pnpm e2e:a2a-v1`
  - JSON-RPC SendMessage → HTTP+JSON GetTask
  - HTTP+JSON SendMessage → JSON-RPC GetTask
  - HTTP+JSON ListTasks contains both completed tasks
- independent `a2x` v1 AgentCard, send, and persisted task-get verification
- ESM import smoke test for `@a2x/sdk` from `packages/server`
- `node --check scripts/a2a-v1-smoke.mjs`
- `git diff --check`
