### PR TITLE
fix(server): sync final Mentionable OAuth federation v0.1 contract

### DIFF
--- a/docs/manage-federated-callers.md
+++ b/docs/manage-federated-callers.md
@@ -309,3 +309,7 @@ Tuple authorization is only the first gate. Check DID reachability and its
 `assertionMethod`, EdDSA keys, assertion audience, type, timestamps, `jti`,
 requested resource, and scopes. See the protocol checks in
 [`oauth-federation.md`](./oauth-federation.md#discovery-and-exchange).
+The bridge retries a key miss or signature mismatch once with a bounded forced
+DID refresh. DNS, timeout, and upstream failures during either lookup return a
+retryable OAuth `server_error`; restore DID endpoint reachability before
+retrying with freshly minted assertions.

--- a/docs/oauth-federation.md
+++ b/docs/oauth-federation.md
@@ -26,7 +26,10 @@ resource authorization without being interpreted under Mentionable semantics.
 Each profile must also declare whether replay protection is required or not
 applicable. Replay-required profiles either return single-use evidence for the
 core to persist or register it atomically inside the verifier when the profile
-contract requires replay rejection before verification returns.
+contract requires replay rejection before verification returns. The
+Mentionable profile stages the client and subject tuples during cryptographic
+verification and commits both in one transaction only after every profile
+check succeeds.
 
 ## Connector-kit dependency status
 
@@ -73,7 +76,9 @@ The bridge parses unverified assertion claims only to select one exact
 receiver-owned allowed-caller entry. A miss is rejected before DID resolution.
 On a hit, it verifies EdDSA, explicit `typ`, the DID `assertionMethod`
 relationship, `iss`/`sub`/`aud`/`iat`/`exp`/`jti`, method, lifetime, and replay.
-A DID signature alone never grants access.
+A DID signature alone never grants access. A missing key or signature mismatch
+triggers one bounded cache-bypassing DID refresh to accommodate key rotation;
+resolution and refresh transport failures return a retryable `server_error`.
 
 ## Operator configuration
 

--- a/docs/oauth-federation.md
+++ b/docs/oauth-federation.md
@@ -24,15 +24,16 @@ operation independently of any profile, then dispatches authorization by that
 identifier. A future profile therefore supplies both exchange verification and
 resource authorization without being interpreted under Mentionable semantics.
 Each profile must also declare whether replay protection is required or not
-applicable; the core refuses issuance when a replay-required profile returns no
-single-use replay evidence.
+applicable. Replay-required profiles either return single-use evidence for the
+core to persist or register it atomically inside the verifier when the profile
+contract requires replay rejection before verification returns.
 
 ## Connector-kit dependency status
 
 The package boundary is intentional, but the copy under
 `vendor/mentionable-connector-kit` is temporary. The authoritative source is
 `packages/connector-kit` in the `planetarium/mentionable` repository. This
-bridge currently pins commit `f32c8898c7d81b254ec9a562ea2892525db14de6`
+bridge currently pins commit `61d86728e841b0ca796c86364b2fa881ef66c87d`
 because the upstream package is still an unpublished `0.0.0` workspace package
 whose `workspace:*` dependencies cannot be installed by a consumer repository.
 

--- a/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
+++ b/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
@@ -13,7 +13,12 @@ import {
 import type { Sql } from '../../db.js';
 import { formatFederatedPrincipal } from '../../auth/principal.js';
 import { mountTokenExchangeRoutes } from '../token-exchange/routes.js';
-import { createMentionableOAuthProfile, MENTIONABLE_OAUTH_PROFILE_ID } from './mentionable-v0.1.js';
+import {
+  createMentionableOAuthProfile,
+  MENTIONABLE_OAUTH_PROFILE_ID,
+  OAUTH_FEDERATION_TYP_CLIENT_ASSERTION,
+  OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION,
+} from './mentionable-v0.1.js';
 
 const fixtureRoot = fileURLToPath(
   new URL('../../../../../vendor/mentionable-connector-kit/fixtures/', import.meta.url),
@@ -46,9 +51,11 @@ test('Mentionable profile keeps the connector-kit v0.1 conformance manifest gree
   for (const entry of manifest) {
     const fixture = await json(entry.file);
     if (entry.kind === 'assertion') {
+      const fixtureIssuerDocument = (fixture.issuerDocument ?? issuerDocument) as IssuerDidDocument;
       const outcome = await verifyOAuthFederationAssertion(fixture.jwt, fixture.verification, {
-        trustedIssuers,
-        resolveIssuerDocument,
+        trustedIssuers: new Set([fixtureIssuerDocument.id]),
+        resolveIssuerDocument: (issuer) =>
+          issuer === fixtureIssuerDocument.id ? fixtureIssuerDocument : undefined,
       });
       assert.equal(outcome.ok, entry.expect === 'accept', entry.file);
       if (!outcome.ok) assert.equal(outcome.reason, entry.reason, entry.file);
@@ -61,6 +68,8 @@ test('Mentionable profile keeps the connector-kit v0.1 conformance manifest gree
         expectedResource: fixture.evaluation.expectedResource,
         trustedIssuers,
         resolveIssuerDocument,
+        authorizeCandidateBeforeFetch: () => true,
+        replayCache: createInMemoryAssertionReplayCache(),
       });
       assert.equal(outcome.ok, entry.expect === 'accept', entry.file);
       if (!outcome.ok) assert.equal(outcome.reason, entry.reason, entry.file);
@@ -100,7 +109,11 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
   const issuer = issuerDocument.id;
   const subject = 'slack:T0123456/U0456789';
   const method = 'urn:mentionable:auth:slack-workspace-member:v0.1';
-  const authorizationKey = formatFederatedPrincipal({ issuer, subject, method });
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    subject,
+    method,
+  });
   assert.ok(authorizationKey);
   const publicUrl = 'https://sts.oauth-fixtures.mentionable.dev';
   const resource = `${publicUrl}/agents/fixture-agent`;
@@ -110,11 +123,14 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
     'resource-substitution': 'invalid_target',
     'duplicate-parameter': 'invalid_request',
     'message-scope-requires-subject-assertion': 'invalid_request',
+    'missing-scope': 'invalid_scope',
+    'missing-requested-token-type': 'invalid_request',
+    'unsupported-requested-token-type': 'invalid_request',
     'unknown-scope': 'invalid_scope',
   };
 
   for (const entry of manifest.filter((candidate) => candidate.kind === 'exchange-request')) {
-    const fixture = await json(entry.file) as {
+    const fixture = (await json(entry.file)) as {
       params: Record<string, string | string[]>;
       evaluation: { expectedResource: string; verifiedAt: string };
     };
@@ -132,12 +148,14 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
         return [{ allowed_callers: [authorizationKey] }];
       }
       if (statement.includes('FROM infra.a2a_tasks')) {
-        return [{
-          owner_principal: subject,
-          owner_actor: issuer,
-          authorization_profile: MENTIONABLE_OAUTH_PROFILE_ID,
-          authorization_key: authorizationKey,
-        }];
+        return [
+          {
+            owner_principal: subject,
+            owner_actor: issuer,
+            authorization_profile: MENTIONABLE_OAUTH_PROFILE_ID,
+            authorization_key: authorizationKey,
+          },
+        ];
       }
       if (statement.includes('INSERT INTO infra.oauth_token_exchange_replays')) {
         return [{ digest: 'fixture-replay' }];
@@ -147,19 +165,24 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
       }
       throw new Error(`unexpected SQL in conformance route test: ${statement}`);
     }) as unknown as Sql;
-    sql.begin = (async (callback: (tx: Sql) => unknown) => callback(sql)) as unknown as Sql['begin'];
+    sql.begin = (async (callback: (tx: Sql) => unknown) =>
+      callback(sql)) as unknown as Sql['begin'];
     sql.json = ((value: unknown) => value) as Sql['json'];
     const app = new Hono();
     mountTokenExchangeRoutes(app, {
       sql,
       publicUrl,
-      profiles: [{
-        ...createMentionableOAuthProfile({
-          resolver: {
-            async resolve() { return issuerDocument as never; },
-          },
-        }),
-      }],
+      profiles: [
+        {
+          ...createMentionableOAuthProfile({
+            resolver: {
+              async resolve() {
+                return issuerDocument as never;
+              },
+            },
+          }),
+        },
+      ],
       now: () => new Date(fixture.evaluation.verifiedAt),
     });
     const response = await app.request('/oauth/token', {
@@ -169,9 +192,105 @@ test('bridge STS route accepts and rejects the connector-kit exchange fixtures',
     });
     assert.equal(response.ok, entry.expect === 'accept', entry.file);
     if (!response.ok) {
-      const body = await response.json() as { error: string; rejection_id?: string };
+      const body = (await response.json()) as {
+        error: string;
+        rejection_id?: string;
+      };
       assert.equal(body.error, expectedErrors[entry.reason!], entry.file);
       assert.match(body.rejection_id!, /^rej_/, entry.file);
     }
+  }
+});
+
+test('every assertion fixture also reaches the bridge STS route', async () => {
+  const manifest = (await json('manifest.json')) as unknown as Array<{
+    file: string;
+    kind: 'assertion' | 'exchange-request' | 'replay';
+    expect: 'accept' | 'reject';
+  }>;
+  const defaultIssuerDocument = (await json('issuer/did.json')) as unknown as IssuerDidDocument;
+  const issuer = defaultIssuerDocument.id;
+  const subject = 'slack:T0123456/U0456789';
+  const method = 'urn:mentionable:auth:slack-workspace-member:v0.1';
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    subject,
+    method,
+  });
+  assert.ok(authorizationKey);
+  const publicUrl = 'https://sts.oauth-fixtures.mentionable.dev';
+  const resource = `${publicUrl}/agents/fixture-agent`;
+
+  for (const entry of manifest.filter((candidate) => candidate.kind === 'assertion')) {
+    const fixture = (await json(entry.file)) as {
+      jwt: string;
+      verification: { typ: string; verifiedAt: string };
+      issuerDocument?: IssuerDidDocument;
+    };
+    const continuation =
+      fixture.verification.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION;
+    const base = (await json(
+      continuation
+        ? 'valid/exchange-request-task-scopes.json'
+        : 'valid/exchange-request-delegation.json',
+    )) as { params: Record<string, string | string[]> };
+    const params = paramsFromFixture(base.params);
+    if (fixture.verification.typ === OAUTH_FEDERATION_TYP_CLIENT_ASSERTION) {
+      params.set('client_assertion', fixture.jwt);
+    } else {
+      params.set('subject_token', fixture.jwt);
+    }
+    params.set('resource', resource);
+
+    const sql = (async (strings: TemplateStringsArray) => {
+      const statement = strings.join('?');
+      if (statement.includes('SELECT allowed_callers FROM agents')) {
+        return [{ allowed_callers: [authorizationKey] }];
+      }
+      if (statement.includes('FROM infra.a2a_tasks')) {
+        return [
+          {
+            owner_principal: subject,
+            owner_actor: issuer,
+            authorization_profile: MENTIONABLE_OAUTH_PROFILE_ID,
+            authorization_key: authorizationKey,
+            authorization_revoked: false,
+          },
+        ];
+      }
+      if (statement.includes('INSERT INTO infra.oauth_token_exchange_replays')) {
+        return [{ digest: 'fixture-replay' }];
+      }
+      if (statement.includes('INSERT INTO infra.oauth_token_exchange_access_tokens')) {
+        return [{ id: 'fixture-token' }];
+      }
+      throw new Error(`unexpected SQL in assertion conformance test: ${statement}`);
+    }) as unknown as Sql;
+    sql.begin = (async (callback: (tx: Sql) => unknown) =>
+      callback(sql)) as unknown as Sql['begin'];
+    sql.json = ((value: unknown) => value) as Sql['json'];
+
+    const issuerDocument = fixture.issuerDocument ?? defaultIssuerDocument;
+    const app = new Hono();
+    mountTokenExchangeRoutes(app, {
+      sql,
+      publicUrl,
+      profiles: [
+        createMentionableOAuthProfile({
+          resolver: {
+            async resolve() {
+              return issuerDocument as never;
+            },
+          },
+        }),
+      ],
+      now: () => new Date(fixture.verification.verifiedAt),
+    });
+    const response = await app.request('/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params,
+    });
+    assert.equal(response.ok, entry.expect === 'accept', entry.file);
   }
 });

