### PR TITLE
feat(client): add R2 caller-isolated Claude Docker runtime

### DIFF
--- a/.changeset/tidy-caller-isolation.md
+++ b/.changeset/tidy-caller-isolation.md
@@ -3,3 +3,5 @@
 ---
 
 Add opt-in Claude caller-isolated Docker execution with bounded transactional workspaces, direct-principal negotiation, cancellation cleanup, crash reconciliation, and offline state inspection/deletion. Requires an upgraded bridge server and a pinned backend image; existing host and single-container modes remain supported.
+
+Preserve existing conversations when queued requests exceed the context limit, and let detached caller daemons finish their cleanup before `stop` escalates to SIGKILL.

--- a/.changeset/tidy-caller-isolation.md
+++ b/.changeset/tidy-caller-isolation.md
@@ -5,3 +5,5 @@
 Add opt-in Claude caller-isolated Docker execution with bounded transactional workspaces, direct-principal negotiation, cancellation cleanup, crash reconciliation, and offline state inspection/deletion. Requires an upgraded bridge server and a pinned backend image; existing host and single-container modes remain supported.
 
 Preserve existing conversations when queued requests exceed the context limit, and let detached caller daemons finish their cleanup before `stop` escalates to SIGKILL.
+
+Allow caller-isolated Claude to reuse the operator's host OAuth login through explicit `host-claude` credential provisioning, forwarding only the current access token per execution. Existing API-key-file configuration remains supported; token refresh remains operator-managed.

--- a/.changeset/tidy-caller-isolation.md
+++ b/.changeset/tidy-caller-isolation.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Add opt-in Claude caller-isolated Docker execution with bounded transactional workspaces, direct-principal negotiation, cancellation cleanup, crash reconciliation, and offline state inspection/deletion. Requires an upgraded bridge server and a pinned backend image; existing host and single-container modes remain supported.

