### PR TITLE
fix(server): persist token-exchange attestations as JSON objects

### DIFF
--- a/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
+++ b/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
@@ -148,6 +148,7 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
       throw new Error(`unexpected SQL in conformance route test: ${statement}`);
     }) as unknown as Sql;
     sql.begin = (async (callback: (tx: Sql) => unknown) => callback(sql)) as unknown as Sql['begin'];
+    sql.json = ((value: unknown) => value) as Sql['json'];
     const app = new Hono();
     mountTokenExchangeRoutes(app, {
       sql,

--- a/packages/server/src/oauth/token-exchange/routes.test.ts
+++ b/packages/server/src/oauth/token-exchange/routes.test.ts
@@ -98,7 +98,7 @@ function requestBody(subjectAssertion: string, clientAssertion: string): URLSear
 
 function sqlWithPolicy(
   allowedCallers: string[],
-  inserted: string[] = [],
+  inserted: unknown[] = [],
   tokenRows: unknown[][] = [],
   task?: {
     principalId: string;
@@ -117,9 +117,7 @@ function sqlWithPolicy(
     }
     if (statement.includes('INSERT INTO infra.oauth_token_exchange_access_tokens')) {
       tokenRows.push(values);
-      inserted.push(
-        String(values.find((value) => typeof value === 'string' && value.startsWith('{'))),
-      );
+      inserted.push(values[6]);
       return [{ id: 'token-row-1' }];
     }
     if (statement.includes('FROM infra.a2a_tasks')) {
@@ -139,6 +137,7 @@ function sqlWithPolicy(
   }) as unknown as Sql;
   (query as Sql & { begin: Sql['begin'] }).begin = (async (callback: (tx: Sql) => unknown) =>
     callback(query)) as unknown as Sql['begin'];
+  query.json = ((value: unknown) => value) as Sql['json'];
   return query;
 }
 
@@ -377,7 +376,7 @@ test('successful exchange stores only a normalized, non-secret attestation', asy
     subject,
   });
   assert.ok(authorizationKey);
-  const inserted: string[] = [];
+  const inserted: unknown[] = [];
   const tokenRows: unknown[][] = [];
   const resolver: DidDocumentResolver = {
     async resolve() {
@@ -407,7 +406,7 @@ test('successful exchange stores only a normalized, non-secret attestation', asy
   assert.equal(tokenRows[0]?.[3], subject, 'effective principal is the platform subject');
   assert.equal(tokenRows[0]?.[4], issuer, 'actor is the authenticated Connector DID');
   assert.equal(tokenRows[0]?.[5], authorizationKey, 'policy binding retains the exact tuple');
-  const attestation = JSON.parse(inserted[0]!) as Record<string, string>;
+  const attestation = inserted[0] as Record<string, string>;
   assert.deepEqual(
     {
       issuer: attestation.issuer,
@@ -417,8 +416,9 @@ test('successful exchange stores only a normalized, non-secret attestation', asy
     { issuer, subject, method },
   );
   assert.match(attestation.credentialId!, /^urn:mentionable:oauth-assertion:/);
-  assert.equal(inserted[0]!.includes(fixture.subjectAssertion), false);
-  assert.equal(inserted[0]!.includes(fixture.clientAssertion), false);
+  const serializedAttestation = JSON.stringify(attestation);
+  assert.equal(serializedAttestation.includes(fixture.subjectAssertion), false);
+  assert.equal(serializedAttestation.includes(fixture.clientAssertion), false);
 });
 
 test('client assertion verification failures map to invalid_client', async () => {

--- a/packages/server/src/oauth/token-exchange/store.test.ts
+++ b/packages/server/src/oauth/token-exchange/store.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import postgres from 'postgres';
+import {
+  issueTokenExchangeAccessToken,
+  verifyTokenExchangeAccessToken,
+} from './store.js';
+
+const hasDb = !!process.env.DATABASE_URL;
+
+test(
+  'token-exchange attestations round-trip through Postgres as JSON objects',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const tag = `token-exchange-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const agentId = `${tag}-agent`;
+    const allowedCaller = `${tag}-caller`;
+    const attestation = {
+      credentialId: `urn:${tag}:credential`,
+      issuer: `did:web:${tag}.example`,
+      subject: `slack:${tag}`,
+      method: 'urn:mentionable:auth:test',
+    };
+
+    try {
+      await sql`
+        INSERT INTO agents (id, owner_principal, name, token_hash, allowed_callers)
+        VALUES (${agentId}, ${`${tag}-owner`}, 'token-exchange-test', ${`${tag}-hash`},
+                ${[allowedCaller]})
+      `;
+
+      const issued = await issueTokenExchangeAccessToken(sql, {
+        profileId: 'urn:test:token-exchange',
+        agentId,
+        resource: `https://bridge.test/agents/${agentId}`,
+        principalId: `slack:${tag}`,
+        actorId: `did:web:${tag}.example`,
+        allowedCaller,
+        attestation,
+        scopes: ['a2a:message.send'],
+        expiresAt: new Date(Date.now() + 60_000),
+      });
+
+      const [stored] = await sql<{ attestation: unknown; kind: string }[]>`
+        SELECT attestation, jsonb_typeof(attestation) AS kind
+        FROM infra.oauth_token_exchange_access_tokens
+        WHERE id = ${issued.token.tokenId}
+      `;
+      assert.equal(stored?.kind, 'object');
+      assert.deepEqual(stored?.attestation, attestation);
+
+      const verified = await verifyTokenExchangeAccessToken(sql, issued.rawToken, agentId);
+      assert.deepEqual(verified.attestation, attestation);
+    } finally {
+      await sql`DELETE FROM agents WHERE id = ${agentId}`;
+      await sql.end();
+    }
+  },
+);

--- a/packages/server/src/oauth/token-exchange/store.ts
+++ b/packages/server/src/oauth/token-exchange/store.ts
@@ -102,7 +102,7 @@ export async function issueTokenExchangeAccessToken(
     SELECT
       ${hashToken(rawToken)}, ${input.profileId}, a.id, ${input.resource}, ${input.principalId},
       ${input.actorId}, ${input.allowedCaller},
-      ${input.attestation ? JSON.stringify(input.attestation) : null}::jsonb,
+      ${input.attestation ? sql.json(input.attestation) : null},
       ${input.scopes}, ${input.taskId ?? null}, ${input.expiresAt}
     FROM (
       SELECT id


### PR DESCRIPTION
## Summary

- persist normalized token-exchange attestations with the postgres.js JSON helper instead of pre-serializing them
- update SQL mocks to model JSON parameters as objects
- add a real-Postgres issue/verify round-trip regression test that asserts the JSONB and recovered attestation remain objects

Fixes #491.

## Why

Passing `JSON.stringify(attestation)` to a parameter inferred as JSONB makes postgres.js serialize the string again. PostgreSQL therefore stores a JSON string scalar, and `verifyTokenExchangeAccessToken()` rejects the recovered value against `CallerAttestationV2`.

## Testing

- `pnpm -r typecheck`
- `pnpm --filter @vicoop-bridge/server test` (512 tests: 435 passed, 77 DB-dependent tests skipped)
- `DATABASE_URL=<temporary-local-postgres> pnpm --filter @vicoop-bridge/server exec tsx --test src/oauth/token-exchange/store.test.ts` (1 passed, 0 skipped)

No changeset: this PR only changes `@vicoop-bridge/server`, which is deployed via `fly deploy` and ignored by Changesets.
