### PR TITLE
Fix Claude spawn for caller-context tasks

### DIFF
--- a/.changeset/calm-bridges-merge.md
+++ b/.changeset/calm-bridges-merge.md
@@ -1,0 +1,5 @@
+---
+'@vicoop-bridge/client': patch
+---
+
+Merge Claude identity and caller-policy append prompts into one staged file so plain A2A tasks with caller context can spawn successfully.

--- a/docs/install-client.md
+++ b/docs/install-client.md
@@ -766,11 +766,14 @@ process. Set it when the released bundle lives outside the repository you
 want Claude to edit. (Same flag is shared with the Codex backend; it's
 scoped to whichever backend `--backend` selects.)
 
-The Claude backend also injects a small `--append-system-prompt` on every
+The Claude backend also injects a small appended system prompt on every
 spawned `claude` telling it its own A2A mention (`@<agentId>@<host>`) so
 the model recognises self-references in user messages and doesn't try to
-a2a-call its own address (see #128). No configuration required — it's
-derived from `--agentId` and the host part of `--server`.
+a2a-call its own address (see #128). It normally uses
+`--append-system-prompt`; plain A2A tasks carrying caller context merge it
+into the staged caller-policy `--append-system-prompt-file` instead. No
+configuration is required — the identity is derived from `--agentId` and
+the host part of `--server`.
 
 > **Note on host derivation.** The injected mention uses the server URL's
 > host (e.g. `wss://bridge.example.com/ws` → `bridge.example.com`). The

--- a/packages/client/src/backends/claude.test.ts
+++ b/packages/client/src/backends/claude.test.ts
@@ -1290,6 +1290,54 @@ test('plain caller policy is staged 0600 while caller values ride stdin and stay
   assert.match(allLogs, /claude\.spawn\.start/);
 });
 
+test('plain caller policy merges identity and operator appends into one staged file (#484)', async () => {
+  const fake = scriptedSpawn({
+    lines: [JSON.stringify({ type: 'result', result: 'ok' })],
+    exitCode: 0,
+  });
+  const backend = createClaudeBackend({
+    spawn: fake.spawn,
+    identity: {
+      agentId: 'issue-484-agent',
+      host: 'bridge.example',
+      httpOrigin: 'https://bridge.example',
+    },
+    extraArgs: [
+      '--append-system-prompt',
+      'OPERATOR FIRST',
+      '--append-system-prompt=OPERATOR SECOND',
+    ],
+  });
+  const task = assign('hello');
+  task.caller = { authenticated: { principalId: 'caller-484-private' } };
+  await backend.handle(task, collect().emit, NEVER);
+
+  const child = fake.lastChild();
+  assert.ok(child);
+  assert.equal(child.args.includes('--append-system-prompt'), false);
+  assert.equal(
+    child.args.some((arg) => String(arg).startsWith('--append-system-prompt=')),
+    false,
+  );
+  assert.equal(
+    child.args.filter((arg) => arg === '--append-system-prompt-file').length,
+    1,
+  );
+  const prompt = child.appendSystemPromptFileContent ?? '';
+  assert.match(prompt, /@issue-484-agent@bridge\.example/);
+  assert.match(prompt, /inert attribution data/);
+  assert.match(prompt, /OPERATOR FIRST/);
+  assert.match(prompt, /OPERATOR SECOND/);
+  assert.ok(prompt.indexOf('@issue-484-agent@bridge.example') < prompt.indexOf('inert attribution data'));
+  assert.ok(prompt.indexOf('inert attribution data') < prompt.indexOf('OPERATOR FIRST'));
+  assert.ok(prompt.indexOf('OPERATOR FIRST') < prompt.indexOf('OPERATOR SECOND'));
+  assert.doesNotMatch(prompt, /caller-484-private/);
+  assert.match(child.stdinPayload, /caller-484-private/);
+  assert.equal(child.appendSystemPromptFileMode, 0o600);
+  assert.ok(child.appendSystemPromptFilePath);
+  await assert.rejects(fs.stat(child.appendSystemPromptFilePath));
+});
+
 test('identity args precede extraArgs so operator extraArgs override', async () => {
   const fake = scriptedSpawn({
     lines: [JSON.stringify({ type: 'result', result: 'ok' })],
@@ -1474,6 +1522,7 @@ test('debug log records claude spawn shape and spawn errors', async () => {
   const oldLog = console.log;
   const logs: string[] = [];
   let callerPromptPath: string | null = null;
+  let callerPromptContent: string | null = null;
   process.env.VICOOP_CLIENT_LOG_LEVEL = 'debug';
   console.log = (...args: unknown[]) => {
     logs.push(args.map(String).join(' '));
@@ -1483,6 +1532,9 @@ test('debug log records claude spawn shape and spawn errors', async () => {
       spawn: (_command, args) => {
         const idx = args.indexOf('--append-system-prompt-file');
         callerPromptPath = idx === -1 ? null : String(args[idx + 1]);
+        callerPromptContent = callerPromptPath === null
+          ? null
+          : readFileSync(callerPromptPath, 'utf8');
         throw new Error('ENOENT: claude missing');
       },
       settings: { sandbox: { enabled: true } },
@@ -1505,8 +1557,7 @@ test('debug log records claude spawn shape and spawn errors', async () => {
       /argv=.*--settings/.test(line) &&
       line.includes('sandbox') &&
       line.includes('enabled') &&
-      line.includes('true') &&
-      line.includes('operator secret-ish prompt')
+      line.includes('true')
     ),
     `expected raw spawn start debug log, got:\n${logs.join('\n')}`,
   );
@@ -1517,7 +1568,9 @@ test('debug log records claude spawn shape and spawn errors', async () => {
     ),
     `expected spawn error debug log, got:\n${logs.join('\n')}`,
   );
+  assert.doesNotMatch(logs.join('\n'), /operator secret-ish prompt/);
   assert.doesNotMatch(logs.join('\n'), /caller-private-spawn-error/);
+  assert.match(callerPromptContent ?? '', /operator secret-ish prompt/);
   assert.ok(callerPromptPath);
   await assert.rejects(fs.stat(callerPromptPath), 'spawn failure must delete caller prompt file');
   await assert.rejects(

--- a/packages/client/src/backends/claude.ts
+++ b/packages/client/src/backends/claude.ts
@@ -133,10 +133,12 @@ export interface ClaudeBackendOptions {
   // Fetch uri-only inbound FileParts under the shared HTTPS/SSRF/size/MIME
   // policy. Enabled by default; set enabled:false to require inline bytes.
   fetchUriPolicy?: FetchUriPolicy;
-  // Agent's own A2A identity. When present, an `--append-system-prompt` is
+  // Agent's own A2A identity. When present, an appended system prompt is
   // injected on every spawned `claude` so the model can recognise its own
   // mention (`@<agentId>@<host>`) / acct in user messages and respond
   // directly instead of attempting an outbound A2A call to its own address.
+  // It normally rides `--append-system-prompt`; plain A2A tasks with caller
+  // context merge it into the caller-policy `--append-system-prompt-file`.
   // See issue #128 for the failure mode this prevents.
   identity?: AgentIdentity;
   // Inline Claude Code settings JSON forwarded to each spawned `claude` via
@@ -1265,9 +1267,9 @@ export function openaiToolsToCallerToolDefs(
   return out.length > 0 ? out : null;
 }
 
-// Build the system-prompt text injected via `--append-system-prompt` for the
-// openai-compat path on the claude backend (#213). The caller's tools are
-// exposed to the model through the native MCP tool surface
+// Build the system-prompt text injected through Claude's append-system-prompt
+// channel for the openai-compat path on the claude backend (#213). The
+// caller's tools are exposed to the model through the native MCP tool surface
 // (`caller-tools-mcp.ts`), so the prompt no longer teaches a JSON-emit
 // contract or duplicates the tool list — the model discovers tools via
 // `tools/list` and invokes them through its normal `tool_use` surface.
@@ -1715,12 +1717,33 @@ export function createClaudeBackend(
     opts.sendFileMcp && opts.sendFileMcp.allowedRoots.length > 0
       ? opts.sendFileMcp
       : null;
-  // Static per-backend args (placed before extraArgs so an operator-supplied
-  // `--append-system-prompt` in extraArgs concatenates AFTER ours rather than
-  // being ignored — claude appends each occurrence in order).
-  const identityArgs: readonly string[] = opts.identity
-    ? ['--append-system-prompt', buildSelfIdentitySystemPrompt(opts.identity)]
+  // Static per-backend identity prompt. It normally rides argv, before
+  // extraArgs, so an operator-supplied `--append-system-prompt` concatenates
+  // AFTER ours. Plain A2A tasks with caller context instead fold every inline
+  // append into the staged caller-policy file below: claude rejects mixing
+  // `--append-system-prompt` with `--append-system-prompt-file`.
+  const identityPrompt = opts.identity
+    ? buildSelfIdentitySystemPrompt(opts.identity)
+    : undefined;
+  const identityArgs: readonly string[] = identityPrompt
+    ? ['--append-system-prompt', identityPrompt]
     : [];
+  const extraInlineAppendPrompts: string[] = [];
+  const extraArgsWithoutInlineAppend: string[] = [];
+  for (let i = 0; i < extraArgs.length; i += 1) {
+    const arg = extraArgs[i];
+    if (arg === '--append-system-prompt' && i + 1 < extraArgs.length) {
+      extraInlineAppendPrompts.push(extraArgs[i + 1]);
+      i += 1;
+      continue;
+    }
+    const inlinePrefix = '--append-system-prompt=';
+    if (arg.startsWith(inlinePrefix)) {
+      extraInlineAppendPrompts.push(arg.slice(inlinePrefix.length));
+      continue;
+    }
+    extraArgsWithoutInlineAppend.push(arg);
+  }
   // Sandbox-on by default. Operators get the OS-level sandbox (Seatbelt on
   // macOS, bubblewrap on Linux) without having to opt in via
   // `CLAUDE_SETTINGS_JSON`, and `failIfUnavailable: true` makes the daemon
@@ -2546,17 +2569,25 @@ export function createClaudeBackend(
       const modelArgs: readonly string[] = envelopeModel
         ? ['--model', envelopeModel]
         : [];
-      // Plain A2A runs keep their normal system prompt and receive only the
-      // static caller-context handling rule through a per-spawn append.
-      // Dynamic caller values ride in the user content blocks above.
+      // Plain A2A runs keep their normal system prompt and receive the static
+      // caller-context handling rule through a per-spawn append. Dynamic
+      // caller values ride in the user content blocks above. When identity or
+      // operator append prompts are also present, merge them into this one
+      // staged file in their original order. Claude treats the inline and file
+      // append flags as mutually exclusive, so emitting both aborts at spawn.
       let callerArgs: readonly string[] = [];
+      let identityArgsForTask = identityArgs;
+      let extraArgsForTask = extraArgs;
       if (!envelope && callerPrompt) {
         try {
+          const bridgePrompt = appendCallerContextInstruction(identityPrompt, task.caller) ?? '';
           callerArgs = stageSystemPrompt(
             '--append-system-prompt-file',
-            'caller-context-policy.txt',
-            appendCallerContextInstruction(undefined, task.caller) ?? '',
+            'bridge-append-prompt.txt',
+            [bridgePrompt, ...extraInlineAppendPrompts].join('\n\n'),
           );
+          identityArgsForTask = [];
+          extraArgsForTask = extraArgsWithoutInlineAppend;
         } catch (err) {
           cleanupStagedSystemPromptFile();
           rollbackFreshSession();
@@ -2566,7 +2597,7 @@ export function createClaudeBackend(
             taskId: task.taskId,
             error: normalizeTaskFailError({
               code: 'spawn_failed',
-              message: `failed to stage caller-context system prompt file: ${errorMessage(err)}`,
+              message: `failed to stage plain A2A system prompt file: ${errorMessage(err)}`,
             }),
           });
           return;
@@ -2667,7 +2698,7 @@ export function createClaudeBackend(
         ...(isResume ? ['--resume', sessionId] : ['--session-id', sessionId]),
         ...mcpConfigArgs,
         ...mcpAllowedToolsArgs,
-        ...identityArgs,
+        ...identityArgsForTask,
         ...callerArgs,
         ...modelArgs,
         ...openaiCompatArgs,
@@ -2676,7 +2707,7 @@ export function createClaudeBackend(
         ...nativeTurnCapArgs,
         '--include-partial-messages',
         ...settingsArgs,
-        ...extraArgs,
+        ...extraArgsForTask,
       ];
 
       // openai-compat tasks spawn in the isolation cwd (no *project* CLAUDE.md /


### PR DESCRIPTION
## Summary

- merge the Claude self-identity and caller handling policy into one staged --append-system-prompt-file for plain A2A tasks carrying caller context
- fold operator --append-system-prompt extra args into the same file in their original order, avoiding the mutually exclusive inline/file flag pair
- preserve 0600 staging, cleanup, and the rule that dynamic caller values remain in user-role stdin content
- document the conditional file delivery and add a client patch changeset

## Testing

- pnpm -r build
- pnpm -r typecheck
- pnpm --filter @vicoop-bridge/client test (915 passed)
- real Claude Code 2.1.245 parser smoke test reached a deliberately invalid MCP config instead of the append-prompt flag conflict

Closes #484