--- a/docs/caller-runtime-rollout.md
+++ b/docs/caller-runtime-rollout.md
@@ -3,6 +3,9 @@
 Tracking: [#497](https://github.com/planetarium/vicoop-bridge/issues/497).
 Design background: [#496](https://github.com/planetarium/vicoop-bridge/issues/496).
 
+R2 implementation and operating contract: [Claude caller runtime](caller-runtime.md).
+The R1 section below describes the earlier release boundary.
+
 ## R1: compatible foundations
 
 R1 supports the existing `host` and `container` modes. Their install,

--- a/docs/caller-runtime.md
+++ b/docs/caller-runtime.md
@@ -160,7 +160,9 @@ A crash during the short owner-file critical section may leave `.guard`; inspect
 owner PID, Docker resources and directory ownership before manually removing this
 lock directory. A wedged Docker engine can leave a quarantine/owner record and
 resources; restore Docker access and restart for reconciliation. Orderly shutdown
-awaits tasks/cleanup for up to 120 seconds, then process exit leaves recovery to the
+awaits tasks/cleanup for up to 120 seconds. Detached `stop` honors the launch-time
+cleanup budget plus a 5-second exit margin, even if configuration changes later;
+its pidfile remains owned until cleanup ends. After the deadline, process exit leaves recovery to the
 watchdog and next startup. The watchdog terminates processes but does not delete
 Docker metadata/networks. Do not manually remove resources belonging to a live
 owner. Rich live inspection, idle eviction and retention automation belong to R3.

--- a/docs/caller-runtime.md
+++ b/docs/caller-runtime.md
@@ -1,0 +1,200 @@
+# Claude caller-isolated Docker runtime (R2)
+
+Opt in with `--backend claude --runtime caller-container`. One public agent and
+bridge connection serve distinct directly authenticated principals. Scope is a
+server-generated SHA-256 digest of policy version, agent ID and principal ID;
+message metadata, model output, context IDs and tool arguments cannot select it.
+A shared bearer credential represents one principal, regardless of how many
+humans use it. Existing `host` and `container` profiles retain their behavior.
+
+## Supported surface
+
+Linux and macOS Docker hosts, a local Docker engine with its default seccomp
+profile and private PID namespaces, Claude plain A2A text and inline image/PDF
+inputs. URI-only input fetching is disabled. The regular Claude parser's MIME
+and byte limits still apply. Use an engine controlled by this operator, with no
+external process changing its context or deleting managed resources during use.
+
+Anonymous requests are rejected even when the agent's allowed-caller list is
+empty. An empty list permits **authenticated direct** callers; a nonempty list
+still restricts their principals. Existing task ownership checks remain in force.
+Delegation/token exchange, isolated Codex/OpenClaw, OpenAI compatibility,
+caller tools, MCP servers, and outgoing file delivery are unsupported. The client
+removes its OpenAI compatibility advertisement and rejects tool/data envelopes.
+Claude runs with strict empty MCP configuration and no user/project setting
+sources. Host cwd, runtime-name and operator Claude settings are rejected.
+Workload files, including `CLAUDE.md`, remain part of that caller's workspace.
+
+## Image and credentials
+
+Build an image with an exact Claude version and an immutable Node base digest:
+
+```sh
+docker build -f packages/client/docker/caller-runtime/Dockerfile \
+  --build-arg CLAUDE_VERSION=2.1.265 \
+  -t my-caller-claude packages/client/docker/caller-runtime
+docker image inspect my-caller-claude --format '{{.Id}}'
+```
+
+The Dockerfile pins Node 22; override `NODE_IMAGE` with another suitable repository
+digest when upgrading. Record the resulting image ID/digest in configuration;
+mutable tags are rejected and images must already be local. The image must have
+Node, POSIX sh, tar, sleep, mkdir and Claude installed read-only, support UID/GID
+1000, and declare no `VOLUME`s. Add any required development tools at image build
+time. No operator configuration, workspace or credentials belong in the image.
+The base recipe is intentionally a minimal toolchain.
+
+Create a dedicated plaintext file containing one Anthropic API key, mode `0600`,
+and an empty state directory, mode `0700`. Paths must be absolute. Example client
+configuration (merge with normal registration/token fields):
+
+```json
+{
+  "backend": "claude",
+  "backends": { "claude": { "runtime": "caller-container" } },
+  "caller_runtime": {
+    "image": "sha256:<64 lowercase hexadecimal characters>",
+    "credentialFile": "/private/path/anthropic-key",
+    "stateDirectory": "/private/path/caller-state",
+    "maxScopes": 8,
+    "queueLimit": 16,
+    "workspaceMiB": 128,
+    "taskTimeoutMs": 600000
+  }
+}
+```
+
+The key is read afresh for every execution and injected as `ANTHROPIC_API_KEY`.
+Replace the file to rotate it; active work keeps its existing key. The workload
+can read and use this credential, including copying it into its own files; this
+profile does not provide credential secrecy from the agent. Docker administrators
+can inspect it in the container environment. Supply a credential appropriate for
+all callers admitted by this agent. Host OAuth/login directories are never copied.
+
+## Execution, persistence and limits
+
+Each scope has one backend/session map while the daemon lives. All tasks within a
+scope are serialized, including allocation, snapshot and cleanup; different scopes
+can run concurrently. Reusing a context ID across callers never shares the backend.
+The ordinary Claude session TTL applies (one hour); a daemon restart creates a new
+conversation even when files survive. A working status reports
+`metadata["vicoop.runtime"] = {workspaceRestored: true, conversationReset: true}`
+for a restored scope's new binding. R3 will add stronger conversation restoration.
+
+Each task gets a unique container and private bridge network. There are no host
+bind mounts, Docker socket or published ports. Rootfs is read-only, capabilities
+are dropped, privilege escalation is disabled, and jobs run as UID 1000. `/state`
+is bounded tmpfs holding workspace, HOME and Claude session files in separate
+subdirectories; `/tmp` is a separate ephemeral 32 MiB tmpfs. A root PID 1 watchdog
+exits after the configured task timeout plus 120 seconds; workload processes cannot
+stop it. Container memory is workspace size plus 512 MiB, swap disabled, CPUs 1,
+PIDs 128. Networks isolate containers from each other; outbound network access is
+available and is not an egress allowlist or VM-level isolation guarantee.
+
+At successful completion, a same-UID supervisor stops workload processes, checks
+thread states, and streams an opaque tar snapshot into a host-owned pending file.
+Docker's archive API does not capture tmpfs contents. The manager confirms whole
+container removal and removes its network before atomically replacing the scope's
+committed snapshot and releasing the execution lease. The host never extracts a
+tar or mounts caller data. Terminal success waits for this barrier. Cancellation
+also removes the whole container; killing the local `docker exec` process is not
+treated as proof that remote descendants exited. Unconfirmed cleanup quarantines
+the scope until startup reconciliation succeeds.
+
+**Persistence is transactional in R2.** Successful checkpoints survive task/container
+recreation and daemon restart. A failed or canceled task discards changes that have
+not reached the atomic checkpoint replacement. A cancellation racing *after* that
+commit retains the new checkpoint and reports that distinction when its terminal
+frame can still be delivered. Cancellation is not a guarantee of rollback after
+commit. Delivery failure or a crash after commit can likewise leave completed
+changes without a received success response; blindly retrying is not exactly-once
+execution. Snapshots target daemon/process restart recovery, not host power-loss
+or filesystem-corruption durability. Previously committed caller data is not
+implicitly deleted by stop, cancellation, cleanup, or upgrade.
+
+| Setting | Default | Accepted range / behavior |
+| --- | --- | --- |
+| `maxScopes` | 8 | 1–32 admitted/retained callers; no automatic eviction |
+| `queueLimit` | 16 | 0–128 additional outstanding tasks; total admission bound is maxScopes + queueLimit |
+| `workspaceMiB` | 128 | 8–512 per scope, includes CLI state and files |
+| `taskTimeoutMs` | 600000 | 1000–3600000; includes queue and allocation |
+| Context bindings | 256 | Per scope, reject new contexts when full |
+| Snapshot bytes | 2 × workspace size | Hard streaming cap for each committed/pending tar |
+| Docker operations | 30 seconds each | Cleanup uses independent deadlines after cancellation |
+
+Admission capacity returns `runtime_capacity`. Each admitted principal reserves a
+slot until daemon restart or offline state deletion; failed initial tasks can
+consume a live-daemon slot too. Queue waiting is cancellable. Allocation has a
+fixed sequence of bounded operations with deadline checks between them; accepted
+Docker mutations are cleaned up even if the deadline expired during the command.
+Maximum host snapshot storage is bounded by two snapshots per admitted scope
+(committed plus pending), each capped as above. Tar overhead counts toward the cap.
+Do not reduce limits below retained state usage; startup explicitly rejects that.
+
+## Inspection, deletion and crash recovery
+
+Live resource identification:
+
+```sh
+docker ps -a --filter label=vicoop.component=caller-runtime
+# Inspect labels vicoop.caller-namespace and vicoop.scope on an identified container.
+```
+
+With the daemon stopped, inspect snapshots or explicitly delete one scope:
+
+```sh
+vicoop-client caller-state --directory /private/path/caller-state --agent-id YOUR_AGENT
+vicoop-client caller-state --directory /private/path/caller-state --agent-id YOUR_AGENT \
+  --delete-scope THE_64_HEX_SCOPE_ID
+```
+
+The management command uses the same exclusive owner lock and refuses a live
+owner or leftover containers. Start the daemon to reconcile after a crash, then
+stop it before deleting data. A directory manifest binds it to an agent/host/schema;
+owner records include hostname, PID and a unique token. A live or incompatible
+owner fails closed. A dead same-host owner can be recovered; startup removes all
+old namespace containers/networks and incomplete snapshots before accepting work.
+Resources are removed and recreated, never adopted with unknown mounts or images.
+
+A crash during the short owner-file critical section may leave `.guard`; inspect
+owner PID, Docker resources and directory ownership before manually removing this
+lock directory. A wedged Docker engine can leave a quarantine/owner record and
+resources; restore Docker access and restart for reconciliation. Orderly shutdown
+awaits tasks/cleanup for up to 120 seconds, then process exit leaves recovery to the
+watchdog and next startup. The watchdog terminates processes but does not delete
+Docker metadata/networks. Do not manually remove resources belonging to a live
+owner. Rich live inspection, idle eviction and retention automation belong to R3.
+
+## Rollout and validation
+
+Deploy the R2 server first, then release/upgrade the client, then opt in. Existing
+modes work in mixed-version deployments. An isolated client requires explicit
+`caller-runtime-v1`, `execution-scope-v1` and replay acknowledgment; R1-only and
+legacy servers cannot activate it. Rolling the server back requires stopping or
+reconfiguring isolated clients first. Switching to host/single-container mode never
+imports isolated state. Keep snapshots while rolling back; R1 does not read them.
+
+Docker smoke uses a local pinned Node image and no model calls:
+
+```sh
+VICOOP_SMOKE_IMAGE=sha256:YOUR_IMAGE_ID pnpm exec tsx packages/client/scripts/caller-runtime-smoke.ts
+bun build --compile packages/client/scripts/caller-runtime-smoke.ts --outfile /tmp/caller-runtime-smoke
+VICOOP_SMOKE_IMAGE=sha256:YOUR_IMAGE_ID /tmp/caller-runtime-smoke
+```
+
+The full CLI smoke uses a **deterministic Claude fixture**, not a paid Claude API
+request. It checks argv, prompt staging, backend session reuse, A/B/A workspaces,
+WebSocket disconnect/replay, forced daemon restart/reset, and shutdown:
+
+```sh
+pnpm -r build
+docker build -t vicoop-caller-fixture packages/client/scripts/fixtures/caller-claude
+bun build --compile packages/client/src/cli.ts --outfile /tmp/vicoop-client
+VICOOP_CLIENT_BIN=/tmp/vicoop-client \
+  VICOOP_SMOKE_IMAGE=$(docker image inspect vicoop-caller-fixture --format '{{.Id}}') \
+  node packages/client/scripts/caller-client-smoke.mjs
+```
+
+Both smoke scripts create unique state and clean up only their own namespace.
+Real Claude image installation/version checks are separate evidence from fixture
+execution; fixture success does not claim a paid model end-to-end run.

--- a/docs/caller-runtime.md
+++ b/docs/caller-runtime.md
@@ -64,12 +64,35 @@ configuration (merge with normal registration/token fields):
 }
 ```
 
+This existing configuration defaults to `"credentialSource": "api-key-file"`.
 The key is read afresh for every execution and injected as `ANTHROPIC_API_KEY`.
 Replace the file to rotate it; active work keeps its existing key. The workload
 can read and use this credential, including copying it into its own files; this
 profile does not provide credential secrecy from the agent. Docker administrators
 can inspect it in the container environment. Supply a credential appropriate for
 all callers admitted by this agent. Host OAuth/login directories are never copied.
+
+To reuse the operator's existing Claude.ai login instead, omit `credentialFile`
+and set `"credentialSource": "host-claude"` in `caller_runtime`. No separate API
+key is required. The daemon reads the default macOS `Claude Code-credentials`
+Keychain entry or Linux `~/.claude/.credentials.json` at startup and before each
+execution. Linux credentials must be a private regular file. Custom
+`CLAUDE_CONFIG_DIR` is currently unsupported; this mode fails rather than choosing
+another account. The macOS credential lookup is asynchronous with a 10-second
+timeout and bounded output.
+
+Only the current access token is injected as `CLAUDE_CODE_OAUTH_TOKEN`; refresh
+tokens, host settings and host conversations are not copied. This is explicit
+operator opt-in to sharing that account's model access with admitted callers.
+As with API keys, the workload and Docker administrators can read the supplied
+access token. The bridge does not refresh tokens or modify the host login.
+Missing, invalid, expired or less-than-one-minute-remaining tokens fail closed;
+refresh the login using host Claude and retry. Later executions reread updated
+credentials, while active work keeps its original token and may fail if it
+expires. No API-key fallback or transparent retry is performed. Automatic refresh
+coordination is not supported in this release. Secrets are supplied via container
+environment, not deliberately included in snapshots; a workload can still copy
+them into its own retained files.
 
 ## Execution, persistence and limits
 
@@ -200,3 +223,15 @@ VICOOP_CLIENT_BIN=/tmp/vicoop-client \
 Both smoke scripts create unique state and clean up only their own namespace.
 Real Claude image installation/version checks are separate evidence from fixture
 execution; fixture success does not claim a paid model end-to-end run.
+
+For an explicit real model request using the host Claude.ai login, run the OAuth
+smoke against a pinned image containing Claude. It uses the actual caller runtime
+pool, validates token-only provisioning, calls Haiku, commits a checkpoint and
+checks resource cleanup. It consumes the operator's model allowance and does not
+test token refresh or the full A2A transport:
+
+```sh
+VICOOP_SMOKE_IMAGE=sha256:YOUR_CLAUDE_IMAGE_ID pnpm exec tsx packages/client/scripts/caller-auth-smoke.ts
+bun build --compile packages/client/scripts/caller-auth-smoke.ts --outfile /tmp/caller-auth-smoke
+VICOOP_SMOKE_IMAGE=sha256:YOUR_CLAUDE_IMAGE_ID /tmp/caller-auth-smoke
+```

--- a/docs/container.md
+++ b/docs/container.md
@@ -210,3 +210,7 @@ Agents SDK, Daytona ships Kata/Sysbox as the upgrade tier. Configure the
 runtime per your orchestrator's documentation (Docker daemon
 `runtimes`, k8s RuntimeClass, etc.) — the bridge client image works
 unchanged.
+
+## Caller-isolated Claude profile
+
+For the opt-in `caller-container` mode, see [caller runtime configuration, persistence and limits](caller-runtime.md). This profile requires a pinned backend-installed image and dedicated state/credential files; `container init` continues to manage the existing single-runtime profile.

--- a/packages/client/docker/caller-runtime/Dockerfile
+++ b/packages/client/docker/caller-runtime/Dockerfile
@@ -1,0 +1,13 @@
+# Supply an immutable base digest and exact Claude package version at build time.
+ARG NODE_IMAGE=node@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+FROM ${NODE_IMAGE}
+ARG CLAUDE_VERSION
+RUN test -n "$CLAUDE_VERSION" && \
+    npm install --engine-strict --global "@anthropic-ai/claude-code@$CLAUDE_VERSION" && \
+    npm cache clean --force && \
+    claude --version
+# No VOLUME declaration: state is supplied as bounded tmpfs by the manager.
+# Image tooling is shared read-only; no operator config or credentials are copied.
+USER 1000:1000
+WORKDIR /state/workspace
+ENTRYPOINT ["claude"]

--- a/packages/client/scripts/caller-auth-smoke.ts
+++ b/packages/client/scripts/caller-auth-smoke.ts
@@ -1,0 +1,58 @@
+// Explicit opt-in: uses the host Claude.ai login for one real model request.
+// Also run as a Bun-compiled executable. Never prints model output or credentials.
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DockerCallerRuntimePool } from '../src/caller-runtime-docker.js';
+import { scopeDigest } from '../src/caller-runtime-store.js';
+import { runDockerCommand } from '../src/docker-command.js';
+
+const image = process.env.VICOOP_SMOKE_IMAGE;
+if (!image) throw new Error('Set VICOOP_SMOKE_IMAGE to a pinned image containing Claude');
+const directory = await mkdtemp(join(tmpdir(), 'vicoop-caller-auth-'));
+const pool = new DockerCallerRuntimePool({
+  image, credentialSource: 'host-claude', stateDirectory: directory,
+  agentId: 'auth-smoke', maxScopes: 1, taskTimeoutMs: 120_000,
+});
+try {
+  await pool.initialize();
+  const runtime = await pool.start(scopeDigest('auth-smoke', 'apikey:test'), new AbortController().signal);
+  try {
+    const child = runtime.spawn('node', ['-e', `
+      const cp = require('child_process');
+      if (!process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_CODE_OAUTH_REFRESH_TOKEN) process.exit(2);
+      const r = cp.spawnSync('claude', ['-p', 'Explain what the JavaScript expression 2 + 2 evaluates to in one sentence.', '--model', 'haiku', '--output-format', 'json', '--max-turns', '1', '--tools', '', '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}', '--setting-sources', '', '--dangerously-skip-permissions'], {encoding:'utf8', timeout:90000, maxBuffer:1048576});
+      let result; try { result = JSON.parse(r.stdout); } catch {}
+      const ok = r.status === 0 && result?.subtype === 'success' && !result?.is_error && typeof result?.result === 'string' && result.result.length > 0 && result?.usage?.output_tokens > 0;
+      console.log(JSON.stringify({success:ok, models:Object.keys(result?.modelUsage ?? {})}));
+      process.exit(ok ? 0 : 1);
+    `], { cwd: '/state/workspace' });
+    let output = '';
+    child.stdout!.on('data', chunk => { output += chunk; });
+    child.stderr!.on('data', () => {});
+    const exited = new Promise<number | null>((resolve, reject) => {
+      child.on('close', resolve);
+      child.on('error', () => reject(new Error('Auth smoke process failed')));
+    });
+    child.stdin!.end();
+    assert.equal(await exited, 0, 'Real Claude OAuth inference failed');
+    assert.equal(JSON.parse(output).success, true);
+    await runtime.finish(true);
+  } catch (error) {
+    await runtime.cancel();
+    throw error;
+  }
+} finally {
+  await pool.close();
+  for (const args of [
+    ['ps', '-aq', '--filter', `label=vicoop.caller-namespace=${pool.store.namespace}`],
+    ['network', 'ls', '-q', '--filter', `label=vicoop.caller-namespace=${pool.store.namespace}`],
+  ]) {
+    const result = await runDockerCommand(args);
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout.trim(), '', 'Auth smoke leaked Docker resources');
+  }
+  await rm(directory, { recursive: true, force: true });
+}
+console.log('PASS: real Claude OAuth inference through DockerCallerRuntimePool, checkpoint and cleanup');

--- a/packages/client/scripts/caller-client-smoke.mjs
+++ b/packages/client/scripts/caller-client-smoke.mjs
@@ -1,0 +1,275 @@
+// Full CLI + real Docker + deterministic Claude stream fixture. No paid model.
+import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import { spawn, execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtemp, writeFile, realpath, rm } from 'node:fs/promises';
+import { tmpdir, hostname } from 'node:os';
+import { join } from 'node:path';
+import { WebSocketServer } from 'ws';
+const exec = promisify(execFile);
+const binary = process.env.VICOOP_CLIENT_BIN;
+const image = process.env.VICOOP_SMOKE_IMAGE;
+if (!binary || !image)
+  throw new Error(
+    'set VICOOP_CLIENT_BIN (absolute compiled CLI path), VICOOP_SMOKE_IMAGE (pinned fixture image)',
+  );
+const directory = await mkdtemp(join(tmpdir(), 'vicoop-caller-client-'));
+const key = join(directory, 'key');
+const configPath = join(directory, 'config.json');
+await writeFile(key, 'fixture-no-api-call', { mode: 0o600 });
+const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+await new Promise((r) => server.once('listening', r));
+const config = {
+  server_url: `ws://127.0.0.1:${server.address().port}`,
+  server_token: 'fixture',
+  agent_id: 'smoke',
+  backend: 'claude',
+  backends: { claude: { runtime: 'caller-container' } },
+  caller_runtime: {
+    image,
+    credentialFile: key,
+    stateDirectory: join(directory, 'state'),
+    workspaceMiB: 16,
+    maxScopes: 2,
+    taskTimeoutMs: 120_000,
+  },
+};
+await writeFile(configPath, JSON.stringify(config), { mode: 0o600 });
+let socket;
+let hellos = 0;
+let child;
+let logs = '';
+let exit;
+const frames = [];
+server.on('connection', (ws) => {
+  ws.on('message', (raw) => {
+    const frame = JSON.parse(raw.toString());
+    if (frame.type === 'hello') {
+      assert.ok(frame.protocolCapabilities.includes('caller-runtime-v1'));
+      assert.equal(
+        frame.agentCard?.capabilities?.extensions?.some((x) =>
+          x.uri.includes('openai-compat'),
+        ),
+        false,
+      );
+      socket = ws;
+      hellos++;
+      ws.send(
+        JSON.stringify({
+          type: 'hello.ack',
+          protocolCapabilities: [
+            'task-replay-v1',
+            'execution-scope-v1',
+            'caller-runtime-v1',
+          ],
+          disconnectGraceMs: 30_000,
+          maxFrameBytes: 1048576,
+        }),
+      );
+    } else {
+      frames.push(frame);
+      if (frame.executionId && frame.seq)
+        ws.send(
+          JSON.stringify({
+            type: 'task.ack',
+            taskId: frame.taskId,
+            executionId: frame.executionId,
+            acceptedSeq: frame.seq,
+          }),
+        );
+    }
+  });
+});
+async function waitFor(predicate, label, timeout = 30_000) {
+  const deadline = Date.now() + timeout;
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timed out: ${label}\n${logs}`);
+    await new Promise((r) => setTimeout(r, 25));
+  }
+}
+async function start() {
+  const previous = hellos;
+  child = spawn(binary, ['start', '--config', configPath], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (x) => {
+    logs += x;
+  });
+  child.stderr.on('data', (x) => {
+    logs += x;
+  });
+  exit = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  await waitFor(() => hellos > previous, 'daemon hello');
+}
+function assign(principal, id, text = 'hello') {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify([
+        'vicoop-execution-scope',
+        'direct-principal-v1',
+        'smoke',
+        principal,
+      ]),
+    )
+    .digest('hex');
+  socket.send(
+    JSON.stringify({
+      type: 'task.assign',
+      taskId: id,
+      executionId: `exec-${id}`,
+      contextId: 'identical-context',
+      caller: { principal: { id: principal } },
+      executionScope: {
+        policy: 'direct-principal-v1',
+        id: digest,
+        agentId: 'smoke',
+        principalId: principal,
+      },
+      message: {
+        role: 'user',
+        messageId: `m-${id}`,
+        parts: [{ kind: 'text', text }],
+      },
+    }),
+  );
+}
+async function completed(id) {
+  await waitFor(
+    () =>
+      frames.some(
+        (x) =>
+          x.taskId === id && ['task.complete', 'task.fail'].includes(x.type),
+      ),
+    id,
+  );
+  const terminal = frames.find(
+    (x) => x.taskId === id && ['task.complete', 'task.fail'].includes(x.type),
+  );
+  assert.equal(terminal.type, 'task.complete', JSON.stringify(terminal));
+  const output = frames
+    .filter((x) => x.taskId === id && x.type === 'task.artifact')
+    .flatMap((x) => x.artifact.parts)
+    .filter((x) => x.kind === 'text')
+    .map((x) => x.text)
+    .join('');
+  return JSON.parse(output);
+}
+async function stop(signal = 'SIGTERM') {
+  if (!child) return;
+  child.kill(signal);
+  const result = await Promise.race([
+    exit,
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error('daemon shutdown timed out')),
+        20_000,
+      ).unref(),
+    ),
+  ]);
+  child = undefined;
+  if (signal === 'SIGTERM') assert.equal(result.code, 0, logs);
+}
+try {
+  await start();
+  assign('apikey:a', 'a1');
+  const a1 = await completed('a1');
+  assign('apikey:b', 'b1');
+  const b1 = await completed('b1');
+  assign('apikey:a', 'a2');
+  const a2 = await completed('a2');
+  assert.equal(a1.turn, 1);
+  assert.equal(b1.turn, 1);
+  assert.equal(a2.turn, 2);
+  assert.equal(a1.session, a2.session);
+  assert.notEqual(a1.session, b1.session);
+  assert.equal(a2.resumed, true);
+  assert.equal(a2.cwd, '/state/workspace');
+  assert.equal(a2.promptStaged, true);
+  const before = hellos;
+  assign('apikey:b', 'replay', 'delay-task');
+  await waitFor(
+    () => frames.some((x) => x.taskId === 'replay'),
+    'replay task started',
+  );
+  socket.terminate();
+  await waitFor(() => hellos > before, 'reconnect hello');
+  assert.equal((await completed('replay')).turn, 2);
+  assign('apikey:a', 'crash', 'hold-task');
+  // Prove the killed generation wrote uncommitted state before forcing exit.
+  const namespace = createHash('sha256')
+    .update(
+      JSON.stringify([
+        hostname(),
+        await realpath(config.caller_runtime.stateDirectory),
+        'smoke',
+      ]),
+    )
+    .digest('hex');
+  let observedWrite = false;
+  for (let attempt = 0; attempt < 50 && !observedWrite; attempt++) {
+    const { stdout } = await exec('docker', [
+      'ps',
+      '--format',
+      '{{.Names}}',
+      '--filter',
+      `label=vicoop.caller-namespace=${namespace}`,
+    ]);
+    for (const name of stdout.trim().split(/\s+/).filter(Boolean)) {
+      try {
+        const result = await exec('docker', [
+          'exec',
+          '--user',
+          '1000:1000',
+          name,
+          'cat',
+          '/state/workspace/counter',
+        ]);
+        if (result.stdout.trim() === '3') observedWrite = true;
+      } catch {
+        /* Allocation may still be staging state. */
+      }
+    }
+    if (!observedWrite) await new Promise((r) => setTimeout(r, 100));
+  }
+  assert.ok(
+    observedWrite,
+    'crashed task must actually mutate its uncommitted workspace',
+  );
+  await stop('SIGKILL');
+  await start();
+  assign('apikey:a', 'restored');
+  const restored = await completed('restored');
+  assert.equal(restored.turn, 3);
+  assert.equal(restored.resumed, false);
+  assert.notEqual(restored.session, a1.session);
+  assert.ok(
+    frames.some(
+      (x) =>
+        x.taskId === 'restored' &&
+        x.metadata?.['vicoop.runtime']?.conversationReset,
+    ),
+  );
+  await stop();
+  console.log(
+    'compiled caller client smoke passed: Claude argv/prompt staging, A/B/A sessions+files, disconnect/replay, forced restart+reset, orderly shutdown',
+  );
+} finally {
+  await stop();
+  for (const ws of server.clients) ws.terminate();
+  await new Promise((r) => server.close(r));
+  // Reconcile any remaining generation after test failure before deleting state.
+  const { DockerCallerRuntimePool } = await import(
+    '../dist/caller-runtime-docker.js'
+  );
+  const pool = new DockerCallerRuntimePool({
+    ...config.caller_runtime,
+    agentId: 'smoke',
+  });
+  await pool.initialize();
+  await pool.close();
+  await rm(directory, { recursive: true });
+}

--- a/packages/client/scripts/caller-client-smoke.mjs
+++ b/packages/client/scripts/caller-client-smoke.mjs
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict';
 import { promisify } from 'node:util';
 import { spawn, execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { mkdtemp, writeFile, realpath, rm } from 'node:fs/promises';
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  writeFile,
+  realpath,
+  rm,
+} from 'node:fs/promises';
 import { tmpdir, hostname } from 'node:os';
 import { join } from 'node:path';
 import { WebSocketServer } from 'ws';
@@ -15,6 +22,9 @@ if (!binary || !image)
     'set VICOOP_CLIENT_BIN (absolute compiled CLI path), VICOOP_SMOKE_IMAGE (pinned fixture image)',
   );
 const directory = await mkdtemp(join(tmpdir(), 'vicoop-caller-client-'));
+const clientHome = join(directory, 'client-home');
+await mkdir(clientHome, { mode: 0o700 });
+const clientEnv = { ...process.env, VICOOP_HOME: clientHome };
 const key = join(directory, 'key');
 const configPath = join(directory, 'config.json');
 await writeFile(key, 'fixture-no-api-call', { mode: 0o600 });
@@ -92,6 +102,7 @@ async function start() {
   const previous = hellos;
   child = spawn(binary, ['start', '--config', configPath], {
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: clientEnv,
   });
   child.stdout.on('data', (x) => {
     logs += x;
@@ -254,11 +265,107 @@ try {
     ),
   );
   await stop();
+
+  // Exercise the public detached start/stop commands, not just direct SIGTERM.
+  // Delay only this test daemon's Docker removals beyond the old 10-second grace.
+  const shimDir = join(directory, 'docker-bin');
+  await mkdir(shimDir, { mode: 0o700 });
+  const realDocker = (await exec('which', ['docker'])).stdout.trim();
+  const marker = join(directory, 'removal-started');
+  await writeFile(
+    join(shimDir, 'docker'),
+    `#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const args = process.argv.slice(2);
+const run = () => {
+  const result = spawnSync(${JSON.stringify(realDocker)}, args, { stdio: 'inherit' });
+  process.exit(result.status === 0 ? 0 : 1);
+};
+if (args[0] === 'rm' && args[1] === '-f') {
+  require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'removing');
+  setTimeout(run, 12000);
+} else run();
+`,
+    { mode: 0o700 },
+  );
+  const detachedEnv = { ...clientEnv, PATH: `${shimDir}:${process.env.PATH}` };
+  const previous = hellos;
+  await exec(binary, ['start', '--detach', '--config', configPath], {
+    env: detachedEnv,
+    timeout: 30_000,
+  });
+  await waitFor(() => hellos > previous, 'detached hello');
+  const pidPath = join(clientHome, 'vicoop.pid');
+  const record = JSON.parse(await readFile(pidPath, 'utf8'));
+  assert.equal(
+    record.shutdownTimeoutMs,
+    120_000,
+    'record the config-selected caller mode at launch',
+  );
+  assign('apikey:a', 'detached-stop', 'hold-task');
+  let active = false;
+  for (let attempt = 0; attempt < 50 && !active; attempt++) {
+    const { stdout } = await exec(realDocker, [
+      'ps',
+      '--format',
+      '{{.Names}}',
+      '--filter',
+      `label=vicoop.caller-namespace=${namespace}`,
+    ]);
+    active = Boolean(stdout.trim());
+    if (!active) await new Promise((r) => setTimeout(r, 100));
+  }
+  assert.ok(active, 'stop while a real caller container exists');
+  // Later config edits must not shorten the already-running daemon's cleanup.
+  await writeFile(
+    configPath,
+    JSON.stringify({ ...config, backends: { claude: { runtime: 'host' } } }),
+    { mode: 0o600 },
+  );
+  const [stopped] = await Promise.all([
+    exec(binary, ['stop'], { env: clientEnv, timeout: 30_000 }),
+    (async () => {
+      await new Promise((r) => setTimeout(r, 11_000));
+      process.kill(record.pid, 0);
+      assert.equal(await readFile(marker, 'utf8'), 'removing');
+      assert.equal(
+        JSON.parse(await readFile(pidPath, 'utf8')).pid,
+        record.pid,
+        'retain ownership during cleanup',
+      );
+    })(),
+  ]);
+  assert.doesNotMatch(stopped.stdout, /force|kill/i);
+  await assert.rejects(readFile(pidPath), { code: 'ENOENT' });
+  await assert.rejects(
+    readFile(join(config.caller_runtime.stateDirectory, 'owner.json')),
+    { code: 'ENOENT' },
+  );
+  const remaining = await exec(realDocker, [
+    'ps',
+    '-aq',
+    '--filter',
+    `label=vicoop.caller-namespace=${namespace}`,
+  ]);
+  assert.equal(remaining.stdout.trim(), '');
+  const remainingNetworks = await exec(realDocker, [
+    'network',
+    'ls',
+    '-q',
+    '--filter',
+    `label=vicoop.caller-namespace=${namespace}`,
+  ]);
+  assert.equal(remainingNetworks.stdout.trim(), '');
+  console.log(
+    'detached stop smoke passed: config-only caller mode, delayed Docker cleanup >10s, retained ownership, no SIGKILL/orphans',
+  );
   console.log(
     'compiled caller client smoke passed: Claude argv/prompt staging, A/B/A sessions+files, disconnect/replay, forced restart+reset, orderly shutdown',
   );
 } finally {
   await stop();
+  // This VICOOP_HOME is unique to the test; never signal the operator's daemon.
+  await exec(binary, ['stop'], { env: clientEnv, timeout: 130_000 });
   for (const ws of server.clients) ws.terminate();
   await new Promise((r) => server.close(r));
   // Reconcile any remaining generation after test failure before deleting state.

--- a/packages/client/scripts/caller-runtime-smoke.ts
+++ b/packages/client/scripts/caller-runtime-smoke.ts
@@ -1,0 +1,182 @@
+// Opt-in, real Docker. No model API call. Also compile this with Bun.
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  DockerCallerRuntimePool,
+  type CallerTaskRuntime,
+} from '../src/caller-runtime-docker.js';
+import { scopeDigest } from '../src/caller-runtime-store.js';
+import { runDockerCommand } from '../src/docker-command.js';
+
+const image = process.env.VICOOP_SMOKE_IMAGE;
+if (!image)
+  throw new Error(
+    'set VICOOP_SMOKE_IMAGE to a local pinned image with sh, sleep, mkdir and UID 1000 support',
+  );
+const directory = await mkdtemp(join(tmpdir(), 'vicoop-caller-smoke-'));
+const key = join(directory, 'key');
+await writeFile(key, 'smoke-key-never-used', { mode: 0o600 });
+const options = {
+  image,
+  credentialFile: key,
+  stateDirectory: join(directory, 'state'),
+  agentId: 'smoke',
+  workspaceMiB: 8,
+  maxScopes: 2,
+};
+let pool = new DockerCallerRuntimePool(options);
+async function shell(
+  runtime: CallerTaskRuntime,
+  code: string,
+  env?: Record<string, string>,
+) {
+  const child = runtime.spawn('sh', ['-c', code], {
+    cwd: '/state/workspace',
+    env,
+  });
+  let output = '';
+  let error = '';
+  child.stdout!.on('data', (chunk) => {
+    output += chunk;
+  });
+  child.stderr!.on('data', (chunk) => {
+    error += chunk;
+  });
+  const exit = new Promise<number | null>((resolve, reject) => {
+    child.on('close', resolve);
+    child.on('error', reject);
+  });
+  child.stdin!.end();
+  assert.equal(await exit, 0, error);
+  return output;
+}
+const a = scopeDigest('smoke', 'apikey:a');
+const b = scopeDigest('smoke', 'apikey:b');
+try {
+  assert.deepEqual(await pool.initialize(), []);
+  await assert.rejects(
+    new DockerCallerRuntimePool(options).initialize(),
+    /live owner/,
+  );
+  let runtime = await pool.start(a, new AbortController().signal);
+  assert.equal(
+    await shell(
+      runtime,
+      'printf A > value; printf session > "$CLAUDE_CONFIG_DIR/session"; printf "%s|%s" "$PWD" "$CHECK"',
+      { CHECK: 'literal $value; spaces' },
+    ),
+    '/state/workspace|literal $value; spaces',
+  );
+  await shell(runtime, 'sleep 90 >/tmp/background.out 2>&1 &');
+  await runtime.finish(true);
+  runtime = await pool.start(b, new AbortController().signal);
+  assert.equal(
+    await shell(
+      runtime,
+      'test ! -e value; test ! -e "$CLAUDE_CONFIG_DIR/session"; printf B > value; cat value',
+    ),
+    'B',
+  );
+  await runtime.finish(true);
+  runtime = await pool.start(a, new AbortController().signal);
+  assert.equal(
+    await shell(runtime, 'cat value; cat "$CLAUDE_CONFIG_DIR/session"'),
+    'Asession',
+  );
+  await shell(runtime, 'printf discarded > value');
+  await runtime.finish(false);
+  await pool.close();
+  pool = new DockerCallerRuntimePool(options);
+  assert.deepEqual((await pool.initialize()).sort(), [a, b].sort());
+  runtime = await pool.start(a, new AbortController().signal);
+  assert.equal(await shell(runtime, 'cat value'), 'A');
+  // The tmpfs size is enforced even when rootfs writes are unavailable.
+  assert.equal(
+    await shell(
+      runtime,
+      'if dd if=/dev/zero of=large bs=1M count=16 2>/dev/null; then exit 1; fi; test ! -w /usr; printf bounded',
+    ),
+    'bounded',
+  );
+  await runtime.finish(false);
+  const controller = new AbortController();
+  runtime = await pool.start(a, controller.signal);
+  const child = runtime.spawn('sh', ['-c', 'sleep 90'], {
+    cwd: '/state/workspace',
+  });
+  const exited = new Promise<void>((resolve, reject) => {
+    child.on('close', () => resolve());
+    child.on('error', reject);
+  });
+  child.stdin!.end();
+  controller.abort();
+  await exited;
+  await runtime.finish(false);
+  const left = await pool.start(a, new AbortController().signal);
+  const right = await pool.start(b, new AbortController().signal);
+  const listener = right.spawn(
+    'node',
+    [
+      '-e',
+      "require('node:net').createServer().listen(43210,'0.0.0.0',()=>console.log('ready'))",
+    ],
+    { cwd: '/state/workspace' },
+  );
+  const ready = new Promise<void>((resolve, reject) => {
+    listener.stdout!.once('data', () => resolve());
+    listener.on('error', reject);
+  });
+  const listenerClosed = new Promise<void>((resolve) => {
+    listener.on('close', () => resolve());
+  });
+  listener.stdin!.end();
+  await ready;
+  const names = await runDockerCommand([
+    'ps',
+    '--format',
+    '{{.Names}}',
+    '--filter',
+    `label=vicoop.caller-namespace=${pool.store.namespace}`,
+    '--filter',
+    `label=vicoop.scope=${b}`,
+  ]);
+  assert.equal(names.exitCode, 0);
+  const address = await runDockerCommand([
+    'inspect',
+    names.stdout.trim(),
+    '--format',
+    '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
+  ]);
+  assert.equal(address.exitCode, 0);
+  assert.match(address.stdout.trim(), /^[0-9.]+$/);
+  assert.equal(
+    await shell(
+      left,
+      `node -e 'const s=require("node:net").connect(43210,process.env.PEER);const t=setTimeout(()=>{s.destroy();console.log("isolated")},500);s.on("connect",()=>process.exit(1));s.on("error",()=>{clearTimeout(t);console.log("isolated")})'`,
+      { PEER: address.stdout.trim() },
+    ),
+    'isolated\n',
+  );
+  await left.finish(false);
+  await right.finish(false);
+  await listenerClosed;
+  await pool.close();
+  const remaining = await runDockerCommand([
+    'ps',
+    '-aq',
+    '--filter',
+    `label=vicoop.caller-namespace=${pool.store.namespace}`,
+  ]);
+  assert.equal(remaining.exitCode, 0);
+  assert.equal(remaining.stdout.trim(), '');
+  assert.ok((await readFile(pool.store.path(a))).length > 0);
+  console.log(
+    'caller runtime Docker smoke passed: A/B/A, state restore, rollback, bounded storage, network separation, cancel, cleanup',
+  );
+} finally {
+  // Do not hide cleanup failures or delete evidence when Docker cleanup fails.
+  await pool.close();
+  await rm(directory, { recursive: true });
+}

--- a/packages/client/scripts/fixtures/caller-claude/Dockerfile
+++ b/packages/client/scripts/fixtures/caller-claude/Dockerfile
@@ -1,0 +1,3 @@
+# Deterministic test fixture only. No model calls or production credentials.
+FROM node@sha256:83f487e0a63425e5b4d146fb5e5be574bcbe1b7b843d3ebafdd95eaf7767a7e5
+COPY --chmod=755 claude.cjs /usr/local/bin/claude

--- a/packages/client/scripts/fixtures/caller-claude/claude.cjs
+++ b/packages/client/scripts/fixtures/caller-claude/claude.cjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const value = (name) => args[args.indexOf(name) + 1];
+let input = '';
+let started = false;
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+  if (!started && input.includes('\n')) {
+    started = true;
+    void run();
+  }
+});
+async function run() {
+  const promptFile = value('--append-system-prompt-file');
+  if (
+    !args.includes('--strict-mcp-config') ||
+    value('--mcp-config') !== '{"mcpServers":{}}' ||
+    value('--setting-sources') !== ''
+  )
+    throw new Error('missing isolation flags');
+  if (!promptFile || !fs.readFileSync(promptFile, 'utf8').length)
+    throw new Error('missing staged caller prompt');
+  const resumed = args.includes('--resume');
+  const session = resumed ? value('--resume') : value('--session-id');
+  const sessionPath = process.env.CLAUDE_CONFIG_DIR + '/fixture-session';
+  if (resumed && fs.readFileSync(sessionPath, 'utf8') !== session)
+    throw new Error('wrong caller session');
+  fs.writeFileSync(sessionPath, session);
+  const turn = fs.existsSync('counter')
+    ? Number(fs.readFileSync('counter', 'utf8')) + 1
+    : 1;
+  fs.writeFileSync('counter', String(turn));
+  console.log(
+    JSON.stringify({ type: 'system', subtype: 'init', session_id: session }),
+  );
+  if (input.includes('hold-task'))
+    await new Promise((r) => setTimeout(r, 60_000));
+  if (input.includes('delay-task'))
+    await new Promise((r) => setTimeout(r, 700));
+  console.log(
+    JSON.stringify({
+      type: 'result',
+      subtype: 'success',
+      result: JSON.stringify({
+        session,
+        turn,
+        resumed,
+        cwd: process.cwd(),
+        promptStaged: true,
+      }),
+    }),
+  );
+  process.stdin.destroy();
+}

--- a/packages/client/src/backend.ts
+++ b/packages/client/src/backend.ts
@@ -21,6 +21,7 @@ export interface DetectedCapabilities {
 
 export interface Backend {
   name: string;
+  readonly requiresCallerScope?: boolean;
   // `signal` is aborted when the task is canceled (A2A `tasks/cancel` or
   // client shutdown). Backends observe it to propagate cancellation to their
   // upstream (abort RPC, kill subprocess, cancel fetch, etc.) and to settle

--- a/packages/client/src/caller-runtime-admin.ts
+++ b/packages/client/src/caller-runtime-admin.ts
@@ -1,0 +1,61 @@
+import { object } from '@optique/core/constructs';
+import { optional } from '@optique/core/modifiers';
+import { command, constant, option } from '@optique/core/primitives';
+import { string } from '@optique/core/valueparser';
+import { message } from '@optique/core/message';
+import { stat, unlink } from 'node:fs/promises';
+import { CallerRuntimeStore } from './caller-runtime-store.js';
+import { runDockerCommand } from './docker-command.js';
+
+export const callerStateCmd = command(
+  'caller-state',
+  object({
+    action: constant('caller-state' as const),
+    directory: option('--directory', string()),
+    agentId: option('--agent-id', string()),
+    deleteScope: optional(option('--delete-scope', string())),
+  }),
+  {
+    brief: message`Inspect caller snapshots or explicitly delete one scope while the daemon is stopped.`,
+  },
+);
+
+export async function runCallerState(args: {
+  directory: string;
+  agentId: string;
+  deleteScope?: string;
+}): Promise<void> {
+  const store = new CallerRuntimeStore(args.directory, args.agentId);
+  await store.lock();
+  try {
+    const result = await runDockerCommand([
+      'ps',
+      '-aq',
+      '--filter',
+      `label=vicoop.caller-namespace=${store.namespace}`,
+    ]);
+    if (result.exitCode !== 0)
+      throw new Error('cannot inspect Docker; deletion is unavailable');
+    if (result.stdout.trim())
+      throw new Error(
+        'managed containers remain: restart the daemon to reconcile, then stop it before inspecting/deleting state',
+      );
+    if (args.deleteScope !== undefined)
+      await unlink(store.path(args.deleteScope));
+    const scopes = await Promise.all(
+      (await store.scopes()).map(async (scopeId) => ({
+        scopeId,
+        bytes: (await stat(store.path(scopeId))).size,
+      })),
+    );
+    console.log(
+      JSON.stringify(
+        { directory: store.directory, namespace: store.namespace, scopes },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    await store.unlock();
+  }
+}

--- a/packages/client/src/caller-runtime-config.ts
+++ b/packages/client/src/caller-runtime-config.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { isAbsolute } from 'node:path';
+
+const absolutePath = z
+  .string()
+  .min(1)
+  .refine(isAbsolute, 'must be an absolute path');
+export const CallerRuntimeConfig = z
+  .object({
+    image: z
+      .string()
+      .regex(/^(?:sha256:[a-f0-9]{64}|\S+@sha256:[a-f0-9]{64})$/),
+    credentialFile: absolutePath,
+    stateDirectory: absolutePath,
+    maxScopes: z.number().int().min(1).max(32).optional(),
+    queueLimit: z.number().int().min(0).max(128).optional(),
+    workspaceMiB: z.number().int().min(8).max(512).optional(),
+    taskTimeoutMs: z.number().int().min(1000).max(3_600_000).optional(),
+  })
+  .strict();

--- a/packages/client/src/caller-runtime-config.ts
+++ b/packages/client/src/caller-runtime-config.ts
@@ -10,11 +10,18 @@ export const CallerRuntimeConfig = z
     image: z
       .string()
       .regex(/^(?:sha256:[a-f0-9]{64}|\S+@sha256:[a-f0-9]{64})$/),
-    credentialFile: absolutePath,
+    credentialSource: z.enum(['api-key-file', 'host-claude']).default('api-key-file'),
+    credentialFile: absolutePath.optional(),
     stateDirectory: absolutePath,
     maxScopes: z.number().int().min(1).max(32).optional(),
     queueLimit: z.number().int().min(0).max(128).optional(),
     workspaceMiB: z.number().int().min(8).max(512).optional(),
     taskTimeoutMs: z.number().int().min(1000).max(3_600_000).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((config, ctx) => {
+    if (config.credentialSource === 'api-key-file' && !config.credentialFile)
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['credentialFile'], message: 'required for api-key-file' });
+    if (config.credentialSource === 'host-claude' && config.credentialFile)
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['credentialFile'], message: 'must be omitted for host-claude' });
+  });

--- a/packages/client/src/caller-runtime-credentials.test.ts
+++ b/packages/client/src/caller-runtime-credentials.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { callerCredentialEnvironment } from './caller-runtime-credentials.js';
+import { CallerRuntimeConfig } from './caller-runtime-config.js';
+
+const now = 1_000_000;
+const login = (accessToken: unknown = 'access-only', expiresAt: unknown = now + 120_000) =>
+  JSON.stringify({ claudeAiOauth: { accessToken, expiresAt, refreshToken: 'never-forward-me' } });
+
+test('host credentials forward only access token and reread on each execution', async () => {
+  let calls = 0;
+  const read = async () => login(`rotated-${++calls}`);
+  const options = { credentialSource: 'host-claude' as const };
+  assert.equal(await callerCredentialEnvironment(options, read, now), 'CLAUDE_CODE_OAUTH_TOKEN=rotated-1');
+  assert.equal(await callerCredentialEnvironment(options, read, now), 'CLAUDE_CODE_OAUTH_TOKEN=rotated-2');
+});
+
+test('host credentials reject unavailable, malformed, missing and expiring credentials without leaking secrets', async () => {
+  const readers = [
+    async () => { throw new Error('never-forward-me'); },
+    async () => 'never-forward-me',
+    async () => 'null',
+    async () => '{}',
+    async () => login('', now + 120_000),
+    async () => login('secret\ninjection'),
+    async () => login('a'.repeat(8193)),
+    async () => login('access', now),
+    async () => login('access', now + 60_000),
+    async () => login('access', 'future'),
+  ];
+  for (const read of readers) {
+    await assert.rejects(callerCredentialEnvironment({ credentialSource: 'host-claude' }, read, now),
+      (error: Error) => !error.message.includes('never-forward-me') && !error.message.includes('injection'));
+  }
+});
+
+test('legacy API key mode remains default, rereads rotation, and rejects public files', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'caller-auth-test-'));
+  const file = join(dir, 'key');
+  try {
+    await writeFile(file, 'first-key\n', { mode: 0o600 });
+    assert.equal(await callerCredentialEnvironment({ credentialFile: file }), 'ANTHROPIC_API_KEY=first-key');
+    await writeFile(file, 'second-key');
+    assert.equal(await callerCredentialEnvironment({ credentialFile: file }), 'ANTHROPIC_API_KEY=second-key');
+    await chmod(file, 0o644);
+    await assert.rejects(callerCredentialEnvironment({ credentialFile: file }), /private regular file/);
+  } finally { await rm(dir, { recursive: true, force: true }); }
+});
+
+test('configuration requires an explicit unambiguous credential source', () => {
+  const base = { image: `sha256:${'a'.repeat(64)}`, stateDirectory: '/state' };
+  assert.equal(CallerRuntimeConfig.parse({ ...base, credentialFile: '/key' }).credentialSource, 'api-key-file');
+  assert.equal(CallerRuntimeConfig.parse({ ...base, credentialSource: 'host-claude' }).credentialSource, 'host-claude');
+  for (const config of [base, { ...base, credentialSource: 'unknown' },
+    { ...base, credentialSource: 'host-claude', credentialFile: '/key' }])
+    assert.equal(CallerRuntimeConfig.safeParse(config).success, false);
+});

--- a/packages/client/src/caller-runtime-credentials.ts
+++ b/packages/client/src/caller-runtime-credentials.ts
@@ -1,0 +1,61 @@
+import { execFile } from 'node:child_process';
+import { readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface CallerCredentialsOptions {
+  credentialSource?: 'api-key-file' | 'host-claude';
+  credentialFile?: string;
+}
+
+// Read-only and bounded: never invoke login/refresh or copy the refresh token.
+async function readHostCredentials(): Promise<string> {
+  if (process.env.CLAUDE_CONFIG_DIR)
+    throw new Error('host-claude currently requires the default Claude config directory; unset CLAUDE_CONFIG_DIR');
+  try {
+    if (process.platform === 'darwin') {
+      return await new Promise<string>((resolve, reject) => {
+        execFile('security', ['find-generic-password', '-s', 'Claude Code-credentials', '-w'],
+          { timeout: 10_000, maxBuffer: 65_536, encoding: 'utf8' },
+          (error, stdout) => error ? reject(new Error('credential lookup failed')) : resolve(stdout));
+      });
+    }
+    if (process.platform === 'linux') {
+      const path = join(homedir(), '.claude', '.credentials.json');
+      const info = await stat(path);
+      if (!info.isFile() || info.size > 65_536 || info.mode & 0o077) throw new Error('invalid credential file');
+      return await readFile(path, 'utf8');
+    }
+  } catch {
+    // Child-process errors may contain credential output. Never propagate them.
+    throw new Error('Cannot read host Claude login; sign in with Claude on this host and retry');
+  }
+  throw new Error('host-claude supports macOS and Linux only');
+}
+
+export async function callerCredentialEnvironment(
+  options: CallerCredentialsOptions,
+  readHost: () => Promise<string> = readHostCredentials,
+  now = Date.now(),
+): Promise<string> {
+  if (options.credentialSource === 'host-claude') {
+    if (options.credentialFile) throw new Error('host-claude cannot use credentialFile');
+    let oauth: { accessToken?: unknown; expiresAt?: unknown } | undefined;
+    try { oauth = JSON.parse(await readHost()).claudeAiOauth; }
+    catch { throw new Error('Cannot read host Claude OAuth login; sign in with Claude on this host and retry'); }
+    if (typeof oauth?.accessToken !== 'string' || !oauth.accessToken || /\s|\0/.test(oauth.accessToken) || oauth.accessToken.length > 8192)
+      throw new Error('Host Claude login has no valid OAuth access token');
+    if (typeof oauth.expiresAt !== 'number' || !Number.isFinite(oauth.expiresAt) || oauth.expiresAt <= now + 60_000)
+      throw new Error('Host Claude OAuth token is expired or expires within one minute; refresh the host Claude login and retry');
+    return `CLAUDE_CODE_OAUTH_TOKEN=${oauth.accessToken}`;
+  }
+  if (options.credentialSource !== undefined && options.credentialSource !== 'api-key-file')
+    throw new Error('Unsupported caller credential source');
+  if (!options.credentialFile) throw new Error('caller credentialFile is required for api-key-file');
+  const info = await stat(options.credentialFile);
+  if (!info.isFile() || info.size > 8192 || info.mode & 0o077)
+    throw new Error('caller credential file must be a private regular file (chmod 600, at most 8 KiB)');
+  const key = (await readFile(options.credentialFile, 'utf8')).trim();
+  if (!key || /\s|\0/.test(key)) throw new Error('caller credential file must contain one Anthropic API key');
+  return `ANTHROPIC_API_KEY=${key}`;
+}

--- a/packages/client/src/caller-runtime-docker.ts
+++ b/packages/client/src/caller-runtime-docker.ts
@@ -1,0 +1,558 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { PassThrough, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { stat, readFile, rename, unlink } from 'node:fs/promises';
+import type { ClaudeSpawnFn, ClaudeChildHandle } from './backends/claude.js';
+import { runDockerCommand } from './docker-command.js';
+import { CallerRuntimeStore } from './caller-runtime-store.js';
+
+export interface CallerDockerOptions {
+  image: string;
+  credentialFile: string;
+  stateDirectory: string;
+  agentId: string;
+  maxScopes?: number;
+  queueLimit?: number;
+  workspaceMiB?: number;
+  taskTimeoutMs?: number;
+}
+
+export interface CallerTaskRuntime {
+  readonly committed?: boolean;
+  spawn: ClaudeSpawnFn;
+  /** Freeze, snapshot on success, and confirm removal before publishing success. */
+  finish(commit: boolean): Promise<void>;
+  /** Exact generation container, never a subsequent task's container. */
+  cancel(): Promise<void>;
+}
+
+export interface CallerRuntimePool {
+  readonly maxScopes: number;
+  readonly queueLimit: number;
+  readonly taskTimeoutMs: number;
+  initialize(): Promise<string[]>;
+  start(scopeId: string, signal: AbortSignal): Promise<CallerTaskRuntime>;
+  close(): Promise<void>;
+}
+
+export class DockerCallerRuntimePool implements CallerRuntimePool {
+  readonly store: CallerRuntimeStore;
+  readonly maxScopes: number;
+  readonly queueLimit: number;
+  readonly taskTimeoutMs: number;
+  private readonly bytes: number;
+  private readonly active = new Set<string>();
+  private initialized = false;
+  constructor(private readonly options: CallerDockerOptions) {
+    if (process.platform === 'win32')
+      throw new Error(
+        'caller-container currently supports Linux and macOS hosts',
+      );
+    if (
+      !/^(?:sha256:[a-f0-9]{64}|\S+@sha256:[a-f0-9]{64})$/.test(options.image)
+    ) {
+      throw new Error(
+        'caller runtime image must be pinned by sha256 ID or repository digest',
+      );
+    }
+    this.maxScopes = bounded(options.maxScopes ?? 8, 1, 32, 'maxScopes');
+    this.queueLimit = bounded(options.queueLimit ?? 16, 0, 128, 'queueLimit');
+    this.taskTimeoutMs = bounded(
+      options.taskTimeoutMs ?? 600_000,
+      1000,
+      3_600_000,
+      'taskTimeoutMs',
+    );
+    this.bytes =
+      bounded(options.workspaceMiB ?? 128, 8, 512, 'workspaceMiB') *
+      1024 *
+      1024;
+    this.store = new CallerRuntimeStore(
+      options.stateDirectory,
+      options.agentId,
+    );
+  }
+  async initialize(): Promise<string[]> {
+    await this.store.lock();
+    try {
+      await command(['version', '--format', '{{.Server.Version}}']);
+      const [image] = JSON.parse(
+        await command(['image', 'inspect', this.options.image]),
+      );
+      if (Object.keys(image.Config?.Volumes ?? {}).length)
+        throw new Error(
+          'caller image must not declare VOLUME mounts (unbounded storage)',
+        );
+      await this.credential();
+      // Every container in this namespace belongs to a previous owner. Never
+      // adopt its mutable mounts/config: remove it before accepting work.
+      const stale = await command([
+        'ps',
+        '-a',
+        '--format',
+        '{{.Names}}',
+        '--filter',
+        `label=vicoop.caller-namespace=${this.store.namespace}`,
+      ]);
+      for (const id of stale.trim().split(/\s+/).filter(Boolean))
+        await removeConfirmed(id);
+      const networks = await command([
+        'network',
+        'ls',
+        '-q',
+        '--filter',
+        `label=vicoop.caller-namespace=${this.store.namespace}`,
+      ]);
+      for (const id of networks.trim().split(/\s+/).filter(Boolean))
+        await command(['network', 'rm', id]);
+      const scopes = await this.store.scopes();
+      if (scopes.length > this.maxScopes)
+        throw new Error(
+          'retained scopes exceed maxScopes; explicitly remove unused snapshots while stopped',
+        );
+      for (const id of scopes) {
+        if ((await stat(this.store.path(id))).size > this.bytes * 2)
+          throw new Error('retained snapshot exceeds configured size limit');
+      }
+      this.initialized = true;
+      return scopes;
+    } catch (error) {
+      await this.store.unlock();
+      throw error;
+    }
+  }
+  private async credential(): Promise<string> {
+    const info = await stat(this.options.credentialFile);
+    if (!info.isFile() || info.size > 8192 || info.mode & 0o077)
+      throw new Error(
+        'caller credential file must be a private regular file (chmod 600, at most 8 KiB)',
+      );
+    const key = (await readFile(this.options.credentialFile, 'utf8')).trim();
+    if (!key || /\s|\0/.test(key))
+      throw new Error(
+        'caller credential file must contain one Anthropic API key',
+      );
+    return key;
+  }
+  async start(
+    scopeId: string,
+    signal: AbortSignal,
+  ): Promise<CallerTaskRuntime> {
+    if (!this.initialized)
+      throw new Error('caller runtime pool is not initialized');
+    this.store.path(scopeId); // validate before touching Docker or paths
+    signal.throwIfAborted();
+    const name = `vb-caller-${randomUUID()}`;
+    const snapshot = this.store.path(scopeId);
+    const pending = this.store.path(scopeId, true);
+    let removed = false;
+    let committed = false;
+    let removal: Promise<void> | undefined;
+    const cancel = () =>
+      (removal ??= removeConfirmed(name).then(() => {
+        removed = true;
+        this.active.delete(name);
+      }));
+    this.active.add(name);
+    try {
+      const key = await this.credential();
+      signal.throwIfAborted();
+      // No host mounts, network aliases, Docker socket, shared config, or
+      // writable root. Only /state is snapshotted; credentials stay in env.
+      await command([
+        'network',
+        'create',
+        '--label',
+        `vicoop.caller-namespace=${this.store.namespace}`,
+        `${name}-net`,
+      ]);
+      signal.throwIfAborted();
+      await command([
+        'create',
+        '--name',
+        name,
+        '--network',
+        `${name}-net`,
+        '--label',
+        `vicoop.caller-namespace=${this.store.namespace}`,
+        '--label',
+        `vicoop.scope=${scopeId}`,
+        '--label',
+        'vicoop.component=caller-runtime',
+        '--restart',
+        'no',
+        '--read-only',
+        '--cap-drop',
+        'ALL',
+        '--security-opt',
+        'no-new-privileges',
+        '--pids-limit',
+        '128',
+        '--memory',
+        String(this.bytes + 512 * 1024 * 1024),
+        '--memory-swap',
+        String(this.bytes + 512 * 1024 * 1024),
+        '--cpus',
+        '1',
+        '--user',
+        '0',
+        '--workdir',
+        '/',
+        '--tmpfs',
+        `/state:rw,nosuid,nodev,size=${this.bytes},uid=1000,gid=1000,mode=0700`,
+        '--tmpfs',
+        '/tmp:rw,nosuid,nodev,size=33554432,mode=1777',
+        '--env',
+        'HOME=/state/home',
+        '--env',
+        'CLAUDE_CONFIG_DIR=/state/claude',
+        '--env',
+        'DISABLE_AUTOUPDATER=1',
+        '--env',
+        'DISABLE_TELEMETRY=1',
+        '--env',
+        `ANTHROPIC_API_KEY=${key}`,
+        '--entrypoint',
+        '/bin/sleep',
+        this.options.image,
+        String(Math.ceil(this.taskTimeoutMs / 1000) + 120),
+      ]);
+      await command(['start', name]);
+      signal.throwIfAborted();
+      try {
+        const info = await stat(snapshot);
+        if (info.size > this.bytes * 2)
+          throw new Error('snapshot exceeds configured size limit');
+        await archiveTransfer(
+          [
+            'exec',
+            '-i',
+            '--user',
+            '1000:1000',
+            name,
+            'tar',
+            '--no-same-owner',
+            '-xf',
+            '-',
+            '-C',
+            '/state',
+          ],
+          snapshot,
+          'upload',
+          this.bytes * 2,
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      await command([
+        'exec',
+        '--user',
+        '1000:1000',
+        name,
+        'mkdir',
+        '-p',
+        '/state/workspace',
+        '/state/home',
+        '/state/claude',
+      ]);
+      signal.throwIfAborted();
+      return {
+        get committed() {
+          return committed;
+        },
+        cancel,
+        spawn: this.spawnFor(name, signal),
+        finish: async (commit) => {
+          try {
+            if (commit && !signal.aborted && !removed) {
+              await archiveTransfer(
+                [
+                  'exec',
+                  '--user',
+                  '1000:1000',
+                  name,
+                  'node',
+                  '-e',
+                  FREEZE_AND_SNAPSHOT,
+                ],
+                pending,
+                'download',
+                this.bytes * 2,
+              );
+            }
+            await cancel();
+            if (commit && !signal.aborted) {
+              await rename(pending, snapshot);
+              committed = true;
+            }
+          } finally {
+            await cancel();
+            await unlink(pending).catch((error) => {
+              if (error.code !== 'ENOENT') throw error;
+            });
+          }
+        },
+      };
+    } catch (error) {
+      try {
+        await cancel();
+      } catch (cleanup) {
+        throw new AggregateError(
+          [error, cleanup],
+          'runtime initialization/cleanup failed',
+        );
+      }
+      throw error;
+    }
+  }
+  private spawnFor(name: string, signal: AbortSignal): ClaudeSpawnFn {
+    return (executable, originalArgs, options) => {
+      const handle = new EventEmitter() as EventEmitter & ClaudeChildHandle;
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      Object.assign(handle, { stdin, stdout, stderr });
+      let child: ReturnType<typeof spawn> | undefined;
+      let canceled = false;
+      let closed = false;
+      const close = (code: number | null, sig: NodeJS.Signals | null) => {
+        if (closed) return;
+        closed = true;
+        signal.removeEventListener('abort', abort);
+        stdout.end();
+        stderr.end();
+        stdin.destroy();
+        handle.emit('close', code, sig);
+      };
+      const abort = () => {
+        canceled = true;
+        child?.kill('SIGKILL');
+        close(null, 'SIGKILL');
+      };
+      handle.kill = () => {
+        abort();
+        return true;
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      // Deferred work allows backend listeners and buffered stdin to attach.
+      void (async () => {
+        const args = [...originalArgs];
+        for (let i = 0; i < args.length; i++) {
+          if (
+            args[i] !== '--append-system-prompt-file' &&
+            args[i] !== '--system-prompt-file'
+          )
+            continue;
+          const hostPath = args[++i];
+          if (!hostPath || (await stat(hostPath)).size > 4 * 1024 * 1024)
+            throw new Error('prompt staging file exceeds 4 MiB');
+          const remote = `/tmp/prompt-${randomUUID()}`;
+          await archiveTransfer(
+            [
+              'exec',
+              '-i',
+              '--user',
+              '1000:1000',
+              name,
+              'sh',
+              '-c',
+              'cat > "$1"',
+              'sh',
+              remote,
+            ],
+            hostPath,
+            'upload',
+            4 * 1024 * 1024,
+          );
+          args[i] = remote;
+        }
+        if (canceled || signal.aborted) {
+          close(null, 'SIGKILL');
+          return;
+        }
+        const envArgs: string[] = [];
+        for (const [key, value] of Object.entries(options.env ?? {})) {
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+            throw new Error('invalid environment variable name');
+          envArgs.push('-e', `${key}=${value}`);
+        }
+        child = spawn(
+          'docker',
+          [
+            'exec',
+            '-i',
+            '--user',
+            '1000:1000',
+            '-w',
+            '/state/workspace',
+            ...envArgs,
+            name,
+            executable,
+            ...args,
+          ],
+          { stdio: ['pipe', 'pipe', 'pipe'] },
+        );
+        stdin.pipe(child.stdin!);
+        child.stdout!.pipe(stdout, { end: false });
+        child.stderr!.pipe(stderr, { end: false });
+        child.stdin!.on('error', () => {
+          /* close/error determines the task outcome */
+        });
+        child.once('error', (error) => {
+          handle.emit('error', error);
+          close(null, null);
+        });
+        child.once('close', close);
+      })().catch((error) => {
+        if (!closed) {
+          handle.emit('error', error);
+          close(null, null);
+        }
+      });
+      return handle;
+    };
+  }
+  async close(): Promise<void> {
+    const results = await Promise.allSettled(
+      [...this.active].map(removeConfirmed),
+    );
+    const failures = results.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+    if (failures.length)
+      throw new AggregateError(
+        failures.map((r) => r.reason),
+        'caller runtimes remain quarantined',
+      );
+    this.active.clear();
+    this.initialized = false;
+    await this.store.unlock();
+  }
+}
+
+function bounded(n: number, min: number, max: number, field: string): number {
+  if (!Number.isSafeInteger(n) || n < min || n > max)
+    throw new Error(`invalid caller runtime ${field}`);
+  return n;
+}
+async function command(args: string[]): Promise<string> {
+  const result = await runDockerCommand(args);
+  if (result.exitCode !== 0)
+    throw new Error(
+      `docker ${args[0]} failed (exit ${result.exitCode}): ${result.stderr}`,
+    );
+  return result.stdout;
+}
+async function removeConfirmed(id: string): Promise<void> {
+  const result = await runDockerCommand(['rm', '-f', id]);
+  if (result.exitCode !== 0 && !/No such container/i.test(result.stderr))
+    throw new Error(`runtime removal failed: ${result.stderr}`);
+  const found = await command([
+    'ps',
+    '-aq',
+    '--filter',
+    id.startsWith('vb-caller-') ? `name=^${id}$` : `id=${id}`,
+  ]);
+  if (found.trim()) throw new Error('runtime removal could not be confirmed');
+  if (id.startsWith('vb-caller-')) {
+    const net = await runDockerCommand(['network', 'rm', `${id}-net`]);
+    if (net.exitCode !== 0 && !/not found|No such network/i.test(net.stderr))
+      throw new Error('runtime network cleanup failed');
+  }
+}
+
+/** Tar streams remain opaque on the host; cap output even for sparse files. */
+async function archiveTransfer(
+  args: string[],
+  path: string,
+  direction: 'upload' | 'download',
+  limit: number,
+): Promise<void> {
+  const child = spawn('docker', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stderr = '';
+  child.stderr!.on('data', (chunk: Buffer) => {
+    stderr = (stderr + chunk.toString()).slice(-4096);
+  });
+  const exit = new Promise<void>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`snapshot transfer failed (${code}): ${stderr}`)),
+    );
+  });
+  let count = 0;
+  const cap = new Transform({
+    transform(chunk: Buffer, _encoding, done) {
+      count += chunk.length;
+      done(
+        count > limit
+          ? new Error('snapshot exceeds configured size limit')
+          : null,
+        chunk,
+      );
+    },
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort();
+    child.kill('SIGKILL');
+  }, 30_000);
+  try {
+    if (direction === 'download') child.stdin!.end();
+    else child.stdout!.resume();
+    const io =
+      direction === 'download'
+        ? pipeline(
+            child.stdout!,
+            cap,
+            createWriteStream(path, { flags: 'w', mode: 0o600 }),
+            { signal: controller.signal },
+          )
+        : pipeline(createReadStream(path), cap, child.stdin!, {
+            signal: controller.signal,
+          });
+    await Promise.all([exit, io]);
+  } finally {
+    clearTimeout(timer);
+    controller.abort();
+    child.kill('SIGKILL');
+  }
+}
+
+// Docker's archive API omits tmpfs contents. A same-UID supervisor first
+// stops every workload process (PID 1 is root and cannot be stopped by it),
+// verifies every workload thread is stopped, then archives the live tmpfs.
+// No untrusted process remains runnable to mutate the tree during tar.
+const FREEZE_AND_SNAPSHOT = `
+const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+const until = Date.now() + 5000;
+let previous = '';
+for (;;) {
+  try { process.kill(-1, 'SIGSTOP'); } catch (e) { if (!['ESRCH', 'EPERM'].includes(e.code)) throw e; }
+  let ready = true;
+  const threads = [];
+  for (const pid of fs.readdirSync('/proc').filter(x => /^[0-9]+$/.test(x))) {
+    if (+pid === process.pid || +pid === 1) continue;
+    try {
+      for (const tid of fs.readdirSync('/proc/' + pid + '/task')) {
+        threads.push(pid + '/' + tid);
+        const status = fs.readFileSync('/proc/' + pid + '/task/' + tid + '/status', 'utf8');
+        if (!/^State:\\s+[TtZ]\\b/m.test(status)) ready = false;
+      }
+    } catch (e) { if (e.code !== 'ENOENT' && e.code !== 'ESRCH') throw e; }
+  }
+  const current = threads.sort().join(',');
+  if (ready && current === previous) break;
+  previous = ready ? current : '#unstable';
+  if (Date.now() > until) throw new Error('workload freeze could not be confirmed');
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+}
+const result = spawnSync('tar', ['-cf', '-', '-C', '/state', '.'], { stdio: 'inherit' });
+if (result.error) throw result.error;
+process.exit(result.status === 0 ? 0 : 1);
+`;

--- a/packages/client/src/caller-runtime-docker.ts
+++ b/packages/client/src/caller-runtime-docker.ts
@@ -4,14 +4,14 @@ import { EventEmitter } from 'node:events';
 import { PassThrough, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { createReadStream, createWriteStream } from 'node:fs';
-import { stat, readFile, rename, unlink } from 'node:fs/promises';
+import { stat, rename, unlink } from 'node:fs/promises';
 import type { ClaudeSpawnFn, ClaudeChildHandle } from './backends/claude.js';
 import { runDockerCommand } from './docker-command.js';
 import { CallerRuntimeStore } from './caller-runtime-store.js';
+import { callerCredentialEnvironment, type CallerCredentialsOptions } from './caller-runtime-credentials.js';
 
-export interface CallerDockerOptions {
+export interface CallerDockerOptions extends CallerCredentialsOptions {
   image: string;
-  credentialFile: string;
   stateDirectory: string;
   agentId: string;
   maxScopes?: number;
@@ -125,17 +125,7 @@ export class DockerCallerRuntimePool implements CallerRuntimePool {
     }
   }
   private async credential(): Promise<string> {
-    const info = await stat(this.options.credentialFile);
-    if (!info.isFile() || info.size > 8192 || info.mode & 0o077)
-      throw new Error(
-        'caller credential file must be a private regular file (chmod 600, at most 8 KiB)',
-      );
-    const key = (await readFile(this.options.credentialFile, 'utf8')).trim();
-    if (!key || /\s|\0/.test(key))
-      throw new Error(
-        'caller credential file must contain one Anthropic API key',
-      );
-    return key;
+    return callerCredentialEnvironment(this.options);
   }
   async start(
     scopeId: string,
@@ -214,7 +204,7 @@ export class DockerCallerRuntimePool implements CallerRuntimePool {
         '--env',
         'DISABLE_TELEMETRY=1',
         '--env',
-        `ANTHROPIC_API_KEY=${key}`,
+        key,
         '--entrypoint',
         '/bin/sleep',
         this.options.image,

--- a/packages/client/src/caller-runtime-store.test.ts
+++ b/packages/client/src/caller-runtime-store.test.ts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, readFile, chmod } from 'node:fs/promises';
+import { tmpdir, hostname } from 'node:os';
+import { join } from 'node:path';
+import { CallerRuntimeStore, scopeDigest } from './caller-runtime-store.js';
+
+test('state ownership protects live owners and agent identity across unlock/restart', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'caller-store-'));
+  const first = new CallerRuntimeStore(directory, 'agent');
+  const second = new CallerRuntimeStore(directory, 'agent');
+  try {
+    await first.lock();
+    await assert.rejects(second.lock(), /live owner/);
+    assert.throws(() => first.path('../victim'), /invalid/);
+    await first.unlock();
+    await assert.rejects(
+      new CallerRuntimeStore(directory, 'other').lock(),
+      /manifest/,
+    );
+    await second.lock();
+    await second.unlock();
+  } finally {
+    await first.unlock();
+    await second.unlock();
+    await rm(directory, { recursive: true });
+  }
+});
+
+test('stale ownership recovery discards pending snapshot but retains committed data', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'caller-store-'));
+  const store = new CallerRuntimeStore(directory, 'agent');
+  const id = scopeDigest('agent', 'apikey:a');
+  try {
+    await store.lock();
+    await store.unlock();
+    await writeFile(
+      join(directory, 'owner.json'),
+      JSON.stringify({
+        pid: 2147483647,
+        host: hostname(),
+        agentId: 'agent',
+        token: 'dead',
+      }),
+    );
+    await writeFile(store.path(id), 'committed');
+    await writeFile(store.path(id, true), 'partial');
+    await store.lock();
+    assert.equal(await readFile(store.path(id), 'utf8'), 'committed');
+    await assert.rejects(readFile(store.path(id, true)), { code: 'ENOENT' });
+    assert.deepEqual(await store.scopes(), [id]);
+  } finally {
+    await store.unlock();
+    await rm(directory, { recursive: true });
+  }
+});
+
+test('state directories with public permissions fail closed', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'caller-store-'));
+  try {
+    await chmod(directory, 0o755);
+    await assert.rejects(
+      new CallerRuntimeStore(directory, 'a').lock(),
+      /private/,
+    );
+  } finally {
+    await rm(directory, { recursive: true });
+  }
+});

--- a/packages/client/src/caller-runtime-store.ts
+++ b/packages/client/src/caller-runtime-store.ts
@@ -1,0 +1,153 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+import {
+  mkdir,
+  readFile,
+  writeFile,
+  unlink,
+  readdir,
+  stat,
+  realpath,
+  rename,
+  rm,
+} from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export const scopeDigest = (agentId: string, principalId: string): string =>
+  createHash('sha256')
+    .update(
+      JSON.stringify([
+        'vicoop-execution-scope',
+        'direct-principal-v1',
+        agentId,
+        principalId,
+      ]),
+    )
+    .digest('hex');
+
+/** Host-owned snapshots are never mounted or extracted on the host. */
+export class CallerRuntimeStore {
+  directory: string;
+  namespace: string;
+  private readonly token = randomUUID();
+  private locked = false;
+  constructor(
+    directory: string,
+    readonly agentId: string,
+  ) {
+    this.directory = resolve(directory);
+    this.namespace = createHash('sha256')
+      .update(JSON.stringify([hostname(), this.directory, agentId]))
+      .digest('hex');
+  }
+  async lock(): Promise<void> {
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    this.directory = await realpath(this.directory);
+    this.namespace = createHash('sha256')
+      .update(JSON.stringify([hostname(), this.directory, this.agentId]))
+      .digest('hex');
+    const mode = await stat(this.directory);
+    if (mode.mode & 0o077)
+      throw new Error(
+        'caller runtime state directory must be private (chmod 700)',
+      );
+    // Serialize *all* owner-file changes. A crash during this short critical
+    // section fails closed; the operator must inspect/remove .guard manually.
+    const guard = join(this.directory, '.guard');
+    await mkdir(guard, { mode: 0o700 });
+    try {
+      let owner: { pid: number; host: string; agentId: string } | undefined;
+      try {
+        owner = JSON.parse(
+          await readFile(join(this.directory, 'owner.json'), 'utf8'),
+        );
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      if (owner) {
+        if (
+          owner.host !== hostname() ||
+          owner.agentId !== this.agentId ||
+          !Number.isSafeInteger(owner.pid) ||
+          owner.pid <= 0
+        ) {
+          throw new Error(
+            'caller runtime owner is incompatible; inspect state before recovery',
+          );
+        }
+        try {
+          process.kill(owner.pid, 0);
+          throw new Error('caller runtime state already has a live owner');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+        }
+      }
+      const manifestPath = join(this.directory, 'manifest.json');
+      const expected = { version: 1, agentId: this.agentId, host: hostname() };
+      try {
+        const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+        if (
+          manifest.version !== 1 ||
+          manifest.agentId !== this.agentId ||
+          manifest.host !== hostname()
+        ) {
+          throw new Error(
+            'caller state manifest is incompatible with this agent/host/version',
+          );
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        await writeFile(manifestPath, JSON.stringify(expected), {
+          mode: 0o600,
+          flag: 'wx',
+        });
+      }
+      // Remove incomplete snapshots before publishing our owner record.
+      for (const file of await readdir(this.directory)) {
+        if (/^[a-f0-9]{64}\.pending$/.test(file))
+          await unlink(join(this.directory, file));
+      }
+      const next = join(this.directory, `.owner-${this.token}`);
+      await writeFile(
+        next,
+        JSON.stringify({
+          pid: process.pid,
+          host: hostname(),
+          agentId: this.agentId,
+          token: this.token,
+        }),
+        { mode: 0o600 },
+      );
+      await rename(next, join(this.directory, 'owner.json'));
+      this.locked = true;
+    } finally {
+      await rm(guard, { recursive: true });
+    }
+  }
+  async unlock(): Promise<void> {
+    if (!this.locked) return;
+    const guard = join(this.directory, '.guard');
+    await mkdir(guard, { mode: 0o700 });
+    try {
+      const owner = JSON.parse(
+        await readFile(join(this.directory, 'owner.json'), 'utf8'),
+      );
+      if (owner.token !== this.token)
+        throw new Error('caller runtime owner changed');
+      await unlink(join(this.directory, 'owner.json'));
+      this.locked = false;
+    } finally {
+      await rm(guard, { recursive: true });
+    }
+  }
+  path(id: string, pending = false): string {
+    if (!/^[a-f0-9]{64}$/.test(id))
+      throw new Error('invalid execution scope ID');
+    return join(this.directory, `${id}.${pending ? 'pending' : 'tar'}`);
+  }
+  async scopes(): Promise<string[]> {
+    return (await readdir(this.directory))
+      .filter((name) => /^[a-f0-9]{64}\.tar$/.test(name))
+      .map((name) => name.slice(0, -4));
+  }
+}

--- a/packages/client/src/caller-scoped-backend.test.ts
+++ b/packages/client/src/caller-scoped-backend.test.ts
@@ -1,0 +1,327 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { TaskAssignFrame, UpFrame } from '@vicoop-bridge/protocol';
+import { CallerScopedBackend } from './caller-scoped-backend.js';
+import { scopeDigest } from './caller-runtime-store.js';
+import type {
+  CallerRuntimePool,
+  CallerTaskRuntime,
+} from './caller-runtime-docker.js';
+import type { Backend } from './backend.js';
+
+function task(
+  principal = 'apikey:a',
+  id = Math.random().toString(),
+): TaskAssignFrame {
+  return {
+    type: 'task.assign',
+    taskId: id,
+    executionId: `exec-${id}`,
+    contextId: 'same-context',
+    message: {
+      role: 'user',
+      messageId: 'm',
+      parts: [{ kind: 'text', text: 'hello' }],
+    },
+    caller: { principal: { id: principal } },
+    executionScope: {
+      policy: 'direct-principal-v1',
+      id: scopeDigest('agent', principal),
+      agentId: 'agent',
+      principalId: principal,
+    },
+  };
+}
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+function fixture(
+  options: {
+    restored?: string[];
+    cleanup?: () => Promise<void>;
+    handle?: Backend['handle'];
+    maxScopes?: number;
+    queueLimit?: number;
+  } = {},
+) {
+  let starts = 0;
+  let finishes = 0;
+  let factories = 0;
+  let active = 0;
+  let peak = 0;
+  const pool: CallerRuntimePool = {
+    maxScopes: options.maxScopes ?? 2,
+    queueLimit: options.queueLimit ?? 2,
+    taskTimeoutMs: 10_000,
+    initialize: async () => options.restored ?? [],
+    close: async () => {},
+    start: async (): Promise<CallerTaskRuntime> => {
+      starts++;
+      active++;
+      peak = Math.max(peak, active);
+      let done = false;
+      return {
+        spawn: () => {
+          throw new Error('unused');
+        },
+        cancel: async () => {},
+        finish: async () => {
+          await options.cleanup?.();
+          if (!done) {
+            finishes++;
+            active--;
+            done = true;
+          }
+        },
+      };
+    },
+  };
+  const backend = new CallerScopedBackend('agent', pool, () => {
+    const instance = ++factories;
+    return {
+      name: 'test',
+      handle:
+        options.handle ??
+        (async (task, emit) => {
+          emit({
+            type: 'task.status',
+            taskId: task.taskId,
+            status: { state: 'working' },
+            metadata: { instance },
+          });
+          emit({
+            type: 'task.complete',
+            taskId: task.taskId,
+            status: { state: 'completed' },
+          });
+        }),
+    };
+  });
+  const run = async (
+    assignment = task(),
+    signal = new AbortController().signal,
+  ) => {
+    const frames: UpFrame[] = [];
+    await backend.handle(assignment, (f) => frames.push(f), signal);
+    return frames;
+  };
+  return {
+    backend,
+    run,
+    stats: () => ({ starts, finishes, factories, active, peak }),
+  };
+}
+
+test('rejects forged/missing scopes, legacy identity, delegation, and tool requests before allocation', async () => {
+  const f = fixture();
+  await f.backend.initialize();
+  const invalid = [
+    { ...task(), executionScope: undefined },
+    { ...task(), executionId: undefined },
+    { ...task(), caller: undefined },
+    {
+      ...task(),
+      executionScope: {
+        ...task().executionScope!,
+        id: scopeDigest('agent', 'victim'),
+      },
+    },
+    {
+      ...task(),
+      caller: { principal: { id: 'apikey:a' }, actor: { id: 'actor' } },
+    },
+    {
+      ...task(),
+      message: {
+        ...task().message,
+        parts: [{ kind: 'data' as const, data: { tools: [] } }],
+      },
+    },
+  ];
+  for (const assignment of invalid)
+    assert.equal((await f.run(assignment))[0]?.type, 'task.fail');
+  assert.equal(f.stats().starts, 0);
+  await f.backend.close();
+});
+
+test('A/B/A with identical context IDs reuses only each caller backend', async () => {
+  const f = fixture();
+  await f.backend.initialize();
+  const frames = await Promise.all(
+    ['apikey:a', 'apikey:b', 'apikey:a'].map((id) => f.run(task(id))),
+  );
+  const instance = (fs: UpFrame[]) =>
+    fs.find((x) => x.type === 'task.status')?.metadata?.instance;
+  assert.equal(instance(frames[0]!), instance(frames[2]!));
+  assert.notEqual(instance(frames[0]!), instance(frames[1]!));
+  assert.equal(f.stats().factories, 2);
+  assert.equal(f.stats().finishes, 3);
+  await f.backend.close();
+});
+
+test('same-scope waiter cancellation does not release the active lease; completion waits for cleanup', async () => {
+  const gate = deferred();
+  const entered = deferred();
+  const cleanup = deferred();
+  let runs = 0;
+  const f = fixture({
+    cleanup: () => cleanup.promise,
+    handle: async (task, emit) => {
+      runs++;
+      entered.resolve();
+      await gate.promise;
+      emit({
+        type: 'task.complete',
+        taskId: task.taskId,
+        status: { state: 'completed' },
+      });
+    },
+  });
+  await f.backend.initialize();
+  const output: UpFrame[] = [];
+  const first = f.backend.handle(
+    task(),
+    (f) => output.push(f),
+    new AbortController().signal,
+  );
+  await entered.promise;
+  const controller = new AbortController();
+  const second = f.run(task(), controller.signal);
+  const third = f.run();
+  controller.abort();
+  assert.equal((await second).at(-1)?.type, 'task.fail');
+  assert.equal(f.stats().starts, 1);
+  gate.resolve();
+  await new Promise((r) => setImmediate(r));
+  assert.equal(output.length, 0);
+  assert.equal(f.stats().starts, 1);
+  cleanup.resolve();
+  await Promise.all([first, third]);
+  assert.equal(runs, 2);
+  assert.equal(f.stats().peak, 1);
+  await f.backend.close();
+});
+
+test('unconfirmed cleanup suppresses success and quarantines the scope', async () => {
+  const f = fixture({
+    cleanup: async () => {
+      throw new Error('Docker unavailable');
+    },
+  });
+  await f.backend.initialize();
+  const output = await f.run();
+  assert.equal(output.at(-1)?.type, 'task.fail');
+  assert.equal(
+    output.some((f) => f.type === 'task.complete'),
+    false,
+  );
+  const again = await f.run();
+  assert.equal(again[0]?.type, 'task.fail');
+  assert.equal(f.stats().starts, 1);
+  await f.backend.close();
+});
+
+test('active cancellation fences late output and discards the old backend binding', async () => {
+  const late = deferred();
+  const entered = deferred();
+  let calls = 0;
+  const f = fixture({
+    handle: async (task, emit) => {
+      calls++;
+      if (calls === 1) {
+        entered.resolve();
+        await late.promise;
+      }
+      emit({
+        type: 'task.complete',
+        taskId: task.taskId,
+        status: { state: 'completed' },
+      });
+    },
+  });
+  await f.backend.initialize();
+  const controller = new AbortController();
+  const first = f.run(task(), controller.signal);
+  await entered.promise;
+  controller.abort();
+  const frames = await first;
+  assert.equal(frames.at(-1)?.type, 'task.fail');
+  assert.equal((await f.run()).at(-1)?.type, 'task.complete');
+  late.resolve();
+  await new Promise((r) => setImmediate(r));
+  assert.equal(
+    frames.some((f) => f.type === 'task.complete'),
+    false,
+  );
+  assert.equal(f.stats().factories, 2);
+  await f.backend.close();
+});
+
+test('restored workspace reports conversation reset and retained capacity is bounded', async () => {
+  const f = fixture({
+    restored: [scopeDigest('agent', 'apikey:a')],
+    maxScopes: 1,
+  });
+  await f.backend.initialize();
+  const output = await f.run();
+  assert.deepEqual(
+    output.find((f) => f.type === 'task.status')?.metadata?.['vicoop.runtime'],
+    { workspaceRestored: true, conversationReset: true },
+  );
+  assert.equal((await f.run(task('apikey:b')))[0]?.type, 'task.fail');
+  assert.equal(f.stats().starts, 1);
+  await f.backend.close();
+});
+
+test('cancellation after checkpoint commit reports retained state instead of rollback', async () => {
+  const controller = new AbortController();
+  let committed = false;
+  const pool: CallerRuntimePool = {
+    maxScopes: 1,
+    queueLimit: 1,
+    taskTimeoutMs: 10_000,
+    initialize: async () => [],
+    close: async () => {},
+    start: async () => ({
+      get committed() {
+        return committed;
+      },
+      spawn: () => {
+        throw new Error('unused');
+      },
+      cancel: async () => {},
+      finish: async (commit) => {
+        if (commit) {
+          committed = true;
+          controller.abort();
+        }
+      },
+    }),
+  };
+  const backend = new CallerScopedBackend('agent', pool, () => ({
+    name: 'test',
+    handle: async (t, emit) => {
+      emit({
+        type: 'task.complete',
+        taskId: t.taskId,
+        status: { state: 'completed' },
+      });
+    },
+  }));
+  await backend.initialize();
+  const frames: UpFrame[] = [];
+  await backend.handle(task(), (f) => frames.push(f), controller.signal);
+  const last = frames.at(-1);
+  assert.equal(last?.type, 'task.fail');
+  if (last?.type === 'task.fail')
+    assert.match(
+      last.error.message ?? '',
+      /after checkpoint commit; saved state is retained/,
+    );
+  assert.equal(committed, true);
+  await backend.close();
+});

--- a/packages/client/src/caller-scoped-backend.test.ts
+++ b/packages/client/src/caller-scoped-backend.test.ts
@@ -325,3 +325,45 @@ test('cancellation after checkpoint commit reports retained state instead of rol
   assert.equal(committed, true);
   await backend.close();
 });
+
+test('queued context capacity rejection preserves existing sessions and the full limit', async () => {
+  const f = fixture();
+  await f.backend.initialize();
+  const context = (id: number) => ({ ...task(), contextId: `context-${id}` });
+  try {
+    for (let id = 1; id <= 255; id++) await f.run(context(id));
+    // Both pass initial admission before the first acquires its queue lease.
+    const [accepted, rejected] = await Promise.all([
+      f.run(context(256)),
+      f.run(context(257)),
+    ]);
+    assert.equal(accepted.at(-1)?.type, 'task.complete');
+    const denied = rejected.at(-1);
+    assert.equal(denied?.type, 'task.fail');
+    if (denied?.type === 'task.fail')
+      assert.equal(denied.error.code, 'runtime_capacity');
+    assert.equal(f.stats().starts, 256);
+    const existing = await f.run(context(1));
+    assert.equal(existing.at(-1)?.type, 'task.complete');
+    assert.equal(
+      existing.find((frame) => frame.type === 'task.status')?.metadata
+        ?.instance,
+      1,
+    );
+    assert.equal(
+      existing.some(
+        (frame) => 'metadata' in frame && frame.metadata?.['vicoop.runtime'],
+      ),
+      false,
+    );
+    assert.equal(f.stats().factories, 1);
+    assert.equal((await f.run(context(257))).at(-1)?.type, 'task.fail');
+    assert.equal(
+      f.stats().starts,
+      257,
+      'capacity rejection allocates nothing and retains the existing context count',
+    );
+  } finally {
+    await f.backend.close();
+  }
+});

--- a/packages/client/src/caller-scoped-backend.ts
+++ b/packages/client/src/caller-scoped-backend.ts
@@ -154,11 +154,20 @@ export class CallerScopedBackend implements Backend {
     let backendOpen = false;
     try {
       await abortable(waiting, controller.signal);
-      acquired = true;
       if (entry.quarantined || this.stopped)
         throw new Error('caller runtime is quarantined or stopping');
-      if (!entry.contexts.has(task.contextId) && entry.contexts.size >= 256)
-        throw new Error('caller conversation capacity reached');
+      if (!entry.contexts.has(task.contextId) && entry.contexts.size >= 256) {
+        // Capacity can change while queued. Reject admission without invalidating
+        // the scope's existing backend/session bindings. finally releases the queue.
+        this.fail(
+          task,
+          emit,
+          'runtime_capacity',
+          'caller conversation capacity reached (256)',
+        );
+        return;
+      }
+      acquired = true;
       allocationAttempted = true;
       runtime = await this.pool.start(scopeId, controller.signal);
       if (!entry.backend) {

--- a/packages/client/src/caller-scoped-backend.ts
+++ b/packages/client/src/caller-scoped-backend.ts
@@ -1,0 +1,321 @@
+import {
+  ExecutionScopeV1,
+  OPENAI_COMPAT_EXTENSION_URI,
+  type TaskAssignFrame,
+  type UpFrame,
+} from '@vicoop-bridge/protocol';
+import type { Backend, Emit } from './backend.js';
+import type { ClaudeSpawnFn } from './backends/claude.js';
+import { scopeDigest } from './caller-runtime-store.js';
+import type {
+  CallerRuntimePool,
+  CallerTaskRuntime,
+} from './caller-runtime-docker.js';
+
+interface ScopeEntry {
+  backend?: Backend;
+  binding?: { runtime?: CallerTaskRuntime };
+  tail: Promise<void>;
+  quarantined: boolean;
+  restored: boolean;
+  checkpointed: boolean;
+  contexts: Set<string>;
+}
+
+/** One execution per scope, including allocation and confirmed cleanup. */
+export class CallerScopedBackend implements Backend {
+  readonly name = 'caller-claude';
+  readonly requiresCallerScope = true;
+  private readonly entries = new Map<string, ScopeEntry>();
+  private readonly controllers = new Set<AbortController>();
+  private readonly active = new Set<Promise<void>>();
+  private pending = 0;
+  private stopped = false;
+  constructor(
+    private readonly agentId: string,
+    private readonly pool: CallerRuntimePool,
+    private readonly factory: (spawn: ClaudeSpawnFn) => Backend,
+  ) {}
+  async initialize(): Promise<void> {
+    for (const id of await this.pool.initialize())
+      this.entries.set(id, this.entry(true));
+  }
+  private entry(restored: boolean): ScopeEntry {
+    return {
+      tail: Promise.resolve(),
+      quarantined: false,
+      restored,
+      checkpointed: restored,
+      contexts: new Set(),
+    };
+  }
+  handle(
+    task: TaskAssignFrame,
+    emit: Emit,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const promise = this.execute(task, emit, signal);
+    this.active.add(promise);
+    void promise.finally(() => this.active.delete(promise)).catch(() => {});
+    return promise;
+  }
+  private async execute(
+    task: TaskAssignFrame,
+    emit: Emit,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let scopeId: string;
+    try {
+      scopeId = this.validate(task);
+    } catch (error) {
+      this.fail(task, emit, 'caller_scope_required', (error as Error).message);
+      return;
+    }
+    if (this.stopped || signal.aborted) {
+      this.fail(
+        task,
+        emit,
+        'runtime_stopped',
+        'execution was canceled or runtime is stopping',
+      );
+      return;
+    }
+    if (this.pending >= this.pool.maxScopes + this.pool.queueLimit) {
+      this.fail(
+        task,
+        emit,
+        'runtime_capacity',
+        'caller execution queue is full',
+      );
+      return;
+    }
+    let entry = this.entries.get(scopeId);
+    if (!entry) {
+      if (this.entries.size >= this.pool.maxScopes) {
+        this.fail(
+          task,
+          emit,
+          'runtime_capacity',
+          'retained caller scope capacity reached',
+        );
+        return;
+      }
+      entry = this.entry(false);
+      this.entries.set(scopeId, entry);
+    }
+    if (entry.quarantined) {
+      this.fail(
+        task,
+        emit,
+        'runtime_quarantined',
+        'previous runtime cleanup is unconfirmed; restart and reconcile before reuse',
+      );
+      return;
+    }
+    if (!entry.contexts.has(task.contextId) && entry.contexts.size >= 256) {
+      this.fail(
+        task,
+        emit,
+        'runtime_capacity',
+        'caller conversation capacity reached (256)',
+      );
+      return;
+    }
+    this.pending++;
+    const controller = new AbortController();
+    this.controllers.add(controller);
+    const forwardAbort = () => controller.abort(signal.reason);
+    signal.addEventListener('abort', forwardAbort, { once: true });
+    if (signal.aborted) forwardAbort();
+    // Deadline includes queue wait, allocation, and execution. Cleanup uses
+    // independent bounded calls so cancellation cannot skip the safety barrier.
+    const timer = setTimeout(
+      () => controller.abort(new Error('caller task deadline exceeded')),
+      this.pool.taskTimeoutMs,
+    );
+    const waiting = entry.tail;
+    let release!: () => void;
+    const lease = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    entry.tail = waiting.then(() => lease);
+    const heartbeat = setInterval(() => {
+      if (!signal.aborted)
+        emit({
+          type: 'task.status',
+          taskId: task.taskId,
+          status: { state: 'working', timestamp: new Date().toISOString() },
+        });
+    }, 5000);
+    let acquired = false;
+    let allocationAttempted = false;
+    let runtime: CallerTaskRuntime | undefined;
+    let terminal: UpFrame | undefined;
+    let backendOpen = false;
+    try {
+      await abortable(waiting, controller.signal);
+      acquired = true;
+      if (entry.quarantined || this.stopped)
+        throw new Error('caller runtime is quarantined or stopping');
+      if (!entry.contexts.has(task.contextId) && entry.contexts.size >= 256)
+        throw new Error('caller conversation capacity reached');
+      allocationAttempted = true;
+      runtime = await this.pool.start(scopeId, controller.signal);
+      if (!entry.backend) {
+        const selected = { runtime } as { runtime?: CallerTaskRuntime };
+        entry.binding = selected;
+        entry.backend = this.factory((command, args, options) => {
+          if (!selected.runtime)
+            throw new Error('no active caller execution lease');
+          return selected.runtime.spawn(command, args, options);
+        });
+      }
+      entry.binding!.runtime = runtime;
+      if (entry.restored && !entry.contexts.has(task.contextId))
+        emit({
+          type: 'task.status',
+          taskId: task.taskId,
+          status: { state: 'working', timestamp: new Date().toISOString() },
+          metadata: {
+            'vicoop.runtime': {
+              workspaceRestored: entry.checkpointed,
+              conversationReset: true,
+            },
+          },
+        });
+      entry.contexts.add(task.contextId);
+      backendOpen = true;
+      const work = entry.backend.handle(
+        task,
+        (frame) => {
+          if (!backendOpen || controller.signal.aborted) return;
+          if (frame.type === 'task.complete' || frame.type === 'task.fail')
+            terminal = frame;
+          else emit(frame);
+        },
+        controller.signal,
+      );
+      await abortable(work, controller.signal);
+      backendOpen = false;
+      // Terminal success is held until state is committed and all processes
+      // are removed; failure here cannot publish a misleading completed task.
+      const commit =
+        terminal?.type === 'task.complete' &&
+        terminal.status.state === 'completed';
+      await runtime.finish(commit);
+      entry.checkpointed ||= runtime.committed ?? commit;
+      controller.signal.throwIfAborted();
+      if (!commit) {
+        entry.backend.stop?.();
+        entry.backend = undefined;
+        entry.restored = true;
+        entry.contexts.clear();
+      }
+      if (terminal) emit(terminal);
+      else throw new Error('backend ended without a terminal result');
+    } catch (error) {
+      backendOpen = false;
+      if (acquired) {
+        if (entry.binding) entry.binding.runtime = undefined;
+        try {
+          entry.backend?.stop?.();
+        } catch {
+          /* Still complete the container cleanup barrier. */
+        }
+        entry.backend = undefined;
+        entry.restored = true;
+        entry.contexts.clear();
+        try {
+          await runtime?.finish(false);
+        } catch {
+          entry.quarantined = true;
+        }
+        // Failed allocation can also mean Docker accepted an unconfirmed
+        // create/remove. Conservatively quarantine until startup reconciliation.
+        if (allocationAttempted && !runtime) entry.quarantined = true;
+      }
+      this.fail(
+        task,
+        emit,
+        entry.quarantined
+          ? 'runtime_quarantined'
+          : controller.signal.aborted
+            ? 'runtime_canceled'
+            : 'runtime_failed',
+        controller.signal.aborted
+          ? runtime?.committed
+            ? 'caller execution canceled after checkpoint commit; saved state is retained'
+            : 'caller execution canceled or deadline exceeded; uncommitted changes discarded'
+          : (error as Error).message,
+      );
+    } finally {
+      backendOpen = false;
+      if (acquired && entry.binding) entry.binding.runtime = undefined;
+      release();
+      clearTimeout(timer);
+      clearInterval(heartbeat);
+      signal.removeEventListener('abort', forwardAbort);
+      this.controllers.delete(controller);
+      this.pending--;
+    }
+  }
+  private validate(task: TaskAssignFrame): string {
+    const scope = ExecutionScopeV1.parse(task.executionScope);
+    const caller = task.caller;
+    if (
+      !task.executionId ||
+      !caller ||
+      !('principal' in caller) ||
+      caller.actor ||
+      caller.principal?.id !== scope.principalId ||
+      scope.agentId !== this.agentId ||
+      scope.id !== scopeDigest(this.agentId, scope.principalId)
+    )
+      throw new Error(
+        'execution scope does not match authenticated caller/agent/generation',
+      );
+    if (
+      (task.requestedExtensions ?? []).includes(OPENAI_COMPAT_EXTENSION_URI) ||
+      (task.message.extensions ?? []).includes(OPENAI_COMPAT_EXTENSION_URI) ||
+      task.message.metadata?.[OPENAI_COMPAT_EXTENSION_URI] !== undefined ||
+      task.message.parts.some((part) => part.kind === 'data')
+    )
+      throw new Error(
+        'caller-container supports plain A2A text/file inputs only; caller tools are unsupported',
+      );
+    return scope.id;
+  }
+  private fail(
+    task: TaskAssignFrame,
+    emit: Emit,
+    code: string,
+    message: string,
+  ): void {
+    emit({ type: 'task.fail', taskId: task.taskId, error: { code, message } });
+  }
+  stop(): void {
+    this.stopped = true;
+    for (const controller of this.controllers)
+      controller.abort(new Error('runtime stopping'));
+  }
+  async close(): Promise<void> {
+    this.stop();
+    await Promise.allSettled([...this.active]);
+    for (const entry of this.entries.values()) entry.backend?.stop?.();
+    await this.pool.close();
+  }
+}
+
+function abortable<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      signal.removeEventListener('abort', abort);
+      reject(signal.reason ?? new Error('execution aborted'));
+    };
+    signal.addEventListener('abort', abort, { once: true });
+    promise
+      .then(resolve, reject)
+      .finally(() => signal.removeEventListener('abort', abort));
+    if (signal.aborted) abort();
+  });
+}

--- a/packages/client/src/cli-args.test.ts
+++ b/packages/client/src/cli-args.test.ts
@@ -649,7 +649,7 @@ test('legacy daemon env vars remain ignored (identity trust is the sole compatib
 });
 
 
-test('reserved caller isolation is rejected from flags and configuration before backend startup', () => {
+test('incomplete or unsupported caller isolation is rejected before backend startup', () => {
   for (const backend of ['claude', 'codex'] as const) {
     for (const source of ['flag', 'config']) {
       const result = mergeClientArgs(
@@ -657,7 +657,16 @@ test('reserved caller isolation is rejected from flags and configuration before 
         source === 'config' ? { backends: { [backend]: { runtime: 'caller-container' } } } : {},
       );
       assert.equal(result.ok, false);
-      if (!result.ok) assert.ok(result.errors.some((error) => error.includes('not available')));
+      if (!result.ok) assert.ok(result.errors.some((error) => error.includes('caller-container')));
     }
   }
+});
+
+test('Claude caller isolation accepts dedicated config but rejects operator workspace/settings', () => {
+  const config = { caller_runtime: { image: `sha256:${'a'.repeat(64)}`, credentialFile: '/key', stateDirectory: '/state' } };
+  const flags = { token: 't', agentId: 'a', backend: 'claude' as const, runtime: 'caller-container' as const };
+  const result = mergeClientArgs(flags, config);
+  assert.equal(result.ok, true);
+  assert.equal(mergeClientArgs({ ...flags, cwd: '/operator' }, config).ok, false);
+  assert.equal(mergeClientArgs({ ...flags, backend: 'codex' }, config).ok, false);
 });

--- a/packages/client/src/cli-args.ts
+++ b/packages/client/src/cli-args.ts
@@ -82,7 +82,7 @@ export const daemonFlagsFields = {
     description: message`Working directory for the spawned backend process. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtime: optional(option('--runtime', choice([...BACKEND_RUNTIMES]), {
-    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. \`caller-container\` is reserved and unavailable in this release. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
+    description: message`Where to run the active backend. \`host\` (default) spawns on the bridge-client host; \`container\` runs inside an existing vicoop-runtime container created by \`vicoop-client container init <kind>\`. \`caller-container\` isolates direct callers for Claude and requires caller_runtime configuration. Only valid with \`--backend claude\` or \`--backend codex\`; pairing with another backend exits non-zero.`,
   })),
   runtimeName: optional(option('--runtime-name', string({ metavar: 'NAME' }), {
     description: message`Runtime container instance name to use with \`--runtime container\`. Omit to use the active backend kind as the generated name.`,
@@ -174,6 +174,7 @@ export interface DaemonArgs {
   cwd?: string;
   runtime?: BackendRuntime;
   runtimeName?: string;
+  callerRuntime?: unknown;
   claudeSettingsFile?: string;
   claudeModel?: string;
   claudeSupportedModels?: string[];
@@ -329,6 +330,7 @@ export function mergeClientArgs(
     card: card === '' ? undefined : card,
     backend,
     backends: config.backends,
+    callerRuntime: config.caller_runtime,
     trustedIdentityIssuers:
       pickExactIdentifierList(flags.trustedIdentityIssuers) ??
       pickConfiguredExactIdentifiers(config.trusted_identity_issuers) ??
@@ -394,7 +396,11 @@ export function mergeClientArgs(
   // lookup, which is the correct behaviour for that source.
   const errors: string[] = [];
   if (resolved.runtime === 'caller-container') {
-    errors.push('caller-container isolation is not available in this release (#497 R2); no backend will be started');
+    if (backend !== 'claude') errors.push('caller-container supports only Claude');
+    if (!resolved.callerRuntime) errors.push('caller-container requires caller_runtime configuration');
+    if (resolved.cwd || resolved.runtimeName || resolved.claudeSettingsFile || backends.claude?.settings) {
+      errors.push('caller-container does not accept cwd, runtime-name, or operator Claude settings');
+    }
   }
   if (flags.runtime !== undefined && !RUNTIME_BACKENDS.has(backend)) {
     errors.push(

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { closeSync, existsSync, openSync, readFileSync } from 'node:fs';
 import { spawn as spawnProcess, type ChildProcess } from 'node:child_process';
-import { AgentCard } from '@vicoop-bridge/protocol';
+import { AgentCard, OPENAI_COMPAT_EXTENSION_URI } from '@vicoop-bridge/protocol';
 import { resolveBundledCard } from './bundled-cards.js';
 import { group, longestMatch, object } from '@optique/core/constructs';
 import { optional, withDefault } from '@optique/core/modifiers';
@@ -11,6 +11,10 @@ import type { InferValue } from '@optique/core/parser';
 import { string } from '@optique/core/valueparser';
 import { run } from '@optique/run';
 import { Client } from './client.js';
+import { callerStateCmd, runCallerState } from './caller-runtime-admin.js';
+import { CallerRuntimeConfig } from './caller-runtime-config.js';
+import { DockerCallerRuntimePool } from './caller-runtime-docker.js';
+import { CallerScopedBackend } from './caller-scoped-backend.js';
 import { echoBackend } from './backends/echo.js';
 import { createOpenclawBackend } from './backends/openclaw.js';
 import { createClaudeBackend, type ClaudeSpawnFn } from './backends/claude.js';
@@ -228,6 +232,7 @@ const cli = longestMatch(
   group('Identity', authCmd),
   group('Agents', agentCmd),
   group('Runtime containers', containerCmd),
+  callerStateCmd,
   group('Maintenance', longestMatch(upgradeCmd, infoCmd)),
   // Hidden by `hidden: 'help'` on each command; kept in the parser tree
   // for back-compat and "did you mean?" suggestions. Sit outside the
@@ -395,6 +400,23 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       };
     }
     case 'claude': {
+      if (args.runtime === 'caller-container') {
+        const config = CallerRuntimeConfig.parse(args.callerRuntime);
+        const pool = new DockerCallerRuntimePool({ ...config, agentId: args.agentId });
+        const backend = new CallerScopedBackend(args.agentId, pool, (spawn) => createClaudeBackend({
+          cwd: '/state/workspace', spawn,
+          identity: deriveIdentity(args.agentId, args.server) ?? undefined,
+          model: args.claudeModel,
+          claudeReasoning: args.claudeReasoning,
+          claudeThinkingBudget: args.claudeThinkingBudget,
+          claudeRetryNarratedToolCall: args.claudeRetryNarratedToolCall,
+          settings: disableClaudeSandboxGuard(undefined),
+          fetchUriPolicy: { enabled: false },
+          extraArgs: ['--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}', '--setting-sources', '', '--dangerously-skip-permissions'],
+        }));
+        await backend.initialize();
+        return { backend, shutdown: () => backend.close() };
+      }
       // settings precedence: --claude-settings-file (flag, path on disk) >
       // backends.claude.settings (config). No env layer (#189 §5).
       const baseSettings = args.claudeSettingsFile
@@ -561,6 +583,7 @@ const SHUTDOWN_TIMEOUT_MS = 15_000;
 async function runWithShutdownTimeout(
   shutdown: () => Promise<void>,
   logger: Logger,
+  timeoutMs = SHUTDOWN_TIMEOUT_MS,
 ): Promise<void> {
   let timer: NodeJS.Timeout | undefined;
   try {
@@ -568,9 +591,9 @@ async function runWithShutdownTimeout(
       shutdown(),
       new Promise<void>((resolve) => {
         timer = setTimeout(() => {
-          logger.warn(`runtime shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms; exiting anyway`);
+          logger.warn(`runtime shutdown exceeded ${timeoutMs}ms; exiting anyway`);
           resolve();
-        }, SHUTDOWN_TIMEOUT_MS);
+        }, timeoutMs);
       }),
     ]);
   } finally {
@@ -637,6 +660,9 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     ? JSON.parse(readFileSync(args.card, 'utf8'))
     : resolveBundledCard(args.backend);
   const agentCard = raw ? AgentCard.parse(raw) : undefined;
+  if (args.runtime === 'caller-container' && agentCard?.capabilities?.extensions) {
+    agentCard.capabilities.extensions = agentCard.capabilities.extensions.filter((extension) => extension.uri !== OPENAI_COMPAT_EXTENSION_URI);
+  }
 
   // Emit the resolved backend at startup so operators can verify which
   // backend the precedence chain picked (flag vs. config vs. default
@@ -664,7 +690,10 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     // failure instead of masking it as a transient disconnect. The
     // Client class deliberately does not call process.exit itself —
     // tests and future in-process embedders pass a non-exiting callback.
-    onFatal: () => process.exit(1),
+    onFatal: () => {
+      if (backendShutdown) void runWithShutdownTimeout(backendShutdown, logger, 120_000).finally(() => process.exit(1));
+      else process.exit(1);
+    },
   });
 
   client.start();
@@ -694,7 +723,7 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
       if (ownsPidFile) removePidFile();
       if (backendShutdown) {
         try {
-          await runWithShutdownTimeout(backendShutdown, logger);
+          await runWithShutdownTimeout(backendShutdown, logger, backend.requiresCallerScope ? 120_000 : SHUTDOWN_TIMEOUT_MS);
         } catch (err) {
           logger.error('shutdown error:', (err as Error).message);
         }
@@ -1087,6 +1116,10 @@ async function main(): Promise<void> {
       break;
     case 'whoami':
       process.exit(await runWhoami(parsed));
+      break;
+    case 'caller-state':
+      await runCallerState(parsed);
+      process.exit(0);
       break;
     case 'container-init':
       process.exit(await runContainerInitCli(parsed));

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -68,6 +68,7 @@ import {
 } from './cli-args.js';
 import { createLogger, type Logger } from './logger.js';
 import {
+  CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS,
   claimPidFile,
   defaultLogPath,
   detachChildArgv,
@@ -691,7 +692,7 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     // Client class deliberately does not call process.exit itself —
     // tests and future in-process embedders pass a non-exiting callback.
     onFatal: () => {
-      if (backendShutdown) void runWithShutdownTimeout(backendShutdown, logger, 120_000).finally(() => process.exit(1));
+      if (backendShutdown) void runWithShutdownTimeout(backendShutdown, logger, CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS).finally(() => process.exit(1));
       else process.exit(1);
     },
   });
@@ -720,14 +721,14 @@ async function runDaemon(parsed: Extract<CliArgs, { action: 'daemon' }>): Promis
     void (async () => {
       logger.info(`shutting down (${signal})`);
       client.stop();
-      if (ownsPidFile) removePidFile();
       if (backendShutdown) {
         try {
-          await runWithShutdownTimeout(backendShutdown, logger, backend.requiresCallerScope ? 120_000 : SHUTDOWN_TIMEOUT_MS);
+          await runWithShutdownTimeout(backendShutdown, logger, backend.requiresCallerScope ? CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS);
         } catch (err) {
           logger.error('shutdown error:', (err as Error).message);
         }
       }
+      if (ownsPidFile) removePidFile();
       process.exit(0);
     })();
   };
@@ -826,6 +827,9 @@ async function startDetached(
     process.exit(1);
   }
 
+  const args = resolveDaemonArgs(parsed);
+  const shutdownBudget = args.runtime === 'caller-container'
+    ? { shutdownTimeoutMs: CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS } : {};
   const path = pidFilePath();
   const logPath = parsed.logFile?.trim() || defaultLogPath();
 
@@ -835,6 +839,7 @@ async function startDetached(
   // sees a coherent "running" record and backs off instead of double-spawning.
   // From here on, every failure path must release the claim via removePidFile.
   const claim = claimPidFile({
+    ...shutdownBudget,
     pid: process.pid,
     startedAt: Date.now(),
     argv: process.argv,
@@ -894,6 +899,7 @@ async function startDetached(
   // identity so `stop`/`status` can later tell it apart from a recycled PID.
   writePidRecord(
     {
+      ...shutdownBudget,
       pid: child.pid,
       startedAt: Date.now(),
       argv: [process.execPath, ...childArgv],

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1974,3 +1974,28 @@ test('a replacement assignment suppresses the older run with the same taskId', a
     await closeServer(server, wss);
   }
 });
+
+test('isolated backend refuses legacy and R1-only servers before dispatch', async () => {
+  for (const r1 of [false, true]) {
+    const server = createServer(); const wss = new WebSocketServer({ server });
+    const url = await listen(server); let calls = 0; let fatal = false; let advertised: string[] = [];
+    wss.on('connection', (ws) => {
+      ws.on('message', (raw) => {
+        const frame = parseUpFrame(raw.toString());
+        if (frame.type !== 'hello') return;
+        advertised = frame.protocolCapabilities ?? [];
+        if (r1) ws.send(encodeFrame({ type: 'hello.ack', protocolCapabilities: [TASK_REPLAY_CAPABILITY, 'execution-scope-v1'], disconnectGraceMs: 1000, maxFrameBytes: 1024 * 1024 }));
+        else ws.send(encodeFrame(makeAssign('legacy')));
+      });
+    });
+    const client = new Client({ serverUrl: url, token: 't', agentId: 'a', backendKind: 'claude', heartbeatIntervalMs: 0,
+      backend: { name: 'isolated', requiresCallerScope: true, handle: async () => { calls++; } },
+      onFatal: () => { fatal = true; },
+    });
+    try {
+      client.start(); await waitFor(() => fatal, 'expected fail-closed negotiation');
+      assert.ok(advertised.includes('caller-runtime-v1')); assert.ok(advertised.includes('execution-scope-v1'));
+      assert.equal(calls, 0);
+    } finally { client.stop(); await closeServer(server, wss); }
+  }
+});

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,6 +5,8 @@ import {
   PROTOCOL_VERSION,
   OPENAI_COMPAT_EXTENSION_URI,
   TASK_REPLAY_CAPABILITY,
+  EXECUTION_SCOPE_V1_CAPABILITY,
+  CALLER_RUNTIME_V1_CAPABILITY,
   encodeFrame,
   parseDownFrame,
   withOpenAICompatModelsAdvertise,
@@ -170,6 +172,7 @@ export class Client {
   // False until the authenticated server replies with hello.ack on each
   // connection. This prevents replay from racing asynchronous authentication.
   private replayReady = false;
+  private callerScopeReady = false;
   private negotiatedMaxFrameBytes: number | null = null;
   private readonly logger: Logger;
 
@@ -329,6 +332,7 @@ export class Client {
   private connect(): void {
     if (this.stopped) return;
     this.replayReady = false;
+    this.callerScopeReady = false;
     this.negotiatedMaxFrameBytes = null;
     const ws = new WebSocket(`${this.opts.serverUrl.replace(/\/$/, '')}/connect`);
     this.ws = ws;
@@ -365,6 +369,7 @@ export class Client {
               CALLER_CONTEXT_V2_CAPABILITY,
               CALLER_CONTEXT_V1_CAPABILITY,
               TASK_REPLAY_CAPABILITY,
+              ...(this.opts.backend.requiresCallerScope ? [EXECUTION_SCOPE_V1_CAPABILITY, CALLER_RUNTIME_V1_CAPABILITY] : []),
             ],
             ...(this.opts.trustedIdentityIssuers !== undefined
               ? {
@@ -411,6 +416,14 @@ export class Client {
 
       switch (frame.type) {
         case 'hello.ack':
+          this.callerScopeReady = [TASK_REPLAY_CAPABILITY, EXECUTION_SCOPE_V1_CAPABILITY, CALLER_RUNTIME_V1_CAPABILITY]
+            .every((cap) => frame.protocolCapabilities.includes(cap));
+          if (this.opts.backend.requiresCallerScope && !this.callerScopeReady) {
+            this.logger.error('server does not support caller-runtime-v1; isolation cannot start');
+            this.stop();
+            this.opts.onFatal?.({ code: 1008, reason: 'caller-runtime negotiation required' });
+            return;
+          }
           if (!frame.protocolCapabilities.includes(TASK_REPLAY_CAPABILITY)) return;
           this.replayReady = true;
           this.negotiatedMaxFrameBytes = frame.maxFrameBytes;
@@ -420,6 +433,12 @@ export class Client {
           this.acknowledgeFrames(frame.executionId, frame.acceptedSeq);
           break;
         case 'task.assign':
+          if (this.opts.backend.requiresCallerScope && !this.callerScopeReady) {
+            this.logger.error('task received without caller-runtime negotiation');
+            this.stop();
+            this.opts.onFatal?.({ code: 1008, reason: 'caller-runtime negotiation required' });
+            return;
+          }
           // A task assignment without an execution ID came from a legacy bridge.
           // It is proof that authentication finished, but reconnect replay is
           // intentionally unavailable on that connection.

--- a/packages/client/src/config.test.ts
+++ b/packages/client/src/config.test.ts
@@ -544,10 +544,21 @@ test('readConfig/writeConfig default to resolveConfigDir() when no path passed',
 });
 
 
-test('reserved caller-container runtime survives normalization so startup can reject it', (t) => {
+test('caller-container runtime survives normalization for explicit startup validation', (t) => {
   const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-isolation-'));
   t.after(() => rmSync(dir, { recursive: true, force: true }));
   const path = join(dir, 'config.json');
   writeFileSync(path, JSON.stringify({ backends: { claude: { runtime: 'caller-container' } } }));
   assert.equal(readConfig(path)?.backends?.claude?.runtime, 'caller-container');
+});
+
+
+test('unsupported isolated backend config cannot silently fall back to shared execution', (t) => {
+  const dir = mkdtempSync(join(tmpdir(), 'vicoop-cfg-isolation-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const path = join(dir, 'config.json');
+  for (const kind of ['openclaw', 'vicoop-codex', 'echo']) {
+    writeFileSync(path, JSON.stringify({ backend: kind, backends: { [kind]: { runtime: 'caller-container' } } }));
+    assert.throws(() => readConfig(path), /refusing to drop isolation configuration/);
+  }
 });

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -105,7 +105,7 @@ export function defaultOwnerSessionPath(): string {
 //                   (today's behavior; default).
 //   - 'container' : `docker exec` into a long-lived vicoop-runtime
 //                   container the bridge client orchestrates (#249).
-// caller-container is reserved configuration, explicitly rejected until R2.
+// caller-container is the opt-in Claude direct-principal isolation profile.
 export type BackendRuntime = 'host' | 'container' | 'caller-container';
 
 export interface ClaudeBackendConfig {
@@ -207,6 +207,7 @@ export interface BackendConfigs {
 // also has a place to live in config.json — no "this knob is only configurable
 // via env" surprises.
 export interface ClientConfig {
+  caller_runtime?: unknown;
   server_url?: string;
   server_token?: string;
   agent_id?: string;
@@ -303,6 +304,7 @@ function pickBackendRuntime(v: unknown): BackendRuntime | undefined {
 // an unknown `backend` / `sandbox_mode` later.
 function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
   const c: ClientConfig = {};
+  if (raw.caller_runtime !== undefined) c.caller_runtime = raw.caller_runtime;
   const serverUrl = asString(raw.server_url);
   if (serverUrl) c.server_url = serverUrl;
   const serverToken = asString(raw.server_token);
@@ -326,6 +328,11 @@ function normalizeConfig(raw: Record<string, unknown>): ClientConfig {
   const telemetry = asString(raw.telemetry);
   if (telemetry === 'on' || telemetry === 'off') c.telemetry = telemetry;
   const backends = asRecord(raw.backends);
+  for (const [kind, value] of Object.entries(backends ?? {})) {
+    if (kind !== 'claude' && kind !== 'codex' && asString(asRecord(value)?.runtime) === 'caller-container') {
+      throw new Error(`caller-container is unsupported for ${kind}; refusing to drop isolation configuration`);
+    }
+  }
   if (backends) {
     const out: BackendConfigs = {};
     const claudeRaw = asRecord(backends.claude);
@@ -466,6 +473,7 @@ export function overlayConfig(base: ClientConfig, top: ClientConfig): ClientConf
     trusted_identity_issuers:
       top.trusted_identity_issuers ?? base.trusted_identity_issuers,
     telemetry: top.telemetry ?? base.telemetry,
+    ...((top.caller_runtime ?? base.caller_runtime) !== undefined ? { caller_runtime: top.caller_runtime ?? base.caller_runtime } : {}),
     backends: mergedBackends,
   };
 }

--- a/packages/client/src/daemon-control.test.ts
+++ b/packages/client/src/daemon-control.test.ts
@@ -411,3 +411,43 @@ test('formatUptime renders compact durations', () => {
   assert.equal(formatUptime(-1), 'unknown');
   assert.equal(formatUptime(Number.NaN), 'unknown');
 });
+
+test('stopDaemon honors recorded caller cleanup budget and remains bounded', async () => {
+  const dir = tmpDir();
+  try {
+    const path = join(dir, 'vicoop.pid');
+    for (const exitAt of [20_000, 120_200, Infinity]) {
+      writePidRecord({ ...sampleRecord, shutdownTimeoutMs: 120_000 }, path);
+      let elapsed = 0;
+      const signals: NodeJS.Signals[] = [];
+      const result = await stopDaemon({ path,
+        probe: { alive: () => elapsed < exitAt, matches: () => true },
+        wait: async (ms) => { elapsed += ms; },
+        kill: (_pid, signal) => { signals.push(signal); },
+      });
+      assert.equal(result.outcome, exitAt === Infinity ? 'killed' : 'stopped');
+      assert.deepEqual(signals, exitAt === Infinity ? ['SIGTERM', 'SIGKILL'] : ['SIGTERM']);
+      assert.ok(elapsed <= 125_200, 'even an unresponsive caller daemon has a bounded stop');
+      assert.equal(readPidRecord(path), null);
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('legacy or invalid recorded cleanup budgets retain the default stop behavior', async () => {
+  const dir = tmpDir();
+  try {
+    const path = join(dir, 'vicoop.pid');
+    for (const shutdownTimeoutMs of [undefined, -1, 0, 1.5, '120000', 120_001]) {
+      writeFileSync(path, JSON.stringify({ ...sampleRecord, shutdownTimeoutMs }));
+      let elapsed = 0;
+      const signals: NodeJS.Signals[] = [];
+      const result = await stopDaemon({ path, probe: aliveProbe,
+        wait: async (ms) => { elapsed += ms; },
+        kill: (_pid, signal) => { signals.push(signal); },
+      });
+      assert.equal(result.outcome, 'killed');
+      assert.equal(elapsed, 10_200);
+      assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/packages/client/src/daemon-control.ts
+++ b/packages/client/src/daemon-control.ts
@@ -35,11 +35,16 @@ import { atomicWriteFile } from './fs-util.js';
 const PID_FILENAME = 'vicoop.pid';
 const LOG_FILENAME = 'vicoop.log';
 
+export const CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS = 120_000;
+const STOP_EXIT_MARGIN_MS = 5_000;
+
 // On-disk pidfile shape. Written by the *parent* immediately after fork
 // (it already holds the child pid), which sidesteps the classic
 // Type=forking race where a supervisor reads the pidfile before the child
 // has written it.
 export interface PidRecord {
+  // Launch-time cleanup budget; optional for compatibility with older daemons.
+  shutdownTimeoutMs?: number;
   pid: number;
   // ms-epoch wall clock at spawn. Used for the `status` uptime readout and
   // as a diagnostic — deliberately NOT the PID-reuse guard (wall clock is
@@ -94,6 +99,9 @@ export function readPidRecord(path: string = pidFilePath()): PidRecord | null {
   }
   return {
     pid: o.pid,
+    ...(typeof o.shutdownTimeoutMs === 'number' && Number.isSafeInteger(o.shutdownTimeoutMs) &&
+      o.shutdownTimeoutMs > 0 && o.shutdownTimeoutMs <= CALLER_RUNTIME_SHUTDOWN_TIMEOUT_MS
+      ? { shutdownTimeoutMs: o.shutdownTimeoutMs } : {}),
     startedAt: typeof o.startedAt === 'number' ? o.startedAt : 0,
     argv: Array.isArray(o.argv)
       ? o.argv.filter((x): x is string => typeof x === 'string')
@@ -322,7 +330,6 @@ export async function stopDaemon(
   } = {},
 ): Promise<StopResult> {
   const path = opts.path ?? pidFilePath();
-  const termGraceMs = opts.termGraceMs ?? 10_000;
   const pollMs = opts.pollMs ?? 200;
   const probe = opts.probe ?? defaultProbe;
   const wait = opts.wait ?? sleep;
@@ -339,6 +346,11 @@ export async function stopDaemon(
     return { outcome: 'already-gone', pid: state.record.pid };
   }
 
+  // Read the recorded budget, not today's config: stop must honor the mode
+  // actually launched even if configuration was edited in the meantime.
+  const termGraceMs = opts.termGraceMs ??
+    (state.record.shutdownTimeoutMs !== undefined
+      ? state.record.shutdownTimeoutMs + STOP_EXIT_MARGIN_MS : 10_000);
   const pid = state.record.pid;
   try {
     kill(pid, 'SIGTERM');

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -18,6 +18,8 @@ export const CALLER_CONTEXT_V2_CAPABILITY = 'caller-context-v2';
 // Wire support only; never evidence that a client isolates execution. R1
 // clients do not advertise this capability. Requires caller-context-v2 and
 // task-replay-v1 so a future isolated client can validate identity/generation.
+export const CALLER_RUNTIME_V1_CAPABILITY = 'caller-runtime-v1';
+
 export const EXECUTION_SCOPE_V1_CAPABILITY = 'execution-scope-v1';
 export const ExecutionScopeV1 = z.object({
   policy: z.literal('direct-principal-v1'),

--- a/packages/server/src/agent-auth.test.ts
+++ b/packages/server/src/agent-auth.test.ts
@@ -433,3 +433,13 @@ test('each rejection gets its own id (no shared / cached id across requests)', a
   const body2 = (await res2.json()) as { error: { data: { rejectionId: string } } };
   assert.notEqual(body1.error.data.rejectionId, body2.error.data.rejectionId);
 });
+
+test('caller runtime public agent requires authentication and accepts verified direct callers', async () => {
+  const { app, registry } = buildApp({ siweDomain: 'bridge.example' });
+  registerAgent(registry, 'isolated-public', [], ['caller-runtime-v1', CALLER_CONTEXT_V2_CAPABILITY]);
+  const url = '/agents/isolated-public';
+  assert.equal((await app.request(url, { method: 'POST' })).status, 401);
+  assert.equal((await app.request(url, { method: 'POST', headers: { Authorization: 'Bearer invalid' } })).status, 401);
+  const bearer = await mintBearer({ domain: 'bridge.example', uri: 'https://bridge.example' });
+  assert.equal((await app.request(url, { method: 'POST', headers: { Authorization: `Bearer ${bearer}` } })).status, 200);
+});

--- a/packages/server/src/agent-auth.ts
+++ b/packages/server/src/agent-auth.ts
@@ -1,3 +1,4 @@
+import { CALLER_RUNTIME_V1_CAPABILITY } from '@vicoop-bridge/protocol';
 import type { Context, Next } from 'hono';
 import type { ClientConnection, Registry } from './registry.js';
 import type { Sql } from './db.js';
@@ -257,6 +258,7 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     // an anonymous public request and bypass immediate revocation.
     if (
       conn.allowedCallers.length === 0 &&
+      !conn.protocolCapabilities?.includes(CALLER_RUNTIME_V1_CAPABILITY) &&
       !bearerToken?.startsWith(TOKEN_EXCHANGE_ACCESS_TOKEN_PREFIX)
     ) {
       return next();
@@ -427,7 +429,8 @@ export function agentAuthMiddleware(registry: Registry, opts: AgentAuthOptions) 
     const allowed =
       caller.tokenExchange !== undefined
         ? true
-        : conn.allowedCallers.some((entry) => matchPrincipal(entry, caller));
+        : (conn.allowedCallers.length === 0 && conn.protocolCapabilities?.includes(CALLER_RUNTIME_V1_CAPABILITY)) ||
+          conn.allowedCallers.some((entry) => matchPrincipal(entry, caller));
     if (!allowed) {
       const rejectionId = newRejectionId();
       logEvent('agent_request_rejected', {

--- a/packages/server/src/agent-card.test.ts
+++ b/packages/server/src/agent-card.test.ts
@@ -484,3 +484,17 @@ test('a paid agent without PUBLIC_URL advertises no price', () => {
   const card = agent.getAgentCard() as AgentCardV03;
   assert.equal(x402Entries(card).length, 0);
 });
+
+test('public caller runtime advertises required direct authentication', () => {
+  const agent = buildAgentA2XServer(
+    fakeConn({ name: 'isolated', description: 'isolated fixture', version: '1', protocolVersion: '0.3.0' },
+      { allowedCallers: [], protocolCapabilities: ['caller-runtime-v1', CALLER_CONTEXT_V2_CAPABILITY] }),
+    new InMemoryTaskStore(), new Registry(),
+    { publicUrl: 'https://bridge.example', deviceFlowEnabled: true },
+  );
+  const card = agent.getAgentCard() as AgentCardV03;
+  assert.ok(card.securitySchemes?.bearerAuth); assert.ok(card.securitySchemes?.deviceFlow);
+  assert.deepEqual(card.security, [{ bearerAuth: [] }, { deviceFlow: [] }]);
+  assert.ok(card.capabilities.extensions?.some((e) => e.uri === SIWE_BEARER_AUTH_EXTENSION_URI));
+  assert.equal(card.capabilities.extensions?.some((e) => e.uri === OAUTH_FEDERATION_EXTENSION_URI), false);
+});

--- a/packages/server/src/agent-card.ts
+++ b/packages/server/src/agent-card.ts
@@ -8,6 +8,8 @@ import {
 } from '@a2x/sdk';
 import {
   CALLER_CONTEXT_V2_CAPABILITY,
+  CALLER_RUNTIME_V1_CAPABILITY,
+  OPENAI_COMPAT_EXTENSION_URI,
   MENTIONABLE_IDENTITY_VC_EXTENSION_URI,
   SIWE_BEARER_AUTH_EXTENSION_URI,
 } from '@vicoop-bridge/protocol';
@@ -138,7 +140,8 @@ export function buildAgentA2XServer(
   // the URI can still authenticate via the opaque vbc_caller_* path on
   // the bridge.
   const wireExtensions = wire.capabilities?.extensions ?? [];
-  const restricted = conn.allowedCallers.length > 0;
+  const callerRuntime = conn.protocolCapabilities?.includes(CALLER_RUNTIME_V1_CAPABILITY) === true;
+  const restricted = conn.allowedCallers.length > 0 || callerRuntime;
   const bridgeWillEmitSiwe = restricted && Boolean(opts.publicUrl);
   const bridgeWillEmitIdentityVc =
     Boolean(opts.publicUrl) &&
@@ -146,11 +149,12 @@ export function buildAgentA2XServer(
     supportsCallerContext(conn.protocolCapabilities) &&
     (conn.identityTrust?.trustedIssuers.length ?? 0) > 0;
   const bridgeWillEmitOAuthFederation =
-    restricted &&
+    !callerRuntime && restricted &&
     Boolean(opts.publicUrl) &&
     conn.protocolCapabilities?.includes(CALLER_CONTEXT_V2_CAPABILITY) === true &&
     conn.allowedCallers.some((entry) => parseFederatedPrincipal(entry) !== null);
   for (const extension of wireExtensions) {
+    if (callerRuntime && extension.uri === OPENAI_COMPAT_EXTENSION_URI) continue;
     if (restricted && extension.uri === SIWE_BEARER_AUTH_EXTENSION_URI) {
       // Bridge owns this advertisement on restricted agents — drop wire
       // entry whether or not we re-emit our own (the latter is gated by

--- a/packages/server/src/executor.test.ts
+++ b/packages/server/src/executor.test.ts
@@ -1135,3 +1135,23 @@ test('executor forwards only negotiated, server-derived direct execution scopes'
     }
   }
 });
+
+test('caller runtime rejects anonymous/delegated identity before binding or payment work', async () => {
+  for (const metadata of [{}, { _principalId: 'apikey:a', _actorId: 'actor' }, { _principalId: 'apikey:a', _authorizationKey: 'grant' }]) {
+    const { ws, sent } = makeWsCapture();
+    const registry = new Registry();
+    registry.registerAgent({ agentId: 'agent', clientId: 'client', ownerPrincipal: 'owner',
+      protocolCapabilities: ['caller-runtime-v1', EXECUTION_SCOPE_V1_CAPABILITY, CALLER_CONTEXT_V2_CAPABILITY, TASK_REPLAY_CAPABILITY],
+      agentCard: makeAgentCard(), allowedCallers: [], ws, connectedAt: 0 });
+    const executor = new WSForwardingExecutor('agent', registry, noopTaskStore());
+    // If currentGate is reached this fixture fails; rejection must precede charging.
+    Object.assign(executor, { currentGate: () => { throw new Error('payment gate must not run'); } });
+    const task = { id: 't-rejected', contextId: 'ctx', status: { state: TaskState.SUBMITTED } } as unknown as Task;
+    const message = { role: 'user', messageId: 'm', parts: [{ text: 'hi' }], metadata } as unknown as Message;
+    const events = [];
+    for await (const event of executor.executeStream(task, message)) events.push(event);
+    assert.equal(events.length, 1); assert.ok(events[0] && 'status' in events[0]);
+    assert.equal(events[0].status.state, TaskState.FAILED);
+    assert.equal(sent.length, 0); assert.equal(registry.getBinding(task.id), undefined);
+  }
+});

--- a/packages/server/src/executor.ts
+++ b/packages/server/src/executor.ts
@@ -24,6 +24,7 @@ import { readTaskUsage } from './x402/usage.js';
 import type { Sql } from './db.js';
 import {
   TASK_REPLAY_CAPABILITY,
+  CALLER_RUNTIME_V1_CAPABILITY,
   type CallerAttestationV2,
   type Part as WirePart,
 } from '@vicoop-bridge/protocol';
@@ -403,6 +404,23 @@ export class WSForwardingExecutor extends AgentExecutor {
     if (rawMetadata) delete rawMetadata[IDENTITY_VC_PRESENTED_METADATA_KEY];
     const forwardMetadata = stripInternalMetadata(rawMetadata);
     const requestedExtensions = message.extensions;
+
+    const capabilities = this.registry.getAgent(this.agentId)?.protocolCapabilities;
+    if (capabilities?.includes(CALLER_RUNTIME_V1_CAPABILITY) && !resolveDirectExecutionScope({
+      agentId: this.agentId, principalId, actorId, authorizationKey, authorizationProfile, capabilities,
+    })) {
+      const status = {
+        state: TaskState.FAILED,
+        timestamp: new Date().toISOString(),
+        message: { messageId: randomUUID(), role: 'agent' as const,
+          parts: [{ text: 'caller-container requires a directly authenticated principal; delegation is unsupported' }], taskId, contextId },
+      };
+      task.status = status;
+      task.history = appendHistoryMessage(appendHistoryMessage(task.history ?? [], message), status.message);
+      await this.taskStore.updateTask(taskId, { status, history: task.history });
+      yield { taskId, contextId, final: true, status };
+      return;
+    }
 
     // x402 payment gate. Runs before the task is bound or forwarded, so an
     // unpaid call never reaches the connected agent and never consumes its

--- a/packages/server/src/ws.test.ts
+++ b/packages/server/src/ws.test.ts
@@ -1378,14 +1378,17 @@ test('execution scope acknowledgement requires the full capability set', async (
       const ack = once(ws, 'message');
       ws.send(encodeFrame({
         type: 'hello', version: PROTOCOL_VERSION, agentId: 'agent-1', token: 'token',
-        protocolCapabilities: [TASK_REPLAY_CAPABILITY, EXECUTION_SCOPE_V1_CAPABILITY,
+        protocolCapabilities: [TASK_REPLAY_CAPABILITY, EXECUTION_SCOPE_V1_CAPABILITY, 'caller-runtime-v1',
           ...(callerV2 ? [CALLER_CONTEXT_V2_CAPABILITY] : [])],
         agentCard: { name: 'agent', version: '0.0.0', protocolVersion: '0.3.0' },
       }));
       const [raw] = await withTimeout(ack, 5_000, 'scope acknowledgement');
       const frame = parseDownFrame(raw.toString());
       assert.equal(frame.type, 'hello.ack');
-      if (frame.type === 'hello.ack') assert.equal(frame.protocolCapabilities.includes(EXECUTION_SCOPE_V1_CAPABILITY), callerV2);
+      if (frame.type === 'hello.ack') {
+        assert.equal(frame.protocolCapabilities.includes(EXECUTION_SCOPE_V1_CAPABILITY), callerV2);
+        assert.equal(frame.protocolCapabilities.includes('caller-runtime-v1'), callerV2);
+      }
     } finally {
       ws.close();
       await closeServer(server);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -7,6 +7,7 @@ import {
   OPENAI_COMPAT_EXTENSION_URI,
   TASK_REPLAY_CAPABILITY,
   EXECUTION_SCOPE_V1_CAPABILITY,
+  CALLER_RUNTIME_V1_CAPABILITY,
   supportsExecutionScopeV1,
   type Part,
   type TaskStatus as WireTaskStatus,
@@ -351,7 +352,8 @@ function handleConnection(ws: WebSocket, _req: IncomingMessage, opts: ServerWsOp
               type: 'hello.ack',
               protocolCapabilities: [
                 TASK_REPLAY_CAPABILITY,
-                ...(supportsExecutionScopeV1(frame.protocolCapabilities) ? [EXECUTION_SCOPE_V1_CAPABILITY] : []),
+                ...(supportsExecutionScopeV1(frame.protocolCapabilities) ? [EXECUTION_SCOPE_V1_CAPABILITY,
+                  ...(frame.protocolCapabilities.includes(CALLER_RUNTIME_V1_CAPABILITY) ? [CALLER_RUNTIME_V1_CAPABILITY] : [])] : []),
               ],
               disconnectGraceMs: opts.registry.getDisconnectGraceMs(),
               maxFrameBytes: MAX_INGRESS_BYTES,


### PR DESCRIPTION
Implements the restricted R2 release of #497 on top of R1 (#498). Opting into `--backend claude --runtime caller-container` gives directly authenticated callers separate workspaces and live conversation bindings while retaining one agent identity and bridge connection. This PR targets `codex/497-docker-runtimes`; it does not merge or deploy to `main`.

The server authenticates callers even for an empty allowlist, advertises the required authentication, derives the scope, and rejects anonymous/delegated execution before payment/allocation. The client requires explicit R2 negotiation and validates the agent/principal/scope/generation before allocation. Existing host and single-container modes remain available.

### Runtime and persistence contract

- Serialize each scope through allocation, execution and confirmed cleanup; bound scope count, queueing, contexts, memory/PIDs, task time and storage. Canceling a waiter does not release another execution's lease. Queued context-capacity rejection preserves existing conversations. Uncertain cleanup quarantines the scope.
- Run each execution in a unique container/private Docker bridge network, with read-only rootfs, bounded tmpfs, no host mounts, non-root jobs and a root watchdog. Freeze and verify workload threads before snapshotting; remove the whole container/network before publishing success.
- **R2 implementation choice:** use separate workspace/HOME/CLI-state directories on bounded tmpfs plus opaque host-owned snapshots, instead of unbounded Docker named volumes. Successful checkpoints persist across executions/restarts. Failure/cancellation discards uncommitted changes; cancellation after atomic commit retains the checkpoint and reports that distinction. Response loss is not exactly-once execution.
- Recover dead owners and remove stale resources before accepting work. Restart restores files and explicitly reports a fresh conversation. `caller-state` provides exclusive offline inspection/deletion. Detached `stop` honors the recorded launch-time cleanup budget (120 seconds plus exit margin) and retains the pidfile until cleanup ends.
- Require an immutable backend-installed image and explicit credential provisioning: the existing private API-key file (default), or `credentialSource: "host-claude"` with no `credentialFile`. Host OAuth mode reads the default macOS Keychain/Linux credential file per execution and forwards only the access token. No refresh token, operator settings or conversations are copied. Invalid/expired/near-expiry credentials fail closed; refresh is operator-managed. Workloads can access the supplied credential.

Supported: Linux/macOS Docker + Claude plain A2A, text and inline image/PDF inputs. Delegation, isolated Codex/OpenClaw, OpenAI compatibility/caller tools, MCP, URI fetching and outgoing file delivery remain unavailable. Includes image recipe, operator configuration/limits, server-first rollout/rollback guidance and a client-only minor changeset. Details: [`docs/caller-runtime.md`](docs/caller-runtime.md).

### Validation

- Repository build/typecheck passed; final client build/typecheck passed after config validation changes.
- Client: **959 passed**. Server: **454 passed / 78 skipped**. Protocol: **11 passed**.
- Real Docker under tsx and a Bun-compiled smoke: A/B/A files, snapshot restoration/rollback, explicit env, bounded storage, cancellation/descendant cleanup and separate caller networks.
- Actual pinned Node 22 + Claude **2.1.265** image built and used for the Bun runtime smoke. Image-default workdir permissions were caught and fixed during this validation.
- Full Bun-compiled CLI with a **deterministic Claude fixture**: strict argv/prompt-file staging, A/B/A live sessions/workspaces, WebSocket disconnect/replay, SIGKILL after an observed uncommitted write, restart/reset and orderly shutdown. The actual `start --detach` / `stop` path also passed with Docker removal delayed 12 seconds, a post-launch config change, and no forced kill or leftover resources. This full-CLI fixture does not call the model.
- Real host OAuth through `DockerCallerRuntimePool`: Claude 2.1.265 / Haiku inference, checkpoint and container/network cleanup passed under tsx and a Bun-compiled smoke. This validates the runtime authentication path, not full A2A OAuth E2E or expiration/refresh. Full compiled-client fixture regression also passed after the change.
- Adversarial security/lifecycle subagent review and follow-up fixes: queue admission accounting, commit/cancel reporting, reasoning option propagation and public-agent authentication advertisement. Follow-up adversarial review of `cc0733e` verified the context-limit/session-preservation and detached-stop grace fixes, with no additional confirmed defects in those changes.
- One initial parallel test run stalled in the unchanged OpenClaw suite; its standalone 80 tests and subsequent complete client runs passed.

Not deployed or released. R3 conversation restoration/idle eviction and R4–R6 features remain separate work.


OAuth follow-up has local validation above; the earlier adversarial review predates this follow-up. No new adversarial review is claimed.
