### PR TITLE
Prepare Docker runtime foundations for caller isolation (R1)

### DIFF
--- a/.changeset/calm-docker-foundations.md
+++ b/.changeset/calm-docker-foundations.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": patch
+---
+
+Keep Docker runtime lifecycle commands responsive with bounded asynchronous execution and pass explicit backend environment overrides into containers. Reserve `caller-container` mode with an explicit unsupported error; caller isolation is not enabled in this release.

--- a/docs/caller-runtime-rollout.md
+++ b/docs/caller-runtime-rollout.md
@@ -1,0 +1,117 @@
+# Caller-scoped Docker runtime rollout
+
+Tracking: [#497](https://github.com/planetarium/vicoop-bridge/issues/497).
+Design background: [#496](https://github.com/planetarium/vicoop-bridge/issues/496).
+
+## R1: compatible foundations
+
+R1 supports the existing `host` and `container` modes. Their install,
+credential locations, runtime/volume names and persistence behavior stay the
+same. R1 does **not** provide caller-isolated execution or change task ownership.
+
+`--runtime caller-container` (or `backends.claude.runtime` /
+`backends.codex.runtime` set to `caller-container`) is reserved and produces an
+error before backend startup. Configuration normalization preserves this value
+so it cannot silently become host execution. R1 clients do not advertise
+`execution-scope-v1` and do not allocate caller runtimes.
+
+Docker lifecycle operations in `RuntimeContainer` and the startup credential
+probe run asynchronously. Ordinary commands have a 30-second timeout and a
+1 MiB aggregate captured-output limit. Image pulls retain visible progress and
+have a 10-minute timeout; readiness polling uses its remaining 10-second budget.
+One-shot `container list`/remove helpers still use the synchronous compatibility
+runner (bounded to 30 seconds per command); they are not request-path APIs.
+
+Timeout/abort stops the local Docker CLI. The Docker daemon may already have
+accepted the operation: inspect the named runtime before retrying. These errors
+do not certify cancellation of in-container processes. The existing spawn
+adapter remains a stdio transport, not a process-group supervisor.
+
+Explicit per-spawn environment overrides are passed to `docker exec -e` without
+a shell. Unspecified variables keep the container environment; the bridge's
+entire host environment is not forwarded. Do not supply secrets as arbitrary
+overrides unless their visibility inside the runtime is intended.
+
+## Execution scope wire contract
+
+The server emits a top-level `task.assign.executionScope` only when the client
+advertises all of `execution-scope-v1`, `caller-context-v2`, and `task-replay-v1`.
+It acknowledges scope wire support in `hello.ack` after authentication. This
+acknowledgement is a protocol capability, not an isolation guarantee or mode.
+
+The strict v1 object contains:
+
+| Field | Meaning |
+| --- | --- |
+| `policy` | `direct-principal-v1` |
+| `agentId` | The exposed agent's identity |
+| `principalId` | Exact authenticated principal from the server auth handoff |
+| `id` | Lowercase SHA-256 hex of the UTF-8 JSON array `["vicoop-execution-scope", policy, agentId, principalId]` |
+
+The ID is an opaque storage association, not a bearer credential. It excludes
+contextId, executionId, credential rotations and attribution attestations.
+Different contexts for one scope share a workspace; different principals or
+agents have different scope IDs. Shared API keys identify one shared principal.
+
+Only the authenticated HTTP handoff can supply the principal. Public message
+metadata named `executionScope`/`execution_scope` is stripped before forwarding;
+it cannot override the top-level value. Existing underscore-prefixed internal
+metadata stripping at HTTP ingress continues to protect the auth handoff.
+
+Missing/invalid caller context, absent principal, distinct actor, token-exchange
+authorization key/profile, or incomplete negotiation yields no v1 scope. No
+grant-derived policy is implemented in R1. Normal single-runtime requests keep
+their existing behavior. R2 must reject missing scopes before allocation and
+validate scope agent/principal against its connection and caller context.
+
+Policy/schema changes require a new version and explicit storage migration;
+never map an unfamiliar policy to an existing directory. Runtime-name encoding,
+ownership-label validation and scope-manager leases are R2 responsibilities.
+The full digest is not constrained to today's 32-character runtime-name limit.
+
+## Deployment and rollback
+
+| Client | Server | Result |
+| --- | --- | --- |
+| Pre-R1 | R1 | Existing wire shape: no scope is sent without all required capabilities |
+| R1 | Pre-R1 | Existing modes work; R1 advertises no new scope capability |
+| R1 | R1 | Existing modes work; caller isolation is unavailable |
+| Future scope-aware | Pre-R1 | No scope acknowledgement/value; isolated mode must refuse work |
+
+R1 client and server may ship in either order. Server changes deploy through
+`fly deploy`; the client ships via its client-only changeset. No database or
+volume migration is introduced. Rollback to pre-R1 is supported for `host` and
+`container`; remove reserved `caller-container` configuration before downgrade
+because older config normalizers can drop unknown values. Do not roll back a
+future enabled isolated client/server using R1 compatibility claims.
+
+## Provider boundary and R2 activation gate
+
+`runtime-provider.ts` specifies the future isolated provider's lifecycle,
+file transfer and supervised-process contract. The legacy Docker spawn adapter
+does not implement that supervisor. No type cast or scope capability should be
+used to claim otherwise.
+
+Before activation R2 must implement authorized scope routing, separate volumes,
+credential provisioning, allocation deduplication, capacity limits, input-file
+staging, active leases, supervised cancellation, execution fencing, and minimum
+crash reconciliation. MCP, Codex and delegation remain explicit unsupported
+combinations until their release gates pass. Automatic eviction and advanced
+conversation restoration can follow the first safe release.
+
+## Reproducible runtime smoke
+
+With Docker and a cached runtime image available, from the repository root:
+
+```sh
+pnpm -r build
+pnpm exec tsx packages/client/scripts/runtime-foundations-smoke.ts
+bun build packages/client/scripts/runtime-foundations-smoke.ts --compile --outfile /tmp/vicoop-runtime-smoke
+/tmp/vicoop-runtime-smoke
+```
+
+Set `VICOOP_SMOKE_IMAGE` to select a compatible runtime image. The script creates
+unique `r1-smoke-*` resources, skips firewall setup for its disposable test,
+checks lifecycle/stdio/EOF/cwd/env/file transfer/volume persistence and removes
+its own container and volumes. It does not authenticate or invoke paid models,
+and it does not validate caller isolation or supervised cancellation.

--- a/packages/client/scripts/runtime-foundations-smoke.ts
+++ b/packages/client/scripts/runtime-foundations-smoke.ts
@@ -27,6 +27,7 @@ async function docker(args: string[]) {
   return result;
 }
 
+const failures: unknown[] = [];
 try {
   await runtime.start();
   let ticks = 0;
@@ -65,15 +66,33 @@ try {
   await docker(['cp', `${container}:${remotePath}`, output]);
   assert.equal(await readFile(output, 'utf8'), 'persistent smoke data\n');
   await reopened.stop();
-  console.log('PASS: lifecycle, responsive event loop, stdio/EOF, cwd/env, file round trip, stop/start persistence');
+} catch (error) {
+  failures.push(error);
 } finally {
   // Always attempt every cleanup, including partial-start failure. Names are
   // unique to this invocation; no pre-existing user runtime is adopted.
-  const cleanup = await runDockerCommand(['rm', '-f', container]);
-  if (cleanup.exitCode !== 0 && !/No such container/i.test(cleanup.stderr)) console.error(cleanup.stderr);
+  const cleanup = async (label: string, action: () => Promise<void>) => {
+    try {
+      await action();
+    } catch (cause) {
+      failures.push(new Error(`cleanup failed: ${label}`, { cause }));
+    }
+  };
+  await cleanup(container, async () => {
+    const result = await runDockerCommand(['rm', '-f', container]);
+    if (result.exitCode !== 0 && !/No such container/i.test(result.stderr)) {
+      throw new Error(`docker rm exited ${result.exitCode}: ${result.stderr}`);
+    }
+  });
   for (const volume of [agentsVolumeName(kind, name), credsVolumeName(kind, name), sessionsVolumeName(kind, name)]) {
-    const result = await runDockerCommand(['volume', 'rm', volume]);
-    if (result.exitCode !== 0 && !/no such volume/i.test(result.stderr)) console.error(result.stderr);
+    await cleanup(volume, async () => {
+      const result = await runDockerCommand(['volume', 'rm', volume]);
+      if (result.exitCode !== 0 && !/no such volume/i.test(result.stderr)) {
+        throw new Error(`docker volume rm exited ${result.exitCode}: ${result.stderr}`);
+      }
+    });
   }
-  await rm(directory, { recursive: true, force: true });
+  await cleanup(directory, () => rm(directory, { recursive: true, force: true }));
 }
+if (failures.length > 0) throw new AggregateError(failures, 'runtime smoke failed (including cleanup)');
+console.log('PASS: lifecycle, responsive event loop, stdio/EOF, cwd/env, file round trip, stop/start persistence, cleanup');

--- a/packages/client/scripts/runtime-foundations-smoke.ts
+++ b/packages/client/scripts/runtime-foundations-smoke.ts
@@ -1,0 +1,79 @@
+// Explicit opt-in smoke: creates a unique runtime and removes only its own
+// container/volumes. Runs under tsx or as a Bun-compiled executable.
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  RuntimeContainer, agentsVolumeName, credsVolumeName, sessionsVolumeName,
+} from '../src/runtime-container.js';
+import { runDockerCommand } from '../src/docker-command.js';
+import { createDockerExecSpawn } from '../src/spawn-adapter.js';
+
+const name = `r1-smoke-${randomUUID().slice(0, 12)}`;
+const kind = 'claude';
+const image = process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest';
+const runtime = new RuntimeContainer({
+  backendKind: kind, runtimeName: name, image, createIfMissing: true,
+  failIfExists: true, skipFirewall: true,
+});
+const container = runtime.getContainerName();
+const directory = await mkdtemp(join(tmpdir(), 'vicoop-runtime-smoke-'));
+
+async function docker(args: string[]) {
+  const result = await runDockerCommand(args);
+  assert.equal(result.exitCode, 0, result.stderr);
+  return result;
+}
+
+try {
+  await runtime.start();
+  let ticks = 0;
+  const timer = setInterval(() => { ticks++; }, 10);
+  try {
+    await docker(['exec', container, 'sleep', '0.2']);
+    assert.ok(ticks > 0, 'Docker commands must not block the host event loop');
+  } finally {
+    clearInterval(timer);
+  }
+  const spawn = createDockerExecSpawn(runtime);
+  const child = spawn('sh', ['-c', 'IFS= read -r line; printf "%s|%s|%s" "$PWD" "$VB_SMOKE" "$line"; printf "stderr" >&2'], {
+    cwd: '/tmp', env: { VB_SMOKE: 'literal $value; with spaces' },
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout!.on('data', (chunk: Buffer) => stdout.push(chunk));
+  child.stderr!.on('data', (chunk: Buffer) => stderr.push(chunk));
+  const exit = new Promise<number | null>((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (code) => resolve(code));
+  });
+  child.stdin!.end('input\n');
+  assert.equal(await exit, 0);
+  assert.equal(Buffer.concat(stdout).toString(), '/tmp|literal $value; with spaces|input');
+  assert.equal(Buffer.concat(stderr).toString(), 'stderr');
+
+  const input = join(directory, 'input.txt');
+  const output = join(directory, 'output.txt');
+  await writeFile(input, 'persistent smoke data\n');
+  const remotePath = '/data/sessions/claude/r1-smoke.txt';
+  await docker(['cp', input, `${container}:${remotePath}`]);
+  await runtime.stop();
+  const reopened = new RuntimeContainer({ backendKind: kind, runtimeName: name, image });
+  await reopened.start();
+  await docker(['cp', `${container}:${remotePath}`, output]);
+  assert.equal(await readFile(output, 'utf8'), 'persistent smoke data\n');
+  await reopened.stop();
+  console.log('PASS: lifecycle, responsive event loop, stdio/EOF, cwd/env, file round trip, stop/start persistence');
+} finally {
+  // Always attempt every cleanup, including partial-start failure. Names are
+  // unique to this invocation; no pre-existing user runtime is adopted.
+  const cleanup = await runDockerCommand(['rm', '-f', container]);
+  if (cleanup.exitCode !== 0 && !/No such container/i.test(cleanup.stderr)) console.error(cleanup.stderr);
+  for (const volume of [agentsVolumeName(kind, name), credsVolumeName(kind, name), sessionsVolumeName(kind, name)]) {
+    const result = await runDockerCommand(['volume', 'rm', volume]);
+    if (result.exitCode !== 0 && !/no such volume/i.test(result.stderr)) console.error(result.stderr);
+  }
+  await rm(directory, { recursive: true, force: true });
+}

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -647,3 +647,17 @@ test('legacy daemon env vars remain ignored (identity trust is the sole compatib
     }
   }
 });