--- a/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
+++ b/packages/server/src/oauth/profiles/mentionable-conformance.test.ts
@@ -207,6 +207,7 @@ test('every assertion fixture also reaches the bridge STS route', async () => {
     file: string;
     kind: 'assertion' | 'exchange-request' | 'replay';
     expect: 'accept' | 'reject';
+    reason?: string;
   }>;
   const defaultIssuerDocument = (await json('issuer/did.json')) as unknown as IssuerDidDocument;
   const issuer = defaultIssuerDocument.id;
@@ -220,6 +221,15 @@ test('every assertion fixture also reaches the bridge STS route', async () => {
   assert.ok(authorizationKey);
   const publicUrl = 'https://sts.oauth-fixtures.mentionable.dev';
   const resource = `${publicUrl}/agents/fixture-agent`;
+  const invalidClientFixtures = new Set([
+    'invalid/kid-not-issuer-fragment.json',
+    'invalid/kid-invalid-fragment-syntax.json',
+    'invalid/vm-controller-mismatch.json',
+    'invalid/vm-wrong-type.json',
+    'invalid/vm-invalid-public-jwk.json',
+    'invalid/vm-private-jwk.json',
+    'invalid/vm-mixed-key-material.json',
+  ]);
 
   for (const entry of manifest.filter((candidate) => candidate.kind === 'assertion')) {
     const fixture = (await json(entry.file)) as {
@@ -272,17 +282,26 @@ test('every assertion fixture also reaches the bridge STS route', async () => {
 
     const issuerDocument = fixture.issuerDocument ?? defaultIssuerDocument;
     const app = new Hono();
+    const profile = createMentionableOAuthProfile({
+      resolver: {
+        async resolve() {
+          return issuerDocument as never;
+        },
+      },
+    });
+    let profileFailureReason: string | undefined;
     mountTokenExchangeRoutes(app, {
       sql,
       publicUrl,
       profiles: [
-        createMentionableOAuthProfile({
-          resolver: {
-            async resolve() {
-              return issuerDocument as never;
-            },
+        {
+          ...profile,
+          async verify(context) {
+            const result = await profile.verify(context);
+            if (!result.ok) profileFailureReason = result.reason;
+            return result;
           },
-        }),
+        },
       ],
       now: () => new Date(fixture.verification.verifiedAt),
     });
@@ -292,5 +311,19 @@ test('every assertion fixture also reaches the bridge STS route', async () => {
       body: params,
     });
     assert.equal(response.ok, entry.expect === 'accept', entry.file);
+    if (!response.ok) {
+      const body = (await response.json()) as { error: string; rejection_id?: string };
+      const expectedOAuthError =
+        entry.file === 'invalid/wrong-typ.json'
+          ? 'invalid_request'
+          : invalidClientFixtures.has(entry.file)
+          ? 'invalid_client'
+          : 'invalid_grant';
+      assert.equal(body.error, expectedOAuthError, entry.file);
+      assert.match(body.rejection_id!, /^rej_/, entry.file);
+      if (entry.file !== 'invalid/wrong-typ.json') {
+        assert.equal(profileFailureReason, entry.reason, entry.file);
+      }
+    }
   }
 });

--- a/packages/server/src/oauth/profiles/mentionable-v0.1.ts
+++ b/packages/server/src/oauth/profiles/mentionable-v0.1.ts
@@ -296,7 +296,7 @@ export function createMentionableOAuthProfile(
               const expiresAt = new Date(
                 now.getTime() +
                   (OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS +
-                    OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) *
+                    2 * OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) *
                     1000,
               );
               try {

--- a/packages/server/src/oauth/profiles/mentionable-v0.1.ts
+++ b/packages/server/src/oauth/profiles/mentionable-v0.1.ts
@@ -145,7 +145,25 @@ export interface MentionableOAuthProfileOptions {
 export const MENTIONABLE_OAUTH_PROFILE_ID = OAUTH_FEDERATION_EXTENSION_URI;
 
 class MentionablePolicyStoreError extends Error {}
-class MentionableReplayStoreError extends Error {}
+class MentionableDidResolutionError extends Error {}
+
+function shouldRefreshIssuerDocument(
+  result: TokenExchangeVerifyResult,
+): result is Exclude<TokenExchangeVerifyResult, { ok: true }> {
+  if (result.ok || (result.stage !== 'client-assertion' && result.stage !== 'subject-assertion')) {
+    return false;
+  }
+  if (result.reason === 'invalid-signature') return true;
+  // The pinned reference verifier uses this detail only after a syntactically
+  // valid issuer-fragment kid fails lookup or key-material validation. Do not
+  // turn malformed kid syntax into an issuer-controlled refresh request.
+  return (
+    result.reason === 'kid-not-authorized' &&
+    result.detail?.startsWith(
+      'verification method is not a public issuer-controlled JsonWebKey Ed25519 method:',
+    ) === true
+  );
+}
 
 function failure(
   status: 400 | 401 | 500,
@@ -205,6 +223,7 @@ export function createMentionableOAuthProfile(
       let authorizationKey: string | undefined;
       let policyCandidate: TokenExchangePolicyCandidate | undefined;
       let issuerDocument: IssuerDidDocument | undefined;
+      let issuerDocumentFor: string | undefined;
       let trustedTask:
         | {
             principalId: string;
@@ -214,105 +233,126 @@ export function createMentionableOAuthProfile(
           }
         | undefined;
       let verification: TokenExchangeVerifyResult;
+      let pendingReplays: Array<{ issuer: string; jti: string }> = [];
       try {
-        verification = await verifyTokenExchange(form, {
-          tokenEndpoint,
-          verifiedAt: now.toISOString(),
-          expectedResource,
-          trustedIssuers: new Set([form.get('client_id')!]),
-          resolveIssuerDocument: (issuer) =>
-            issuer === policyCandidate?.issuer ? issuerDocument : undefined,
-          authorizeCandidateBeforeFetch: async (candidate) => {
-            if (candidate.resource !== expectedResource) return false;
-            if (
-              candidate.scopes.length === 0 ||
-              candidate.scopes.some(
-                (scope) => !(OAUTH_FEDERATION_SCOPES as readonly string[]).includes(scope),
-              )
-            ) {
-              return false;
-            }
-
-            let matchedAuthorizationKey: string | undefined;
-            if (candidate.kind === 'platform') {
-              matchedAuthorizationKey =
-                formatFederatedPrincipal({
-                  issuer: candidate.issuer,
-                  method: candidate.method,
-                  subject: candidate.subject,
-                }) ?? undefined;
+        const verifyOnce = async () => {
+          authorizationKey = undefined;
+          policyCandidate = undefined;
+          trustedTask = undefined;
+          const attemptReplays: Array<{ issuer: string; jti: string }> = [];
+          const attemptReplayKeys = new Set<string>();
+          const result = await verifyTokenExchange(form, {
+            tokenEndpoint,
+            verifiedAt: now.toISOString(),
+            expectedResource,
+            trustedIssuers: new Set([form.get('client_id')!]),
+            resolveIssuerDocument: (issuer) =>
+              issuer === policyCandidate?.issuer ? issuerDocument : undefined,
+            authorizeCandidateBeforeFetch: async (candidate) => {
+              if (candidate.resource !== expectedResource) return false;
               if (
-                matchedAuthorizationKey === undefined ||
-                !allowedCallers.includes(matchedAuthorizationKey)
+                candidate.scopes.length === 0 ||
+                candidate.scopes.some(
+                  (scope) => !(OAUTH_FEDERATION_SCOPES as readonly string[]).includes(scope),
+                )
               ) {
                 return false;
               }
-            } else {
-              let task;
-              try {
-                task = await loadTokenExchangeTaskAuthorization(sql, agentId, candidate.taskId);
-              } catch (error) {
-                throw new MentionablePolicyStoreError('task policy lookup failed', {
-                  cause: error,
-                });
-              }
-              if (
-                !task?.principalId ||
-                !task.actorId ||
-                task.authorizationRevoked ||
-                task.profileId !== MENTIONABLE_OAUTH_PROFILE_ID ||
-                !task.authorizationKey ||
-                task.principalId !== candidate.subject ||
-                task.actorId !== candidate.issuer ||
-                !allowedCallers.includes(task.authorizationKey)
-              ) {
-                return false;
-              }
-              matchedAuthorizationKey = task.authorizationKey;
-              trustedTask = {
-                principalId: task.principalId,
-                actorId: task.actorId,
-                authorizationKey: task.authorizationKey,
-                taskId: candidate.taskId,
-              };
-            }
 
-            // Preserve the receiver-owned key independently from the
-            // verifier's boolean callback result. The DID fetch happens only
-            // after this exact candidate has matched local policy.
-            authorizationKey = matchedAuthorizationKey;
-            policyCandidate = candidate;
-            try {
-              issuerDocument = asConnectorKitDidDocument(
-                await options.resolver.resolve(candidate.issuer),
-              );
-            } catch {
-              issuerDocument = undefined;
-            }
-            return true;
-          },
-          replayCache: {
-            async register(tuple) {
-              const expiresAt = new Date(
-                now.getTime() +
-                  (OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS +
-                    2 * OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) *
-                    1000,
-              );
-              try {
-                await consumeTokenExchangeReplays(sql, MENTIONABLE_OAUTH_PROFILE_ID, [
-                  { ...tuple, expiresAt },
-                ]);
-                return true;
-              } catch (error) {
-                if (error instanceof TokenExchangeReplayError) return false;
-                throw new MentionableReplayStoreError('assertion replay registration failed', {
-                  cause: error,
-                });
+              let matchedAuthorizationKey: string | undefined;
+              if (candidate.kind === 'platform') {
+                matchedAuthorizationKey =
+                  formatFederatedPrincipal({
+                    issuer: candidate.issuer,
+                    method: candidate.method,
+                    subject: candidate.subject,
+                  }) ?? undefined;
+                if (
+                  matchedAuthorizationKey === undefined ||
+                  !allowedCallers.includes(matchedAuthorizationKey)
+                ) {
+                  return false;
+                }
+              } else {
+                let task;
+                try {
+                  task = await loadTokenExchangeTaskAuthorization(sql, agentId, candidate.taskId);
+                } catch (error) {
+                  throw new MentionablePolicyStoreError('task policy lookup failed', {
+                    cause: error,
+                  });
+                }
+                if (
+                  !task?.principalId ||
+                  !task.actorId ||
+                  task.authorizationRevoked ||
+                  task.profileId !== MENTIONABLE_OAUTH_PROFILE_ID ||
+                  !task.authorizationKey ||
+                  task.principalId !== candidate.subject ||
+                  task.actorId !== candidate.issuer ||
+                  !allowedCallers.includes(task.authorizationKey)
+                ) {
+                  return false;
+                }
+                matchedAuthorizationKey = task.authorizationKey;
+                trustedTask = {
+                  principalId: task.principalId,
+                  actorId: task.actorId,
+                  authorizationKey: task.authorizationKey,
+                  taskId: candidate.taskId,
+                };
               }
+
+              // Preserve the receiver-owned key independently from the
+              // verifier's boolean callback result. The DID fetch happens only
+              // after this exact candidate has matched local policy.
+              authorizationKey = matchedAuthorizationKey;
+              policyCandidate = candidate;
+              if (issuerDocumentFor !== candidate.issuer) {
+                try {
+                  issuerDocument = asConnectorKitDidDocument(
+                    await options.resolver.resolve(candidate.issuer),
+                  );
+                  issuerDocumentFor = candidate.issuer;
+                } catch (error) {
+                  throw new MentionableDidResolutionError('issuer DID resolution failed', {
+                    cause: error,
+                  });
+                }
+              }
+              return true;
             },
-          },
-        });
+            replayCache: {
+              register(tuple) {
+                const key = `${tuple.issuer}\0${tuple.jti}`;
+                if (attemptReplayKeys.has(key)) return false;
+                attemptReplayKeys.add(key);
+                attemptReplays.push(tuple);
+                return true;
+              },
+            },
+          });
+          return { result, replays: attemptReplays };
+        };
+
+        let attempt = await verifyOnce();
+        if (shouldRefreshIssuerDocument(attempt.result)) {
+          const issuer = policyCandidate?.issuer;
+          if (issuer === undefined) {
+            throw new Error('verification requested DID refresh without a policy candidate');
+          }
+          try {
+            issuerDocument = asConnectorKitDidDocument(
+              await options.resolver.resolve(issuer, { refresh: true }),
+            );
+            issuerDocumentFor = issuer;
+          } catch (error) {
+            throw new MentionableDidResolutionError('issuer DID refresh failed', { cause: error });
+          }
+          attempt = await verifyOnce();
+        }
+        verification = attempt.result;
+        pendingReplays = attempt.replays;
       } catch (error) {
         if (error instanceof MentionablePolicyStoreError) {
           return failure(
@@ -323,13 +363,13 @@ export function createMentionableOAuthProfile(
             'policy',
           );
         }
-        if (error instanceof MentionableReplayStoreError) {
+        if (error instanceof MentionableDidResolutionError) {
           return failure(
             500,
             'server_error',
             'token exchange temporarily unavailable',
-            'replay_store_failed',
-            'replay',
+            'did_resolution_failed',
+            'did_resolution',
           );
         }
         return failure(
@@ -401,6 +441,51 @@ export function createMentionableOAuthProfile(
           'invalid_grant',
           'subject assertion exceeds caller context limits',
           'context_limits',
+        );
+      }
+
+      if (pendingReplays.length !== 2) {
+        return failure(
+          500,
+          'server_error',
+          'token exchange temporarily unavailable',
+          'replay_evidence_missing',
+          'profile_contract',
+        );
+      }
+
+      // The reference verifier calls the cache once per assertion. Stage the
+      // tuples until every profile check succeeds, then persist both in one
+      // transaction so a failed subject assertion cannot burn a valid client
+      // assertion (and a conflict on either tuple rolls both inserts back).
+      const replayExpiresAt = new Date(
+        now.getTime() +
+          (OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS + 2 * OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) *
+            1000,
+      );
+      try {
+        await consumeTokenExchangeReplays(
+          sql,
+          MENTIONABLE_OAUTH_PROFILE_ID,
+          pendingReplays.map((tuple) => ({ ...tuple, expiresAt: replayExpiresAt })),
+        );
+      } catch (error) {
+        if (error instanceof TokenExchangeReplayError) {
+          const clientAssertionReplay = error.tupleIndex === 0;
+          return failure(
+            clientAssertionReplay ? 401 : 400,
+            clientAssertionReplay ? 'invalid_client' : 'invalid_grant',
+            `${clientAssertionReplay ? 'client' : 'subject'}-assertion verification failed`,
+            'replayed-jti',
+            clientAssertionReplay ? 'client-assertion' : 'subject-assertion',
+          );
+        }
+        return failure(
+          500,
+          'server_error',
+          'token exchange temporarily unavailable',
+          'replay_store_failed',
+          'replay',
         );
       }
 

--- a/packages/server/src/oauth/profiles/mentionable-v0.1.ts
+++ b/packages/server/src/oauth/profiles/mentionable-v0.1.ts
@@ -5,22 +5,29 @@ import {
   evaluateTokenExchangeRequest,
   OAUTH_FEDERATION_CLAIM_METHOD,
   OAUTH_FEDERATION_CLAIM_TASK_ID,
+  OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS,
   OAUTH_FEDERATION_CLOCK_SKEW_SECONDS,
   OAUTH_FEDERATION_EXTENSION_URI,
   OAUTH_FEDERATION_SCOPES,
   OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION,
   OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION,
+  OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_PRIVATE_KEY_JWT,
   OAUTH_TOKEN_TYPE_JWT,
 } from '@mentionable/connector-kit';
 import {
   verifyTokenExchange,
   type IssuerDidDocument,
+  type TokenExchangePolicyCandidate,
   type TokenExchangeVerifyResult,
 } from '@mentionable/connector-kit/signing';
-import { decodeJwt, decodeProtectedHeader, type JWTPayload } from 'jose';
+import { decodeJwt, decodeProtectedHeader } from 'jose';
 import { formatFederatedPrincipal, parseFederatedPrincipal } from '../../auth/principal.js';
 import type { DidDocumentResolver, ResolvedDidDocument } from '../../identity-vc/types.js';
-import { loadTokenExchangeTaskAuthorization } from '../token-exchange/store.js';
+import {
+  consumeTokenExchangeReplays,
+  loadTokenExchangeTaskAuthorization,
+  TokenExchangeReplayError,
+} from '../token-exchange/store.js';
 import type {
   TokenExchangeErrorCode,
   TokenExchangeFailure,
@@ -61,13 +68,13 @@ function decodeCandidate(token: string): CandidateAssertion | null {
 }
 
 function asConnectorKitDidDocument(doc: ResolvedDidDocument): IssuerDidDocument {
-  const assertionMethod: (string | { id: string })[] = [];
+  const assertionMethod: IssuerDidDocument['assertionMethod'] = [];
   for (const entry of Array.isArray(doc.assertionMethod) ? doc.assertionMethod : []) {
     if (typeof entry === 'string') {
       assertionMethod.push(entry);
     } else if (typeof entry === 'object' && entry !== null) {
-      const id = (entry as { id?: unknown }).id;
-      if (typeof id === 'string') assertionMethod.push({ id });
+      const value = entry as Record<string, unknown>;
+      if (typeof value.id === 'string') assertionMethod.push({ ...value, id: value.id });
     }
   }
   return {
@@ -77,23 +84,11 @@ function asConnectorKitDidDocument(doc: ResolvedDidDocument): IssuerDidDocument 
       ? doc.verificationMethod.flatMap((entry) => {
           if (typeof entry !== 'object' || entry === null) return [];
           const value = entry as Record<string, unknown>;
-          if (typeof value.id !== 'string' || value.controller !== doc.id) return [];
+          if (typeof value.id !== 'string') return [];
           return [{ ...value, id: value.id }];
         })
       : undefined,
     assertionMethod,
-  };
-}
-
-function verifiedReplayTuple(payload: JWTPayload): {
-  issuer: string;
-  jti: string;
-  expiresAt: Date;
-} {
-  return {
-    issuer: payload.iss as string,
-    jti: payload.jti as string,
-    expiresAt: new Date(((payload.exp as number) + OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) * 1000),
   };
 }
 
@@ -127,6 +122,14 @@ function verificationError(result: Exclude<TokenExchangeVerifyResult, { ok: true
       reason: result.reason,
     };
   }
+  if (result.stage === 'policy') {
+    return {
+      status: 400,
+      error: result.error,
+      stage: result.stage,
+      reason: result.reason,
+    };
+  }
   return {
     status: 400,
     error: 'invalid_request',
@@ -140,6 +143,9 @@ export interface MentionableOAuthProfileOptions {
 }
 
 export const MENTIONABLE_OAUTH_PROFILE_ID = OAUTH_FEDERATION_EXTENSION_URI;
+
+class MentionablePolicyStoreError extends Error {}
+class MentionableReplayStoreError extends Error {}
 
 function failure(
   status: 400 | 401 | 500,
@@ -164,15 +170,14 @@ export function createMentionableOAuthProfile(
   return {
     id: MENTIONABLE_OAUTH_PROFILE_ID,
     replayProtection: 'required',
-    clientAuthMethods: ['private_key_jwt'],
+    replayPersistence: 'profile',
+    clientAuthMethods: [OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_PRIVATE_KEY_JWT],
     clientAuthSigningAlgorithms: ['EdDSA'],
     scopes: OAUTH_FEDERATION_SCOPES,
     subjectTokenTypes: [OAUTH_TOKEN_TYPE_JWT],
     authorizationServerMetadata: {
       mentionable_profile: OAUTH_FEDERATION_EXTENSION_URI,
     },
-    // Mentionable v0.1 pins replayed subject assertions to invalid_grant.
-    replayFailure: failure(400, 'invalid_grant', 'assertion replayed', 'replayed_jti'),
     recognizes(form) {
       const token = form.get('subject_token');
       if (!token) return false;
@@ -193,31 +198,13 @@ export function createMentionableOAuthProfile(
           'shape',
         );
       }
-      if (shape.scopes.length === 0) {
-        return failure(
-          400,
-          'invalid_scope',
-          'at least one scope is required',
-          'empty_scope',
-          'shape',
-        );
-      }
       return undefined;
     },
     async verify({ sql, form, tokenEndpoint, expectedResource, agentId, allowedCallers, now }) {
       const subjectToken = form.get('subject_token')!;
-      const candidate = decodeCandidate(subjectToken);
-      if (!candidate) {
-        return failure(
-          400,
-          'invalid_request',
-          'malformed subject assertion',
-          'malformed_subject',
-          'shape',
-        );
-      }
-
       let authorizationKey: string | undefined;
+      let policyCandidate: TokenExchangePolicyCandidate | undefined;
+      let issuerDocument: IssuerDidDocument | undefined;
       let trustedTask:
         | {
             principalId: string;
@@ -226,95 +213,125 @@ export function createMentionableOAuthProfile(
             taskId: string;
           }
         | undefined;
-      if (candidate.typ === OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION) {
-        if (!candidate.method) {
-          return failure(
-            400,
-            'invalid_grant',
-            'subject assertion has no authentication method',
-            'missing_method',
-          );
-        }
-        authorizationKey =
-          formatFederatedPrincipal({
-            issuer: candidate.issuer,
-            method: candidate.method,
-            subject: candidate.subject,
-          }) ?? undefined;
-        if (!authorizationKey || !allowedCallers.includes(authorizationKey)) {
-          return failure(
-            400,
-            'invalid_grant',
-            'subject is not authorized for this resource',
-            'caller_not_allowed',
-          );
-        }
-      } else if (candidate.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION) {
-        if (!candidate.taskId) {
-          return failure(
-            400,
-            'invalid_grant',
-            'continuation assertion has no task binding',
-            'missing_task_id',
-          );
-        }
-        const task = await loadTokenExchangeTaskAuthorization(sql, agentId, candidate.taskId);
-        if (
-          !task?.principalId ||
-          !task.actorId ||
-          task.authorizationRevoked ||
-          task.profileId !== MENTIONABLE_OAUTH_PROFILE_ID ||
-          !task.authorizationKey ||
-          task.principalId !== candidate.subject ||
-          task.actorId !== candidate.issuer ||
-          !allowedCallers.includes(task.authorizationKey)
-        ) {
-          return failure(
-            400,
-            'invalid_grant',
-            'task continuation is not authorized',
-            'task_binding_mismatch',
-          );
-        }
-        authorizationKey = task.authorizationKey;
-        trustedTask = {
-          principalId: task.principalId,
-          actorId: task.actorId,
-          authorizationKey: task.authorizationKey,
-          taskId: candidate.taskId,
-        };
-      } else {
-        return failure(400, 'invalid_grant', 'unsupported subject assertion type', 'wrong_typ');
-      }
-
-      // Exact receiver policy has matched. Only now may an issuer-controlled
-      // did:web URL be resolved.
-      let issuerDocument: IssuerDidDocument;
-      try {
-        issuerDocument = asConnectorKitDidDocument(
-          await options.resolver.resolve(candidate.issuer),
-        );
-      } catch {
-        return failure(
-          400,
-          'invalid_grant',
-          'subject assertion verification failed',
-          'did_resolution_failed',
-          'subject-assertion',
-        );
-      }
-
       let verification: TokenExchangeVerifyResult;
       try {
         verification = await verifyTokenExchange(form, {
           tokenEndpoint,
           verifiedAt: now.toISOString(),
           expectedResource,
-          trustedIssuers: new Set([candidate.issuer]),
+          trustedIssuers: new Set([form.get('client_id')!]),
           resolveIssuerDocument: (issuer) =>
-            issuer === candidate.issuer ? issuerDocument : undefined,
+            issuer === policyCandidate?.issuer ? issuerDocument : undefined,
+          authorizeCandidateBeforeFetch: async (candidate) => {
+            if (candidate.resource !== expectedResource) return false;
+            if (
+              candidate.scopes.length === 0 ||
+              candidate.scopes.some(
+                (scope) => !(OAUTH_FEDERATION_SCOPES as readonly string[]).includes(scope),
+              )
+            ) {
+              return false;
+            }
+
+            let matchedAuthorizationKey: string | undefined;
+            if (candidate.kind === 'platform') {
+              matchedAuthorizationKey =
+                formatFederatedPrincipal({
+                  issuer: candidate.issuer,
+                  method: candidate.method,
+                  subject: candidate.subject,
+                }) ?? undefined;
+              if (
+                matchedAuthorizationKey === undefined ||
+                !allowedCallers.includes(matchedAuthorizationKey)
+              ) {
+                return false;
+              }
+            } else {
+              let task;
+              try {
+                task = await loadTokenExchangeTaskAuthorization(sql, agentId, candidate.taskId);
+              } catch (error) {
+                throw new MentionablePolicyStoreError('task policy lookup failed', {
+                  cause: error,
+                });
+              }
+              if (
+                !task?.principalId ||
+                !task.actorId ||
+                task.authorizationRevoked ||
+                task.profileId !== MENTIONABLE_OAUTH_PROFILE_ID ||
+                !task.authorizationKey ||
+                task.principalId !== candidate.subject ||
+                task.actorId !== candidate.issuer ||
+                !allowedCallers.includes(task.authorizationKey)
+              ) {
+                return false;
+              }
+              matchedAuthorizationKey = task.authorizationKey;
+              trustedTask = {
+                principalId: task.principalId,
+                actorId: task.actorId,
+                authorizationKey: task.authorizationKey,
+                taskId: candidate.taskId,
+              };
+            }
+
+            // Preserve the receiver-owned key independently from the
+            // verifier's boolean callback result. The DID fetch happens only
+            // after this exact candidate has matched local policy.
+            authorizationKey = matchedAuthorizationKey;
+            policyCandidate = candidate;
+            try {
+              issuerDocument = asConnectorKitDidDocument(
+                await options.resolver.resolve(candidate.issuer),
+              );
+            } catch {
+              issuerDocument = undefined;
+            }
+            return true;
+          },
+          replayCache: {
+            async register(tuple) {
+              const expiresAt = new Date(
+                now.getTime() +
+                  (OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS +
+                    OAUTH_FEDERATION_CLOCK_SKEW_SECONDS) *
+                    1000,
+              );
+              try {
+                await consumeTokenExchangeReplays(sql, MENTIONABLE_OAUTH_PROFILE_ID, [
+                  { ...tuple, expiresAt },
+                ]);
+                return true;
+              } catch (error) {
+                if (error instanceof TokenExchangeReplayError) return false;
+                throw new MentionableReplayStoreError('assertion replay registration failed', {
+                  cause: error,
+                });
+              }
+            },
+          },
         });
-      } catch {
+      } catch (error) {
+        if (error instanceof MentionablePolicyStoreError) {
+          return failure(
+            500,
+            'server_error',
+            'token exchange temporarily unavailable',
+            'policy_store_failed',
+            'policy',
+          );
+        }
+        if (error instanceof MentionableReplayStoreError) {
+          return failure(
+            500,
+            'server_error',
+            'token exchange temporarily unavailable',
+            'replay_store_failed',
+            'replay',
+          );
+        }
         return failure(
           500,
           'server_error',
@@ -324,10 +341,17 @@ export function createMentionableOAuthProfile(
       }
       if (!verification.ok) {
         const mapped = verificationError(verification);
+        const policyDescription =
+          mapped.stage === 'policy'
+            ? decodeCandidate(subjectToken)?.typ ===
+              OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
+              ? 'task continuation is not authorized'
+              : 'subject is not authorized for this resource'
+            : undefined;
         return failure(
           mapped.status,
           mapped.error,
-          `${mapped.stage} verification failed`,
+          policyDescription ?? `${mapped.stage} verification failed`,
           mapped.reason,
           mapped.stage,
         );
@@ -335,8 +359,9 @@ export function createMentionableOAuthProfile(
 
       const context = verification.authorization;
       if (
-        context.actor !== candidate.issuer ||
-        context.principal !== candidate.subject ||
+        policyCandidate === undefined ||
+        context.actor !== policyCandidate.issuer ||
+        context.principal !== policyCandidate.subject ||
         (trustedTask !== undefined && context.task_id !== trustedTask.taskId) ||
         (trustedTask === undefined && context.task_id !== undefined)
       ) {
@@ -379,7 +404,6 @@ export function createMentionableOAuthProfile(
         );
       }
 
-      const verifiedClientPayload = decodeJwt(form.get('client_assertion')!);
       return {
         ok: true,
         principalId: context.principal,
@@ -388,10 +412,7 @@ export function createMentionableOAuthProfile(
         attestation: attestationResult.data,
         scopes: verification.scopes,
         ...(context.task_id !== undefined ? { taskId: context.task_id } : {}),
-        replays: [
-          verifiedReplayTuple(verifiedClientPayload),
-          verifiedReplayTuple(verifiedSubjectPayload),
-        ],
+        replays: [],
         kind: context.task_id === undefined ? 'platform_subject' : 'task_continuation',
       };
     },

--- a/packages/server/src/oauth/token-exchange/routes.test.ts
+++ b/packages/server/src/oauth/token-exchange/routes.test.ts
@@ -7,8 +7,10 @@ import { formatFederatedPrincipal } from '../../auth/principal.js';
 import type { DidDocumentResolver, ResolvedDidDocument } from '../../identity-vc/types.js';
 import {
   OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER,
+  OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS,
   OAUTH_FEDERATION_CLAIM_METHOD,
   OAUTH_FEDERATION_CLAIM_TASK_ID,
+  OAUTH_FEDERATION_CLOCK_SKEW_SECONDS,
   OAUTH_FEDERATION_SCOPES,
   OAUTH_FEDERATION_SCOPE_MESSAGE_SEND,
   OAUTH_FEDERATION_SCOPE_TASK_CANCEL,
@@ -49,10 +51,11 @@ function mountMentionableTokenExchangeRoutes(
   });
 }
 
-async function assertions() {
+async function assertions(options: { issuedAt?: number; lifetimeSeconds?: number } = {}) {
   const { privateKey, publicKey } = await generateKeyPair('EdDSA');
   const publicKeyJwk = await exportJWK(publicKey);
-  const issuedAt = Math.floor(now().getTime() / 1000);
+  const issuedAt = options.issuedAt ?? Math.floor(now().getTime() / 1000);
+  const lifetimeSeconds = options.lifetimeSeconds ?? 300;
   const base = (typ: string, sub: string, jti: string, claims: Record<string, unknown> = {}) =>
     new SignJWT(claims)
       .setProtectedHeader({ alg: 'EdDSA', typ, kid })
@@ -60,7 +63,7 @@ async function assertions() {
       .setSubject(sub)
       .setAudience(tokenEndpoint)
       .setIssuedAt(issuedAt)
-      .setExpirationTime(issuedAt + 300)
+      .setExpirationTime(issuedAt + lifetimeSeconds)
       .setJti(jti)
       .sign(privateKey);
   const didDocument: ResolvedDidDocument = {
@@ -108,6 +111,7 @@ function sqlWithPolicy(
     authorizationRevoked?: boolean;
   },
   taskLookupError?: Error,
+  replayExpirations: Date[] = [],
 ): Sql {
   const replayDigests = new Set<string>();
   const query = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
@@ -119,6 +123,7 @@ function sqlWithPolicy(
       const digest = (values[0] as Buffer).toString('hex');
       if (replayDigests.has(digest)) return [];
       replayDigests.add(digest);
+      replayExpirations.push(values[2] as Date);
       return [{ digest: values[0] }];
     }
     if (statement.includes('INSERT INTO infra.oauth_token_exchange_access_tokens')) {
@@ -566,6 +571,42 @@ test('the profile-managed replay cache rejects a repeated exchange', async () =>
   const replay = await request();
   assert.equal(replay.status, 401);
   assert.equal(((await replay.json()) as { error: string }).error, 'invalid_client');
+});
+
+test('replay retention covers the maximum future-skew assertion lifetime', async () => {
+  const verifiedAtSeconds = Math.floor(now().getTime() / 1000);
+  const issuedAt = verifiedAtSeconds + OAUTH_FEDERATION_CLOCK_SKEW_SECONDS;
+  const fixture = await assertions({
+    issuedAt,
+    lifetimeSeconds: OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS,
+  });
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  const replayExpirations: Date[] = [];
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey], [], [], undefined, undefined, replayExpirations),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        return fixture.didDocument;
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(response.status, 200);
+  assert.equal(replayExpirations.length, 2);
+
+  const assertionExpiresAt = (issuedAt + OAUTH_FEDERATION_ASSERTION_MAX_TTL_SECONDS) * 1000;
+  const requiredRetention = assertionExpiresAt + OAUTH_FEDERATION_CLOCK_SKEW_SECONDS * 1000;
+  for (const expiresAt of replayExpirations) {
+    assert.ok(expiresAt.getTime() >= requiredRetention);
+  }
 });
 
 test('client assertion verification failures map to invalid_client', async () => {

--- a/packages/server/src/oauth/token-exchange/routes.test.ts
+++ b/packages/server/src/oauth/token-exchange/routes.test.ts
@@ -9,6 +9,7 @@ import {
   OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER,
   OAUTH_FEDERATION_CLAIM_METHOD,
   OAUTH_FEDERATION_CLAIM_TASK_ID,
+  OAUTH_FEDERATION_SCOPES,
   OAUTH_FEDERATION_SCOPE_MESSAGE_SEND,
   OAUTH_FEDERATION_SCOPE_TASK_CANCEL,
   OAUTH_FEDERATION_SCOPE_TASK_READ,
@@ -64,7 +65,7 @@ async function assertions() {
       .sign(privateKey);
   const didDocument: ResolvedDidDocument = {
     id: issuer,
-    verificationMethod: [{ id: kid, controller: issuer, publicKeyJwk }],
+    verificationMethod: [{ id: kid, type: 'JsonWebKey', controller: issuer, publicKeyJwk }],
     assertionMethod: [kid],
   };
   return {
@@ -106,13 +107,18 @@ function sqlWithPolicy(
     authorizationKey: string;
     authorizationRevoked?: boolean;
   },
+  taskLookupError?: Error,
 ): Sql {
+  const replayDigests = new Set<string>();
   const query = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
     const statement = strings.join('?');
     if (statement.includes('SELECT allowed_callers FROM agents')) {
       return [{ allowed_callers: allowedCallers }];
     }
     if (statement.includes('INSERT INTO infra.oauth_token_exchange_replays')) {
+      const digest = (values[0] as Buffer).toString('hex');
+      if (replayDigests.has(digest)) return [];
+      replayDigests.add(digest);
       return [{ digest: values[0] }];
     }
     if (statement.includes('INSERT INTO infra.oauth_token_exchange_access_tokens')) {
@@ -121,15 +127,16 @@ function sqlWithPolicy(
       return [{ id: 'token-row-1' }];
     }
     if (statement.includes('FROM infra.a2a_tasks')) {
+      if (taskLookupError) throw taskLookupError;
       return task
         ? [
             {
-            owner_principal: task.principalId,
-            owner_actor: task.actorId,
-            authorization_profile: 'https://mentionable.dev/ns/oauth-federation/v0.1',
-            authorization_key: task.authorizationKey,
-            authorization_revoked: task.authorizationRevoked ?? false,
-          },
+              owner_principal: task.principalId,
+              owner_actor: task.actorId,
+              authorization_profile: 'https://mentionable.dev/ns/oauth-federation/v0.1',
+              authorization_key: task.authorizationKey,
+              authorization_revoked: task.authorizationRevoked ?? false,
+            },
           ]
         : [];
     }
@@ -162,6 +169,9 @@ test('RFC 8414 discovery points token exchange at the shared /oauth/token endpoi
     token_endpoint: string;
     grant_types_supported: string[];
     token_endpoint_auth_methods_supported: string[];
+    token_endpoint_auth_signing_alg_values_supported: string[];
+    scopes_supported: string[];
+    subject_token_types_supported: string[];
     token_exchange_profiles_supported: string[];
   };
   assert.equal(metadata.token_endpoint, tokenEndpoint);
@@ -170,6 +180,9 @@ test('RFC 8414 discovery points token exchange at the shared /oauth/token endpoi
     'urn:ietf:params:oauth:grant-type:device_code',
   ]);
   assert.deepEqual(metadata.token_endpoint_auth_methods_supported, ['private_key_jwt', 'none']);
+  assert.deepEqual(metadata.token_endpoint_auth_signing_alg_values_supported, ['EdDSA']);
+  assert.deepEqual(metadata.scopes_supported, OAUTH_FEDERATION_SCOPES);
+  assert.deepEqual(metadata.subject_token_types_supported, [OAUTH_TOKEN_TYPE_JWT]);
   assert.equal(
     (metadata as { device_authorization_endpoint?: string }).device_authorization_endpoint,
     `${publicUrl}/oauth/device/code`,
@@ -270,7 +283,10 @@ test('a replay-required profile cannot issue a token without replay evidence', a
       resource: `${publicUrl}/agents/agent-1`,
     }),
   });
-  const body = (await response.json()) as { error: string; rejection_id?: string };
+  const body = (await response.json()) as {
+    error: string;
+    rejection_id?: string;
+  };
   assert.equal(response.status, 500);
   assert.equal(body.error, 'server_error');
   assert.match(body.rejection_id!, /^rej_/);
@@ -368,6 +384,100 @@ test('token exchange checks exact receiver policy before resolving an untrusted 
   assert.equal(resolutions, 0);
 });
 
+test('malformed protected headers fail before policy or DID resolution', async () => {
+  const fixture = await assertions();
+  let resolutions = 0;
+  const malformed = fixture.subjectAssertion.split('.');
+  malformed[0] = '%not-base64url';
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([]),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        resolutions += 1;
+        return fixture.didDocument;
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(malformed.join('.'), fixture.clientAssertion),
+  });
+  assert.equal(response.status, 400);
+  assert.equal(((await response.json()) as { error: string }).error, 'invalid_request');
+  assert.equal(resolutions, 0);
+});
+
+test('continuation policy-store failures are typed server_error and do not resolve a DID', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    method,
+    subject,
+  });
+  assert.ok(authorizationKey);
+  let resolutions = 0;
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey], [], [], undefined, new Error('database offline')),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        resolutions += 1;
+        return fixture.didDocument;
+      },
+    },
+    now,
+  });
+  const body = requestBody(fixture.continuationAssertion, fixture.clientAssertion);
+  body.set('scope', OAUTH_FEDERATION_SCOPE_TASK_READ);
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  assert.equal(response.status, 500);
+  assert.equal(((await response.json()) as { error: string }).error, 'server_error');
+  assert.equal(resolutions, 0);
+});
+
+test('embedded assertionMethod verification objects are preserved and accepted', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    method,
+    subject,
+  });
+  assert.ok(authorizationKey);
+  const verificationMethod = fixture.didDocument.verificationMethod?.[0];
+  assert.equal(typeof verificationMethod, 'object');
+  const embeddedDocument: ResolvedDidDocument = {
+    id: issuer,
+    verificationMethod: [],
+    assertionMethod: [verificationMethod],
+  };
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey]),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        return embeddedDocument;
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(response.status, 200);
+});
+
 test('successful exchange stores only a normalized, non-secret attestation', async () => {
   const fixture = await assertions();
   const authorizationKey = formatFederatedPrincipal({
@@ -398,10 +508,16 @@ test('successful exchange stores only a normalized, non-secret attestation', asy
   assert.equal(response.status, 200);
   const body = (await response.json()) as {
     access_token: string;
+    issued_token_type: string;
+    token_type: string;
     expires_in: number;
+    scope: string;
   };
   assert.match(body.access_token, /^vbc_oauth_/);
+  assert.equal(body.issued_token_type, OAUTH_TOKEN_TYPE_ACCESS_TOKEN);
+  assert.equal(body.token_type, 'Bearer');
   assert.equal(body.expires_in, 300);
+  assert.equal(body.scope, OAUTH_FEDERATION_SCOPE_MESSAGE_SEND);
   assert.equal(inserted.length, 1);
   assert.equal(tokenRows[0]?.[3], subject, 'effective principal is the platform subject');
   assert.equal(tokenRows[0]?.[4], issuer, 'actor is the authenticated Connector DID');
@@ -419,6 +535,37 @@ test('successful exchange stores only a normalized, non-secret attestation', asy
   const serializedAttestation = JSON.stringify(attestation);
   assert.equal(serializedAttestation.includes(fixture.subjectAssertion), false);
   assert.equal(serializedAttestation.includes(fixture.clientAssertion), false);
+});
+
+test('the profile-managed replay cache rejects a repeated exchange', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    method,
+    subject,
+  });
+  assert.ok(authorizationKey);
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey]),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        return fixture.didDocument;
+      },
+    },
+    now,
+  });
+  const request = () =>
+    app.request('/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+    });
+  assert.equal((await request()).status, 200);
+  const replay = await request();
+  assert.equal(replay.status, 401);
+  assert.equal(((await replay.json()) as { error: string }).error, 'invalid_client');
 });
 
 test('client assertion verification failures map to invalid_client', async () => {
@@ -492,7 +639,11 @@ test('task continuation exchange keeps the originating tuple and task binding', 
 
 test('task continuation exchange stays revoked after the exact tuple is re-added', async () => {
   const fixture = await assertions();
-  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  const authorizationKey = formatFederatedPrincipal({
+    issuer,
+    method,
+    subject,
+  });
   assert.ok(authorizationKey);
   const app = new Hono();
   mountMentionableTokenExchangeRoutes(app, {
@@ -518,7 +669,10 @@ test('task continuation exchange stays revoked after the exact tuple is re-added
     body,
   });
   assert.equal(response.status, 400);
-  const responseBody = (await response.json()) as { error: string; error_description: string };
+  const responseBody = (await response.json()) as {
+    error: string;
+    error_description: string;
+  };
   assert.equal(responseBody.error, 'invalid_grant');
   assert.equal(responseBody.error_description, 'task continuation is not authorized');
 });
@@ -528,9 +682,15 @@ test('chunked token requests are rejected while streaming once they cross the si
   mountMentionableTokenExchangeRoutes(app, {
     sql: sqlWithPolicy([]),
     publicUrl,
-    resolver: { async resolve() { throw new Error('not reached'); } },
+    resolver: {
+      async resolve() {
+        throw new Error('not reached');
+      },
+    },
   });
-  const prefix = new TextEncoder().encode(`grant_type=${encodeURIComponent(TOKEN_EXCHANGE_GRANT_TYPE)}&`);
+  const prefix = new TextEncoder().encode(
+    `grant_type=${encodeURIComponent(TOKEN_EXCHANGE_GRANT_TYPE)}&`,
+  );
   const body = new ReadableStream<Uint8Array>({
     start(controller) {
       controller.enqueue(prefix);
@@ -552,7 +712,9 @@ test('chunked token requests are rejected while streaming once they cross the si
 });
 
 test('target lookup failures return an audited OAuth server_error response', async () => {
-  const sql = (async () => { throw new Error('database unavailable'); }) as unknown as Sql;
+  const sql = (async () => {
+    throw new Error('database unavailable');
+  }) as unknown as Sql;
   const profile: TokenExchangeProfile = {
     id: 'urn:example:lookup-profile',
     replayProtection: 'required',
@@ -561,7 +723,9 @@ test('target lookup failures return an audited OAuth server_error response', asy
     scopes: [],
     subjectTokenTypes: [],
     recognizes: () => true,
-    async verify() { throw new Error('not reached'); },
+    async verify() {
+      throw new Error('not reached');
+    },
   };
   const app = new Hono();
   mountTokenExchangeRoutes(app, {
@@ -577,7 +741,10 @@ test('target lookup failures return an audited OAuth server_error response', asy
       resource: `${publicUrl}/agents/agent-1`,
     }),
   });
-  const body = (await response.json()) as { error: string; rejection_id?: string };
+  const body = (await response.json()) as {
+    error: string;
+    rejection_id?: string;
+  };
   assert.equal(response.status, 500);
   assert.equal(body.error, 'server_error');
   assert.match(body.rejection_id!, /^rej_/);
@@ -593,7 +760,9 @@ test('unexpected profile failures return an audited OAuth server_error response'
     scopes: [],
     subjectTokenTypes: [],
     recognizes: () => true,
-    async verify() { throw new Error('adapter failure'); },
+    async verify() {
+      throw new Error('adapter failure');
+    },
   };
   const app = new Hono();
   mountTokenExchangeRoutes(app, {
@@ -609,7 +778,10 @@ test('unexpected profile failures return an audited OAuth server_error response'
       resource: `${publicUrl}/agents/agent-1`,
     }),
   });
-  const body = (await response.json()) as { error: string; rejection_id?: string };
+  const body = (await response.json()) as {
+    error: string;
+    rejection_id?: string;
+  };
   assert.equal(response.status, 500);
   assert.equal(body.error, 'server_error');
   assert.match(body.rejection_id!, /^rej_/);

--- a/packages/server/src/oauth/token-exchange/routes.test.ts
+++ b/packages/server/src/oauth/token-exchange/routes.test.ts
@@ -449,6 +449,121 @@ test('continuation policy-store failures are typed server_error and do not resol
   assert.equal(resolutions, 0);
 });
 
+test('transient DID resolution failures are retryable server errors', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  let resolutions = 0;
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey]),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        resolutions += 1;
+        throw new Error('DNS timeout');
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(response.status, 500);
+  assert.equal(((await response.json()) as { error: string }).error, 'server_error');
+  assert.equal(resolutions, 1);
+});
+
+test('an unknown cached kid triggers one bounded DID refresh before replay consumption', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  const refreshes: boolean[] = [];
+  const replayExpirations: Date[] = [];
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey], [], [], undefined, undefined, replayExpirations),
+    publicUrl,
+    resolver: {
+      async resolve(_issuer, options) {
+        const refresh = options?.refresh === true;
+        refreshes.push(refresh);
+        return refresh
+          ? fixture.didDocument
+          : { id: issuer, verificationMethod: [], assertionMethod: [] };
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(refreshes, [false, true]);
+  assert.equal(replayExpirations.length, 2);
+});
+
+test('same-kid key-material rotation triggers one bounded DID refresh', async () => {
+  const staleFixture = await assertions();
+  const currentFixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  const refreshes: boolean[] = [];
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey]),
+    publicUrl,
+    resolver: {
+      async resolve(_issuer, options) {
+        const refresh = options?.refresh === true;
+        refreshes.push(refresh);
+        return refresh ? currentFixture.didDocument : staleFixture.didDocument;
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(currentFixture.subjectAssertion, currentFixture.clientAssertion),
+  });
+  assert.equal(response.status, 200);
+  assert.deepEqual(refreshes, [false, true]);
+});
+
+test('a failed DID refresh remains a retryable server error', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  const refreshes: boolean[] = [];
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey]),
+    publicUrl,
+    resolver: {
+      async resolve(_issuer, options) {
+        const refresh = options?.refresh === true;
+        refreshes.push(refresh);
+        if (refresh) throw new Error('DID endpoint unavailable');
+        return { id: issuer, verificationMethod: [], assertionMethod: [] };
+      },
+    },
+    now,
+  });
+  const response = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(response.status, 500);
+  assert.equal(((await response.json()) as { error: string }).error, 'server_error');
+  assert.deepEqual(refreshes, [false, true]);
+});
+
 test('embedded assertionMethod verification objects are preserved and accepted', async () => {
   const fixture = await assertions();
   const authorizationKey = formatFederatedPrincipal({
@@ -571,6 +686,43 @@ test('the profile-managed replay cache rejects a repeated exchange', async () =>
   const replay = await request();
   assert.equal(replay.status, 401);
   assert.equal(((await replay.json()) as { error: string }).error, 'invalid_client');
+});
+
+test('failed subject verification does not consume the valid client replay tuple', async () => {
+  const fixture = await assertions();
+  const authorizationKey = formatFederatedPrincipal({ issuer, method, subject });
+  assert.ok(authorizationKey);
+  const replayExpirations: Date[] = [];
+  const app = new Hono();
+  mountMentionableTokenExchangeRoutes(app, {
+    sql: sqlWithPolicy([authorizationKey], [], [], undefined, undefined, replayExpirations),
+    publicUrl,
+    resolver: {
+      async resolve() {
+        return fixture.didDocument;
+      },
+    },
+    now,
+  });
+  const tamperedSegments = fixture.subjectAssertion.split('.');
+  tamperedSegments[2] =
+    (tamperedSegments[2]!.startsWith('A') ? 'B' : 'A') + tamperedSegments[2]!.slice(1);
+  const rejected = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(tamperedSegments.join('.'), fixture.clientAssertion),
+  });
+  assert.equal(rejected.status, 400);
+  assert.equal(((await rejected.json()) as { error: string }).error, 'invalid_grant');
+  assert.equal(replayExpirations.length, 0);
+
+  const accepted = await app.request('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: requestBody(fixture.subjectAssertion, fixture.clientAssertion),
+  });
+  assert.equal(accepted.status, 200);
+  assert.equal(replayExpirations.length, 2);
 });
 
 test('replay retention covers the maximum future-skew assertion lifetime', async () => {

--- a/packages/server/src/oauth/token-exchange/routes.ts
+++ b/packages/server/src/oauth/token-exchange/routes.ts
@@ -151,12 +151,10 @@ export function mountTokenExchangeRoutes(app: Hono, options: TokenExchangeRouteO
         TOKEN_EXCHANGE_GRANT_TYPE,
         ...(options.additionalGrantTypes ?? []),
       ]),
-      token_endpoint_auth_methods_supported: unique(
-        [
-          ...options.profiles.flatMap((profile) => [...profile.clientAuthMethods]),
-          ...(options.additionalTokenEndpointAuthMethods ?? []),
-        ],
-      ),
+      token_endpoint_auth_methods_supported: unique([
+        ...options.profiles.flatMap((profile) => [...profile.clientAuthMethods]),
+        ...(options.additionalTokenEndpointAuthMethods ?? []),
+      ]),
       token_endpoint_auth_signing_alg_values_supported: unique(
         options.profiles.flatMap((profile) => [...profile.clientAuthSigningAlgorithms]),
       ),
@@ -312,7 +310,12 @@ export function mountTokenExchangeRoutes(app: Hono, options: TokenExchangeRouteO
       );
     }
     if (!result.ok) return reject(result, { agentId, profileId: profile.id });
-    if (profile.replayProtection === 'required' && result.replays.length === 0) {
+    const profileManagedReplay = profile.replayPersistence === 'profile';
+    if (
+      profile.replayProtection === 'required' &&
+      !profileManagedReplay &&
+      result.replays.length === 0
+    ) {
       return reject(
         {
           ok: false,
@@ -326,26 +329,28 @@ export function mountTokenExchangeRoutes(app: Hono, options: TokenExchangeRouteO
       );
     }
 
-    try {
-      await consumeTokenExchangeReplays(options.sql, profile.id, result.replays);
-    } catch (error) {
-      const failure: TokenExchangeFailure =
-        error instanceof TokenExchangeReplayError
-          ? profile.replayFailure ?? {
-              ok: false,
-              status: 400,
-              error: 'invalid_request',
-              description: 'assertion replayed',
-              reason: 'replayed_jti',
-            }
-          : {
-              ok: false,
-              status: 500,
-              error: 'server_error',
-              description: 'token exchange temporarily unavailable',
-              reason: 'replay_store_failed',
-            };
-      return reject(failure, { agentId, profileId: profile.id });
+    if (!profileManagedReplay) {
+      try {
+        await consumeTokenExchangeReplays(options.sql, profile.id, result.replays);
+      } catch (error) {
+        const failure: TokenExchangeFailure =
+          error instanceof TokenExchangeReplayError
+            ? profile.replayFailure ?? {
+                ok: false,
+                status: 400,
+                error: 'invalid_request',
+                description: 'assertion replayed',
+                reason: 'replayed_jti',
+              }
+            : {
+                ok: false,
+                status: 500,
+                error: 'server_error',
+                description: 'token exchange temporarily unavailable',
+                reason: 'replay_store_failed',
+              };
+        return reject(failure, { agentId, profileId: profile.id });
+      }
     }
 
     const expiresAt = new Date(now.getTime() + TOKEN_EXCHANGE_ACCESS_TOKEN_TTL_SECONDS * 1000);

--- a/packages/server/src/oauth/token-exchange/store.test.ts
+++ b/packages/server/src/oauth/token-exchange/store.test.ts
@@ -2,7 +2,9 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import postgres from 'postgres';
 import {
+  consumeTokenExchangeReplays,
   issueTokenExchangeAccessToken,
+  TokenExchangeReplayError,
   verifyTokenExchangeAccessToken,
 } from './store.js';
 
@@ -54,6 +56,62 @@ test(
       assert.deepEqual(verified.attestation, attestation);
     } finally {
       await sql`DELETE FROM agents WHERE id = ${agentId}`;
+      await sql.end();
+    }
+  },
+);
+
+test(
+  'Postgres replay registration is exchange-atomic and admits one concurrent winner',
+  { skip: !hasDb },
+  async () => {
+    const sql = postgres(process.env.DATABASE_URL!);
+    const tag = `token-exchange-replay-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const expiresAt = new Date(Date.now() + 60_000);
+    const atomicProfile = `urn:test:${tag}:atomic`;
+    const concurrentProfile = `urn:test:${tag}:concurrent`;
+
+    try {
+      await consumeTokenExchangeReplays(sql, atomicProfile, [
+        { issuer: 'did:web:connector.example', jti: 'subject-existing', expiresAt },
+      ]);
+      await assert.rejects(
+        consumeTokenExchangeReplays(sql, atomicProfile, [
+          { issuer: 'did:web:connector.example', jti: 'client-fresh', expiresAt },
+          { issuer: 'did:web:connector.example', jti: 'subject-existing', expiresAt },
+        ]),
+        (error: unknown) => error instanceof TokenExchangeReplayError && error.tupleIndex === 1,
+      );
+      const [atomicCount] = await sql<{ count: string }[]>`
+        SELECT count(*)::text AS count
+        FROM infra.oauth_token_exchange_replays
+        WHERE profile_id = ${atomicProfile}
+      `;
+      assert.equal(Number(atomicCount?.count), 1, 'the fresh first tuple must roll back');
+
+      const concurrentTuples = [
+        { issuer: 'did:web:connector.example', jti: 'client', expiresAt },
+        { issuer: 'did:web:connector.example', jti: 'subject', expiresAt },
+      ];
+      const outcomes = await Promise.allSettled([
+        consumeTokenExchangeReplays(sql, concurrentProfile, concurrentTuples),
+        consumeTokenExchangeReplays(sql, concurrentProfile, concurrentTuples),
+      ]);
+      assert.equal(outcomes.filter((outcome) => outcome.status === 'fulfilled').length, 1);
+      const rejected = outcomes.find((outcome) => outcome.status === 'rejected');
+      assert.ok(rejected && rejected.status === 'rejected');
+      assert.ok(rejected.reason instanceof TokenExchangeReplayError);
+      const [concurrentCount] = await sql<{ count: string }[]>`
+        SELECT count(*)::text AS count
+        FROM infra.oauth_token_exchange_replays
+        WHERE profile_id = ${concurrentProfile}
+      `;
+      assert.equal(Number(concurrentCount?.count), 2);
+    } finally {
+      await sql`
+        DELETE FROM infra.oauth_token_exchange_replays
+        WHERE profile_id IN (${atomicProfile}, ${concurrentProfile})
+      `;
       await sql.end();
     }
   },

--- a/packages/server/src/oauth/token-exchange/store.ts
+++ b/packages/server/src/oauth/token-exchange/store.ts
@@ -36,7 +36,7 @@ export class TokenExchangeTokenError extends Error {
 }
 
 export class TokenExchangeReplayError extends Error {
-  constructor() {
+  constructor(readonly tupleIndex?: number) {
     super('OAuth token-exchange assertion replayed');
     this.name = 'TokenExchangeReplayError';
   }
@@ -60,7 +60,7 @@ export async function consumeTokenExchangeReplays(
   tuples: Array<{ issuer: string; jti: string; expiresAt: Date }>,
 ): Promise<void> {
   await sql.begin(async (tx) => {
-    for (const tuple of tuples) {
+    for (const [tupleIndex, tuple] of tuples.entries()) {
       const digest = tokenExchangeReplayDigest(profileId, tuple.issuer, tuple.jti);
       const rows = await tx<{ digest: Buffer }[]>`
         INSERT INTO infra.oauth_token_exchange_replays (digest, profile_id, expires_at)
@@ -70,7 +70,7 @@ export async function consumeTokenExchangeReplays(
       `;
       // Throwing rolls the transaction back, so a replay in either assertion
       // cannot partially consume the other assertion's fresh jti.
-      if (rows.length !== 1) throw new TokenExchangeReplayError();
+      if (rows.length !== 1) throw new TokenExchangeReplayError(tupleIndex);
     }
   });
 }

--- a/packages/server/src/oauth/token-exchange/types.ts
+++ b/packages/server/src/oauth/token-exchange/types.ts
@@ -62,10 +62,11 @@ export interface TokenExchangeProfileContext {
 /**
  * One authorization profile layered on RFC 8693.
  *
- * The core owns HTTP parsing, resource selection, opaque token issuance,
- * replay persistence, and the RFC response. A profile owns assertion syntax,
- * trust establishment, cryptographic verification, scopes, and the derived
- * principal/actor authorization context.
+ * The core owns HTTP parsing, resource selection, opaque token issuance, and
+ * the RFC response. It persists replay evidence by default; a profile may do
+ * so inside its verifier when that ordering is part of the profile contract.
+ * A profile owns assertion syntax, trust establishment, cryptographic
+ * verification, scopes, and the derived principal/actor authorization context.
  */
 export interface TokenExchangeProfile {
   id: string;
@@ -76,6 +77,12 @@ export interface TokenExchangeProfile {
    * credentials are not replayable assertions.
    */
   replayProtection: 'required' | 'not-applicable';
+  /**
+   * Where required assertion replays are atomically registered. The generic
+   * core consumes `result.replays` by default; profiles whose reference
+   * verifier requires an in-verifier replay cache set this to `profile`.
+   */
+  replayPersistence?: 'core' | 'profile';
   clientAuthMethods: readonly string[];
   clientAuthSigningAlgorithms: readonly string[];
   scopes: readonly string[];

--- a/vendor/mentionable-connector-kit/README.md
+++ b/vendor/mentionable-connector-kit/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the OAuth federation wire registry, request evaluator,
 and reference verifier from `planetarium/mentionable` commit
-`f32c8898c7d81b254ec9a562ea2892525db14de6` (`packages/connector-kit`).
+`61d86728e841b0ca796c86364b2fa881ef66c87d` (`packages/connector-kit`).
 
 The upstream package is a `0.0.0` unpublished workspace package whose
 `workspace:*` dependencies cannot currently be installed from a consumer

--- a/vendor/mentionable-connector-kit/fixtures/README.md
+++ b/vendor/mentionable-connector-kit/fixtures/README.md
@@ -23,12 +23,12 @@ Connector self-assertion is REMOVED. Gateways/brokers, independent actors,
 arbitrary `actor_token` support, and actor-less authentication of relay
 subjects are deferred to a later profile version.
 
-**The spec document is deliberately deferred** (implementation-first decision
-on #618): until it lands, the typed constants in
-`packages/connector-kit/src/oauth-federation.ts` plus these fixtures ARE the
-wire contract. STS implementations (e.g. planetarium/vicoop-bridge#487) test
-against this directory offline; the fixture JSON files are standalone
-artifacts consumable without any Mentionable package.
+The normative profile is
+[`docs/spec/oauth-federation-v0.1.md`](../../../docs/spec/oauth-federation-v0.1.md).
+The typed constants in `packages/connector-kit/src/oauth-federation.ts` plus
+these fixtures pin its byte-level wire contract. STS implementations (e.g.
+planetarium/vicoop-bridge#487) test against this directory offline; the fixture
+JSON files are standalone artifacts consumable without any Mentionable package.
 
 ## Layout
 
@@ -50,10 +50,14 @@ artifacts consumable without any Mentionable package.
   principal = platform subject, actor = Connector DID) and a task-scope-only
   exchange whose `subject_token` is a task-continuation assertion
   (`expected.authorization` additionally pins `task_id`).
-- `invalid/` — security-failure cases: expired assertion, wrong `aud`, wrong
+- `invalid/` — security-failure cases: expired assertion, zero/negative or
+  excessive lifetime, wrong `aud`, wrong
   `typ`, wrong `alg` (an unsigned `alg: "none"` token — RFC 8725
-  alg-stripping), `kid` not authorized by the issuer DID, not-yet-valid, TTL
-  over the 600 s cap, tampered signature, a subject assertion issued by a
+  alg-stripping), invalid `mentionable_method`, a `kid` outside the issuer
+  fragment namespace or with malformed fragment-URI syntax, malformed issuer
+  controller/type/public Ed25519 JWK
+  (including private `d` or mixed multibase material), `kid` not authorized
+  by the issuer DID, not-yet-valid, tampered signature, a subject assertion issued by a
   DIFFERENT Connector than the authenticated `client_id` (the
   stolen/forwarded-assertion case — `issuer-client-mismatch`; the same
   reason also covers a decodable subject token with NO `iss` claim, since
@@ -66,7 +70,8 @@ artifacts consumable without any Mentionable package.
   exchange using a task-continuation `subject_token` (#618 decision 8 as
   amended — a continuation can never send new messages as the subject), a
   continuation assertion missing its mandatory `mentionable_task_id` claim
-  (`missing-claim`), and a scope token outside the v0.1 registry
+  (`missing-claim`), a missing/empty scope, a missing/wrong
+  `requested_token_type`, and a scope token outside the v0.1 registry
   (`invalid_scope` — the fixture's tab-embedded scope string is ONE unknown
   token after RFC 6749 space-splitting, closing a whitespace re-split
   smuggle).
@@ -78,6 +83,9 @@ artifacts consumable without any Mentionable package.
 Assertion fixtures carry `{ jwt, verification }`, where `verification` is
 the receiver-side binding (`typ` expected in that presentation slot, the
 token endpoint the `aud` must equal, and the receiver clock `verifiedAt`).
+Verification-method policy fixtures additionally carry an `issuerDocument`
+override whose deliberately malformed method must be used in place of the
+shared `issuer/did.json`.
 Exchange-request fixtures carry `{ params, evaluation }` — the exact
 form-encoded request parameters plus the target's canonical resource —
 and accept fixtures additionally pin `expected.authorization`, the context an
@@ -85,11 +93,15 @@ STS derives via the verified path. Two verification layers apply: the
 fetch-only shape gate (`evaluateTokenExchangeRequest`) is UNVERIFIED and
 returns only `{ scopes, unverifiedSubjectClaims }`, never an authorization
 decision; the authenticated `verifyTokenExchange` — the required STS entry
-point — verifies both the subject and the client assertion (each binding to
-the token endpoint as `aud`, with `expectedResource` mandatory) and only then
-produces `expected.authorization` (`{ purpose: "delegation", principal,
-actor }`). The reject reasons in `manifest.json` for `exchange-request`
-fixtures are shape-gate reasons.
+point — requires its receiver-owned `authorizeCandidateBeforeFetch` callback
+to approve the exact unverified platform tuple or continuation task key before
+any DID resolution, verifies both subject and client assertions (each binding
+to the token endpoint as `aud`, with `expectedResource` and a replay cache
+mandatory), and only after policy plus verification produces `expected.authorization`
+(`{ purpose: "delegation", principal, actor }`). The callback's caller must
+separately retain the matched local policy key for access-token/task binding.
+The reject reasons in `manifest.json` for `exchange-request` fixtures are
+shape-gate reasons.
 
 ## Regenerating
 

--- a/vendor/mentionable-connector-kit/fixtures/invalid/exchange-empty-scope.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/exchange-empty-scope.json
@@ -1,0 +1,18 @@
+{
+  "params": {
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJmNWU2YTdiOC1jOWQwLTRlMWYtOGEzYi00YzVkNmU3ZjhhOWIifQ.2thAJdECkTn2yhNFJYKZrASJPKgE1wvdmhU8sPBNQHveofaE8K7iBhLiAALNbLbkbdOC4-FDMs9UYEtCjL8uDA",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "resource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "scope": "",
+    "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+    "client_id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    "client_assertion": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLWNsaWVudC1hc3NlcnRpb24rand0Iiwia2lkIjoiZGlkOndlYjpjb25uZWN0b3Iub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2I29hdXRoLWZpeHR1cmUtMjAyNi0wOCJ9.eyJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJhdWQiOiJodHRwczovL3N0cy5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYvb2F1dGgvdG9rZW4iLCJpYXQiOjE3ODcwOTc2MDAsImV4cCI6MTc4NzA5NzkwMCwianRpIjoiYjdhOGM5ZDAtZTFmMi00YTNiLThjNWQtNmU3ZjhhOWIwYzFkIn0.21sdTIZbslCwrzxdQ8ykuc96GsA_COH1quJpvnM29R9bM6jObl2hsRU5f2wwjKaLf1W3-fHeUZLNUPYVrAM5Aw"
+  },
+  "evaluation": {
+    "expectedResource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/exchange-missing-requested-token-type.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/exchange-missing-requested-token-type.json
@@ -1,0 +1,17 @@
+{
+  "params": {
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJmNWU2YTdiOC1jOWQwLTRlMWYtOGEzYi00YzVkNmU3ZjhhOWIifQ.2thAJdECkTn2yhNFJYKZrASJPKgE1wvdmhU8sPBNQHveofaE8K7iBhLiAALNbLbkbdOC4-FDMs9UYEtCjL8uDA",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "resource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "scope": "a2a:message.send",
+    "client_id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    "client_assertion": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLWNsaWVudC1hc3NlcnRpb24rand0Iiwia2lkIjoiZGlkOndlYjpjb25uZWN0b3Iub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2I29hdXRoLWZpeHR1cmUtMjAyNi0wOCJ9.eyJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJhdWQiOiJodHRwczovL3N0cy5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYvb2F1dGgvdG9rZW4iLCJpYXQiOjE3ODcwOTc2MDAsImV4cCI6MTc4NzA5NzkwMCwianRpIjoiYjdhOGM5ZDAtZTFmMi00YTNiLThjNWQtNmU3ZjhhOWIwYzFkIn0.21sdTIZbslCwrzxdQ8ykuc96GsA_COH1quJpvnM29R9bM6jObl2hsRU5f2wwjKaLf1W3-fHeUZLNUPYVrAM5Aw"
+  },
+  "evaluation": {
+    "expectedResource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/exchange-missing-scope.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/exchange-missing-scope.json
@@ -1,0 +1,17 @@
+{
+  "params": {
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJmNWU2YTdiOC1jOWQwLTRlMWYtOGEzYi00YzVkNmU3ZjhhOWIifQ.2thAJdECkTn2yhNFJYKZrASJPKgE1wvdmhU8sPBNQHveofaE8K7iBhLiAALNbLbkbdOC4-FDMs9UYEtCjL8uDA",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "resource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "requested_token_type": "urn:ietf:params:oauth:token-type:access_token",
+    "client_id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    "client_assertion": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLWNsaWVudC1hc3NlcnRpb24rand0Iiwia2lkIjoiZGlkOndlYjpjb25uZWN0b3Iub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2I29hdXRoLWZpeHR1cmUtMjAyNi0wOCJ9.eyJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJhdWQiOiJodHRwczovL3N0cy5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYvb2F1dGgvdG9rZW4iLCJpYXQiOjE3ODcwOTc2MDAsImV4cCI6MTc4NzA5NzkwMCwianRpIjoiYjdhOGM5ZDAtZTFmMi00YTNiLThjNWQtNmU3ZjhhOWIwYzFkIn0.21sdTIZbslCwrzxdQ8ykuc96GsA_COH1quJpvnM29R9bM6jObl2hsRU5f2wwjKaLf1W3-fHeUZLNUPYVrAM5Aw"
+  },
+  "evaluation": {
+    "expectedResource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/exchange-wrong-requested-token-type.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/exchange-wrong-requested-token-type.json
@@ -1,0 +1,18 @@
+{
+  "params": {
+    "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+    "subject_token": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJmNWU2YTdiOC1jOWQwLTRlMWYtOGEzYi00YzVkNmU3ZjhhOWIifQ.2thAJdECkTn2yhNFJYKZrASJPKgE1wvdmhU8sPBNQHveofaE8K7iBhLiAALNbLbkbdOC4-FDMs9UYEtCjL8uDA",
+    "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "resource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "scope": "a2a:message.send",
+    "requested_token_type": "urn:ietf:params:oauth:token-type:jwt",
+    "client_id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+    "client_assertion": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLWNsaWVudC1hc3NlcnRpb24rand0Iiwia2lkIjoiZGlkOndlYjpjb25uZWN0b3Iub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2I29hdXRoLWZpeHR1cmUtMjAyNi0wOCJ9.eyJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJhdWQiOiJodHRwczovL3N0cy5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYvb2F1dGgvdG9rZW4iLCJpYXQiOjE3ODcwOTc2MDAsImV4cCI6MTc4NzA5NzkwMCwianRpIjoiYjdhOGM5ZDAtZTFmMi00YTNiLThjNWQtNmU3ZjhhOWIwYzFkIn0.21sdTIZbslCwrzxdQ8ykuc96GsA_COH1quJpvnM29R9bM6jObl2hsRU5f2wwjKaLf1W3-fHeUZLNUPYVrAM5Aw"
+  },
+  "evaluation": {
+    "expectedResource": "https://agents.oauth-fixtures.mentionable.dev/fixture-agent/a2a",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/invalid-method.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/invalid-method.json
@@ -1,0 +1,8 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJzbGFjay13b3Jrc3BhY2UtbWVtYmVyIiwiaXNzIjoiZGlkOndlYjpjb25uZWN0b3Iub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2Iiwic3ViIjoic2xhY2s6VDAxMjM0NTYvVTA0NTY3ODkiLCJhdWQiOiJodHRwczovL3N0cy5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYvb2F1dGgvdG9rZW4iLCJpYXQiOjE3ODcwOTc2MDAsImV4cCI6MTc4NzA5NzkwMCwianRpIjoiZjhlOWEwYjEtYzJkMy00ZTRmLThhNWItNmM3ZDhlOWYwYTFjIn0.0CT0dCYp_IwFr2hQVQMHO19k6RG345LSf9FWiAKSSWtPRRDmVqpZeIjHP9_5qlX8wM6pqxr1vU4VkZssfzFtDQ",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/kid-invalid-fragment-syntax.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/kid-invalid-fragment-syntax.json
@@ -1,0 +1,25 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiMlenoifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMGExYzJkMy1lNGY1LTRhNmItOGM3ZC04ZTlmMGExYjJjM2UifQ.wvU50twzeZo0U5Y3q3Ie5yoF3fAZ4A7f_hhhHNMF7IZYpsr7CJrUrfGWY_Xme86-NsML0ac0lXMUaYGX5xjoBQ",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#%zz",
+        "type": "JsonWebKey",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP"
+        }
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#%zz"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/kid-not-issuer-fragment.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/kid-not-issuer-fragment.json
@@ -1,0 +1,25 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6b3RoZXIub2F1dGgtZml4dHVyZXMubWVudGlvbmFibGUuZGV2I29hdXRoLWZpeHR1cmUtMjAyNi0wOCJ9.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJhOWYwYjFjMi1kM2U0LTRmNWEtOWI2Yy03ZDhlOWYwYTFiMmQifQ.GsJNhAQL5aAgmlAZcnGfqvb2liESzzeT4EilnQt0PdgBEWRoBT_S-KYm0b-_y9ZZy0E4hKN7AbuBLEQzN8e9Dg",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:other.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP"
+        }
+      }
+    ],
+    "assertionMethod": ["did:web:other.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/negative-lifetime.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/negative-lifetime.json
@@ -1,0 +1,8 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3NTk5LCJqdGkiOiJlN2Q4ZjlhMC1iMWMyLTRkM2UtOWY0YS01YjZjN2Q4ZTlmMGIifQ.JdkoyCg5ui1KPEjQYNMjUeofZDcjWCPMN1xXlhheCb2rg_ZU4DkxgDgEmmZ2qvQ0KGyiOveBwCUPOnhUUtxdBA",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/vm-controller-mismatch.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/vm-controller-mismatch.json
@@ -1,0 +1,25 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMWEyYzNkNC1lNWY2LTRhN2ItOGM5ZC0wZTFmMmEzYjRjNWQifQ.eUEtEwPCNF1QmUa6y0mQVj-5RL5twn8C_3xo1NjOfAebz8M2XuzqIDHNx5XGhH9Wn2em9s7mMiwQdUF1M0icAw",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey",
+        "controller": "did:web:other-connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP"
+        }
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/vm-invalid-public-jwk.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/vm-invalid-public-jwk.json
@@ -1,0 +1,21 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMWEyYzNkNC1lNWY2LTRhN2ItOGM5ZC0wZTFmMmEzYjRjNWQifQ.eUEtEwPCNF1QmUa6y0mQVj-5RL5twn8C_3xo1NjOfAebz8M2XuzqIDHNx5XGhH9Wn2em9s7mMiwQdUF1M0icAw",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": { "crv": "Ed25519", "x": "", "kty": "OKP" }
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/vm-mixed-key-material.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/vm-mixed-key-material.json
@@ -1,0 +1,26 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMWEyYzNkNC1lNWY2LTRhN2ItOGM5ZC0wZTFmMmEzYjRjNWQifQ.eUEtEwPCNF1QmUa6y0mQVj-5RL5twn8C_3xo1NjOfAebz8M2XuzqIDHNx5XGhH9Wn2em9s7mMiwQdUF1M0icAw",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP"
+        },
+        "publicKeyMultibase": "z6MkMixedForbidden"
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/vm-private-jwk.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/vm-private-jwk.json
@@ -1,0 +1,26 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMWEyYzNkNC1lNWY2LTRhN2ItOGM5ZC0wZTFmMmEzYjRjNWQifQ.eUEtEwPCNF1QmUa6y0mQVj-5RL5twn8C_3xo1NjOfAebz8M2XuzqIDHNx5XGhH9Wn2em9s7mMiwQdUF1M0icAw",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP",
+          "d": "private-material-forbidden"
+        }
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/vm-wrong-type.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/vm-wrong-type.json
@@ -1,0 +1,25 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3OTAwLCJqdGkiOiJiMWEyYzNkNC1lNWY2LTRhN2ItOGM5ZC0wZTFmMmEzYjRjNWQifQ.eUEtEwPCNF1QmUa6y0mQVj-5RL5twn8C_3xo1NjOfAebz8M2XuzqIDHNx5XGhH9Wn2em9s7mMiwQdUF1M0icAw",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  },
+  "issuerDocument": {
+    "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/jwk/v1"],
+    "id": "did:web:connector.oauth-fixtures.mentionable.dev",
+    "verificationMethod": [
+      {
+        "id": "did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08",
+        "type": "JsonWebKey2020",
+        "controller": "did:web:connector.oauth-fixtures.mentionable.dev",
+        "publicKeyJwk": {
+          "crv": "Ed25519",
+          "x": "UGfideXk63XnzqYdisiTAZ64iAHklpZox4h4kECItXU",
+          "kty": "OKP"
+        }
+      }
+    ],
+    "assertionMethod": ["did:web:connector.oauth-fixtures.mentionable.dev#oauth-fixture-2026-08"]
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/invalid/zero-lifetime.json
+++ b/vendor/mentionable-connector-kit/fixtures/invalid/zero-lifetime.json
@@ -1,0 +1,8 @@
+{
+  "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im1lbnRpb25hYmxlLXN1YmplY3QtYXNzZXJ0aW9uK2p3dCIsImtpZCI6ImRpZDp3ZWI6Y29ubmVjdG9yLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldiNvYXV0aC1maXh0dXJlLTIwMjYtMDgifQ.eyJtZW50aW9uYWJsZV9tZXRob2QiOiJ1cm46bWVudGlvbmFibGU6YXV0aDpzbGFjay13b3Jrc3BhY2UtbWVtYmVyOnYwLjEiLCJpc3MiOiJkaWQ6d2ViOmNvbm5lY3Rvci5vYXV0aC1maXh0dXJlcy5tZW50aW9uYWJsZS5kZXYiLCJzdWIiOiJzbGFjazpUMDEyMzQ1Ni9VMDQ1Njc4OSIsImF1ZCI6Imh0dHBzOi8vc3RzLm9hdXRoLWZpeHR1cmVzLm1lbnRpb25hYmxlLmRldi9vYXV0aC90b2tlbiIsImlhdCI6MTc4NzA5NzYwMCwiZXhwIjoxNzg3MDk3NjAwLCJqdGkiOiJkNmM3ZThmOS1hMGIxLTRjMmQtOGUzZi00YTViNmM3ZDhlOWEifQ.7_4LwQz3FshS8mwRXxWmriQBLslh2PsmxznC_cQ7CE-yuvd4V8xhtGOzc3kOu3xDUr_b_gPVo7j_K5ZpCB4sAg",
+  "verification": {
+    "typ": "mentionable-subject-assertion+jwt",
+    "tokenEndpoint": "https://sts.oauth-fixtures.mentionable.dev/oauth/token",
+    "verifiedAt": "2026-08-19T00:01:00Z"
+  }
+}

--- a/vendor/mentionable-connector-kit/fixtures/manifest.json
+++ b/vendor/mentionable-connector-kit/fixtures/manifest.json
@@ -49,6 +49,66 @@
     "reason": "ttl-exceeded"
   },
   {
+    "file": "invalid/zero-lifetime.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "invalid-lifetime"
+  },
+  {
+    "file": "invalid/negative-lifetime.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "invalid-lifetime"
+  },
+  {
+    "file": "invalid/invalid-method.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "invalid-method"
+  },
+  {
+    "file": "invalid/kid-not-issuer-fragment.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/kid-invalid-fragment-syntax.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/vm-controller-mismatch.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/vm-wrong-type.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/vm-invalid-public-jwk.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/vm-private-jwk.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
+    "file": "invalid/vm-mixed-key-material.json",
+    "kind": "assertion",
+    "expect": "reject",
+    "reason": "kid-not-authorized"
+  },
+  {
     "file": "invalid/tampered-signature.json",
     "kind": "assertion",
     "expect": "reject",
@@ -107,6 +167,30 @@
     "kind": "exchange-request",
     "expect": "reject",
     "reason": "unknown-scope"
+  },
+  {
+    "file": "invalid/exchange-missing-scope.json",
+    "kind": "exchange-request",
+    "expect": "reject",
+    "reason": "missing-scope"
+  },
+  {
+    "file": "invalid/exchange-empty-scope.json",
+    "kind": "exchange-request",
+    "expect": "reject",
+    "reason": "missing-scope"
+  },
+  {
+    "file": "invalid/exchange-missing-requested-token-type.json",
+    "kind": "exchange-request",
+    "expect": "reject",
+    "reason": "missing-requested-token-type"
+  },
+  {
+    "file": "invalid/exchange-wrong-requested-token-type.json",
+    "kind": "exchange-request",
+    "expect": "reject",
+    "reason": "unsupported-requested-token-type"
   },
   {
     "file": "replay/replayed-jti.json",

--- a/vendor/mentionable-connector-kit/package.json
+++ b/vendor/mentionable-connector-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentionable/connector-kit",
-  "version": "0.0.0-vendored.f32c8898",
+  "version": "0.0.0-vendored.61d86728",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/vendor/mentionable-connector-kit/src/oauth-federation-exchange.ts
+++ b/vendor/mentionable-connector-kit/src/oauth-federation-exchange.ts
@@ -18,7 +18,7 @@
 // `client_id` — the stolen / forwarded-assertion case — is rejected.
 //
 // Retry semantics: this client NEVER retries. Every recognized OAuth error
-// code is a client fault (`retryable: false`) — in particular
+// code except a 5xx `server_error` is a client fault (`retryable: false`) — in particular
 // `invalid_request` (e.g. issuer/client inequality) and `invalid_grant`
 // (expired/replayed assertion) mean the request itself must change;
 // re-sending the same bytes cannot succeed. Only transport-level failures
@@ -44,8 +44,12 @@ import {
   OAUTH_TOKEN_TYPE_JWT,
   isTokenExchangeErrorCode,
   scopesRequireSubjectAssertion,
+  type OAuthFederationScope,
   type TokenExchangeErrorCode,
 } from './oauth-federation.js'
+
+/** The v0.1 scope registry as a set — unknown scopes fail closed. */
+const KNOWN_SCOPES: ReadonlySet<string> = new Set(OAUTH_FEDERATION_SCOPES)
 
 // ---------------------------------------------------------------------------
 // Request building
@@ -60,13 +64,16 @@ export type TokenExchangeRequest = {
    */
   subjectToken: string
   /** Defaults to `urn:ietf:params:oauth:token-type:jwt` — the only v0.1 type. */
-  subjectTokenType?: string
+  subjectTokenType?: typeof OAUTH_TOKEN_TYPE_JWT
   /** Exactly one canonical resource (RFC 8707) — the agent's advertised A2A endpoint URL. */
   resource: string
-  /** Requested scopes (space-joined on the wire). */
-  scope?: readonly string[]
+  /**
+   * Requested scopes (space-joined on the wire). v0.1 requires at least one
+   * member of the closed profile registry.
+   */
+  scope: readonly OAuthFederationScope[]
   /** Defaults to `urn:ietf:params:oauth:token-type:access_token`. */
-  requestedTokenType?: string
+  requestedTokenType?: typeof OAUTH_TOKEN_TYPE_ACCESS_TOKEN
   /** OAuth client id — the Connector DID. */
   clientId: string
   /** RFC 7523 client assertion JWT (`private_key_jwt`). */
@@ -79,14 +86,32 @@ export type TokenExchangeRequest = {
  * fixtures and consuming tests can pin the exact wire shape.
  */
 export function buildTokenExchangeBody(request: TokenExchangeRequest): URLSearchParams {
+  if (
+    request.scope === undefined ||
+    request.scope.length === 0 ||
+    request.scope.some((scope) => !KNOWN_SCOPES.has(scope))
+  ) {
+    throw new TypeError(
+      'buildTokenExchangeBody: scope must contain at least one known OAuth federation v0.1 scope',
+    )
+  }
+  if (request.subjectTokenType !== undefined && request.subjectTokenType !== OAUTH_TOKEN_TYPE_JWT) {
+    throw new TypeError(`buildTokenExchangeBody: subjectTokenType must be ${OAUTH_TOKEN_TYPE_JWT}`)
+  }
+  if (
+    request.requestedTokenType !== undefined &&
+    request.requestedTokenType !== OAUTH_TOKEN_TYPE_ACCESS_TOKEN
+  ) {
+    throw new TypeError(
+      `buildTokenExchangeBody: requestedTokenType must be ${OAUTH_TOKEN_TYPE_ACCESS_TOKEN}`,
+    )
+  }
   const body = new URLSearchParams()
   body.set('grant_type', OAUTH_GRANT_TYPE_TOKEN_EXCHANGE)
   body.set('subject_token', request.subjectToken)
   body.set('subject_token_type', request.subjectTokenType ?? OAUTH_TOKEN_TYPE_JWT)
   body.set('resource', request.resource)
-  if (request.scope !== undefined && request.scope.length > 0) {
-    body.set('scope', request.scope.join(' '))
-  }
+  body.set('scope', request.scope.join(' '))
   body.set('requested_token_type', request.requestedTokenType ?? OAUTH_TOKEN_TYPE_ACCESS_TOKEN)
   body.set('client_id', request.clientId)
   body.set('client_assertion_type', OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER)
@@ -102,9 +127,9 @@ export type TokenExchangeSuccess = {
   ok: true
   accessToken: string
   /** RFC 8693 `issued_token_type` — `urn:ietf:params:oauth:token-type:access_token` in v0.1. */
-  issuedTokenType: string
+  issuedTokenType: typeof OAUTH_TOKEN_TYPE_ACCESS_TOKEN
   /** RFC 6749 `token_type` — `Bearer` in v0.1 (DPoP is reserved). */
-  tokenType: string
+  tokenType: 'Bearer'
   /** Lifetime in seconds, when the STS provided `expires_in`. */
   expiresIn?: number
   /** Granted scopes (split from the space-delimited `scope`), when returned. */
@@ -125,9 +150,9 @@ export type TokenExchangeFailure = {
   errorDescription?: string
   errorUri?: string
   /**
-   * `false` for every recognized OAuth error code (client faults — never
-   * re-send the same request; see module header). `true` only for
-   * transport-level failures (5xx / unparseable) the caller may back off on.
+   * `false` for client-fault OAuth errors. `true` for a 5xx `server_error`
+   * or an unparseable 5xx response the caller may back off on. This client
+   * does not perform the retry itself.
    */
   retryable: boolean
   /** The parsed response body when there was one. */
@@ -158,15 +183,14 @@ function parseSuccess(status: number, body: Record<string, unknown>): TokenExcha
   if (
     typeof accessToken !== 'string' ||
     accessToken.length === 0 ||
-    typeof issuedTokenType !== 'string' ||
-    typeof tokenType !== 'string'
+    issuedTokenType !== OAUTH_TOKEN_TYPE_ACCESS_TOKEN ||
+    tokenType !== 'Bearer'
   ) {
     return {
       ok: false,
       status,
       error: 'invalid_response',
-      errorDescription:
-        'token endpoint returned 2xx without access_token/issued_token_type/token_type',
+      errorDescription: 'token endpoint returned a malformed or unsupported access-token response',
       retryable: false,
       raw: body,
     }
@@ -179,9 +203,44 @@ function parseSuccess(status: number, body: Record<string, unknown>): TokenExcha
     raw: body,
   }
   const expiresIn = body['expires_in']
-  if (typeof expiresIn === 'number' && Number.isFinite(expiresIn)) out.expiresIn = expiresIn
+  if (expiresIn !== undefined) {
+    if (typeof expiresIn !== 'number' || !Number.isInteger(expiresIn) || expiresIn <= 0) {
+      return {
+        ok: false,
+        status,
+        error: 'invalid_response',
+        errorDescription: 'token endpoint returned malformed expires_in',
+        retryable: false,
+        raw: body,
+      }
+    }
+    out.expiresIn = expiresIn
+  }
   const scope = body['scope']
-  if (typeof scope === 'string' && scope.length > 0) out.scope = scope.split(' ')
+  if (scope !== undefined) {
+    if (typeof scope !== 'string' || scope.length === 0) {
+      return {
+        ok: false,
+        status,
+        error: 'invalid_response',
+        errorDescription: 'token endpoint returned malformed scope',
+        retryable: false,
+        raw: body,
+      }
+    }
+    const scopes = scope.split(' ')
+    if (scopes.some((token) => token.length === 0 || !KNOWN_SCOPES.has(token))) {
+      return {
+        ok: false,
+        status,
+        error: 'invalid_response',
+        errorDescription: 'token endpoint returned malformed or unknown scope',
+        retryable: false,
+        raw: body,
+      }
+    }
+    out.scope = scopes
+  }
   return out
 }
 
@@ -191,7 +250,7 @@ function parseFailure(status: number, body: unknown): TokenExchangeFailure {
       ok: false,
       status,
       error: body['error'],
-      retryable: false,
+      retryable: body['error'] === 'server_error' && status >= 500,
       raw: body,
     }
     if (typeof body['error_description'] === 'string') {
@@ -279,6 +338,8 @@ export type ExchangeRequestRejectReason =
   | 'missing-subject-token'
   | 'undecodable-subject-token'
   | 'unsupported-subject-token-type'
+  | 'missing-requested-token-type'
+  | 'unsupported-requested-token-type'
   | 'missing-resource'
   | 'resource-substitution'
   | 'missing-client-id'
@@ -289,6 +350,7 @@ export type ExchangeRequestRejectReason =
   | 'unexpected-actor-token'
   | 'issuer-client-mismatch'
   | 'message-scope-requires-subject-assertion'
+  | 'missing-scope'
   | 'unknown-scope'
 
 /**
@@ -338,9 +400,6 @@ const SINGLE_VALUED_PARAMS = [
   'client_assertion',
   'client_assertion_type',
 ] as const
-
-/** The v0.1 scope registry as a set — requested scopes outside it are rejected. */
-const KNOWN_SCOPES: ReadonlySet<string> = new Set(OAUTH_FEDERATION_SCOPES)
 
 /** Decode a JWT's protected header without verifying anything; null when undecodable. */
 function tryDecodeHeader(jwt: string): { typ?: string } | null {
@@ -404,6 +463,17 @@ export function evaluateTokenExchangeRequest(
   if (params.get('subject_token_type') !== OAUTH_TOKEN_TYPE_JWT) {
     return { ok: false, error: 'invalid_request', reason: 'unsupported-subject-token-type' }
   }
+  const subjectHeader = tryDecodeHeader(subjectToken)
+  if (subjectHeader === null) {
+    return { ok: false, error: 'invalid_request', reason: 'undecodable-subject-token' }
+  }
+  const requestedTokenType = params.get('requested_token_type')
+  if (requestedTokenType === null || requestedTokenType.length === 0) {
+    return { ok: false, error: 'invalid_request', reason: 'missing-requested-token-type' }
+  }
+  if (requestedTokenType !== OAUTH_TOKEN_TYPE_ACCESS_TOKEN) {
+    return { ok: false, error: 'invalid_request', reason: 'unsupported-requested-token-type' }
+  }
   // v0.1 sends NO actor token — the actor is derived from the authenticated
   // client. Any actor_token/actor_token_type present is a deferred-feature
   // request and fails closed rather than being silently ignored.
@@ -429,6 +499,9 @@ export function evaluateTokenExchangeRequest(
   }
   if (params.get('client_assertion_type') !== OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER) {
     return { ok: false, error: 'invalid_client', reason: 'unsupported-client-assertion-type' }
+  }
+  if (tryDecodeHeader(clientAssertion) === null) {
+    return { ok: false, error: 'invalid_client', reason: 'undecodable-client-assertion' }
   }
   // RFC 7523 §3: the client assertion's `iss` and `sub` are the client_id.
   // A decodable assertion naming a DIFFERENT party than the request's
@@ -471,7 +544,10 @@ export function evaluateTokenExchangeRequest(
     return { ok: false, error: 'invalid_request', reason: 'undecodable-subject-token' }
   }
   const scope = params.get('scope')
-  const scopes = scope === null || scope.length === 0 ? [] : scope.split(' ')
+  if (scope === null || scope.length === 0) {
+    return { ok: false, error: 'invalid_scope', reason: 'missing-scope' }
+  }
+  const scopes = scope.split(' ')
   // Requested scopes are restricted to the known v0.1 registry. This kills a
   // smuggling class: e.g. "a2a:message.send\ta2a:task.read" splits (on the
   // RFC 6749 space delimiter) into ONE unknown token that would otherwise
@@ -488,8 +564,7 @@ export function evaluateTokenExchangeRequest(
   // UNVERIFIED typ header; verifyTokenExchange re-checks on the VERIFIED
   // typ.
   if (scopesRequireSubjectAssertion(scopes)) {
-    const header = tryDecodeHeader(subjectToken)
-    if (header !== null && header.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION) {
+    if (subjectHeader.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION) {
       return {
         ok: false,
         error: 'invalid_request',

--- a/vendor/mentionable-connector-kit/src/oauth-federation-verifier.ts
+++ b/vendor/mentionable-connector-kit/src/oauth-federation-verifier.ts
@@ -7,8 +7,9 @@
 // issuer and verifier pin the exact same constants.
 //
 // THE documented STS entry point is `verifyTokenExchange(params, options)`:
-// it runs the fetch-only shape gate, cryptographically verifies BOTH the
-// subject assertion and the `private_key_jwt` client assertion, enforces
+// it runs the fetch-only shape gate, requires receiver-owned policy approval
+// before any DID resolution, cryptographically verifies BOTH the subject
+// assertion and the `private_key_jwt` client assertion, enforces
 // `subject_token.iss == client_id` on the VERIFIED claims, and only then
 // returns a `DerivedAuthorizationContext`. It is the ONLY function here that
 // yields an authorization decision. `evaluateTokenExchangeRequest` (fetch-only
@@ -51,7 +52,10 @@ import {
   OAUTH_FEDERATION_TYP_CLIENT_ASSERTION,
   OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION,
   OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION,
+  isOAuthFederationAbsoluteUri,
+  isOAuthFederationMethodUri,
   scopesRequireSubjectAssertion,
+  type OAuthFederationScope,
   type TokenExchangeErrorCode,
 } from './oauth-federation.js'
 
@@ -64,10 +68,12 @@ export type AssertionRejectReason =
   | 'missing-claim'
   | 'wrong-audience'
   | 'subject-mismatch'
+  | 'invalid-lifetime'
   | 'ttl-exceeded'
   | 'not-yet-valid'
   | 'expired'
   | 'invalid-signature'
+  | 'invalid-method'
   | 'replayed-jti'
 
 export type AssertionVerifyOutcome =
@@ -77,18 +83,24 @@ export type AssertionVerifyOutcome =
 /**
  * Minimal DID-document shape the verifier consumes: `verificationMethod`
  * entries carrying an Ed25519 `publicKeyJwk` (`{ kty: "OKP", crv: "Ed25519",
- * x }`), and an `assertionMethod` relation listing the AUTHORIZED method ids.
- * A key present in `verificationMethod` but absent from `assertionMethod` is
- * NOT authorized to sign assertions.
+ * x }`), and an `assertionMethod` relation listing AUTHORIZED string/id-only
+ * references or full embedded methods. A referenced key present in
+ * `verificationMethod` but absent from `assertionMethod` is NOT authorized to
+ * sign assertions; embedded methods receive the same strict key checks.
  */
+export type IssuerVerificationMethod = {
+  id: string
+  type?: string
+  controller?: string
+  publicKeyJwk?: Record<string, unknown>
+  publicKeyMultibase?: unknown
+  [key: string]: unknown
+}
+
 export type IssuerDidDocument = {
   id: string
-  verificationMethod?: {
-    id: string
-    publicKeyJwk?: Record<string, unknown>
-    [key: string]: unknown
-  }[]
-  assertionMethod?: (string | { id: string })[]
+  verificationMethod?: IssuerVerificationMethod[]
+  assertionMethod?: (string | IssuerVerificationMethod)[]
   [key: string]: unknown
 }
 
@@ -98,8 +110,11 @@ export type IssuerDidDocument = {
  * 600 s + 60 s); an unbounded set is acceptable only for fixture runs.
  */
 export type AssertionReplayCache = {
-  /** Returns true when the tuple was newly recorded, false on replay. */
-  register(tuple: { issuer: string; jti: string }): boolean
+  /**
+   * Atomically register a tuple: true when newly recorded, false on replay.
+   * Async results support shared database/Redis adapters.
+   */
+  register(tuple: { issuer: string; jti: string }): boolean | Promise<boolean>
 }
 
 /** Test-scale replay cache — never evicts; see {@link AssertionReplayCache}. */
@@ -125,7 +140,11 @@ export type VerifyAssertionExpectations = {
 }
 
 export type VerifyAssertionOptions = {
-  /** Exact issuer DIDs the receiver trusts. Checked before any resolution. */
+  /**
+   * Issuer DIDs eligible for resolution. This SSRF allowlist is checked
+   * before any DID fetch, but is not caller authorization by itself; the
+   * combined exchange path separately requires candidate policy approval.
+   */
   trustedIssuers: ReadonlySet<string>
   /**
    * Resolve a TRUSTED issuer's DID document (offline in fixture runs;
@@ -146,11 +165,21 @@ const KNOWN_TYPS: ReadonlySet<string> = new Set([
   OAUTH_FEDERATION_TYP_CLIENT_ASSERTION,
 ])
 
-const assertionMethodIds = (doc: IssuerDidDocument): string[] => {
-  if (!Array.isArray(doc.assertionMethod)) return []
-  return doc.assertionMethod
-    .map((entry) => (typeof entry === 'string' ? entry : entry.id))
-    .filter((id) => typeof id === 'string' && id.length > 0)
+const authorizedAssertionMethod = (
+  doc: IssuerDidDocument,
+  kid: string,
+): IssuerVerificationMethod | undefined => {
+  if (!Array.isArray(doc.assertionMethod)) return undefined
+  const relationship = doc.assertionMethod.find((entry) =>
+    typeof entry === 'string'
+      ? entry === kid
+      : typeof entry === 'object' && entry !== null && entry.id === kid,
+  )
+  if (relationship === undefined) return undefined
+  if (typeof relationship === 'object' && Object.keys(relationship).some((key) => key !== 'id')) {
+    return relationship
+  }
+  return doc.verificationMethod?.find((method) => method.id === kid)
 }
 
 const audienceMatches = (aud: JWTPayload['aud'], expected: string): boolean => {
@@ -158,6 +187,27 @@ const audienceMatches = (aud: JWTPayload['aud'], expected: string): boolean => {
   if (Array.isArray(aud)) return aud.length === 1 && aud[0] === expected
   return false
 }
+
+const isIssuerFragmentDidUrl = (kid: string, issuer: string): boolean => {
+  const delimiter = kid.indexOf('#')
+  if (
+    delimiter !== issuer.length ||
+    kid.slice(0, delimiter) !== issuer ||
+    delimiter === kid.length - 1 ||
+    kid.indexOf('#', delimiter + 1) !== -1 ||
+    !isOAuthFederationAbsoluteUri(kid)
+  ) {
+    return false
+  }
+  return kid.startsWith('did:')
+}
+
+const isPublicEd25519Jwk = (jwk: Record<string, unknown>): boolean =>
+  jwk['kty'] === 'OKP' &&
+  jwk['crv'] === 'Ed25519' &&
+  typeof jwk['x'] === 'string' &&
+  jwk['x'].length > 0 &&
+  !Object.hasOwn(jwk, 'd')
 
 /**
  * Verify one profile assertion JWT against the expectations of a
@@ -212,18 +262,34 @@ export async function verifyOAuthFederationAssertion(
     return { ok: false, reason: 'untrusted-issuer', detail: issuer }
   }
 
+  if (!isIssuerFragmentDidUrl(header.kid, issuer)) {
+    return {
+      ok: false,
+      reason: 'kid-not-authorized',
+      detail: `kid is not an absolute fragment DID URL under issuer: ${header.kid}`,
+    }
+  }
+
   // 4. kid must be a verification method the issuer DID document authorizes
   //    under `assertionMethod`.
   const doc = options.resolveIssuerDocument(issuer)
   if (doc === undefined || doc.id !== issuer) {
     return { ok: false, reason: 'untrusted-issuer', detail: `no issuer document: ${issuer}` }
   }
-  if (!assertionMethodIds(doc).includes(header.kid)) {
-    return { ok: false, reason: 'kid-not-authorized', detail: header.kid }
-  }
-  const method = doc.verificationMethod?.find((vm) => vm.id === header.kid)
-  if (method?.publicKeyJwk === undefined) {
-    return { ok: false, reason: 'kid-not-authorized', detail: `no publicKeyJwk: ${header.kid}` }
+  const method = authorizedAssertionMethod(doc, header.kid)
+  if (
+    method === undefined ||
+    method.controller !== issuer ||
+    method.type !== 'JsonWebKey' ||
+    method.publicKeyJwk === undefined ||
+    !isPublicEd25519Jwk(method.publicKeyJwk) ||
+    Object.hasOwn(method, 'publicKeyMultibase')
+  ) {
+    return {
+      ok: false,
+      reason: 'kid-not-authorized',
+      detail: `verification method is not a public issuer-controlled JsonWebKey Ed25519 method: ${header.kid}`,
+    }
   }
 
   // 5. Claim profile. Presence checks enforce the claim's TYPE, not just
@@ -247,6 +313,9 @@ export async function verifyOAuthFederationAssertion(
   const iat = payload.iat as number
   const exp = payload.exp as number
   const verifiedAt = Math.floor(verifiedAtMs / 1000)
+  if (exp <= iat) {
+    return { ok: false, reason: 'invalid-lifetime', detail: 'exp must be greater than iat' }
+  }
   if (exp - iat > MAX_TTL_SECONDS) {
     return { ok: false, reason: 'ttl-exceeded' }
   }
@@ -284,8 +353,12 @@ export async function verifyOAuthFederationAssertion(
   } else {
     // Platform-subject assertion: requires the method claim; the subject is
     // a platform principal, never the issuer itself.
-    if (typeof payload[OAUTH_FEDERATION_CLAIM_METHOD] !== 'string') {
+    const methodClaim = payload[OAUTH_FEDERATION_CLAIM_METHOD]
+    if (typeof methodClaim !== 'string' || methodClaim.length === 0) {
       return { ok: false, reason: 'missing-claim', detail: OAUTH_FEDERATION_CLAIM_METHOD }
+    }
+    if (!isOAuthFederationMethodUri(methodClaim)) {
+      return { ok: false, reason: 'invalid-method', detail: methodClaim }
     }
     if (payload.sub === issuer) {
       return { ok: false, reason: 'subject-mismatch', detail: 'sub equals iss' }
@@ -311,7 +384,7 @@ export async function verifyOAuthFederationAssertion(
   // 7. Replay posture: only a caching verifier gets one-time semantics.
   //    (`jti` is guaranteed a non-empty string by the layer-5 claim checks.)
   if (options.replayCache !== undefined) {
-    if (!options.replayCache.register({ issuer, jti: payload.jti as string })) {
+    if (!(await options.replayCache.register({ issuer, jti: payload.jti as string }))) {
       return { ok: false, reason: 'replayed-jti' }
     }
   }
@@ -379,7 +452,8 @@ export async function verifyClientAssertion(
  * platform subject, for both the message path (subject assertion) and the
  * task path (task-continuation assertion, whose `sub` is the ORIGINATING
  * platform subject) — and `actor` is the authenticated `client_id`. Produced
- * ONLY by {@link verifyTokenExchange}, never by the fetch-only shape gate.
+ * ONLY by {@link verifyTokenExchange} after its required policy gate and
+ * cryptographic checks, never by the fetch-only shape gate.
  *
  * `task_id` is present IFF the subject token was a task-continuation
  * assertion (taken from its VERIFIED `mentionable_task_id` claim). When it
@@ -403,7 +477,36 @@ export type DerivedAuthorizationContext = {
   task_id?: string
 }
 
-export type VerifyTokenExchangeOptions = VerifyAssertionOptions & {
+/**
+ * Unverified, exact-string policy lookup key decoded before any issuer-owned
+ * network fetch. It is safe only as input to receiver-owned allowlist/task
+ * state lookup; cryptographic verification remains mandatory afterward.
+ */
+export type TokenExchangePolicyCandidate =
+  | {
+      readonly kind: 'platform'
+      readonly issuer: string
+      readonly subject: string
+      readonly method: string
+      readonly resource: string
+      readonly scopes: readonly OAuthFederationScope[]
+    }
+  | {
+      readonly kind: 'continuation'
+      readonly issuer: string
+      readonly subject: string
+      readonly taskId: string
+      readonly resource: string
+      readonly scopes: readonly OAuthFederationScope[]
+    }
+
+export type VerifyTokenExchangeOptions = Omit<VerifyAssertionOptions, 'replayCache'> & {
+  /**
+   * REQUIRED replay cache for both assertion slots. Production adapters must
+   * be atomic across instances. Unlike the standalone assertion verifier,
+   * the combined STS path never permits a cache-less successful exchange.
+   */
+  replayCache: AssertionReplayCache
   /** The STS's own token endpoint — the `aud` both assertions must bind to. */
   tokenEndpoint: string
   /** Receiver clock at verification time (ISO 8601). */
@@ -415,15 +518,37 @@ export type VerifyTokenExchangeOptions = VerifyAssertionOptions & {
    * path. Throws when absent or empty.
    */
   expectedResource: string
+  /**
+   * REQUIRED pre-network receiver policy gate. It receives exact raw strings
+   * decoded from the unverified subject assertion and request after shape and
+   * type-specific claim checks. The candidate object and its scope array are
+   * frozen before the callback and before either assertion can trigger DID
+   * resolution. Return false for a policy miss. Throws propagate so callers
+   * can map policy-store/programming failures to `server_error`.
+   *
+   * A successful callback must also preserve its receiver-owned policy key
+   * outside this verifier and bind that key to the issued access token/task;
+   * the boolean result intentionally does not turn unverified data into an
+   * authorization context.
+   */
+  authorizeCandidateBeforeFetch: (
+    candidate: TokenExchangePolicyCandidate,
+  ) => boolean | Promise<boolean>
 }
 
 export type TokenExchangeVerifyResult =
-  | { ok: true; scopes: string[]; authorization: DerivedAuthorizationContext }
+  | { ok: true; scopes: OAuthFederationScope[]; authorization: DerivedAuthorizationContext }
   | {
       ok: false
       stage: 'shape'
       error: TokenExchangeErrorCode
       reason: ExchangeRequestRejectReason
+    }
+  | {
+      ok: false
+      stage: 'policy'
+      error: 'invalid_grant'
+      reason: 'candidate-not-authorized'
     }
   | {
       ok: false
@@ -441,19 +566,22 @@ export type TokenExchangeVerifyResult =
  * THE required STS entry point for authorizing an RFC 8693 token exchange
  * under this profile. It (1) runs the fetch-only shape gate
  * ({@link evaluateTokenExchangeRequest}) with the mandatory `expectedResource`
- * binding, (2) cryptographically verifies the `private_key_jwt` client
- * assertion ({@link verifyClientAssertion}), (3) cryptographically verifies
+ * binding, (2) decodes the exact platform tuple or continuation task key and
+ * requires the receiver-owned `authorizeCandidateBeforeFetch` policy gate,
+ * (3) cryptographically verifies the `private_key_jwt` client assertion
+ * ({@link verifyClientAssertion}), (4) cryptographically verifies
  * the subject assertion ({@link verifyOAuthFederationAssertion}) — a
  * task-continuation assertion when the subject token declares that `typ`
  * (task-scope re-exchange, #618 v0.1 amendment 2), a platform-subject
- * assertion otherwise — (4) re-checks `subject_token.iss == client_id` AND
+ * assertion otherwise — (5) re-checks `subject_token.iss == client_id` AND
  * the typ/scope rule (a continuation subject covers task scopes ONLY) on the
- * VERIFIED claims, and only then (5) returns the
+ * VERIFIED claims, and only then (6) returns the
  * {@link DerivedAuthorizationContext} — including the verified
  * `mentionable_task_id` as `task_id` for a continuation exchange. Both
- * assertions bind to `tokenEndpoint` as `aud`; both are single-use when a
- * `replayCache` is supplied. Nothing short of an `ok: true` from THIS
- * function authorizes an exchange.
+ * assertions bind to `tokenEndpoint` as `aud`; the REQUIRED `replayCache`
+ * makes both single-use. Nothing short of an `ok: true` from THIS
+ * function plus the receiver-owned policy key retained by the callback may
+ * authorize token issuance.
  *
  * `expectedResource` is required — an absent/empty value throws, because the
  * resource-substitution defense must not be skippable on the authenticated
@@ -468,11 +596,15 @@ export async function verifyTokenExchange(
       'verifyTokenExchange: options.expectedResource is required — the resource-substitution defense must not be skippable',
     )
   }
-
-  const assertionOptions: VerifyAssertionOptions = {
-    trustedIssuers: options.trustedIssuers,
-    resolveIssuerDocument: options.resolveIssuerDocument,
-    ...(options.replayCache !== undefined ? { replayCache: options.replayCache } : {}),
+  if (typeof options.authorizeCandidateBeforeFetch !== 'function') {
+    throw new TypeError(
+      'verifyTokenExchange: options.authorizeCandidateBeforeFetch is required — receiver policy must run before DID resolution',
+    )
+  }
+  if (options.replayCache === undefined || typeof options.replayCache.register !== 'function') {
+    throw new TypeError(
+      'verifyTokenExchange: options.replayCache is required — the combined STS path must reject assertion replay',
+    )
   }
 
   // 1. Shape gate (unverified) — a required precondition, not authorization.
@@ -488,7 +620,76 @@ export async function verifyTokenExchange(
   const clientAssertion = params.get('client_assertion') as string
   const subjectToken = params.get('subject_token') as string
 
-  // 2. Verify the client assertion (this authenticates client_id).
+  // 2. Receiver-owned policy before network. Decode only enough unverified
+  //    subject data to build the exact lookup key. Type-specific claims are
+  //    validated before invoking the callback, so it never receives a
+  //    partial candidate and malformed input never reaches a resolver.
+  let subjectHeader
+  let subjectPayload: JWTPayload
+  try {
+    subjectHeader = decodeProtectedHeader(subjectToken)
+    subjectPayload = decodeJwt(subjectToken)
+  } catch (error) {
+    return { ok: false, stage: 'subject-assertion', reason: 'malformed', detail: String(error) }
+  }
+  const issuer = shape.unverifiedSubjectClaims.iss
+  const subject = shape.unverifiedSubjectClaims.sub
+  const resource = params.get('resource') as string
+  const scopes = Object.freeze([...shape.scopes]) as readonly OAuthFederationScope[]
+  let candidate: TokenExchangePolicyCandidate
+  if (
+    subjectHeader.typ !== OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION &&
+    subjectHeader.typ !== OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
+  ) {
+    return {
+      ok: false,
+      stage: 'subject-assertion',
+      reason: 'wrong-typ',
+      detail: String(subjectHeader.typ),
+    }
+  }
+  if (subjectHeader.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION) {
+    const taskId = subjectPayload[OAUTH_FEDERATION_CLAIM_TASK_ID]
+    if (typeof taskId !== 'string' || taskId.length === 0) {
+      return {
+        ok: false,
+        stage: 'subject-assertion',
+        reason: 'missing-claim',
+        detail: OAUTH_FEDERATION_CLAIM_TASK_ID,
+      }
+    }
+    candidate = Object.freeze({ kind: 'continuation', issuer, subject, taskId, resource, scopes })
+  } else {
+    const method = subjectPayload[OAUTH_FEDERATION_CLAIM_METHOD]
+    if (typeof method !== 'string' || method.length === 0) {
+      return {
+        ok: false,
+        stage: 'subject-assertion',
+        reason: 'missing-claim',
+        detail: OAUTH_FEDERATION_CLAIM_METHOD,
+      }
+    }
+    if (!isOAuthFederationMethodUri(method)) {
+      return { ok: false, stage: 'subject-assertion', reason: 'invalid-method', detail: method }
+    }
+    candidate = Object.freeze({ kind: 'platform', issuer, subject, method, resource, scopes })
+  }
+  if (!(await options.authorizeCandidateBeforeFetch(candidate))) {
+    return {
+      ok: false,
+      stage: 'policy',
+      error: 'invalid_grant',
+      reason: 'candidate-not-authorized',
+    }
+  }
+
+  const assertionOptions: VerifyAssertionOptions = {
+    trustedIssuers: options.trustedIssuers,
+    resolveIssuerDocument: options.resolveIssuerDocument,
+    replayCache: options.replayCache,
+  }
+
+  // 3. Verify the client assertion (this authenticates client_id).
   const clientOutcome = await verifyClientAssertion(
     clientAssertion,
     { clientId, tokenEndpoint: options.tokenEndpoint, verifiedAt: options.verifiedAt },
@@ -503,20 +704,14 @@ export async function verifyTokenExchange(
     }
   }
 
-  // 3. Verify the subject assertion. The expected `typ` comes from the
+  // 4. Verify the subject assertion. The expected `typ` comes from the
   //    UNVERIFIED header — the verifier enforces an exact `typ` match, and the
   //    shape gate already rejected a continuation subject carrying message
   //    scopes, so a lie here can only produce a `wrong-typ` rejection.
-  let subjectTyp: string = OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION
-  try {
-    if (
-      decodeProtectedHeader(subjectToken).typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
-    ) {
-      subjectTyp = OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
-    }
-  } catch {
-    // Leave as subject-assertion; verification rejects a malformed token.
-  }
+  const subjectTyp =
+    subjectHeader.typ === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
+      ? OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
+      : OAUTH_FEDERATION_TYP_SUBJECT_ASSERTION
   const subjectOutcome = await verifyOAuthFederationAssertion(
     subjectToken,
     { typ: subjectTyp, tokenEndpoint: options.tokenEndpoint, verifiedAt: options.verifiedAt },
@@ -532,13 +727,13 @@ export async function verifyTokenExchange(
   }
   const isContinuation = subjectTyp === OAUTH_FEDERATION_TYP_TASK_CONTINUATION_ASSERTION
 
-  // 4. Bindings on VERIFIED claims. The shape gate checked these on
+  // 5. Bindings on VERIFIED claims. The shape gate checked these on
   //    unverified bytes; these are the enforced, authenticated checks.
-  //    4a. The subject assertion's issuer must be the authenticated client.
+  //    5a. The subject assertion's issuer must be the authenticated client.
   if (subjectOutcome.payload.iss !== clientId) {
     return { ok: false, stage: 'binding', reason: 'issuer-client-mismatch' }
   }
-  //    4b. Typ/scope rule (#618 v0.1 amendment 2): a continuation subject
+  //    5b. Typ/scope rule (#618 v0.1 amendment 2): a continuation subject
   //    covers task-operation scopes ONLY — the verified typ is authoritative,
   //    so re-check here even though the shape gate screened the unverified
   //    header.
@@ -546,13 +741,13 @@ export async function verifyTokenExchange(
     return { ok: false, stage: 'binding', reason: 'message-scope-requires-subject-assertion' }
   }
 
-  // 5. Derived authorization — fixed delegation semantics from VERIFIED
+  // 6. Derived authorization — fixed delegation semantics from VERIFIED
   //    claims. `sub` is a non-empty string (verifier's required-claim check);
   //    for a continuation exchange the VERIFIED `mentionable_task_id`
   //    (guaranteed a non-empty string by the claims profile) binds the task.
   return {
     ok: true,
-    scopes: shape.scopes,
+    scopes: [...scopes],
     authorization: {
       purpose: 'delegation',
       principal: subjectOutcome.payload.sub as string,

--- a/vendor/mentionable-connector-kit/src/oauth-federation.ts
+++ b/vendor/mentionable-connector-kit/src/oauth-federation.ts
@@ -1,13 +1,12 @@
 // DID-backed OAuth federation profile v0.1 — wire constants (#618, #619).
 //
-// This module IS the profile's wire registry until the docs/spec document is
-// extracted (implementation-first decision recorded on #618): the typed
-// constants below are the contract both the Connector issuer/client half
-// (this package) and consuming STS / resource-server implementations
-// (planetarium/vicoop-bridge#487) import. Keep it dependency-free and
-// runtime-neutral — no node:crypto, no fetch; issuance lives under the
-// `@mentionable/connector-kit/signing` subpath, the exchange client and
-// discovery helpers next door in this package's main entry.
+// The normative profile is docs/spec/oauth-federation-v0.1.md. The typed
+// constants below pin its byte-level wire registry for both the Connector
+// issuer/client half (this package) and consuming STS / resource-server
+// implementations (planetarium/vicoop-bridge#487) import. Keep it
+// dependency-free and runtime-neutral — no node:crypto, no fetch; issuance
+// lives under the `@mentionable/connector-kit/signing` subpath, the exchange
+// client and discovery helpers next door in this package's main entry.
 //
 // Profile summary (settled in #618: two decision comments + the v0.1 scope
 // amendment "direct Connector delegation only", which supersedes the earlier
@@ -95,6 +94,9 @@ export const OAUTH_TOKEN_TYPE_ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:a
 export const OAUTH_CLIENT_ASSERTION_TYPE_JWT_BEARER =
   'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
 
+/** RFC 8414 metadata value for RFC 7523 JWT client authentication. */
+export const OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_PRIVATE_KEY_JWT = 'private_key_jwt'
+
 // ---------------------------------------------------------------------------
 // JWT typing (RFC 8725 §3.11 explicit typing)
 // ---------------------------------------------------------------------------
@@ -152,6 +154,114 @@ export const OAUTH_FEDERATION_TYP_CLIENT_ASSERTION = 'mentionable-client-asserti
  * `credentialSubject.method`.
  */
 export const OAUTH_FEDERATION_CLAIM_METHOD = 'mentionable_method'
+
+const isIpv4Address = (value: string): boolean => {
+  const pieces = value.split('.')
+  return (
+    pieces.length === 4 &&
+    pieces.every(
+      (piece) =>
+        /^(?:0|[1-9][0-9]{0,2})$/.test(piece) && Number(piece) >= 0 && Number(piece) <= 255,
+    )
+  )
+}
+
+const isIpv6Address = (value: string): boolean => {
+  let address = value
+  const lastColon = address.lastIndexOf(':')
+  const ipv4Tail = address.slice(lastColon + 1)
+  if (ipv4Tail.includes('.')) {
+    if (!isIpv4Address(ipv4Tail) || lastColon < 0) return false
+    address = `${address.slice(0, lastColon)}:0:0`
+  }
+  if (!/^[0-9A-Fa-f:]+$/.test(address)) return false
+  const compression = address.indexOf('::')
+  if (compression !== -1 && address.indexOf('::', compression + 2) !== -1) return false
+  const groups = address.split(':').filter((piece) => piece.length > 0)
+  if (groups.some((piece) => piece.length > 4)) return false
+  const groupCount = groups.length
+  return compression === -1 ? groupCount === 8 : groupCount < 8
+}
+
+const isValidAuthorityPort = (value: string): boolean =>
+  /^[0-9]+$/.test(value) && Number(value) <= 65_535
+
+const hasValidAuthoritySyntax = (remainder: string): boolean => {
+  if (!remainder.startsWith('//')) {
+    return !remainder.includes('[') && !remainder.includes(']')
+  }
+  const authorityEndOffset = remainder.slice(2).search(/[/?#]/)
+  const authorityEnd = authorityEndOffset === -1 ? remainder.length : authorityEndOffset + 2
+  const authority = remainder.slice(2, authorityEnd)
+  if (/[[\]]/.test(remainder.slice(authorityEnd))) return false
+
+  const firstAt = authority.indexOf('@')
+  if (firstAt !== authority.lastIndexOf('@')) return false
+  if (firstAt !== -1) {
+    const userInfo = authority.slice(0, firstAt)
+    if (!/^(?:[A-Za-z0-9._~!$&'()*+,;=:]|%[0-9A-Fa-f]{2})*$/.test(userInfo)) return false
+  }
+  const hostAndPort = authority.slice(firstAt + 1)
+  if (!hostAndPort.includes('[') && !hostAndPort.includes(']')) {
+    const firstColon = hostAndPort.indexOf(':')
+    if (firstColon !== hostAndPort.lastIndexOf(':')) return false
+    const host = firstColon === -1 ? hostAndPort : hostAndPort.slice(0, firstColon)
+    const port = firstColon === -1 ? undefined : hostAndPort.slice(firstColon + 1)
+    if (!/^(?:[A-Za-z0-9._~!$&'()*+,;=-]|%[0-9A-Fa-f]{2})+$/.test(host)) return false
+    return port === undefined || isValidAuthorityPort(port)
+  }
+
+  const closingBracket = hostAndPort.indexOf(']')
+  if (
+    !hostAndPort.startsWith('[') ||
+    closingBracket <= 1 ||
+    hostAndPort.indexOf('[', 1) !== -1 ||
+    hostAndPort.indexOf(']', closingBracket + 1) !== -1
+  ) {
+    return false
+  }
+  const port = hostAndPort.slice(closingBracket + 1)
+  if (port.length > 0 && (!port.startsWith(':') || !isValidAuthorityPort(port.slice(1)))) {
+    return false
+  }
+
+  const literal = hostAndPort.slice(1, closingBracket)
+  return isIpv6Address(literal)
+}
+
+/**
+ * True when `value` is in the conservative absolute-URI lexical subset used
+ * by this profile. It accepts RFC 3986 ASCII URI characters and valid `%HH`
+ * escapes without WHATWG normalization, permits at most one fragment
+ * delimiter, and permits brackets only around an IPv6 host in an authority.
+ * Raw authority userinfo/host/port syntax is checked before parsing. A
+ * non-empty scheme-specific part is required. URL parsing is used only as a
+ * final structure check after the raw lexical checks have passed.
+ */
+export function isOAuthFederationAbsoluteUri(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  const schemeMatch = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/.exec(value)
+  if (schemeMatch === null) return false
+  const remainder = schemeMatch[2]!
+  const schemeSpecificPart = remainder.split(/[?#]/, 1)[0]!
+  if (schemeSpecificPart.length === 0) return false
+  if ((remainder.match(/#/g)?.length ?? 0) > 1) return false
+  if (!/^(?:[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=-]|%[0-9A-Fa-f]{2})+$/.test(remainder)) {
+    return false
+  }
+  if (!hasValidAuthoritySyntax(remainder)) return false
+  try {
+    const parsed = new URL(value)
+    return !remainder.startsWith('//') || parsed.host.length > 0
+  } catch {
+    return false
+  }
+}
+
+/** Profile-specific alias documenting where the shared URI syntax is used. */
+export function isOAuthFederationMethodUri(value: unknown): value is string {
+  return isOAuthFederationAbsoluteUri(value)
+}
 
 /**
  * Profile-specific claim on a task-continuation assertion naming the bound
@@ -255,8 +365,9 @@ export function scopesRequireSubjectAssertion(scopes: Iterable<string>): boolean
 // ---------------------------------------------------------------------------
 
 /**
- * Token-endpoint error codes a conforming STS returns. All of them are
- * client faults: a Connector MUST NOT retry the same request — in particular
+ * Token-endpoint error codes a conforming STS returns. All except
+ * `server_error` are client faults: a Connector MUST NOT retry the same
+ * request — in particular
  * never on `invalid_request` (e.g. a subject-token issuer that is not the
  * authenticated client, per the #618 v0.1 amendment) or `invalid_grant`
  * (e.g. an expired or replayed assertion); it must surface the failure and
@@ -271,6 +382,8 @@ export const TOKEN_EXCHANGE_ERROR_CODES = [
   'invalid_scope',
   /** RFC 8693 §2.2.2 — unknown/unacceptable `resource` or `audience`. */
   'invalid_target',
+  /** Profile error used for transient STS-side failures. */
+  'server_error',
 ] as const
 
 export type TokenExchangeErrorCode = (typeof TOKEN_EXCHANGE_ERROR_CODES)[number]


### PR DESCRIPTION
## Summary

- sync the vendored Mentionable connector-kit OAuth registry, verifier, request handling, and all 36 final conformance fixtures from `planetarium/mentionable@61d86728`
- move exact platform/continuation authorization into the required async `authorizeCandidateBeforeFetch` boundary, retaining the matched receiver-owned key while preventing DID resolution before a policy match
- preserve embedded `assertionMethod` verification objects and enforce the final URI, lifetime, Ed25519 JWK/controller, request, discovery, response, and typed `server_error` rules
- register assertion replays atomically inside the final verifier path and avoid duplicate core replay consumption
- run every final assertion and exchange fixture through both the vendored verifier and the bridge STS route, with focused policy-store, malformed-header, embedded-method, replay, discovery, and response coverage

## Verification

- `pnpm --filter @vicoop-bridge/server test` — 517 tests, 440 passed, 77 DB/environment-dependent skipped, 0 failed
- `pnpm -r typecheck`
- `pnpm -r build`
- upstream source and fixture directories verified byte-for-byte against Mentionable merge commit `61d86728e841b0ca796c86364b2fa881ef66c87d`

No changeset: this PR only changes the server and its private vendored workspace package.

Closes #493