+
+
+test('reserved caller isolation is rejected from flags and configuration before backend startup', () => {
+  for (const backend of ['claude', 'codex'] as const) {
+    for (const source of ['flag', 'config']) {
+      const result = mergeClientArgs(
+        { token: 't', agentId: 'a', backend, ...(source === 'flag' ? { runtime: 'caller-container' as const } : {}) },
+        source === 'config' ? { backends: { [backend]: { runtime: 'caller-container' } } } : {},
+      );
+      assert.equal(result.ok, false);
+      if (!result.ok) assert.ok(result.errors.some((error) => error.includes('not available')));
+    }
+  }
+});

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -31,7 +31,7 @@ export type CodexSandboxMode = (typeof SANDBOX_MODES)[number];
 export const BACKEND_KINDS = ['echo', 'openclaw', 'claude', 'codex', 'vicoop-codex'] as const;
 export type BackendKind = (typeof BACKEND_KINDS)[number];
 
-const BACKEND_RUNTIMES = ['host', 'container'] as const;
+const BACKEND_RUNTIMES = ['host', 'container', 'caller-container'] as const;
 
 // Optique daemon-mode grammar. Every operator-tunable knob is a flag here,
 // including the ones that used to be env-only (CLAUDE_CWD, CODEX_SANDBOX_MODE,
@@ -82,7 +82,7 @@ export const daemonFlagsFields = {
     description: message`Working directory for the spawned backend process. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
+    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. \`caller-container\` is reserved and unavailable in this release. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtimeName: optional(option('--runtime-name', string({ metavar: 'NAME' }), {
     description: message`Runtime container instance name to use with \`--runtime container\`. Omit to use the active backend kind as the generated name.`,
@@ -393,6 +393,9 @@ export function mergeClientArgs(
   // overlay are silently dropped above by the active-backend-scoped
   // lookup, which is the correct behaviour for that source.
   const errors: string[] = [];
+  if (resolved.runtime === 'caller-container') {
+    errors.push('caller-container isolation is not available in this release (#497 R2); no backend will be started');
+  }
   if (flags.runtime !== undefined && !RUNTIME_BACKENDS.has(backend)) {
     errors.push(
       `--runtime is not supported by --backend ${backend}; only claude / codex have a runtime container profile`,

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -491,11 +491,14 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
 //   the bind-mount source from container init.
 async function resolveRuntime(args: {
   kind: 'claude' | 'codex';
-  runtime: 'host' | 'container' | undefined;
+  runtime: 'host' | 'container' | 'caller-container' | undefined;
   runtimeName: string | undefined;
   cwd: string | undefined;
   bridgeUrl: string;
 }): Promise<{ spawn?: SpawnFn; cwd?: string; runtime?: RuntimeContainer }> {
+  if (args.runtime === 'caller-container') {
+    throw new Error('caller-container isolation is not available in this release (#497 R2)');
+  }
   if ((args.runtime ?? 'host') !== 'container') {
     return { cwd: args.cwd };
   }

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -542,3 +542,12 @@ test('readConfig/writeConfig default to resolveConfigDir() when no path passed',
   // Side check: file lives under VICOOP_HOME, not under homedir().
   assert.notEqual(defaultConfigPath(), join(homedir(), '.vicoop', 'config.json'));
 });
+
+
+test('reserved caller-container runtime survives normalization so startup can reject it', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-isolation-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'config.json');
+  writeFileSync(path, JSON.stringify({ backends: { claude: { runtime: 'caller-container' } } }));
+  assert.equal(readConfig(path)?.backends?.claude?.runtime, 'caller-container');
+});

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -105,7 +105,8 @@ export function defaultOwnerSessionPath(): string {
 //                   (today's behavior; default).
 //   - 'container' : `docker exec` into a long-lived vicoop-runtime
 //                   container the bridge client orchestrates (#249).
-export type BackendRuntime = 'host' | 'container';
+// caller-container is reserved configuration, explicitly rejected until R2.
+export type BackendRuntime = 'host' | 'container' | 'caller-container';
 
 export interface ClaudeBackendConfig {
   cwd?: string;
@@ -284,7 +285,7 @@ const KNOWN_CODEX_SANDBOX_MODES = new Set([
   'workspace-write',
   'danger-full-access',
 ]);
-const KNOWN_BACKEND_RUNTIMES = new Set<BackendRuntime>(['host', 'container']);
+const KNOWN_BACKEND_RUNTIMES = new Set<BackendRuntime>(['host', 'container', 'caller-container']);
 
 function pickBackendRuntime(v: unknown): BackendRuntime | undefined {
   if (typeof v !== 'string') return undefined;

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -17,6 +17,7 @@
 // survives across daemon restarts; this command is what makes it
 // usable in the first place.
 
+import { runDockerCommand, type AsyncDockerRun } from './docker-command.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -299,11 +300,11 @@ export function expectedCredsPath(kind: InstallableBackendKind): string {
 export async function assertContainerCredsPresent(
   containerName: string,
   kind: InstallableBackendKind,
-  opts: { dockerRun?: DockerRun } = {},
+  opts: { dockerRun?: AsyncDockerRun } = {},
 ): Promise<void> {
-  const dockerRun = opts.dockerRun ?? defaultDockerRun;
+  const dockerRun = opts.dockerRun ?? runDockerCommand;
   const path = expectedCredsPath(kind);
-  const r = dockerRun(['exec', containerName, 'test', '-f', path]);
+  const r = await dockerRun(['exec', containerName, 'test', '-f', path]);
   if (r.exitCode === 0) return;
   throw new Error(
     `runtime container '${containerName}' has no ${kind} creds at ${path}. ` +

--- a/packages/client/src/docker-command.test.ts
+++ b/packages/client/src/docker-command.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runBoundedCommand } from './docker-command.js';
+
+test('bounded commands keep the event loop responsive and preserve output/exit status', async () => {
+  let ticked = false;
+  const timer = setTimeout(() => { ticked = true; }, 10);
+  const result = await runBoundedCommand(process.execPath, ['-e',
+    'setTimeout(() => { process.stdout.write("out"); process.stderr.write("err"); process.exitCode = 7; }, 80)',
+  ]);
+  clearTimeout(timer);
+  assert.equal(ticked, true);
+  assert.deepEqual(result, { stdout: 'out', stderr: 'err', exitCode: 7 });
+});
+
+test('timeout and abort bound commands that never finish', async () => {
+  const args = ['-e', 'setInterval(() => {}, 1000)'];
+  await assert.rejects(runBoundedCommand(process.execPath, args, { timeoutMs: 50 }), /timed out/);
+  const controller = new AbortController();
+  const pending = runBoundedCommand(process.execPath, args, { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(pending, /aborted/);
+  await assert.rejects(runBoundedCommand('must-not-be-spawned', [], { signal: controller.signal }), /before start/);
+});
+
+test('spawn errors and excessive output settle with errors', async () => {
+  await assert.rejects(runBoundedCommand('/nonexistent/vicoop-497-command', []), /ENOENT/);
+  await assert.rejects(runBoundedCommand(process.execPath, ['-e',
+    'process.stdout.write(Buffer.alloc(2 * 1024 * 1024)); setInterval(() => {}, 1000)',
+  ]), /exceeded/);
+});

--- a/packages/client/src/docker-command.ts
+++ b/packages/client/src/docker-command.ts
@@ -1,0 +1,89 @@
+import { spawn } from 'node:child_process';
+
+export interface DockerCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DockerCommandOptions {
+  timeoutMs?: number;
+  /** Preserve progress output for operator-initiated image pulls. */
+  inheritOutput?: boolean;
+  signal?: AbortSignal;
+}
+
+export type AsyncDockerRun = (
+  args: readonly string[],
+  options?: DockerCommandOptions,
+) => DockerCommandResult | Promise<DockerCommandResult>;
+
+/**
+ * Bounded, shell-free CLI execution. Timeout/abort describes the local CLI
+ * only: Docker may have already accepted a mutation. Callers must reconcile
+ * daemon state before retrying; this is not an in-container job supervisor.
+ */
+export function runDockerCommand(
+  args: readonly string[],
+  options: DockerCommandOptions = {},
+): Promise<DockerCommandResult> {
+  return runBoundedCommand('docker', args, options);
+}
+
+export function runBoundedCommand(
+  command: string,
+  args: readonly string[],
+  options: DockerCommandOptions = {},
+): Promise<DockerCommandResult> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return Promise.reject(new Error('command timeout must be finite and positive'));
+  }
+  if (options.signal?.aborted) return Promise.reject(new Error('command aborted before start'));
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, Array.from(args), {
+      stdio: ['ignore', options.inheritOutput ? 'inherit' : 'pipe', options.inheritOutput ? 'inherit' : 'pipe'],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let bytes = 0;
+    let failure: Error | undefined;
+    let settled = false;
+    const finish = (error?: Error, code?: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener('abort', abort);
+      if (error) reject(error);
+      else resolve({
+        stdout: Buffer.concat(stdout).toString('utf8'),
+        stderr: Buffer.concat(stderr).toString('utf8'),
+        exitCode: code ?? -1,
+      });
+    };
+    const stop = (error: Error) => {
+      if (failure || settled) return;
+      failure = error;
+      child.kill('SIGKILL');
+      child.stdout?.destroy();
+      child.stderr?.destroy();
+      // Do not wait indefinitely for close (e.g. inherited descendant pipes).
+      // This promise does not certify that a remote Docker operation stopped.
+      finish(error);
+    };
+    const abort = () => stop(new Error('command aborted; Docker state may require reconciliation'));
+    const timer = setTimeout(() => stop(new Error(`command timed out after ${timeoutMs}ms; Docker state may require reconciliation`)), timeoutMs);
+    options.signal?.addEventListener('abort', abort, { once: true });
+    if (options.signal?.aborted) abort();
+    const collect = (target: Buffer[], chunk: Buffer) => {
+      if (settled) return;
+      bytes += chunk.length;
+      if (bytes > 1024 * 1024) stop(new Error('command output exceeded 1 MiB'));
+      else target.push(chunk);
+    };
+    child.stdout?.on('data', (chunk: Buffer) => collect(stdout, chunk));
+    child.stderr?.on('data', (chunk: Buffer) => collect(stderr, chunk));
+    child.once('error', (error) => finish(error));
+    child.once('close', (code) => finish(failure, code));
+  });
+}

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -310,3 +310,32 @@ test('runtimeName selects container and volume names', async () => {
     createCmd.some((a) => a === 'type=volume,source=vicoop-creds-work,target=/data/creds/codex'),
   );
 });
+
+
+test('start awaits asynchronous Docker results including bounded streamed image pull', async () => {
+  const calls: Array<{ args: readonly string[]; options: unknown }> = [];
+  const responses = happyCreateResponses();
+  responses.splice(2, 1, fail('image missing'), ok());
+  const fixture = makeDockerFixture(responses);
+  const runtime = new RuntimeContainer({
+    backendKind: 'claude', createIfMissing: true,
+    dockerRun: async (args, options) => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      calls.push({ args, options });
+      return fixture.run(args);
+    },
+  });
+  await runtime.start();
+  assert.deepEqual(calls.find((call) => call.args[0] === 'pull')?.options, {
+    inheritOutput: true, timeoutMs: 600_000,
+  });
+  await runtime.stop();
+  assert.equal(calls.at(-1)?.args[0], 'stop');
+});
+
+test('failed image pull aborts creation before touching volumes', async () => {
+  const fixture = makeDockerFixture([ok('27'), ok(), fail('missing image'), fail('pull failed')]);
+  const runtime = new RuntimeContainer({ backendKind: 'claude', createIfMissing: true, dockerRun: fixture.run });
+  await assert.rejects(runtime.start(), /docker pull/);
+  assert.equal(fixture.calls.some((args) => args[0] === 'volume' || args[0] === 'create'), false);
+});

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -16,8 +16,8 @@
 //   bridge client shutdown
 //     → backend.stop() → runtime.stop() awaited
 //
-// Implementation note: everything in here goes through the `docker`
-// CLI (spawnSync), not the dockerode programmatic API. The hijack
+// Lifecycle commands use the asynchronous `docker` CLI rather than
+// dockerode. The one-shot listing/removal runner remains synchronous. The hijack
 // stream parts already shelled out to the CLI because of
 // oven-sh/bun#22412; once the hijack path was off the table the
 // remaining dockerode lifecycle calls were carrying ssh2 /
@@ -27,7 +27,8 @@
 // `docker context` is resolved by the CLI itself — no custom socket
 // path lookup needed.
 
-import { spawnSync, spawn } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { runDockerCommand, type AsyncDockerRun } from './docker-command.js';
 import { createLogger, type Logger } from './logger.js';
 
 export const DEFAULT_RUNTIME_IMAGE = 'ghcr.io/planetarium/vicoop-runtime:latest';
@@ -67,7 +68,7 @@ export interface RuntimeContainerOptions {
   logger?: Logger;
   // Test seam — inject a custom docker CLI runner so tests can
   // capture argv + script responses without shelling out.
-  dockerRun?: DockerRun;
+  dockerRun?: AsyncDockerRun;
 }
 
 export interface DockerResult {
@@ -79,7 +80,9 @@ export interface DockerResult {
 export type DockerRun = (args: readonly string[]) => DockerResult;
 
 export function defaultDockerRun(args: readonly string[]): DockerResult {
-  const r = spawnSync('docker', Array.from(args), { encoding: 'utf8' });
+  // Synchronous compatibility path for one-shot container list/remove commands.
+  // Daemon startup and RuntimeContainer lifecycle use runDockerCommand instead.
+  const r = spawnSync('docker', Array.from(args), { encoding: 'utf8', timeout: 30_000 });
   return {
     stdout: r.stdout ?? '',
     stderr: r.stderr ?? '',
@@ -125,7 +128,7 @@ export class RuntimeContainer {
   private readonly opts: Required<Pick<RuntimeContainerOptions, 'backendKind' | 'image' | 'runtimeName'>> &
     RuntimeContainerOptions;
   private readonly log: Logger;
-  private readonly run: DockerRun;
+  private readonly run: AsyncDockerRun;
   private started = false;
 
   constructor(opts: RuntimeContainerOptions) {
@@ -135,29 +138,29 @@ export class RuntimeContainer {
       image: opts.image ?? DEFAULT_RUNTIME_IMAGE,
     };
     this.log = opts.logger ?? createLogger();
-    this.run = opts.dockerRun ?? defaultDockerRun;
+    this.run = opts.dockerRun ?? runDockerCommand;
   }
 
-  // Boots the runtime container, blocking until it's running. Resolves
+  // Boots the runtime container, awaiting readiness without blocking the event loop. Resolves
   // with no value; on any failure throws — callers should let the
   // exception propagate so the daemon exits with a clear error rather
   // than degrade silently.
   async start(): Promise<void> {
-    this.ensureDaemonReachable();
+    await this.ensureDaemonReachable();
 
     const name = containerName(this.opts.backendKind, this.opts.runtimeName);
-    if (this.findContainer(name)) {
+    if (await this.findContainer(name)) {
       if (this.opts.failIfExists) {
         throw new Error(
           `runtime container '${name}' already exists. ` +
             `Remove it first with \`${this.removeHint()}\`, then rerun init.`,
         );
       }
-      if (this.inspectRunning(name)) {
+      if (await this.inspectRunning(name)) {
         this.log.info(`runtime container '${name}' already running — reusing`);
       } else {
         this.log.info(`runtime container '${name}' exists but stopped — starting`);
-        this.runDocker(['start', name]);
+        await this.runDocker(['start', name]);
       }
     } else {
       if (!this.opts.createIfMissing) {
@@ -168,12 +171,12 @@ export class RuntimeContainer {
         );
       }
       if (this.opts.failIfExists) {
-        this.ensureFreshVolumes();
+        await this.ensureFreshVolumes();
       }
       await this.ensureImage();
-      this.ensureVolumes();
-      this.createContainer(name);
-      this.runDocker(['start', name]);
+      await this.ensureVolumes();
+      await this.createContainer(name);
+      await this.runDocker(['start', name]);
       this.log.info(`runtime container '${name}' created and started`);
     }
 
@@ -186,7 +189,7 @@ export class RuntimeContainer {
   // stopped. Already-stopped / missing containers are tolerated.
   async stop(): Promise<void> {
     const name = containerName(this.opts.backendKind, this.opts.runtimeName);
-    const r = this.run(['stop', '-t', '10', name]);
+    const r = await this.run(['stop', '-t', '10', name]);
     if (r.exitCode === 0) {
       this.log.info(`runtime container '${name}' stopped`);
       return;
@@ -206,8 +209,8 @@ export class RuntimeContainer {
   }
 
   // ──────────────────────────────────────────────────────────────────
-  private runDocker(args: readonly string[]): DockerResult {
-    const r = this.run(args);
+  private async runDocker(args: readonly string[]): Promise<DockerResult> {
+    const r = await this.run(args);
     if (r.exitCode !== 0) {
       throw new Error(
         `docker ${args[0]} failed (exit ${r.exitCode}): ${r.stderr.trim()}`,
@@ -216,11 +219,11 @@ export class RuntimeContainer {
     return r;
   }
 
-  private ensureDaemonReachable(): void {
+  private async ensureDaemonReachable(): Promise<void> {
     // `docker version --format '{{.Server.Version}}'` exits non-zero
     // when the daemon is unreachable and prints a stderr line we
     // forward verbatim into the operator-facing message.
-    const r = this.run(['version', '--format', '{{.Server.Version}}']);
+    const r = await this.run(['version', '--format', '{{.Server.Version}}']);
     if (r.exitCode !== 0 || r.stdout.trim().length === 0) {
       throw new Error(
         `docker daemon is not reachable (${r.stderr.trim() || `exit ${r.exitCode}`}). ` +
@@ -232,28 +235,25 @@ export class RuntimeContainer {
 
   private async ensureImage(): Promise<void> {
     const image = this.opts.image;
-    const inspect = this.run(['image', 'inspect', image]);
+    const inspect = await this.run(['image', 'inspect', image]);
     if (inspect.exitCode === 0) return;
     this.log.info(`pulling runtime image ${image}`);
-    // Streamed pull instead of captured: a cold pull of the runtime
-    // image is ~200MB and takes long enough that swallowing layer
-    // progress looks like a hang to an operator watching the
-    // terminal. The test seam (dockerRun) is bypassed for this one
-    // call by design — pull is operator-visible side-effect, not
-    // a unit-testable step.
-    const r = spawnSync('docker', ['pull', image], { stdio: 'inherit' });
-    if (r.status !== 0) {
-      throw new Error(`docker pull ${image} failed (exit ${r.status ?? -1})`);
+    const r = await this.run(['pull', image], {
+      inheritOutput: true,
+      timeoutMs: 10 * 60_000,
+    });
+    if (r.exitCode !== 0) {
+      throw new Error(`docker pull ${image} failed (exit ${r.exitCode})`);
     }
   }
 
-  private ensureVolumes(): void {
+  private async ensureVolumes(): Promise<void> {
     const kind = this.opts.backendKind;
     const runtimeName = this.opts.runtimeName;
     for (const name of this.volumeNames()) {
-      const inspect = this.run(['volume', 'inspect', name]);
+      const inspect = await this.run(['volume', 'inspect', name]);
       if (inspect.exitCode === 0) continue;
-      this.runDocker([
+      await this.runDocker([
         'volume',
         'create',
         '--label',
@@ -270,10 +270,11 @@ export class RuntimeContainer {
     }
   }
 
-  private ensureFreshVolumes(): void {
-    const existing = this.volumeNames().filter(
-      (name) => this.run(['volume', 'inspect', name]).exitCode === 0,
-    );
+  private async ensureFreshVolumes(): Promise<void> {
+    const existing: string[] = [];
+    for (const name of this.volumeNames()) {
+      if ((await this.run(['volume', 'inspect', name])).exitCode === 0) existing.push(name);
+    }
     if (existing.length === 0) return;
     throw new Error(
       `runtime volumes already exist: ${existing.join(', ')}. ` +
@@ -291,10 +292,10 @@ export class RuntimeContainer {
     ];
   }
 
-  private findContainer(name: string): boolean {
+  private async findContainer(name: string): Promise<boolean> {
     // Anchored regex (`^…$`) so `vicoop-runtime-codex` doesn't false-
     // positive on a hypothetical `vicoop-runtime-codex-2`.
-    const r = this.run([
+    const r = await this.run([
       'ps',
       '-a',
       '--filter',
@@ -305,12 +306,12 @@ export class RuntimeContainer {
     return r.exitCode === 0 && r.stdout.trim().length > 0;
   }
 
-  private inspectRunning(name: string): boolean {
-    const r = this.run(['inspect', '--format', '{{.State.Running}}', name]);
+  private async inspectRunning(name: string): Promise<boolean> {
+    const r = await this.run(['inspect', '--format', '{{.State.Running}}', name]);
     return r.exitCode === 0 && r.stdout.trim() === 'true';
   }
 
-  private createContainer(name: string): void {
+  private async createContainer(name: string): Promise<void> {
     const kind = this.opts.backendKind;
     const runtimeName = this.opts.runtimeName;
     const args: string[] = [
@@ -365,7 +366,7 @@ export class RuntimeContainer {
       );
     }
     args.push(this.opts.image);
-    this.runDocker(args);
+    await this.runDocker(args);
   }
 
   private removeHint(): string {
@@ -376,7 +377,9 @@ export class RuntimeContainer {
     const start = Date.now();
     const timeoutMs = 10_000;
     while (Date.now() - start < timeoutMs) {
-      const r = this.run(['inspect', '--format', '{{.State.Status}}', name]);
+      const r = await this.run(['inspect', '--format', '{{.State.Status}}', name], {
+        timeoutMs: Math.max(1, timeoutMs - (Date.now() - start)),
+      });
       if (r.exitCode === 0) {
         const status = r.stdout.trim();
         if (status === 'running') return;

--- a/packages/client/src/runtime-provider.ts
+++ b/packages/client/src/runtime-provider.ts
@@ -1,0 +1,39 @@
+import type { ExecutionScopeV1 } from '@vicoop-bridge/protocol';
+import type { SpawnOptions } from './spawn-adapter.js';
+
+/**
+ * Contract for the R2 isolated provider; the legacy docker-exec adapter does
+ * NOT implement supervised termination and must not be cast to this contract.
+ * Authorization, allocation deduplication and leases belong to the router.
+ */
+export interface RuntimeProvider {
+  acquire(scope: ExecutionScopeV1, signal: AbortSignal): Promise<ExecutionRuntime>;
+}
+
+export interface ExecutionRuntime {
+  readonly scopeId: string;
+  readonly runtimeId: string;
+  spawn(command: string, args: readonly string[], options: SpawnOptions & {
+    executionId: string;
+    signal: AbortSignal;
+  }): Promise<RuntimeProcess>;
+  /** Absolute runtime paths; implementations must enforce allowed roots. */
+  upload(hostPath: string, runtimePath: string, signal: AbortSignal): Promise<void>;
+  download(runtimePath: string, hostPath: string, signal: AbortSignal): Promise<void>;
+  /** Manager must hold exclusive lifecycle ownership, with no active leases. */
+  stop(signal: AbortSignal): Promise<void>;
+  /** Explicit operation, never implied by stop; refuses active runtimes. */
+  deleteData(signal: AbortSignal): Promise<void>;
+}
+
+export interface RuntimeProcess {
+  readonly executionId: string;
+  readonly processId: string;
+  readonly stdin: NodeJS.WritableStream;
+  readonly stdout: NodeJS.ReadableStream;
+  readonly stderr: NodeJS.ReadableStream;
+  /** Resolves only after supervised work is gone; rejects on unknown state. */
+  readonly exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+  /** Terminates the in-runtime process group and observes exit, or rejects. */
+  terminate(signal: AbortSignal): Promise<void>;
+}

--- a/packages/client/src/runtime-smoke.test.ts
+++ b/packages/client/src/runtime-smoke.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Run the actual smoke entrypoint against a disposable fake Docker CLI. This
+// exercises exit status and cleanup without altering real Docker resources or
+// rewriting the script under test. The fake executable is POSIX-only.
+const smoke = fileURLToPath(new URL('../scripts/runtime-foundations-smoke.ts', import.meta.url));
+const fakeDocker = `#!${process.execPath}
+const fs = require('node:fs');
+const path = require('node:path');
+const root = process.env.VICOOP_SMOKE_FIXTURE;
+const mode = process.env.VICOOP_SMOKE_FAILURE;
+const args = process.argv.slice(2);
+fs.appendFileSync(path.join(root, 'calls'), JSON.stringify(args) + '\\n');
+const statePath = path.join(root, 'state');
+const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath)) : { exists: false, running: false, stops: 0 };
+function fail(message) { process.stderr.write(message); process.exitCode = 1; }
+switch (args[0]) {
+  case 'version':
+    if (mode === 'work-failure') fail('original daemon failure');
+    else process.stdout.write('27.4.0');
+    break;
+  case 'ps': if (state.exists) process.stdout.write('container-id'); break;
+  case 'image': break;
+  case 'volume':
+    if (args[1] === 'inspect') fail('no such volume');
+    else if (args[1] === 'rm' && mode === 'missing') fail('no such volume');
+    else if (args[1] === 'rm' && ['nonzero', 'work-failure'].includes(mode)) fail('volume cleanup denied');
+    break;
+  case 'create': state.exists = true; break;
+  case 'start': state.running = true; break;
+  case 'stop':
+    state.running = false;
+    if (++state.stops === 2 && mode === 'reject') fs.unlinkSync(__filename);
+    break;
+  case 'inspect': process.stdout.write(args.includes('{{.State.Running}}') ? String(state.running) : 'running'); break;
+  case 'exec':
+    if (args.includes('sleep')) setTimeout(() => {}, 200);
+    else {
+      process.stdin.resume();
+      process.stdin.on('end', () => {
+        process.stdout.write('/tmp|literal $value; with spaces|input');
+        process.stderr.write('stderr');
+      });
+    }
+    break;
+  case 'cp':
+    if (args[2].includes(':')) fs.copyFileSync(args[1], path.join(root, 'remote-file'));
+    else fs.copyFileSync(path.join(root, 'remote-file'), args[2]);
+    break;
+  case 'rm':
+    if (mode === 'missing') fail('No such container');
+    else if (['nonzero', 'work-failure'].includes(mode)) fail('container cleanup denied');
+    break;
+  default: fail('unexpected command: ' + args[0]);
+}
+fs.writeFileSync(statePath, JSON.stringify(state));
+`;
+
+for (const mode of ['success', 'missing', 'nonzero', 'reject', 'work-failure']) {
+  test(`runtime smoke cleanup: ${mode}`, { skip: process.platform === 'win32', timeout: 20_000 }, async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'vicoop-smoke-regression-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const bin = join(root, 'bin');
+    const temp = join(root, 'temp');
+    await mkdir(bin);
+    await mkdir(temp);
+    await writeFile(join(bin, 'docker'), fakeDocker, { mode: 0o755 });
+    const result = await new Promise<{ failed: boolean; stdout: string; stderr: string }>((resolve) => {
+      execFile(process.execPath, ['--import', 'tsx', smoke], {
+        timeout: 15_000,
+        env: {
+          // Do not fall through to the real Docker CLI when the fake removes
+          // itself in the ENOENT scenario. Both Node entrypoints use absolute paths.
+          ...process.env, PATH: bin, TSX_DISABLE_CACHE: '1',
+          TMPDIR: temp, TMP: temp, TEMP: temp,
+          VICOOP_SMOKE_FIXTURE: root, VICOOP_SMOKE_FAILURE: mode,
+        },
+      }, (error, stdout, stderr) => resolve({ failed: error !== null, stdout, stderr }));
+    });
+    const success = mode === 'success' || mode === 'missing';
+    assert.equal(result.failed, !success, result.stderr);
+    assert.equal(result.stdout.includes('PASS:'), success, result.stdout);
+    assert.deepEqual((await readdir(temp)).filter((name) => name.startsWith('vicoop-runtime-smoke-')), [],
+      'local smoke data is removed even if Docker cleanup fails');
+    const calls = (await readFile(join(root, 'calls'), 'utf8')).trim().split('\n').map((line) => JSON.parse(line) as string[]);
+    if (mode === 'reject') {
+      // The fake Docker binary disappears before cleanup, causing ENOENT for
+      // every command. All four failures must be retained in the aggregate.
+      for (const prefix of ['runtime', 'agents', 'creds', 'sessions']) {
+        assert.match(result.stderr, new RegExp(`cleanup failed: vicoop-${prefix}-r1-smoke-`));
+      }
+    } else {
+      assert.equal(calls.filter((args) => args[0] === 'rm').length, 1);
+      assert.equal(calls.filter((args) => args[0] === 'volume' && args[1] === 'rm').length, 3);
+    }
+    if (mode === 'work-failure') {
+      assert.match(result.stderr, /original daemon failure/);
+      assert.match(result.stderr, /container cleanup denied/);
+      assert.match(result.stderr, /volume cleanup denied/);
+    }
+  });
+}

--- a/packages/client/src/spawn-adapter.test.ts
+++ b/packages/client/src/spawn-adapter.test.ts
@@ -69,3 +69,14 @@ test('createDockerExecSpawn: handle exposes stdin/stdout/stderr + kill', () => {
   assert.ok(child.stderr, 'stderr available');
   assert.equal(child.kill('SIGTERM'), true);
 });
+
+
+test('Docker env overrides are argv values; host secrets are not implicitly forwarded', () => {
+  const { calls, spawnImpl } = makeSpawnStub();
+  const spawn = createDockerExecSpawn(runtimeStub, { spawnImpl });
+  const value = 'spaces; $(echo unsafe) `literal`';
+  spawn('claude', [], { env: { BRIDGE_TEST: value, OMIT: undefined } });
+  assert.deepEqual(calls[0].args, ['exec', '-i', '-e', `BRIDGE_TEST=${value}`, 'vicoop-runtime-test', 'claude']);
+  assert.throws(() => spawn('claude', [], { env: { 'BAD=KEY': 'value' } }), /invalid runtime environment/);
+  assert.equal(calls.length, 1);
+});

--- a/packages/client/src/spawn-adapter.ts
+++ b/packages/client/src/spawn-adapter.ts
@@ -50,6 +50,7 @@ export interface ChildHandle {
 
 export interface SpawnOptions {
   cwd?: string;
+  env?: NodeJS.ProcessEnv;
 }
 
 export type SpawnFn = (
@@ -66,6 +67,7 @@ export function createHostSpawn(): SpawnFn {
     nodeSpawn(command, Array.from(args), {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(options.env ? { env: { ...process.env, ...options.env } } : {}),
     }) as unknown as ChildHandle;
 }
 
@@ -74,8 +76,8 @@ export function createHostSpawn(): SpawnFn {
 // child process; the returned ChildHandle is just that subprocess
 // (already structurally satisfies ChildHandle). stdin / stdout /
 // stderr forward bidirectionally, close fires when the in-container
-// process exits, and signals propagate via the docker CLI's own
-// handling.
+// process exits. kill() targets the host Docker CLI, not a supervised
+// in-container process group; caller-isolated execution must add supervision.
 //
 // `spawnImpl` is a test seam — production passes through to
 // node:child_process.spawn unchanged.
@@ -88,6 +90,11 @@ export function createDockerExecSpawn(
   return (command, args, options) => {
     const dockerArgs = ['exec', '-i'];
     if (options.cwd) dockerArgs.push('-w', options.cwd);
+    for (const [key, value] of Object.entries(options.env ?? {})) {
+      if (value === undefined) continue;
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) throw new Error('invalid runtime environment variable name');
+      dockerArgs.push('-e', `${key}=${value}`);
+    }
     dockerArgs.push(containerName, command, ...args);
     return spawnImpl('docker', dockerArgs, {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,6 +15,22 @@ export const OPENAI_COMPAT_EXTENSION_URI =
   'https://github.com/planetarium/oai2a2a/extensions/openai-compat/v1';
 export const CALLER_CONTEXT_V1_CAPABILITY = 'caller-context-v1';
 export const CALLER_CONTEXT_V2_CAPABILITY = 'caller-context-v2';
+// Wire support only; never evidence that a client isolates execution. R1
+// clients do not advertise this capability. Requires caller-context-v2 and
+// task-replay-v1 so a future isolated client can validate identity/generation.
+export const EXECUTION_SCOPE_V1_CAPABILITY = 'execution-scope-v1';
+export const ExecutionScopeV1 = z.object({
+  policy: z.literal('direct-principal-v1'),
+  id: z.string().regex(/^[a-f0-9]{64}$/),
+  agentId: z.string().min(1).max(512),
+  principalId: z.string().min(1).max(512),
+}).strict();
+export type ExecutionScopeV1 = z.infer<typeof ExecutionScopeV1>;
+
+export function supportsExecutionScopeV1(capabilities: readonly string[] | undefined): boolean {
+  return [EXECUTION_SCOPE_V1_CAPABILITY, CALLER_CONTEXT_V2_CAPABILITY, TASK_REPLAY_CAPABILITY]
+    .every((capability) => capabilities?.includes(capability));
+}
 // Compatibility alias for callers compiled against the original v1 API.
 export const CALLER_CONTEXT_CAPABILITY = CALLER_CONTEXT_V1_CAPABILITY;
 export const MENTIONABLE_IDENTITY_VC_EXTENSION_URI =
@@ -557,6 +573,7 @@ export const TaskAssignFrame = z.object({
   message: Message,
   requestedExtensions: z.array(z.string()).optional(),
   caller: CallerContext.optional(),
+  executionScope: ExecutionScopeV1.optional(),
 });
 
 export const TaskCancelFrame = z.object({

--- a/packages/server/src/execution-scope.test.ts
+++ b/packages/server/src/execution-scope.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  EXECUTION_SCOPE_V1_CAPABILITY,
+  CALLER_CONTEXT_V2_CAPABILITY,
+  TASK_REPLAY_CAPABILITY,
+  ExecutionScopeV1,
+  TaskAssignFrame,
+} from '@vicoop-bridge/protocol';
+import { resolveDirectExecutionScope } from './execution-scope.js';
+
+const capabilities = [EXECUTION_SCOPE_V1_CAPABILITY, CALLER_CONTEXT_V2_CAPABILITY, TASK_REPLAY_CAPABILITY];
+const input = { agentId: 'agent', principalId: 'apikey:alice', capabilities };
+
+test('direct scope is stable and separated by agent and exact principal', () => {
+  const scope = resolveDirectExecutionScope(input)!;
+  assert.ok(ExecutionScopeV1.safeParse(scope).success);
+  assert.deepEqual(resolveDirectExecutionScope({ ...input }), scope);
+  assert.notEqual(resolveDirectExecutionScope({ ...input, agentId: 'other' })!.id, scope.id);
+  assert.notEqual(resolveDirectExecutionScope({ ...input, principalId: 'apikey:bob' })!.id, scope.id);
+  assert.notEqual(
+    resolveDirectExecutionScope({ ...input, agentId: 'a:b', principalId: 'c' })!.id,
+    resolveDirectExecutionScope({ ...input, agentId: 'a', principalId: 'b:c' })!.id,
+  );
+});
+
+test('missing identity, unsupported negotiation, and grants never become direct scopes', () => {
+  for (const capabilitiesSubset of [undefined, [], ...capabilities.map((c) => capabilities.filter((v) => v !== c))]) {
+    assert.equal(resolveDirectExecutionScope({ ...input, capabilities: capabilitiesSubset }), undefined);
+  }
+  for (const patch of [
+    { principalId: undefined }, { principalId: '' }, { principalId: 'x'.repeat(513) },
+    { actorId: 'connector' }, { actorId: input.principalId },
+    { authorizationKey: 'grant' }, { authorizationProfile: 'profile' },
+  ]) assert.equal(resolveDirectExecutionScope({ ...input, ...patch }), undefined);
+});
+
+test('wire schema accepts legacy assignments and rejects unknown scope policies/fields', () => {
+  const legacy = {
+    type: 'task.assign', taskId: 't', contextId: 'c',
+    message: { role: 'user', parts: [{ kind: 'text', text: 'hi' }], messageId: 'm' },
+  };
+  assert.equal(TaskAssignFrame.parse(legacy).executionScope, undefined);
+  const scope = resolveDirectExecutionScope(input)!;
+  assert.deepEqual(TaskAssignFrame.parse({ ...legacy, executionScope: scope }).executionScope, scope);
+  for (const patch of [{ policy: 'future-v2' }, { id: '../victim' }, { runtimeName: 'victim' }]) {
+    assert.equal(TaskAssignFrame.safeParse({ ...legacy, executionScope: { ...scope, ...patch } }).success, false);
+  }
+});

--- a/packages/server/src/execution-scope.ts
+++ b/packages/server/src/execution-scope.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto';
+import { ExecutionScopeV1, supportsExecutionScopeV1 } from '@vicoop-bridge/protocol';
+
+/** Input is the executor's authenticated HTTP handoff, NOT public metadata. */
+export function resolveDirectExecutionScope(input: {
+  agentId: string;
+  principalId?: string;
+  actorId?: string;
+  authorizationKey?: string;
+  authorizationProfile?: string;
+  capabilities?: readonly string[];
+}): ExecutionScopeV1 | undefined {
+  if (!supportsExecutionScopeV1(input.capabilities)) return undefined;
+  // Token exchange/grant boundaries need a separate policy, even when actor
+  // and principal happen to match. Attestations never enter this function.
+  if (!input.principalId || input.actorId !== undefined ||
+      input.authorizationKey !== undefined || input.authorizationProfile !== undefined) return undefined;
+  const policy = 'direct-principal-v1' as const;
+  const id = createHash('sha256')
+    .update(JSON.stringify(['vicoop-execution-scope', policy, input.agentId, input.principalId]))
+    .digest('hex');
+  const parsed = ExecutionScopeV1.safeParse({
+    policy, id, agentId: input.agentId, principalId: input.principalId,
+  });
+  return parsed.success ? parsed.data : undefined;
+}

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@a2x/sdk';
 import {
   CALLER_CONTEXT_CAPABILITY,
+  EXECUTION_SCOPE_V1_CAPABILITY,
   CALLER_CONTEXT_V2_CAPABILITY,
   OPENAI_COMPAT_EXTENSION_URI,
   parseDownFrame,
@@ -1085,4 +1086,52 @@ test('an agent with no pricing is forwarded normally even when the payment path 
 
   const assign = sent.map((raw) => parseDownFrame(raw)).find((f) => f.type === 'task.assign');
   assert.ok(assign, 'the message should have been forwarded to the connected agent');
+});
+
+
+test('executor forwards only negotiated, server-derived direct execution scopes', async () => {
+  const full = [EXECUTION_SCOPE_V1_CAPABILITY, CALLER_CONTEXT_V2_CAPABILITY, TASK_REPLAY_CAPABILITY];
+  const cases = [
+    { caps: full, internal: { _principalId: 'apikey:alice' }, expected: true },
+    { caps: undefined, internal: { _principalId: 'apikey:alice' }, expected: false },
+    { caps: [CALLER_CONTEXT_V2_CAPABILITY, TASK_REPLAY_CAPABILITY], internal: { _principalId: 'apikey:alice' }, expected: false },
+    { caps: full, internal: {}, expected: false },
+    { caps: full, internal: { _principalId: 'apikey:alice', _authorizationProfile: 'delegated' }, expected: false },
+  ];
+  for (const entry of cases) {
+    const { ws, sent } = makeWsCapture();
+    const registry = new Registry();
+    registry.registerAgent({
+      agentId: 'agent', clientId: 'client', ownerPrincipal: 'owner',
+      protocolCapabilities: entry.caps, agentCard: makeAgentCard(), allowedCallers: [], ws, connectedAt: 0,
+    });
+    const executor = new WSForwardingExecutor('agent', registry, noopTaskStore());
+    const task = { id: 't-scope', contextId: 'same-context', status: { state: TaskState.SUBMITTED } } as unknown as Task;
+    const message = {
+      role: 'user', messageId: 'm', parts: [{ kind: 'text', text: 'select victim runtime' }],
+      metadata: { ...entry.internal, executionScope: { id: 'victim' }, execution_scope: 'victim', userField: 'keep' },
+    } as unknown as Message;
+    const gen = executor.executeStream(task, message);
+    const first = gen.next();
+    try {
+      const frame = parseDownFrame(sent[0]!);
+      assert.equal(frame.type, 'task.assign');
+      if (frame.type === 'task.assign') {
+        assert.equal(frame.executionScope !== undefined, entry.expected);
+        if (entry.expected) {
+          assert.equal(frame.executionScope?.principalId, 'apikey:alice');
+          assert.equal(frame.executionScope?.agentId, 'agent');
+          assert.match(frame.executionScope?.id ?? '', /^[a-f0-9]{64}$/);
+        }
+        assert.deepEqual(frame.message.metadata, { userField: 'keep' });
+      }
+    } finally {
+      const binding = registry.getBinding(task.id)!;
+      binding.sink.pushStatus({ taskId: task.id, contextId: task.contextId!, final: true,
+        status: { state: TaskState.COMPLETED, timestamp: new Date().toISOString() } });
+      binding.sink.finish();
+      await first;
+      for await (const event of gen) void event;
+    }
+  }
 });

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -28,6 +28,7 @@ import {
   type Part as WirePart,
 } from '@vicoop-bridge/protocol';
 import { IDENTITY_VC_PRESENTED_METADATA_KEY } from './identity-vc/types.js';
+import { resolveDirectExecutionScope } from './execution-scope.js';
 import {
   createCanonicalCallerContext,
   selectCallerContextVersion,
@@ -128,6 +129,7 @@ export function stripInternalMetadata(
     // cross the WS boundary where a backend might mistake them for verified
     // context.
     if (key === 'caller' || key === 'callerContext' || key === 'caller_context') continue;
+    if (key === 'executionScope' || key === 'execution_scope') continue;
     if (
       key === 'mentionable' &&
       typeof value === 'object' &&
@@ -465,6 +467,10 @@ export class WSForwardingExecutor extends AgentExecutor {
           })
         : undefined;
     const caller = serializeCallerContext(canonicalCaller, callerContextVersion);
+    const executionScope = caller === undefined ? undefined : resolveDirectExecutionScope({
+      agentId: this.agentId, principalId, actorId, authorizationKey, authorizationProfile,
+      capabilities: this.registry.getAgent(this.agentId)?.protocolCapabilities,
+    });
     if (callerContextVersion !== undefined && hasCallerInput && caller === undefined) {
       // Do not put the raw principal or schema details in logs. An invalid
       // transport-owned value is omitted instead of emitting a task.assign
@@ -558,6 +564,7 @@ export class WSForwardingExecutor extends AgentExecutor {
       },
       ...(message.extensions !== undefined ? { requestedExtensions: message.extensions } : {}),
       ...(caller !== undefined ? { caller } : {}),
+      ...(executionScope !== undefined ? { executionScope } : {}),
     });
 
     if (!sent) {

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -6,6 +6,8 @@ import WebSocket from 'ws';
 import type { TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2x/sdk';
 import {
   CALLER_CONTEXT_CAPABILITY,
+  CALLER_CONTEXT_V2_CAPABILITY,
+  EXECUTION_SCOPE_V1_CAPABILITY,
   encodeFrame,
   OPENAI_COMPAT_EXTENSION_URI,
   parseDownFrame,
@@ -1360,5 +1362,33 @@ test('a terminal replay from an old execution cannot complete a reused taskId', 
   } finally {
     ws.close();
     await closeServer(server);
+  }
+});
+
+
+test('execution scope acknowledgement requires the full capability set', async () => {
+  for (const callerV2 of [false, true]) {
+    const server = createServer();
+    const registry = new Registry();
+    attachWsServer(server, { db: mockSql(), registry });
+    const port = await listen(server);
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/connect`);
+    try {
+      await once(ws, 'open');
+      const ack = once(ws, 'message');
+      ws.send(encodeFrame({
+        type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
+        protocolCapabilities: [TASK_REPLAY_CAPABILITY, EXECUTION_SCOPE_V1_CAPABILITY,
+          ...(callerV2 ? [CALLER_CONTEXT_V2_CAPABILITY] : [])],
+        agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
+      }));
+      const [raw] = await withTimeout(ack, 5_000, 'scope acknowledgement');
+      const frame = parseDownFrame(raw.toString());
+      assert.equal(frame.type, 'hello.ack');
+      if (frame.type === 'hello.ack') assert.equal(frame.protocolCapabilities.includes(EXECUTION_SCOPE_V1_CAPABILITY), callerV2);
+    } finally {
+      ws.close();
+      await closeServer(server);
+    }
   }
 });

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -6,6 +6,8 @@ import {
   PROTOCOL_VERSION,
   OPENAI_COMPAT_EXTENSION_URI,
   TASK_REPLAY_CAPABILITY,
+  EXECUTION_SCOPE_V1_CAPABILITY,
+  supportsExecutionScopeV1,
   type Part,
   type TaskStatus as WireTaskStatus,
   type Message as WireMessage,
@@ -347,7 +349,10 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
           ws.send(
             encodeFrame({
               type: 'hello.ack',
-              protocolCapabilities: [TASK_REPLAY_CAPABILITY],
+              protocolCapabilities: [
+                TASK_REPLAY_CAPABILITY,
+                ...(supportsExecutionScopeV1(frame.protocolCapabilities) ? [EXECUTION_SCOPE_V1_CAPABILITY] : []),
+              ],
               disconnectGraceMs: opts.registry.getDisconnectGraceMs(),
               maxFrameBytes: MAX_INGRESS_BYTES,
             }),


### PR DESCRIPTION
## Problem and behavior

Docker runtime startup, image preparation and shutdown currently block the bridge event loop. Future caller-scoped allocation also needs a server-owned execution-scope contract and an explicit unavailable-mode gate before it can safely ship.

Implement R1 of #497 against the long-term integration branch `codex/497-docker-runtimes`:

- Run runtime lifecycle commands and the startup credential probe asynchronously with bounded time/output; keep streamed image-pull progress and the synchronous one-shot list/remove compatibility path.
- Pass explicit per-spawn env overrides into Docker without forwarding the entire host environment.
- Add the strict `direct-principal-v1` scope schema and server derivation, sent only under the complete scope/caller-v2/replay capability combination. Strip forged scope metadata. Missing identity and delegated authorization do not receive a direct scope.
- Reserve `caller-container` configuration and fail before backend startup. R1 clients do not advertise scope support or enable caller isolation.
- Specify the future supervised-process/file/lifecycle provider contract, add a reproducible Docker/Bun smoke script, and document deployment/rollback and the R2 activation gate.

The existing Docker spawn adapter remains a stdio transport: killing its local CLI does not certify in-container process-group termination. The new command timeout similarly requires reconciliation of possibly accepted Docker mutations. Supervision, caller allocation and active leases remain R2 work.

## Validation

- `pnpm -r build` and `pnpm -r typecheck`: passed.
- Client suite: 939 passed, including five cleanup regression cases (success, absent resources, nonzero cleanup, spawn failure, and original work + cleanup failure).
- Server suite: 451 passed, 78 skipped by the existing suite (529 total).
- Protocol suite: 11 passed.
- Real Docker 27.4.0: disposable runtime creation, responsive event loop, stdio/EOF, cwd/env, file round trip and stop/start volume persistence passed under tsx and a Bun-compiled smoke executable; test resources removed.
- Compiled client: CLI/config `caller-container` requests both reject before startup; host echo task and no new scope advertisement verified against local simulated legacy and replay-aware servers.

No paid backend calls, caller-isolation E2E claim, server deployment or client release. Existing modes require no database/volume migration; client/server R1 can ship in either order. Remove reserved config before downgrading to older clients whose normalizer can discard unknown runtime values. Includes a client-only patch changeset.


## Adversarial review follow-up

Fixed the smoke cleanup finding: every cleanup is attempted independently, original work errors and cleanup errors are aggregated, and PASS is emitted only after cleanup succeeds. Regression tests execute the actual entrypoint against a fixture-only Docker PATH so a missing fake executable cannot fall through to the host Docker CLI. Re-review confirmed both the original cleanup finding and the test-isolation issue are resolved, with no additional confirmed findings. Real Docker and Bun-compiled smoke both passed after the fix.
