### PR TITLE
feat(client): keep Claude container credentials in a host authentication broker

### DIFF
--- a/.changeset/quiet-claude-broker.md
+++ b/.changeset/quiet-claude-broker.md
@@ -1,0 +1,5 @@
+---
+"@vicoop-bridge/client": minor
+---
+
+Move Claude external-container authentication to a built-in host broker so real OAuth/API credentials stay outside the workload. Existing runtimes require migration: preserve volumes, recreate with `container init claude --reuse-state`, and authenticate on the host. The old credentials volume remains detached; selected conversations and todos are preserved. Private/host-network services are now blocked for Claude runtimes. See `docs/claude-auth-broker.md` for supported modes, migration and rollback limits. Codex, host mode and bundled-direct authentication are unchanged.

--- a/docs/claude-auth-broker.md
+++ b/docs/claude-auth-broker.md
@@ -125,7 +125,8 @@ caller scope, lease and generation before caller-isolation claims are made.
 The runtime runs as `node` with `no-new-privileges`. Before agent use, the host
 installs firewall rules through a privileged Docker control-plane exec. Private,
 link-local and host interface/gateway destinations are rejected, and IPv6 egress
-is blocked except loopback. Public internet tool traffic remains subject to the
+is blocked except loopback. DNS (UDP/TCP port 53) is allowed only to the
+configured IPv4 resolvers, including Docker default-bridge private resolvers. Public internet tool traffic remains subject to the
 image's existing egress policy. Failure to apply this boundary stops startup;
 `VICOOP_SKIP_FIREWALL` cannot disable these broker-specific rules. Workloads can
 no longer reach private repositories, LAN services or host-local MCP servers;
@@ -133,6 +134,11 @@ move required services to an appropriately authenticated public endpoint or keep
 using host mode for that workload. A workload cannot alter these rules using
 its unprivileged exec user. Host administrative APIs and credential stores are
 not exposed by the relay.
+
+Host-generated `--system-prompt-file` and `--append-system-prompt-file` inputs
+are transferred in bounded chunks over the same Docker channel (16 MiB total).
+The relay rewrites their arguments to private execution-owned temporary files
+and removes those files on exit. Workload frames cannot request host files.
 
 Completion, cancellation, transport loss and shutdown revoke the grant and close
 active upstream connections. The relay owns an agent process group and terminates
@@ -210,3 +216,12 @@ files. **Actual API-key inference (`--real-api`) and native Linux-host operation
 validation**; no host API key was available during implementation. R2's real A/B/A,
 lease/generation, replay/checkpoint and full A2A acceptance tests remain follow-up
 work and this change must not close #500 or #497.
+
+
+A main-first production-server smoke on 2026-09-10 also exercised the compiled
+client with a newly installed Claude 2.1.267 runtime: an authenticated A2A request
+created and read back a workspace file, and a separate task lookup confirmed
+`completed`. Fresh installation exposed a Docker private-DNS exception missing
+from the firewall, while the first A2A request exposed host prompt-file paths;
+both paths now have fixes and regression coverage. This is single-runtime A2A
+evidence, not R2 caller-isolation acceptance evidence.

--- a/docs/claude-auth-broker.md
+++ b/docs/claude-auth-broker.md
@@ -1,0 +1,212 @@
+# Claude container authentication broker
+
+Claude `--runtime container` now uses the host bridge's built-in authentication
+broker. Claude and its tools still execute inside the external runtime. Real
+provider credentials are read only by the host and are never passed to Docker,
+agent arguments, workload environment, mounted login files or broker errors.
+No additional account, proxy service, port configuration or package is required.
+
+This is the **main-first implementation of #500**. It does not complete #500's
+caller-scoped R2 integration or #497's release gates. An external runtime remains
+one shared security domain; different callers using it are not isolated.
+
+## Supported authentication
+
+| Mode | Host source | Workload receives |
+| --- | --- | --- |
+| Claude subscription OAuth | Existing host Claude login (macOS Keychain or credentials file) | Temporary execution grant |
+| Explicit OAuth token | Host `CLAUDE_CODE_OAUTH_TOKEN` | Temporary execution grant |
+| Anthropic API key | Host `ANTHROPIC_API_KEY` | Temporary execution grant |
+
+Set at most one credential environment variable. If neither is set, the bridge
+selects the host login store. An explicit `CLAUDE_CONFIG_DIR` selects that
+credentials file; otherwise macOS selects an existing Keychain entry first,
+then the default credentials file if no entry exists at startup. Other hosts
+select the credentials file. The chosen store/type stays pinned for the daemon's
+lifetime. Removal or failure never falls back to another store or API key.
+Operators must not replace a selected store with another account while work is
+running: store pinning is not account-identity verification.
+
+Credentials are reread before each provider request, so token rotation in the
+selected store takes effect without copying anything into the container. An
+OAuth expiry within 30 seconds fails closed. **The bridge does not refresh
+OAuth** and does not read/use refresh tokens for refresh operations. Renew the
+login with Claude on the host, then retry the failed task. Explicit environment
+credentials must be changed by restarting the daemon. Missing/expired login
+fails startup; loss during execution returns a sanitized broker error and a
+host-side instruction to renew the selected credential. Provider errors never
+trigger automatic broker retries, request replay or a credential fallback.
+Claude itself may retry a request; each attempt counts against the grant limit.
+
+Bedrock, Vertex, Foundry, custom Anthropic origins, `ANTHROPIC_AUTH_TOKEN`,
+container-local login and `apiKeyHelper` authentication are not supported by this
+mode. Do not pass authentication settings or secrets through agent settings,
+workspace files, prompts or mounted state. Host mode, Codex authentication and
+the bundled-direct image keep their existing behavior; this broker does not
+make their provider credentials inaccessible to their agent processes.
+
+## Fresh setup
+
+Log into Claude on the **host**, or supply one supported credential variable to
+the host bridge process. Then run:
+
+```sh
+vicoop-client container init claude
+vicoop-client --backend claude --runtime container
+```
+
+`container init claude --from-host` is accepted for compatibility but does not
+copy secrets. Both forms validate host authentication. The runtime image must
+contain Node, `iptables`, `ip6tables` and the normal install recipe (the existing
+`vicoop-runtime` image includes them).
+
+## Existing runtime migration
+
+Stop the bridge daemon first. Preserve the original runtime image reference and
+any workspace bind-mount path in your operational records. Then, replacing
+`claude` with your runtime instance name:
+
+```sh
+vicoop-client container remove claude --preserve-volumes
+vicoop-client container init claude --name claude --reuse-state --from-host
+vicoop-client --backend claude --runtime container --runtime-name claude
+```
+
+The explicit removal discards the old container's writable layer. Back up any
+files kept there before running it. Named agent/session volumes remain and are
+reused; the legacy credentials volume is retained **without being mounted into
+the new workload**. `--reuse-state` also runs a short-lived, networkless helper
+which mounts that legacy volume read-only and copies only `projects/**/*.jsonl`
+and `todos/**/*.json` into the new session config directory. Existing destination
+files are kept; symlinks, settings, login files and environment snapshots are
+excluded. The helper exits and is removed before normal agent use. No host login
+is overwritten, imported from the container or deleted.
+
+For a custom `/workspace` bind mount, add `--workspace /original/host/path`
+to the replacement `container init` command, and keep the original daemon
+`--cwd /original/host/path` setting. The data on the host is retained by
+container removal. Do not mount the operator's home, credential stores or Docker
+socket into the workload. The runtime refuses mounts outside the agent/session
+volumes, `/workspace`, and designated temporary directories. Legacy runtimes or
+containers with provider environment variables fail before any new agent spawn.
+
+The new `CLAUDE_CONFIG_DIR` is `/data/sessions/claude/config`. The old credential
+path is an empty tmpfs. The guarantee starts with the new broker runtime: this
+migration does **not** sanitize tokens that previous tools copied into code,
+conversation transcripts, todos, backups or snapshots. If old work may contain
+secrets, rotate them on the host and use a fresh runtime name without reusing
+state. Operator-supplied images and workspace contents remain trusted inputs.
+
+Rollback to an older bridge can restore direct credential exposure if the old
+credentials volume is mounted again. Do not use the old `container remove`
+without `--preserve-volumes` if the retained data is needed. Recover a legacy
+installation from your saved image/mount configuration and retained volumes;
+there is no automatic downgrade or silent direct-auth fallback.
+
+## Transport and lifecycle
+
+Each agent spawn owns a random grant, an HTTP broker on a Unix socket in a
+host-private temporary directory (mode 0700), and a Docker exec relay. No host
+TCP port is opened and no Unix socket/path is mounted into Docker. The relay
+listens only on `127.0.0.1` inside its runtime and multiplexes HTTP and agent
+stdio through Docker exec. The host supplies only a fixed local Unix-socket
+destination; workload frames cannot choose host paths or forwarding targets.
+This uses the same transport on macOS Docker Desktop and Linux Docker. There is
+no container-to-host network hop requiring TLS; host-to-Anthropic uses HTTPS.
+A trusted local Docker daemon is required; Windows hosts and remote Docker
+transports have not been validated for this implementation.
+
+A token stolen by another runtime cannot authenticate to that runtime's broker,
+and the owning relay is unreachable outside its container loopback. Workload
+code in the **same** runtime can read/use an active grant: main's single runtime
+is not a caller boundary. R2 must bind relay/runtime ownership to the authorized
+caller scope, lease and generation before caller-isolation claims are made.
+
+The runtime runs as `node` with `no-new-privileges`. Before agent use, the host
+installs firewall rules through a privileged Docker control-plane exec. Private,
+link-local and host interface/gateway destinations are rejected, and IPv6 egress
+is blocked except loopback. Public internet tool traffic remains subject to the
+image's existing egress policy. Failure to apply this boundary stops startup;
+`VICOOP_SKIP_FIREWALL` cannot disable these broker-specific rules. Workloads can
+no longer reach private repositories, LAN services or host-local MCP servers;
+move required services to an appropriately authenticated public endpoint or keep
+using host mode for that workload. A workload cannot alter these rules using
+its unprivileged exec user. Host administrative APIs and credential stores are
+not exposed by the relay.
+
+Completion, cancellation, transport loss and shutdown revoke the grant and close
+active upstream connections. The relay owns an agent process group and terminates
+it on cancellation or Docker stdin loss; killing only the host `docker exec`
+process is not used as proof of agent termination. Startup failure, malformed
+frames and transport limits fail the child execution. A new daemon/spawn creates
+new random grants; old grants have no surviving broker and cannot be resumed.
+A hard host crash can leave an inert Unix socket file in its private temporary
+directory, but no credential or reusable grant is persisted there. Temporary
+files may be removed by normal host temporary-directory cleanup.
+
+Transport cancellation does not prove the provider immediately stopped inference
+or billing. Broker failure must be handled as failed/uncertain work by the existing
+backend; no grant is reissued to replay uncertain requests. An expired grant
+terminates the child after at most one hour even if a caller disconnects.
+
+## Protocol and resource limits
+
+Only POST `/v1/messages` and `/v1/messages/count_tokens`, optionally with exactly
+`?beta=true`, are forwarded to `https://api.anthropic.com`. Other paths, methods,
+queries, destinations and redirects are rejected. Model IDs must be in the
+Claude Haiku/Sonnet/Opus families; the broker does not translate model names. The
+internal broker API can further restrict an execution to an explicit model list.
+
+Request authentication/cookie/routing headers are dropped. The broker sets the
+provider credential, content type and Anthropic version; forwards the syntactically
+validated Anthropic beta list, user-agent and x-app; and adds the OAuth beta for
+OAuth credentials (and strips that OAuth beta for API keys). The workload CLI
+receives the temporary grant in the environment variable matching its selected
+authentication mode. Successful response bodies, including SSE and usage/cache
+accounting, pass through unchanged. Only content-type is retained from upstream
+headers. Error bodies/headers and redirects are discarded. Successful model
+content is trusted Anthropic output, not a general-purpose secret-redaction filter.
+
+Defaults per execution: one-hour grant, 256 admitted requests, four concurrent
+requests, 16 MiB request body, 64 MiB response, 128,000 maximum output tokens per
+messages request, five-minute request timeout, and 16 transport sockets. Headers
+are bounded to 16 KiB. Framing/stdio queues are bounded; excessively slow consumers
+fail the execution instead of causing unbounded buffering. These are resource
+limits, **not** spending caps or guarantees about provider billing.
+
+## Reproduction and evidence
+
+From the repository root:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm -r build
+pnpm -r typecheck
+pnpm --filter @vicoop-bridge/client test
+bun test packages/client/src/claude-auth-broker.test.ts packages/client/src/claude-broker-spawn.test.ts
+pnpm exec tsx packages/client/scripts/auth-broker/smoke.ts
+bun build --compile packages/client/scripts/auth-broker/smoke.ts --outfile /tmp/vicoop-auth-broker-smoke
+/tmp/vicoop-auth-broker-smoke
+
+# Uses existing host OAuth allowance for two short Haiku turns.
+# Requires a cached image with /usr/local/bin/claude; override as needed.
+VICOOP_SMOKE_CLAUDE_IMAGE=vicoop-caller-r2-validation:latest \
+  /tmp/vicoop-auth-broker-smoke --real
+```
+
+`VICOOP_SMOKE_IMAGE` overrides the cached runtime image. The smoke creates only
+randomly named test containers/volumes and removes them in `finally`. It prints
+sanitized outcomes, not credentials or raw model diagnostics. The local source
+spike was replaced by the reviewable modules and smoke script in this change.
+
+Validated on 2026-09-10 with macOS Docker Desktop (Linux Docker engine): Node/tsx
+and Bun-compiled Docker mock requests, OAuth inference and continuation, workload
+credential probes, process cancellation, abrupt bridge death, stolen-grant rejection across two
+runtimes, a listening host-service access probe, Docker migration and cleanup. Node and Bun unit tests also
+cover API-key substitution, token-counting policy, SSE/cache usage, grant rejection,
+rotation/source pinning, errors/redirects and active upstream disconnection observed
+by an independent Node process. Migration tests cover preservation and excluded
+files. **Actual API-key inference (`--real-api`) and native Linux-host operation still need release
+validation**; no host API key was available during implementation. R2's real A/B/A,
+lease/generation, replay/checkpoint and full A2A acceptance tests remain follow-up
+work and this change must not close #500 or #497.

--- a/docs/claude-auth-broker.md
+++ b/docs/claude-auth-broker.md
@@ -154,6 +154,11 @@ or runs workload commands as root. It drops the relay to UID/GID 1000 before
 execution. Workload code cannot signal the supervisor. On relay exit, stdin loss
 or TTL expiry, it stops and kills all descendants of that execution's subreaper,
 including detached/double-forked children, while preserving other executions.
+Cancellation revokes the grant and destroys the host's supervisor-input pipe,
+discarding queued frames; it does not depend on the relay processing a signal.
+The supervisor drains input with a bounded queue rather than pausing input on
+relay backpressure, so a SIGSTOP'd relay cannot hide cancellation EOF. Both
+SIGTERM and SIGKILL cancellation requests use this forced cleanup path.
 The host waits for supervisor exit and pipe drainage before reporting task close.
 If supervisor/Docker exit leaves cleanup uncertain, the adapter stops accepting
 work and attempts to stop the entire shared runtime through Docker; this also
@@ -226,7 +231,8 @@ and Bun-compiled Docker mock requests, OAuth inference and continuation, workloa
 credential probes, process cancellation, abrupt bridge death, stolen-grant rejection across two
 runtimes, a listening host-service access probe, Docker migration and cleanup.
 Adversarial Docker regressions additionally cover privileged PATH shadowing on
-restart, relay SIGKILL, detached descendants, supervisor signal protection, and
+restart, relay SIGKILL, detached descendants, supervisor signal protection,
+SIGSTOP'd relay cancellation (including blocked input), and
 preservation of concurrent executions. Node and Bun unit tests also
 cover API-key substitution, token-counting policy, SSE/cache usage, grant rejection,
 rotation/source pinning, errors/redirects and active upstream disconnection observed

--- a/docs/claude-auth-broker.md
+++ b/docs/claude-auth-broker.md
@@ -57,7 +57,7 @@ vicoop-client --backend claude --runtime container
 
 `container init claude --from-host` is accepted for compatibility but does not
 copy secrets. Both forms validate host authentication. The runtime image must
-contain Node, `iptables`, `ip6tables` and the normal install recipe (the existing
+contain Node at `/usr/local/bin/node`, `/usr/bin/tini`, `iptables`, `ip6tables` and the normal install recipe (the existing
 `vicoop-runtime` image includes them).
 
 ## Existing runtime migration
@@ -125,8 +125,10 @@ code in the **same** runtime can read/use an active grant: main's single runtime
 is not a caller boundary. R2 must bind relay/runtime ownership to the authorized
 caller scope, lease and generation before caller-isolation claims are made.
 
-The runtime runs as `node` with `no-new-privileges`. Before agent use, the host
-installs firewall rules through a privileged Docker control-plane exec. Private,
+The workload runs as `node` with `no-new-privileges`. Before agent use, the host
+installs firewall rules through a privileged Docker control-plane exec using an
+absolute shell path and a fixed system-only PATH. Writable agent binaries cannot
+replace these privileged commands on restart. Private,
 link-local and host interface/gateway destinations are rejected, and IPv6 egress
 is blocked except loopback. DNS (UDP/TCP port 53) is allowed only to the
 configured IPv4 resolvers, including Docker default-bridge private resolvers. Public internet tool traffic remains subject to the
@@ -144,9 +146,20 @@ The relay rewrites their arguments to private execution-owned temporary files
 and removes those files on exit. Workload frames cannot request host files.
 
 Completion, cancellation, transport loss and shutdown revoke the grant and close
-active upstream connections. The relay owns an agent process group and terminates
-it on cancellation or Docker stdin loss; killing only the host `docker exec`
-process is not used as proof of agent termination. Startup failure, malformed
+active upstream connections. Each execution runs under its own root-owned tini
+subreaper and supervisor, started using absolute image-owned binaries with Node
+and dynamic-loader injection variables cleared. The supervisor only forwards
+opaque stdio and manages process lifetime; it never interprets workload frames
+or runs workload commands as root. It drops the relay to UID/GID 1000 before
+execution. Workload code cannot signal the supervisor. On relay exit, stdin loss
+or TTL expiry, it stops and kills all descendants of that execution's subreaper,
+including detached/double-forked children, while preserving other executions.
+The host waits for supervisor exit and pipe drainage before reporting task close.
+If supervisor/Docker exit leaves cleanup uncertain, the adapter stops accepting
+work and attempts to stop the entire shared runtime through Docker; this also
+interrupts other tasks. Docker control-plane availability remains required for
+that fallback. Killing only the host `docker exec` process is not used as proof
+of agent termination. Startup failure, malformed
 frames and transport limits fail the child execution. A new daemon/spawn creates
 new random grants; old grants have no surviving broker and cannot be resumed.
 A hard host crash can leave an inert Unix socket file in its private temporary
@@ -211,7 +224,10 @@ spike was replaced by the reviewable modules and smoke script in this change.
 Validated on 2026-09-10 with macOS Docker Desktop (Linux Docker engine): Node/tsx
 and Bun-compiled Docker mock requests, OAuth inference and continuation, workload
 credential probes, process cancellation, abrupt bridge death, stolen-grant rejection across two
-runtimes, a listening host-service access probe, Docker migration and cleanup. Node and Bun unit tests also
+runtimes, a listening host-service access probe, Docker migration and cleanup.
+Adversarial Docker regressions additionally cover privileged PATH shadowing on
+restart, relay SIGKILL, detached descendants, supervisor signal protection, and
+preservation of concurrent executions. Node and Bun unit tests also
 cover API-key substitution, token-counting policy, SSE/cache usage, grant rejection,
 rotation/source pinning, errors/redirects and active upstream disconnection observed
 by an independent Node process. Migration tests cover preservation and excluded

--- a/docs/claude-auth-broker.md
+++ b/docs/claude-auth-broker.md
@@ -105,7 +105,10 @@ there is no automatic downgrade or silent direct-auth fallback.
 
 ## Transport and lifecycle
 
-Each agent spawn owns a random grant, an HTTP broker on a Unix socket in a
+Each agent spawn owns a random `vbc_exec_<64 hex characters>` grant. This
+provider-independent prefix distinguishes it from real Anthropic credentials;
+the environment variable still matches the selected OAuth/API-key mode. The
+spawn also owns an HTTP broker on a Unix socket in a
 host-private temporary directory (mode 0700), and a Docker exec relay. No host
 TCP port is opened and no Unix socket/path is mounted into Docker. The relay
 listens only on `127.0.0.1` inside its runtime and multiplexes HTTP and agent

--- a/docs/container.md
+++ b/docs/container.md
@@ -12,6 +12,10 @@ agent runtime containers via `docker exec`. The two profiles coexist;
 choose whichever fits your deployment. This doc is the bundled-direct
 side ([#244][244]).
 
+For Claude **external-runtime** authentication and migration, see
+[Claude host authentication broker](./claude-auth-broker.md). The credential
+environment examples below apply only to bundled-direct.
+
 [244]: https://github.com/planetarium/vicoop-bridge/issues/244
 [249]: https://github.com/planetarium/vicoop-bridge/issues/249
 

--- a/packages/client/scripts/auth-broker/smoke.ts
+++ b/packages/client/scripts/auth-broker/smoke.ts
@@ -38,12 +38,13 @@ const docker = (args: string[]) => {
   if (r.status !== 0) throw new Error(`Docker ${args[0]} failed (exit ${r.status}); output withheld`);
   return r.stdout;
 };
-function capture(child: ChildHandle, input = '') {
+function capture(child: ChildHandle, input = '', endInput = true) {
   let stdout = ''; let stderr = '';
   child.stdout!.on('data', c => stdout += c);
   child.stderr!.on('data', c => stderr += c);
   const closed = new Promise<{ code: number | null; stdout: string; stderr: string }>(resolve => child.on('close', code => resolve({ code, stdout, stderr })));
-  child.stdin!.end(input);
+  if (endInput) child.stdin!.end(input);
+  else if (input) child.stdin!.write(input);
   return closed;
 }
 let forwarded = 0;
@@ -176,7 +177,7 @@ try {
   const survivorDone=capture(survivor);
   try {
     await survivorReady;
-    for (const mode of ['relay-death','cancel-detached']) {
+    for (const mode of ['relay-death','cancel-detached','stopped-relay-term','stopped-relay-kill','stopped-relay-blocked-input']) {
       const attack=adapter.spawn('node',['-e',`
         const {spawn}=require('child_process');
         const stat=require('fs').readFileSync('/proc/'+process.ppid+'/stat','utf8');
@@ -186,18 +187,37 @@ try {
         require('assert/strict').ok(protectedSupervisor,'workload can kill its supervisor');
         const detached=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:'ignore'});
         detached.unref();
-        console.log(JSON.stringify({pid:process.pid,detached:detached.pid}));
+        console.log(JSON.stringify({pid:process.pid,detached:detached.pid,relay:process.ppid}));
         ${mode==='relay-death' ? "setTimeout(()=>process.kill(process.ppid,'SIGKILL'),50);" : ''}
+        ${mode.startsWith('stopped-relay') ? "setTimeout(()=>process.kill(process.ppid,'SIGSTOP'),50);" : ''}
         setInterval(()=>{},1000);
       `],{});
       let attackText='';
       const attackReady=new Promise<void>(resolve=>attack.stdout!.on('data',c=>{attackText+=c;if(attackText.includes('\n'))resolve();}));
-      const attackDone=capture(attack);
+      const attackDone=capture(attack,'',mode!=='stopped-relay-blocked-input');
       await attackReady;
-      if(mode==='cancel-detached') attack.kill('SIGTERM');
-      const outcome=await attackDone;
-      assert.notEqual(outcome.code,0,'attack must not report success');
       const pids=JSON.parse(attackText);
+      if (mode.startsWith('stopped-relay')) {
+        let stopped=false;
+        for(let n=0;n<30;n++) {
+          const stat=docker(['exec',container,'/bin/cat',`/proc/${pids.relay}/stat`]);
+          stopped=stat.slice(stat.lastIndexOf(')')+2).startsWith('T ');
+          if(stopped) break;
+          await new Promise(r=>setTimeout(r,25));
+        }
+        assert.ok(stopped,'attack did not stop the relay');
+        if(mode==='stopped-relay-blocked-input') {
+          attack.stdin!.write(Buffer.alloc(2*1024*1024,120));
+          await new Promise(r=>setTimeout(r,100));
+        }
+        attack.kill(mode==='stopped-relay-kill' ? 'SIGKILL' : 'SIGTERM');
+      }
+      if(mode==='cancel-detached') attack.kill('SIGTERM');
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const outcome=await Promise.race([attackDone,new Promise<never>((_,reject)=>{
+        timeout=setTimeout(()=>reject(new Error(`${mode}: cancellation exceeded 5 seconds`)),5000);
+      })]).finally(()=>clearTimeout(timeout));
+      assert.notEqual(outcome.code,0,'attack must not report success');
       for(const pid of [pids.pid,pids.detached]) {
         assert.notEqual(spawnSync('docker',['exec',container,'/usr/bin/test','-e',`/proc/${pid}`]).status,0,
           `${mode}: workload survived completed cleanup`);
@@ -262,7 +282,7 @@ try {
     }
     assert.ok(!exists,'workload survived abrupt bridge death');
   } finally { worker.kill('SIGKILL'); rmSync(workerTemp,{recursive:true,force:true}); }
-  console.log(JSON.stringify({mode:real?`real-${authentication}`:'mock-oauth-and-api-key', success:true, mockRequests:real?undefined:forwarded, cancellation:true, hostCrash:true, stolenGrantRejected:true, privilegedPathIsolated:true, relayDeathCleanup:true, detachedCleanup:true, concurrentExecutionPreserved:true}));
+  console.log(JSON.stringify({mode:real?`real-${authentication}`:'mock-oauth-and-api-key', success:true, mockRequests:real?undefined:forwarded, cancellation:true, hostCrash:true, stolenGrantRejected:true, privilegedPathIsolated:true, relayDeathCleanup:true, detachedCleanup:true, stoppedRelayCancellation:true, blockedInputCancellation:true, concurrentExecutionPreserved:true}));
 } finally {
   adapter.close(); upstream.closeAllConnections(); await new Promise<void>(r => upstream.close(() => r()));
   spawnSync('docker', ['rm', '-f', container], { stdio: 'ignore' });

--- a/packages/client/scripts/auth-broker/smoke.ts
+++ b/packages/client/scripts/auth-broker/smoke.ts
@@ -74,6 +74,20 @@ try {
     '--entrypoint','sh',process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest',
     '-c','mkdir -p /legacy/projects; echo legacy-secret > /legacy/.credentials.json; echo conversation > /legacy/projects/history.jsonl; chmod -R a+rX /legacy']);
   await runtime.start();
+  // A previous task can write to the agent PATH. Restart must never run its
+  // shell or firewall commands as root. Poison only this disposable runtime.
+  docker(['exec','--user','0',container,'/bin/chown','node:node','/data/agents/claude']);
+  docker(['exec',container,'/usr/local/bin/node','-e',String.raw`
+    const fs=require('fs'); fs.mkdirSync('/data/agents/claude/bin',{recursive:true});
+    for (const [name,target] of [['sh','/bin/sh'],['iptables','/usr/sbin/iptables'],['awk','/usr/bin/awk']]) {
+      fs.writeFileSync('/data/agents/claude/bin/'+name,
+        '#!/bin/sh\n/usr/bin/touch /tmp/root-path-poisoned\nexec '+target+' "$@"\n',{mode:0o755});
+    }
+  `]);
+  await new RuntimeContainer({backendKind:'claude',runtimeName:id}).start();
+  assert.notEqual(spawnSync('docker',['exec',container,'/usr/bin/test','-e','/tmp/root-path-poisoned']).status,0,
+    'workload-controlled PATH ran during privileged startup');
+  docker(['exec',container,'/bin/rm','/data/agents/claude/bin/sh','/data/agents/claude/bin/iptables','/data/agents/claude/bin/awk']);
   docker(['exec', '--user', '0', container, 'chown', '-R', 'node:node', '/data/sessions/claude']);
   await migrateClaudeSessions(id, process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest', createLogger());
   assert.equal(docker(['exec',container,'cat','/data/sessions/claude/config/projects/history.jsonl']).trim(),'conversation');
@@ -154,6 +168,44 @@ try {
   const pid = Number(pidText.trim()); assert.ok(Number.isInteger(pid));
   const alive = spawnSync('docker', ['exec', container, 'test', '-e', `/proc/${pid}`]);
   assert.notEqual(alive.status, 0, 'cancelled process survived');
+  // Cleanup is independent of the unprivileged relay, includes setsid children,
+  // and must not kill another execution in the same shared runtime.
+  const survivor=adapter.spawn('node',['-e','console.log(process.pid);setInterval(()=>{},1000)'],{});
+  let survivorText='';
+  const survivorReady=new Promise<void>(resolve=>survivor.stdout!.on('data',c=>{survivorText+=c;if(survivorText.includes('\n'))resolve();}));
+  const survivorDone=capture(survivor);
+  try {
+    await survivorReady;
+    for (const mode of ['relay-death','cancel-detached']) {
+      const attack=adapter.spawn('node',['-e',`
+        const {spawn}=require('child_process');
+        const stat=require('fs').readFileSync('/proc/'+process.ppid+'/stat','utf8');
+        const supervisor=Number(stat.slice(stat.lastIndexOf(')')+2).split(' ')[1]);
+        let protectedSupervisor=false;
+        try {process.kill(supervisor,'SIGKILL');} catch(e) {protectedSupervisor=e.code==='EPERM';}
+        require('assert/strict').ok(protectedSupervisor,'workload can kill its supervisor');
+        const detached=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:'ignore'});
+        detached.unref();
+        console.log(JSON.stringify({pid:process.pid,detached:detached.pid}));
+        ${mode==='relay-death' ? "setTimeout(()=>process.kill(process.ppid,'SIGKILL'),50);" : ''}
+        setInterval(()=>{},1000);
+      `],{});
+      let attackText='';
+      const attackReady=new Promise<void>(resolve=>attack.stdout!.on('data',c=>{attackText+=c;if(attackText.includes('\n'))resolve();}));
+      const attackDone=capture(attack);
+      await attackReady;
+      if(mode==='cancel-detached') attack.kill('SIGTERM');
+      const outcome=await attackDone;
+      assert.notEqual(outcome.code,0,'attack must not report success');
+      const pids=JSON.parse(attackText);
+      for(const pid of [pids.pid,pids.detached]) {
+        assert.notEqual(spawnSync('docker',['exec',container,'/usr/bin/test','-e',`/proc/${pid}`]).status,0,
+          `${mode}: workload survived completed cleanup`);
+      }
+      assert.equal(spawnSync('docker',['exec',container,'/usr/bin/test','-e',`/proc/${Number(survivorText.trim())}`]).status,0,
+        'cleanup killed an unrelated execution');
+    }
+  } finally {survivor.kill('SIGKILL');await survivorDone;}
   // A stolen grant must fail in a second runtime, not just a second request.
   const peerId = `${id}-peer`;
   const peer = new RuntimeContainer({backendKind:'claude',runtimeName:peerId,
@@ -210,7 +262,7 @@ try {
     }
     assert.ok(!exists,'workload survived abrupt bridge death');
   } finally { worker.kill('SIGKILL'); rmSync(workerTemp,{recursive:true,force:true}); }
-  console.log(JSON.stringify({mode:real?`real-${authentication}`:'mock-oauth-and-api-key', success:true, mockRequests:real?undefined:forwarded, cancellation:true, hostCrash:true, stolenGrantRejected:true}));
+  console.log(JSON.stringify({mode:real?`real-${authentication}`:'mock-oauth-and-api-key', success:true, mockRequests:real?undefined:forwarded, cancellation:true, hostCrash:true, stolenGrantRejected:true, privilegedPathIsolated:true, relayDeathCleanup:true, detachedCleanup:true, concurrentExecutionPreserved:true}));
 } finally {
   adapter.close(); upstream.closeAllConnections(); await new Promise<void>(r => upstream.close(() => r()));
   spawnSync('docker', ['rm', '-f', container], { stdio: 'ignore' });

--- a/packages/client/scripts/auth-broker/smoke.ts
+++ b/packages/client/scripts/auth-broker/smoke.ts
@@ -83,7 +83,7 @@ try {
     (async () => {
       const assert = require('assert/strict'), fs = require('fs');
       assert.ok(!JSON.stringify(process.env).includes(['fixture','host','only'].join('-')));
-      assert.ok(!process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY.startsWith('sk-ant-api03-bridge-'));
+      assert.ok((process.env.CLAUDE_CODE_OAUTH_TOKEN || process.env.ANTHROPIC_API_KEY || '').startsWith('vbc_exec_'));
       assert.ok(!fs.existsSync('/data/creds/claude/.credentials.json'));
       assert.ok(!fs.existsSync('/data/sessions/claude/config/.credentials.json'));
       assert.ok(!fs.readFileSync('/proc/self/cmdline','utf8').includes(['fixture','host','only'].join('-')));

--- a/packages/client/scripts/auth-broker/smoke.ts
+++ b/packages/client/scripts/auth-broker/smoke.ts
@@ -1,0 +1,219 @@
+// Real Docker transport/runtime smoke. --real uses the existing host OAuth
+// allowance for two small Haiku turns; otherwise only a local mock is called.
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { spawnSync, spawn } from 'node:child_process';
+import { createClaudeBrokerSpawn } from '../../src/claude-broker-spawn.js';
+import { createClaudeCredentialReader } from '../../src/claude-auth-broker.js';
+import { RuntimeContainer } from '../../src/runtime-container.js';
+import { migrateClaudeSessions } from '../../src/container-init.js';
+import { createLogger } from '../../src/logger.js';
+import type { ChildHandle } from '../../src/spawn-adapter.js';
+
+// A separate bridge process used to verify abrupt host death, including under
+// Bun --compile. Its only output is the workload PID, never its grant/secret.
+const workerIndex = process.argv.indexOf('--crash-worker');
+if (workerIndex >= 0) {
+  const workerAdapter = createClaudeBrokerSpawn(process.argv[workerIndex + 1], {
+    credential: () => ({kind:'oauth',secret:'fixture-host-only'}),
+  });
+  const child = workerAdapter.spawn('node',['-e','console.log(process.pid); setInterval(()=>{},1000)'],{});
+  child.stdout!.on('data',c=>process.stdout.write(c)); child.stderr!.resume(); child.stdin!.end();
+  await new Promise(() => {});
+}
+
+const real = process.argv.includes('--real') || process.argv.includes('--real-api');
+const authentication = process.argv.includes('--real-api') ? 'api-key' : 'oauth';
+const id = `auth-${randomBytes(6).toString('hex')}`;
+const runtime = new RuntimeContainer({ backendKind: 'claude', runtimeName: id,
+  image: process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest', createIfMissing: true, failIfExists: true });
+const container = runtime.getContainerName();
+const docker = (args: string[]) => {
+  const r = spawnSync('docker', args, { encoding: 'utf8', timeout: 60_000, maxBuffer: 4 * 1024 * 1024 });
+  if (r.status !== 0) throw new Error(`Docker ${args[0]} failed (exit ${r.status}); output withheld`);
+  return r.stdout;
+};
+function capture(child: ChildHandle, input = '') {
+  let stdout = ''; let stderr = '';
+  child.stdout!.on('data', c => stdout += c);
+  child.stderr!.on('data', c => stderr += c);
+  const closed = new Promise<{ code: number | null; stdout: string; stderr: string }>(resolve => child.on('close', code => resolve({ code, stdout, stderr })));
+  child.stdin!.end(input);
+  return closed;
+}
+let forwarded = 0;
+let hostProbeReached = 0;
+let fakeKind: 'oauth' | 'api-key' = 'oauth';
+const upstream = createServer(async (req, res) => {
+  if (req.method === 'GET') { hostProbeReached++; res.end('test host service'); return; }
+  assert.equal(req.headers[fakeKind === 'oauth' ? 'authorization' : 'x-api-key'], fakeKind === 'oauth' ? 'Bearer fixture-host-only' : 'fixture-host-only');
+  for await (const _ of req) { /* drain */ }
+  forwarded++;
+  res.writeHead(200, { 'content-type': 'text/event-stream', 'x-secret': 'fixture-host-only' });
+  res.end('data: {"ok":true}\n\n');
+});
+// Test-only host service to prove the workload cannot reach a listening port.
+upstream.listen(0, '0.0.0.0'); await once(upstream, 'listening');
+const credential = real ? createClaudeCredentialReader() : () => ({ kind: fakeKind, secret: 'fixture-host-only' });
+if (real) assert.equal((await credential()).kind,authentication,'Real smoke auth mode must match the selected host credential');
+const adapter = createClaudeBrokerSpawn(container, {
+  credential, authentication,
+  ...(real ? {} : { upstream: `http://127.0.0.1:${(upstream.address() as {port:number}).port}` }),
+  ttlMs: 180_000,
+});
+try {
+  // Legacy fixture contains a sentinel login plus a conversation. No real secret.
+  docker(['volume','create',`vicoop-creds-${id}`]);
+  docker(['run','--rm','--network','none','--user','0',
+    '--mount',`type=volume,source=vicoop-creds-${id},target=/legacy`,
+    '--entrypoint','sh',process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest',
+    '-c','mkdir -p /legacy/projects; echo legacy-secret > /legacy/.credentials.json; echo conversation > /legacy/projects/history.jsonl; chmod -R a+rX /legacy']);
+  await runtime.start();
+  docker(['exec', '--user', '0', container, 'chown', '-R', 'node:node', '/data/sessions/claude']);
+  await migrateClaudeSessions(id, process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest', createLogger());
+  assert.equal(docker(['exec',container,'cat','/data/sessions/claude/config/projects/history.jsonl']).trim(),'conversation');
+  const inspect = JSON.parse(docker(['inspect', '--format', '{{json .}}', container]));
+  assert.ok(!inspect.Mounts.some((m: {Destination:string}) => m.Destination === '/data/creds/claude' && m.Type !== 'tmpfs'));
+  const probe = await capture(adapter.spawn('node', ['-e', `
+    (async () => {
+      const assert = require('assert/strict'), fs = require('fs');
+      assert.ok(!JSON.stringify(process.env).includes(['fixture','host','only'].join('-')));
+      assert.ok(!process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY.startsWith('sk-ant-api03-bridge-'));
+      assert.ok(!fs.existsSync('/data/creds/claude/.credentials.json'));
+      assert.ok(!fs.existsSync('/data/sessions/claude/config/.credentials.json'));
+      assert.ok(!fs.readFileSync('/proc/self/cmdline','utf8').includes(['fixture','host','only'].join('-')));
+      // Network boundary: the private host gateway is not reachable.
+      let denied = false;
+      try { await fetch('http://host.docker.internal:${(upstream.address() as {port:number}).port}', {signal:AbortSignal.timeout(1000)}); } catch { denied = true; }
+      assert.ok(denied);
+      if (!${real}) {
+        const r = await fetch(process.env.ANTHROPIC_BASE_URL+'/v1/messages', {
+          method:'POST',headers:{authorization:'Bearer '+process.env.CLAUDE_CODE_OAUTH_TOKEN},
+          body:JSON.stringify({model:'claude-haiku-4-5',max_tokens:32,messages:[]})});
+        assert.equal(r.status,200); assert.equal(r.headers.get('x-secret'),null);
+        assert.equal(await r.text(),'data: {"ok":true}\\n\\n');
+      }
+      console.log(JSON.stringify({probe:'pass',env:process.env,argv:fs.readFileSync('/proc/self/cmdline','utf8'),processEnv:fs.readFileSync('/proc/self/environ','utf8')}));
+    })().catch(() => { console.log('probe-fail'); process.exitCode=1; });
+  `], {}));
+  assert.equal(probe.code, 0, 'workload probe failed (diagnostics withheld)');
+  assert.ok(probe.stdout.includes('\"probe\":\"pass\"'),'workload probe did not complete');
+  const providerSecret=(await credential()).secret;
+  assert.ok(!(probe.stdout+probe.stderr).includes(providerSecret),'workload exposed the host provider credential');
+  assert.equal(hostProbeReached,0,'workload reached the listening host service');
+  if (!real) {
+    fakeKind = 'api-key';
+    const apiAdapter = createClaudeBrokerSpawn(container,{credential,authentication:'api-key',upstream:`http://127.0.0.1:${(upstream.address() as {port:number}).port}`});
+    const r = await capture(apiAdapter.spawn('node', ['-e', `
+      if (process.env.CLAUDE_CODE_OAUTH_TOKEN) throw Error('unexpected OAuth token');
+      fetch(process.env.ANTHROPIC_BASE_URL+'/v1/messages/count_tokens', {method:'POST',
+        headers:{'x-api-key':process.env.ANTHROPIC_API_KEY},
+        body:JSON.stringify({model:'claude-sonnet-4-6',messages:[]})})
+      .then(r=>{if(r.status!==200)process.exitCode=1;return r.text()}).catch(()=>process.exitCode=1);
+    `], {}));
+    apiAdapter.close();
+    assert.equal(r.code, 0); assert.equal(forwarded, 2);
+  } else {
+    // Install the already-cached test Claude binary, never copying credentials.
+    const source = `${id}-binary`;
+    const image = process.env.VICOOP_SMOKE_CLAUDE_IMAGE ?? 'vicoop-caller-r2-validation:latest';
+    const temp = mkdtempSync(join(tmpdir(), 'vicoop-auth-binary-'));
+    try {
+      docker(['create', '--name', source, '--network', 'none', image]);
+      docker(['cp', '-L', `${source}:/usr/local/bin/claude`, join(temp, 'claude')]);
+      docker(['exec', '--user', '0', container, 'mkdir', '-p', '/data/agents/claude/bin']);
+      docker(['cp', join(temp, 'claude'), `${container}:/data/agents/claude/bin/claude`]);
+    } finally { spawnSync('docker', ['rm', '-f', source], { stdio: 'ignore' }); rmSync(temp, {recursive:true,force:true}); }
+    const common = ['-p', '--model', 'haiku', '--output-format', 'json', '--max-turns', '1', '--tools', '',
+      '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}', '--setting-sources', '', '--dangerously-skip-permissions'];
+    const first = await capture(adapter.spawn('claude', [...common, 'Remember the word ORCHID. Reply only OK.'], {}));
+    assert.ok(!(first.stdout+first.stderr).includes(providerSecret),'inference diagnostics exposed a provider credential');
+    let result; try { result = JSON.parse(first.stdout); } catch {}
+    console.log(JSON.stringify({mode:`real-${authentication}`, turn:1, code:first.code, subtype:result?.subtype}));
+    assert.equal(first.code, 0, 'real inference failed (raw diagnostics withheld)');
+    assert.equal(result?.subtype, 'success'); assert.ok(result?.usage?.output_tokens > 0);
+    const next = await capture(adapter.spawn('claude', [...common, '--resume', result.session_id, 'What word did I ask you to remember? Reply only that word.'], {}));
+    assert.ok(!(next.stdout+next.stderr).includes(providerSecret),'continuation diagnostics exposed a provider credential');
+    let continuation; try { continuation = JSON.parse(next.stdout); } catch {}
+    console.log(JSON.stringify({mode:`real-${authentication}`, turn:2, code:next.code, subtype:continuation?.subtype}));
+    assert.equal(next.code, 0); assert.equal(continuation?.subtype, 'success');
+    assert.match(continuation.result, /ORCHID/);
+    const snapshot = docker(['exec', container, 'sh', '-c', 'test ! -f /data/sessions/claude/config/.credentials.json && test ! -f /data/creds/claude/.credentials.json && echo clean']);
+    assert.match(snapshot, /clean/);
+  }
+  const child = adapter.spawn('node', ['-e', `console.log(process.pid); setInterval(()=>{},1000)`], {});
+  let pidText = '';
+  const pidReady = new Promise<void>(resolve => child.stdout!.on('data', c => { pidText += c; if (pidText.includes('\n')) resolve(); }));
+  const done = capture(child);
+  await pidReady; child.kill('SIGTERM'); await done;
+  const pid = Number(pidText.trim()); assert.ok(Number.isInteger(pid));
+  const alive = spawnSync('docker', ['exec', container, 'test', '-e', `/proc/${pid}`]);
+  assert.notEqual(alive.status, 0, 'cancelled process survived');
+  // A stolen grant must fail in a second runtime, not just a second request.
+  const peerId = `${id}-peer`;
+  const peer = new RuntimeContainer({backendKind:'claude',runtimeName:peerId,
+    image:process.env.VICOOP_SMOKE_IMAGE ?? 'ghcr.io/planetarium/vicoop-runtime:latest',createIfMissing:true,failIfExists:true});
+  const peerAdapter = createClaudeBrokerSpawn(peer.getContainerName(),{credential:()=>({kind:'oauth',secret:'fixture-host-only'})});
+  const owner = adapter.spawn('node',['-e',"console.log(JSON.stringify({token:process.env.CLAUDE_CODE_OAUTH_TOKEN||process.env.ANTHROPIC_API_KEY,url:process.env.ANTHROPIC_BASE_URL}));setInterval(()=>{},1000)"],{});
+  let grantText='';
+  const ownerDone=capture(owner);
+  try {
+    await new Promise<void>(resolve=>owner.stdout!.on('data',c=>{grantText+=c;if(grantText.includes('\n'))resolve();}));
+    const grant=JSON.parse(grantText);
+    await peer.start();
+    const rejected=await capture(peerAdapter.spawn('node',['-e',`
+      (async()=>{
+        const assert=require('assert/strict');
+        const response=await fetch(process.env.ANTHROPIC_BASE_URL+'/v1/messages',{method:'POST',
+          headers:{authorization:'Bearer '+${JSON.stringify(grant.token)}},
+          body:JSON.stringify({model:'claude-haiku-4-5',max_tokens:32,messages:[]})});
+        assert.equal(response.status,401);
+        // A's loopback endpoint is not exposed at A's container IP.
+        let unreachable=false;
+        try {await fetch('http://${JSON.parse(docker(['inspect','--format','{{json .NetworkSettings.IPAddress}}',container]))}:'+new URL(${JSON.stringify(grant.url)}).port,{signal:AbortSignal.timeout(1000)});}
+        catch {unreachable=true;}
+        assert.ok(unreachable);
+      })().catch(()=>{process.exitCode=1;});
+    `],{}));
+    assert.equal(rejected.code,0,'stolen grant crossed runtime boundary');
+  } finally {
+    owner.kill('SIGKILL'); await ownerDone; peerAdapter.close();
+    spawnSync('docker',['rm','-f',peer.getContainerName()],{stdio:'ignore'});
+    for(const prefix of ['agents','sessions'])spawnSync('docker',['volume','rm',`vicoop-${prefix}-${peerId}`],{stdio:'ignore'});
+  }
+
+  // Kill the owning host process without any orderly shutdown callback.
+  const workerArgs = process.versions.bun && !process.argv[1]?.endsWith('.ts')
+    ? ['--crash-worker',container]
+    : [...process.execArgv,process.argv[1],'--crash-worker',container];
+  const workerTemp=mkdtempSync(join(tmpdir(),'vbc-'));
+  const worker = spawn(process.execPath,workerArgs,{stdio:['ignore','pipe','pipe'],env:{...process.env,TMPDIR:workerTemp}});
+  let workerPidText = '';
+  try {
+    await new Promise<void>((resolve,reject)=>{
+      const timer=setTimeout(()=>reject(new Error('Crash worker startup timed out')),15000);
+      worker.stdout.on('data',c=>{workerPidText+=c;if(workerPidText.includes('\n')){clearTimeout(timer);resolve();}});
+      worker.on('error',()=>{clearTimeout(timer);reject(new Error('Crash worker failed'));});
+    });
+    const workloadPid=Number(workerPidText.trim()); assert.ok(Number.isInteger(workloadPid));
+    worker.kill('SIGKILL'); await once(worker,'close');
+    let exists=true;
+    for(let attempt=0;attempt<30;attempt++) {
+      exists=spawnSync('docker',['exec',container,'test','-e',`/proc/${workloadPid}`]).status===0;
+      if(!exists)break;
+      await new Promise(r=>setTimeout(r,100));
+    }
+    assert.ok(!exists,'workload survived abrupt bridge death');
+  } finally { worker.kill('SIGKILL'); rmSync(workerTemp,{recursive:true,force:true}); }
+  console.log(JSON.stringify({mode:real?`real-${authentication}`:'mock-oauth-and-api-key', success:true, mockRequests:real?undefined:forwarded, cancellation:true, hostCrash:true, stolenGrantRejected:true}));
+} finally {
+  adapter.close(); upstream.closeAllConnections(); await new Promise<void>(r => upstream.close(() => r()));
+  spawnSync('docker', ['rm', '-f', container], { stdio: 'ignore' });
+  for (const prefix of ['agents','sessions','creds']) spawnSync('docker', ['volume','rm',`vicoop-${prefix}-${id}`], { stdio: 'ignore' });
+  assert.equal(docker(['ps','-aq','--filter',`name=^/${container}$`]).trim(), '');
+}

--- a/packages/client/src/backends/claude-usage.ts
+++ b/packages/client/src/backends/claude-usage.ts
@@ -161,6 +161,37 @@ export function readClaudeOAuthCreds(
   return null;
 }
 
+// Broker credentials must keep reading the same store after rotation/removal.
+// Unlike the usage UI's best-effort reader, a missing selected Keychain entry
+// must not silently switch to a possibly different credentials-file account.
+function brokerKeychainLookup(service: string): string | null {
+  try {
+    return execFileSync('security', ['find-generic-password', '-s', service, '-w'],
+      { stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000 }).toString().trim() || null;
+  } catch (error) {
+    // security maps errSecItemNotFound (-25300) to exit status 44. Other
+    // failures (locked store, permissions, timeout) must not select a file.
+    if ((error as { status?: number }).status === 44) return null;
+    throw new Error('Cannot read host Claude Keychain login');
+  }
+}
+
+export function createPinnedClaudeOAuthReader(env: ClaudeCredEnv = {}): () => ClaudeOAuthCreds | null {
+  const platform = env.platform ?? process.platform;
+  const configDir = env.configDir ?? process.env.CLAUDE_CONFIG_DIR;
+  const path = join(configDir || join((env.homedir ?? homedir)(), '.claude'), '.credentials.json');
+  const lookup = env.keychainLookup ?? brokerKeychainLookup;
+  const read = env.readFileSync ?? readFileSync;
+  if (platform === 'darwin' && !configDir) {
+    let initial: string | null;
+    try { initial = lookup(CLAUDE_KEYCHAIN_SERVICE); } catch { throw new Error('Cannot read host Claude Keychain login'); }
+    if (initial) return () => {
+      try { const raw = lookup(CLAUDE_KEYCHAIN_SERVICE); return raw ? parseCreds(raw) : null; } catch { return null; }
+    };
+  }
+  return () => { try { return parseCreds(read(path).toString()); } catch { return null; } };
+}
+
 // Discover the installed Claude Code CLI version for the User-Agent (mirrors the
 // official client). Returns null on any failure; the caller substitutes the
 // fallback version.

--- a/packages/client/src/claude-auth-broker.test.ts
+++ b/packages/client/src/claude-auth-broker.test.ts
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { createServer as createTcpServer } from 'node:net';
+import { once } from 'node:events';
+import { createClaudeAuthBroker, createClaudeCredentialReader, type BrokerOptions } from './claude-auth-broker.js';
+import { createPinnedClaudeOAuthReader } from './backends/claude-usage.js';
+
+async function fixture(opts: Partial<BrokerOptions> = {}) {
+  const requests: { url: string | undefined; headers: Record<string, unknown>; body: unknown }[] = [];
+  let status = 200;
+  const upstream = createServer(async (req, res) => {
+    const parts: Buffer[] = []; for await (const p of req) parts.push(p);
+    requests.push({ url: req.url, headers: req.headers, body: JSON.parse(Buffer.concat(parts).toString()) });
+    res.writeHead(status, { location: 'http://unsafe.invalid', 'x-secret': 'HOST_SECRET' });
+    res.end(status === 200 ? '{"usage":{"cache_read_input_tokens":123}}' : 'HOST_SECRET');
+  });
+  upstream.listen(0, '127.0.0.1'); await once(upstream, 'listening');
+  const broker = createClaudeAuthBroker({ credential: () => ({ kind: 'api-key', secret: 'HOST_SECRET' }),
+    upstream: `http://127.0.0.1:${(upstream.address() as {port:number}).port}`, ...opts });
+  const tcp = createTcpServer(socket => broker.attach(socket));
+  tcp.listen(0, '127.0.0.1'); await once(tcp, 'listening');
+  const base = `http://127.0.0.1:${(tcp.address() as {port:number}).port}`;
+  const request = (path = '/v1/messages', body: unknown = { model: 'claude-sonnet-4-6', max_tokens: 1024, messages: [] }, token = broker.token) => fetch(base + path, {
+    method: 'POST', headers: { 'x-api-key': token, cookie: 'do-not-forward', 'x-forwarded-host': 'evil.invalid' }, body: JSON.stringify(body),
+  });
+  return { broker, requests, request, status: (s: number) => { status = s; }, async close() {
+    broker.revoke(); upstream.closeAllConnections();
+    await Promise.all([new Promise<void>(r => tcp.close(() => r())), new Promise<void>(r => upstream.close(() => r()))]);
+  } };
+}
+
+test('API key substitution, endpoint policy, usage and model pass through; errors and redirects sanitized', async () => {
+  const f = await fixture();
+  try {
+    assert.equal((await f.request('/v1/messages', undefined, 'forged')).status, 401);
+    assert.equal((await f.request('/v1/models')).status, 403);
+    assert.equal((await f.request('/v1/messages?destination=evil')).status, 403);
+    assert.equal((await f.request('/v1/messages', { model: 'gpt-test', max_tokens: 1 })).status, 403);
+    assert.equal(f.requests.length, 0);
+    const response = await f.request();
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-secret'), null);
+    assert.deepEqual(await response.json(), { usage: { cache_read_input_tokens: 123 } });
+    assert.equal(f.requests[0].headers['x-api-key'], 'HOST_SECRET');
+    assert.equal(f.requests[0].headers.authorization, undefined);
+    assert.equal(f.requests[0].headers.cookie, undefined);
+    assert.equal(f.requests[0].headers['x-forwarded-host'], undefined);
+    assert.equal((f.requests[0].body as {model:string}).model, 'claude-sonnet-4-6');
+    assert.equal((await f.request('/v1/messages/count_tokens?beta=true', { model: 'claude-opus-4-8', messages: [] })).status, 200);
+    f.status(302); const redirect = await f.request();
+    assert.equal(redirect.status, 502); assert.ok(!(await redirect.text()).includes('HOST_SECRET'));
+    f.status(401); const denied = await f.request();
+    assert.equal(denied.status, 401); assert.ok(!(await denied.text()).includes('HOST_SECRET'));
+  } finally { await f.close(); }
+});
+
+test('grants are execution-bound, request-limited, expire and revoke', async () => {
+  const a = await fixture({ maxRequests: 1 }); const b = await fixture();
+  try {
+    assert.equal((await b.request('/v1/messages', undefined, a.broker.token)).status, 401);
+    assert.equal(b.requests.length, 0);
+    assert.equal((await a.request()).status, 200);
+    assert.equal((await a.request()).status, 429);
+    a.broker.revoke(); await assert.rejects(a.request());
+  } finally { await a.close(); await b.close(); }
+  const expired = await fixture({ ttlMs: 20 });
+  try { await new Promise(r => setTimeout(r, 30)); await assert.rejects(expired.request()); assert.equal(expired.requests.length, 0); }
+  finally { await expired.close(); }
+});
+
+test('credential failure is sanitized and does not make upstream calls', async () => {
+  const f = await fixture({ credential: () => { throw new Error('HOST_SECRET'); } });
+  try { const r = await f.request(); assert.equal(r.status, 503); assert.ok(!(await r.text()).includes('HOST_SECRET')); assert.equal(f.requests.length, 0); }
+  finally { await f.close(); }
+});
+
+test('credential source is pinned; keychain removal cannot fall back to credentials file', () => {
+  let keychain: string | null = JSON.stringify({ claudeAiOauth: { accessToken: 'initial' } });
+  const reader = createPinnedClaudeOAuthReader({ platform: 'darwin', configDir: '', keychainLookup: () => keychain,
+    readFileSync: () => JSON.stringify({ claudeAiOauth: { accessToken: 'other-account' } }) });
+  assert.equal(reader()?.accessToken, 'initial');
+  keychain = JSON.stringify({ claudeAiOauth: { accessToken: 'rotated' } });
+  assert.equal(reader()?.accessToken, 'rotated');
+  keychain = null; assert.equal(reader(), null);
+  const env = { ANTHROPIC_API_KEY: 'initial' }; const api = createClaudeCredentialReader(env);
+  assert.deepEqual(api(), { kind: 'api-key', secret: 'initial' });
+  env.ANTHROPIC_API_KEY = ''; assert.throws(api, /unavailable/);
+  assert.throws(() => createClaudeCredentialReader({ ANTHROPIC_API_KEY: 'a', CLAUDE_CODE_OAUTH_TOKEN: 'b' }), /only one/);
+  assert.throws(() => createClaudeCredentialReader({ CLAUDE_CODE_USE_BEDROCK: '1' }), /unsupported/);
+});
+
+test('in-flight admission is bounded before credentials or upstream I/O', async () => {
+  let release!: () => void; let admitted!: () => void;
+  const entered = new Promise<void>(r => admitted = r);
+  const held = new Promise<void>(r => release = r);
+  const f = await fixture({ maxConcurrent:1, credential:async () => { admitted(); await held; return {kind:'oauth',secret:'HOST_SECRET'}; } });
+  try {
+    const first = f.request(); await entered;
+    assert.equal((await f.request()).status,429);
+    assert.equal(f.requests.length,0);
+    release(); assert.equal((await first).status,200);
+  } finally { release(); await f.close(); }
+});
+
+test('body resources and explicit model grants are enforced', async () => {
+  const f = await fixture({models:['claude-haiku-4-5']});
+  try {
+    assert.equal((await f.request()).status,403);
+    assert.equal((await f.request('/v1/messages',{model:'claude-haiku-4-5',max_tokens:128001})).status,403);
+    assert.equal((await f.request('/v1/messages',{model:'claude-haiku-4-5',max_tokens:32,messages:['x'.repeat(16*1024*1024)]})).status,413);
+    assert.equal(f.requests.length,0);
+  } finally { await f.close(); }
+});
+
+test('expired host login fails closed and rotation in its selected file recovers', async () => {
+  const {mkdtempSync,writeFileSync,rmSync} = await import('node:fs');
+  const {tmpdir} = await import('node:os'); const {join} = await import('node:path');
+  const dir = mkdtempSync(join(tmpdir(),'claude-login-test-'));
+  try {
+    const path = join(dir,'.credentials.json');
+    writeFileSync(path,JSON.stringify({claudeAiOauth:{accessToken:'expired',expiresAt:Date.now()-1}}));
+    const reader = createClaudeCredentialReader({CLAUDE_CONFIG_DIR:dir});
+    assert.throws(reader,/expired/);
+    writeFileSync(path,JSON.stringify({claudeAiOauth:{accessToken:'rotated',expiresAt:Date.now()+60000}}));
+    assert.deepEqual(reader(),{kind:'oauth',secret:'rotated'});
+    rmSync(path); assert.throws(reader,/missing/);
+  } finally { rmSync(dir,{recursive:true,force:true}); }
+});
+
+test('provider secrets/helpers in agent settings are rejected without echoing values', async () => {
+  const {assertClaudeBrokerSettings} = await import('./claude-auth-broker.js');
+  for (const settings of [{apiKeyHelper:'print SECRET'}, {env:{ANTHROPIC_API_KEY:'SECRET'}}, {env:{ANTHROPIC_BASE_URL:'http://other'}}]) {
+    assert.throws(()=>assertClaudeBrokerSettings(settings), e=>e instanceof Error && !e.message.includes('SECRET'));
+  }
+  assert.doesNotThrow(()=>assertClaudeBrokerSettings({env:{ENABLE_PROMPT_CACHING_1H:'1'}}));
+});

--- a/packages/client/src/claude-auth-broker.ts
+++ b/packages/client/src/claude-auth-broker.ts
@@ -74,7 +74,8 @@ export function createClaudeAuthBroker(opts: BrokerOptions) {
       !(origin.origin === 'https://api.anthropic.com' || (origin.protocol === 'http:' && origin.hostname === '127.0.0.1'))) {
     throw new Error('Invalid broker upstream');
   }
-  const token = `sk-ant-${opts.authentication === 'api-key' ? 'api03' : 'oat01'}-bridge-${randomBytes(32).toString('hex')}`;
+  // A bridge execution grant, deliberately distinct from provider credentials.
+  const token = `vbc_exec_${randomBytes(32).toString('hex')}`;
   const active = new Set<() => void>();
   const sockets = new Set<Duplex>();
   const stats = { forwarded: 0, rejected: 0 };

--- a/packages/client/src/claude-auth-broker.ts
+++ b/packages/client/src/claude-auth-broker.ts
@@ -1,0 +1,217 @@
+// One execution, one private Unix socket, no host TCP listener. Only the
+// owning Docker stdio transport can attach sockets; no host path is mounted.
+// A real socket (rather than Server.emit(connection, Duplex)) is necessary
+// for the native HTTP parser in Bun-compiled clients.
+import { createServer, request as httpRequest, type IncomingMessage, type ClientRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+import { once } from 'node:events';
+import type { Duplex } from 'node:stream';
+import { connect } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createPinnedClaudeOAuthReader } from './backends/claude-usage.js';
+
+export type ClaudeProviderCredential = { kind: 'oauth' | 'api-key'; secret: string };
+export type CredentialReader = () => ClaudeProviderCredential | Promise<ClaudeProviderCredential>;
+
+// Pin the source at daemon startup. Reread it on every request, without
+// falling back to a different credential type after expiry or removal.
+export function createClaudeCredentialReader(env: NodeJS.ProcessEnv = process.env): CredentialReader {
+  for (const key of ['CLAUDE_CODE_USE_BEDROCK', 'CLAUDE_CODE_USE_VERTEX', 'CLAUDE_CODE_USE_FOUNDRY']) {
+    if (env[key] && env[key] !== '0') throw new Error(`${key} is unsupported by Claude container authentication`);
+  }
+  if (env.ANTHROPIC_BASE_URL && env.ANTHROPIC_BASE_URL !== 'https://api.anthropic.com') {
+    throw new Error('Claude container authentication requires the direct Anthropic API');
+  }
+  const sources = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN'].filter(k => env[k]);
+  if (sources.length > 1) throw new Error('Set only one Claude host credential environment variable');
+  if (env.ANTHROPIC_AUTH_TOKEN) throw new Error('Use ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN for Claude container authentication');
+  const source = sources[0];
+  const readOAuth = source ? undefined : createPinnedClaudeOAuthReader({ configDir: env.CLAUDE_CONFIG_DIR });
+  return () => {
+    if (source) {
+      const secret = env[source];
+      if (!secret || /\s/.test(secret)) throw new Error('Claude host credential is unavailable; restore it and restart the daemon');
+      return { kind: source === 'ANTHROPIC_API_KEY' ? 'api-key' : 'oauth', secret };
+    }
+    const creds = readOAuth!();
+    if (!creds || /\s/.test(creds.accessToken) || (creds.expiresAt !== undefined && creds.expiresAt <= Date.now() + 30_000)) {
+      throw new Error('Claude host login is missing or expired; log in with Claude on the host and retry. The bridge does not refresh OAuth tokens.');
+    }
+    return { kind: 'oauth', secret: creds.accessToken };
+  };
+}
+
+export function assertClaudeBrokerSettings(settings: Record<string, unknown> | undefined): void {
+  if (!settings) return;
+  if (['apiKeyHelper', 'awsAuthRefresh', 'awsCredentialExport'].some(k => k in settings)) {
+    throw new Error('Claude container authentication helpers are unsupported; use host login or a host API key');
+  }
+  if (settings.env && typeof settings.env === 'object' && Object.keys(settings.env).some(k =>
+    /^(ANTHROPIC_|CLAUDE_CODE_OAUTH|CLAUDE_CODE_USE_|AWS_|AZURE_|GOOGLE_APPLICATION_CREDENTIALS$)/.test(k))) {
+    throw new Error('Claude container provider environment must be configured on the host, not in agent settings');
+  }
+}
+
+export interface BrokerOptions {
+  credential: CredentialReader;
+  authentication?: ClaudeProviderCredential['kind'];
+  // Trusted test seam; production never supplies a destination.
+  upstream?: string;
+  ttlMs?: number;
+  timeoutMs?: number;
+  maxRequests?: number;
+  maxConcurrent?: number;
+  models?: readonly string[];
+  onCredentialFailure?: () => void;
+}
+
+export function createClaudeAuthBroker(opts: BrokerOptions) {
+  const origin = new URL(opts.upstream ?? 'https://api.anthropic.com');
+  if (origin.pathname !== '/' || origin.search || origin.hash || origin.username || origin.password ||
+      !(origin.origin === 'https://api.anthropic.com' || (origin.protocol === 'http:' && origin.hostname === '127.0.0.1'))) {
+    throw new Error('Invalid broker upstream');
+  }
+  const token = `sk-ant-${opts.authentication === 'api-key' ? 'api03' : 'oat01'}-bridge-${randomBytes(32).toString('hex')}`;
+  const active = new Set<() => void>();
+  const sockets = new Set<Duplex>();
+  const stats = { forwarded: 0, rejected: 0 };
+  let revoked = false;
+  let admitted = 0;
+  const timeoutMs = opts.timeoutMs ?? 300_000;
+  const deadline = Date.now() + (opts.ttlMs ?? 60 * 60_000);
+  const server = createServer({ maxHeaderSize: 16 * 1024 }, async (req, res) => {
+    const deny = (status: number) => {
+      stats.rejected++;
+      res.writeHead(status, { 'content-type': 'application/json', connection: 'close', 'cache-control': 'no-store' });
+      res.end('{"error":{"type":"authentication_broker_error","message":"Request rejected by host authentication broker"}}');
+    };
+    const supplied = Buffer.from(req.headers.authorization?.replace(/^Bearer /, '') ?? String(req.headers['x-api-key'] ?? ''));
+    const expected = Buffer.from(token);
+    if (revoked || Date.now() >= deadline || supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) return deny(401);
+    if (req.method !== 'POST' || !['/v1/messages', '/v1/messages?beta=true', '/v1/messages/count_tokens', '/v1/messages/count_tokens?beta=true'].includes(req.url ?? '')) return deny(403);
+    if (active.size >= (opts.maxConcurrent ?? 4) || admitted >= (opts.maxRequests ?? 256)) return deny(429);
+    admitted++;
+    const controller = new AbortController();
+    let upstreamRequest: ClientRequest | undefined;
+    let upstreamResponse: IncomingMessage | undefined;
+    const stopUpstream = () => {
+      upstreamResponse?.socket?.destroy();
+      upstreamRequest?.socket?.destroy();
+      upstreamResponse?.destroy();
+      upstreamRequest?.destroy(new Error('Cancelled'));
+    };
+    const abort = () => { controller.abort(); req.destroy(); res.destroy(); };
+    active.add(abort);
+    const timer = setTimeout(abort, timeoutMs);
+    controller.signal.addEventListener('abort', stopUpstream, { once: true });
+    const disconnected = () => { if (!res.writableEnded) controller.abort(); };
+    res.on('close', disconnected);
+    try {
+      const chunks: Buffer[] = [];
+      let bytes = 0;
+      for await (const chunk of req) {
+        bytes += chunk.length;
+        if (bytes > 16 * 1024 * 1024) { deny(413); return; }
+        chunks.push(Buffer.from(chunk));
+      }
+      const body = Buffer.concat(chunks);
+      let data;
+      try { data = JSON.parse(body.toString('utf8')); } catch { deny(400); return; }
+      if (!data || typeof data !== 'object' || typeof data.model !== 'string' ||
+          !/^claude-(?:haiku|sonnet|opus)-[a-zA-Z0-9.-]+$/.test(data.model) ||
+          (opts.models && !opts.models.includes(data.model)) ||
+          (!req.url!.includes('count_tokens') && (!Number.isInteger(data.max_tokens) || data.max_tokens < 1 || data.max_tokens > 128_000))) {
+        deny(403); return;
+      }
+      let credential: ClaudeProviderCredential;
+      try { credential = await opts.credential(); } catch {
+        opts.onCredentialFailure?.();
+        deny(503); return;
+      }
+      if (controller.signal.aborted || revoked) return;
+      if (!credential.secret || /\s/.test(credential.secret)) { deny(503); return; }
+      const headers: Record<string, string> = { 'content-type': 'application/json', 'anthropic-version': '2023-06-01' };
+      headers[credential.kind === 'oauth' ? 'authorization' : 'x-api-key'] = credential.kind === 'oauth' ? `Bearer ${credential.secret}` : credential.secret;
+      const beta = String(req.headers['anthropic-beta'] ?? '');
+      if (!/^[a-zA-Z0-9,._-]*$/.test(beta)) { deny(400); return; }
+      const betas = beta.split(',').filter(v => v && (credential.kind === 'oauth' || v !== 'oauth-2025-04-20'));
+      if (credential.kind === 'oauth') betas.push('oauth-2025-04-20');
+      if (betas.length) headers['anthropic-beta'] = [...new Set(betas)].join(',');
+      for (const name of ['user-agent', 'x-app']) if (typeof req.headers[name] === 'string') headers[name] = req.headers[name];
+      stats.forwarded++;
+      const result = await new Promise<IncomingMessage>((resolve, reject) => {
+        upstreamRequest = (origin.protocol === 'https:' ? httpsRequest : httpRequest)(
+          `${origin.origin}${req.url}`, { method: 'POST', headers, agent: false }, resolve);
+        upstreamRequest.on('error', reject);
+        upstreamRequest.end(body);
+      });
+      upstreamResponse = result;
+      if (controller.signal.aborted) { result.destroy(); return; }
+      const status = result.statusCode ?? 502;
+      if (status < 200 || status >= 300) {
+        result.destroy();
+        if (status === 401 || status === 403) opts.onCredentialFailure?.();
+        deny(status >= 300 && status < 400 ? 502 : status); return;
+      }
+      res.writeHead(status, { 'content-type': result.headers['content-type'] ?? 'application/json', 'cache-control': 'no-store' });
+      let received = 0;
+      for await (const chunk of result) {
+        received += chunk.length;
+        if (received > 64 * 1024 * 1024) { abort(); return; }
+        if (!res.write(chunk)) await once(res, 'drain', { signal: controller.signal });
+      }
+      res.end();
+    } catch {
+      if (!res.destroyed) {
+        if (res.headersSent) res.destroy(); else deny(502);
+      }
+    } finally {
+      clearTimeout(timer);
+      controller.signal.removeEventListener('abort', stopUpstream);
+      stopUpstream();
+      active.delete(abort);
+      res.off('close', disconnected);
+    }
+  });
+  server.requestTimeout = timeoutMs;
+  server.headersTimeout = Math.min(timeoutMs, 10_000);
+  server.maxHeadersCount = 32;
+  server.on('clientError', (_err, socket) => socket.destroy());
+  const directory = mkdtempSync(join(tmpdir(), 'vab-'));
+  const socketPath = join(directory, 'http.sock');
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(socketPath, () => resolve());
+  });
+  // Observe startup errors even if the workload never opens a connection.
+  ready.catch(() => revoke());
+  const revoke = () => {
+    if (revoked) return;
+    revoked = true;
+    clearTimeout(expiry);
+    for (const abort of active) abort();
+    for (const socket of sockets) socket.destroy();
+    server.closeAllConnections();
+    server.close(() => rmSync(directory, { recursive: true, force: true }));
+  };
+  const expiry = setTimeout(revoke, Math.max(1, deadline - Date.now()));
+  expiry.unref();
+  return { token, stats, revoke, ready,
+    attach(socket: Duplex) {
+      if (revoked || sockets.size >= 16) { socket.destroy(); return; }
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+      void ready.then(() => {
+        if (revoked || socket.destroyed) { socket.destroy(); return; }
+        const peer = connect(socketPath);
+        peer.on('error', () => socket.destroy());
+        peer.on('close', () => socket.destroy());
+        socket.on('close', () => peer.destroy());
+        socket.pipe(peer).pipe(socket);
+      }, () => socket.destroy());
+    },
+  };
+}

--- a/packages/client/src/claude-broker-relay.ts
+++ b/packages/client/src/claude-broker-relay.ts
@@ -1,0 +1,94 @@
+// Runs INSIDE the workload. Contains no host credential or host destination.
+// JSON-lines multiplex raw HTTP sockets and the agent's stdio over docker exec.
+// Keep as source text so Bun-compiled clients need no extra runtime asset.
+export const CLAUDE_BROKER_RELAY = String.raw`
+'use strict';
+const net = require('node:net');
+const {spawn} = require('node:child_process');
+let child, server, next = 0, pending = '', started = false, closing = false;
+const sockets = new Map();
+function send(frame) {
+  if (process.stdout.writableLength > 8 * 1024 * 1024) return shutdown(1);
+  process.stdout.write(JSON.stringify(frame) + '\n');
+}
+function killGroup(signal) {
+  if (child && child.pid) { try { process.kill(-child.pid, signal); } catch {} }
+}
+function shutdown(code) {
+  if (closing) return;
+  closing = true;
+  killGroup('SIGKILL');
+  for (const socket of sockets.values()) socket.destroy();
+  if (server) server.close();
+  process.exit(code);
+}
+process.stdin.on('end', () => shutdown(1));
+process.stdin.on('error', () => shutdown(1));
+process.stdout.on('error', () => shutdown(1));
+process.on('SIGTERM', () => shutdown(1));
+process.on('SIGINT', () => shutdown(1));
+process.stdin.on('data', chunk => {
+  pending += chunk.toString('utf8');
+  let end;
+  while ((end = pending.indexOf('\n')) !== -1) {
+    if (end > 256 * 1024) return shutdown(1);
+    const line = pending.slice(0, end); pending = pending.slice(end + 1);
+    try { receive(JSON.parse(line)); } catch { return shutdown(1); }
+  }
+  if (pending.length > 256 * 1024) shutdown(1);
+});
+function receive(m) {
+  if (m.t === 'start' && !started) {
+    started = true;
+    server = net.createServer(socket => {
+      if (sockets.size >= 16) return socket.destroy();
+      const id = ++next;
+      sockets.set(id, socket);
+      send({t:'open', id});
+      socket.on('data', data => send({t:'data', id, data:data.toString('base64')}));
+      socket.on('error', () => {});
+      socket.on('close', () => { sockets.delete(id); send({t:'close', id}); });
+    });
+    server.on('error', () => shutdown(1));
+    server.listen(0, '127.0.0.1', () => {
+      // Container creation rejects provider credentials; also strip inherited
+      // provider overrides so a custom image cannot redirect the selected API.
+      const env = {...process.env};
+      for (const k of Object.keys(env)) {
+        if (/^(ANTHROPIC_|CLAUDE_CODE_OAUTH|CLAUDE_CODE_USE_)/.test(k)) delete env[k];
+      }
+      Object.assign(env, m.env, {
+        ANTHROPIC_BASE_URL:'http://127.0.0.1:' + server.address().port,
+        ...(m.authentication === 'api-key' ? {ANTHROPIC_API_KEY:m.token} : {CLAUDE_CODE_OAUTH_TOKEN:m.token}),
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC:'1',
+      });
+      child = spawn(m.command, m.args, {cwd:m.cwd, env, detached:true, stdio:['pipe','pipe','pipe']});
+      child.stdout.on('data', data => send({t:'stdout', data:data.toString('base64')}));
+      child.stderr.on('data', data => send({t:'stderr', data:data.toString('base64')}));
+      child.stdin.on('error', () => {});
+      child.on('error', () => { send({t:'error'}); shutdown(1); });
+      child.on('exit', () => killGroup('SIGKILL'));
+      child.on('close', (code, signal) => {
+        killGroup('SIGKILL');
+        send({t:'exit', code, signal});
+        // Flush the exit frame before closing the Docker stream.
+        process.stdout.write('', () => shutdown(0));
+      });
+      send({t:'ready'});
+    });
+  } else if (m.t === 'stdin' && child) {
+    if (child.stdin.writableLength > 8 * 1024 * 1024) return shutdown(1);
+    child.stdin.write(Buffer.from(m.data, 'base64'));
+  } else if (m.t === 'end' && child) child.stdin.end();
+  else if (m.t === 'kill') {
+    killGroup(m.signal === 'SIGKILL' ? 'SIGKILL' : 'SIGTERM');
+    setTimeout(() => shutdown(1), 2000).unref();
+  } else if (m.t === 'data') {
+    const socket = sockets.get(m.id);
+    if (socket) {
+      if (socket.writableLength > 1024 * 1024) socket.destroy();
+      else socket.write(Buffer.from(m.data, 'base64'));
+    }
+  } else if (m.t === 'close') sockets.get(m.id)?.destroy();
+}
+`;

--- a/packages/client/src/claude-broker-relay.ts
+++ b/packages/client/src/claude-broker-relay.ts
@@ -5,6 +5,9 @@ export const CLAUDE_BROKER_RELAY = String.raw`
 'use strict';
 const net = require('node:net');
 const {spawn} = require('node:child_process');
+const fs = require('node:fs');
+const promptFiles = new Map();
+let promptDirectory, stagedBytes = 0;
 let child, server, next = 0, pending = '', started = false, closing = false;
 const sockets = new Map();
 function send(frame) {
@@ -20,6 +23,7 @@ function shutdown(code) {
   killGroup('SIGKILL');
   for (const socket of sockets.values()) socket.destroy();
   if (server) server.close();
+  if (promptDirectory) fs.rmSync(promptDirectory,{recursive:true,force:true});
   process.exit(code);
 }
 process.stdin.on('end', () => shutdown(1));
@@ -38,8 +42,27 @@ process.stdin.on('data', chunk => {
   if (pending.length > 256 * 1024) shutdown(1);
 });
 function receive(m) {
+  if (m.t === 'file' && !started) {
+    if (![0,1].includes(m.id)) return shutdown(1);
+    const data = Buffer.from(m.data,'base64');
+    stagedBytes += data.length;
+    if (stagedBytes > 16 * 1024 * 1024) return shutdown(1);
+    if (!promptFiles.has(m.id)) promptFiles.set(m.id,[]);
+    promptFiles.get(m.id).push(data);
+    return;
+  }
   if (m.t === 'start' && !started) {
     started = true;
+    if (m.files && m.files.length) {
+      promptDirectory = fs.mkdtempSync('/tmp/vicoop-prompt-');
+      for (const file of m.files) {
+        if (![0,1].includes(file.id) || !Number.isInteger(file.argIndex) || file.argIndex < 1 || file.argIndex >= m.args.length) return shutdown(1);
+        const path = promptDirectory + '/prompt-' + file.id + '.txt';
+        fs.writeFileSync(path,Buffer.concat(promptFiles.get(file.id) || []),{mode:0o600});
+        m.args[file.argIndex] = path;
+      }
+      promptFiles.clear();
+    }
     server = net.createServer(socket => {
       if (sockets.size >= 16) return socket.destroy();
       const id = ++next;

--- a/packages/client/src/claude-broker-spawn.test.ts
+++ b/packages/client/src/claude-broker-spawn.test.ts
@@ -9,6 +9,26 @@ import { createClaudeBrokerSpawn } from './claude-broker-spawn.js';
 const localSpawn: typeof spawn = ((_cmd: string, args: string[], opts: object) =>
   spawn(process.execPath, ['-e', args[args.length - 1]], { ...opts, env: { PATH: process.env.PATH } })) as typeof spawn;
 
+test('an exit frame cannot report completion before the supervisor transport exits', async () => {
+  let transportClosed = false;
+  const earlyExit: typeof spawn = ((_cmd: string, _args: string[], opts: object) => {
+    const child = spawn(process.execPath, ['-e', `
+      console.log(JSON.stringify({t:'exit',code:0}));
+      setTimeout(()=>process.exit(0),100);
+    `], opts);
+    child.on('close',()=>{transportClosed=true;});
+    return child;
+  }) as typeof spawn;
+  const adapter = createClaudeBrokerSpawn('fixture', {spawnImpl:earlyExit,
+    credential:()=>({kind:'oauth',secret:'mock-only'})});
+  try {
+    const child=adapter.spawn('unused',[],{});
+    child.stdout!.resume();child.stderr!.resume();
+    await new Promise<void>(resolve=>child.on('close',()=>resolve()));
+    assert.ok(transportClosed, 'untrusted exit frame bypassed supervisor cleanup');
+  } finally {adapter.close();}
+});
+
 test('stdio broker substitutes host OAuth, preserves SSE and per-spawn env, strips headers', async () => {
   const upstream = createServer(async (req, res) => {
     assert.equal(req.headers.authorization, 'Bearer host-secret');

--- a/packages/client/src/claude-broker-spawn.test.ts
+++ b/packages/client/src/claude-broker-spawn.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { createClaudeBrokerSpawn } from './claude-broker-spawn.js';
+
+// Exercise the real relay/HTTP parser through OS pipes, with no Docker needed.
+const localSpawn: typeof spawn = ((_cmd: string, args: string[], opts: object) =>
+  spawn(process.execPath, ['-e', args[args.length - 1]], { ...opts, env: { PATH: process.env.PATH } })) as typeof spawn;
+
+test('stdio broker substitutes host OAuth, preserves SSE and per-spawn env, strips headers', async () => {
+  const upstream = createServer(async (req, res) => {
+    assert.equal(req.headers.authorization, 'Bearer host-secret');
+    assert.equal(req.headers['x-api-key'], undefined);
+    assert.equal(req.headers.cookie, undefined);
+    assert.match(req.headers['anthropic-beta'] as string, /oauth-2025-04-20/);
+    for await (const _chunk of req) { /* drain */ }
+    res.writeHead(200, { 'content-type': 'text/event-stream', 'x-secret': 'host-secret' });
+    res.write('data: {"usage":{"input_tokens":12}}\n\n');
+    res.end('data: [DONE]\n\n');
+  });
+  upstream.listen(0, '127.0.0.1'); await once(upstream, 'listening');
+  const adapter = createClaudeBrokerSpawn('fixture', {
+    credential: () => ({ kind: 'oauth', secret: 'host-secret' }),
+    upstream: `http://127.0.0.1:${(upstream.address() as { port: number }).port}`, spawnImpl: localSpawn,
+  });
+  try {
+    const child = adapter.spawn(process.execPath, ['-e', `
+      (async () => {
+        const assert = require('node:assert/strict');
+        assert.equal(process.env.ENABLE_PROMPT_CACHING_1H, '1');
+        assert.ok(!JSON.stringify(process.env).includes('host-secret'));
+        const r = await fetch(process.env.ANTHROPIC_BASE_URL + '/v1/messages?beta=true', {
+          method:'POST', headers:{authorization:'Bearer '+process.env.CLAUDE_CODE_OAUTH_TOKEN, cookie:'drop-me'},
+          body:JSON.stringify({model:'claude-haiku-4-5',max_tokens:32,messages:[]})});
+        assert.equal(r.status, 200); assert.equal(r.headers.get('x-secret'), null);
+        process.stdout.write(await r.text());
+      })().catch(e => { console.error(e); process.exitCode=1; });
+    `], { env: { ENABLE_PROMPT_CACHING_1H: '1' } });
+    let output = ''; let error = '';
+    child.stdout!.on('data', c => output += c);
+    child.stderr!.on('data', c => error += c);
+    const done = new Promise<number | null>(resolve => child.on('close', resolve));
+    child.stdin!.end('prompt');
+    assert.equal(await done, 0, error);
+    assert.equal(output, 'data: {"usage":{"input_tokens":12}}\n\ndata: [DONE]\n\n');
+  } finally { adapter.close(); upstream.closeAllConnections(); await new Promise<void>(r => upstream.close(() => r())); }
+});
+
+test('cancellation closes an active upstream transport, observed by an independent Node process', async () => {
+  const upstream = spawn('node', ['-e', `
+    const server = require('http').createServer(async (req,res) => {
+      for await (const c of req) {}
+      res.writeHead(200,{'content-type':'text/event-stream'});
+      res.write('data: {"started":true}\\n\\n');
+      console.log('active');
+      res.on('close',()=>{console.log('disconnected');});
+    });
+    server.listen(0,'127.0.0.1',()=>console.log(server.address().port));
+  `], {stdio:['ignore','pipe','pipe']});
+  let output = '';
+  const waitFor = (pattern: RegExp) => new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => { upstream.stdout.off('data',check); reject(new Error('Upstream event timed out')); },4000);
+    const check = () => { if (pattern.test(output)) { clearTimeout(timeout); upstream.stdout.off('data',check); resolve(); } };
+    upstream.stdout.on('data',check); check();
+  });
+  upstream.stdout.on('data', c => output += c);
+  await waitFor(/^\d+\n/);
+  const adapter = createClaudeBrokerSpawn('fixture', { spawnImpl:localSpawn,
+    credential: () => ({kind:'oauth',secret:'host-secret'}), upstream:`http://127.0.0.1:${Number(output.split('\n')[0])}` });
+  try {
+    const child = adapter.spawn('node',['-e', `
+      fetch(process.env.ANTHROPIC_BASE_URL+'/v1/messages',{method:'POST',
+        headers:{authorization:'Bearer '+process.env.CLAUDE_CODE_OAUTH_TOKEN},
+        body:JSON.stringify({model:'claude-haiku-4-5',max_tokens:32,messages:[]})})
+      .then(r=>r.text()).catch(()=>{});
+    `],{});
+    child.stdout!.resume(); child.stderr!.resume();
+    const done = new Promise<void>(r => child.on('close',()=>r()));
+    child.stdin!.end();
+    await waitFor(/active/); child.kill('SIGTERM');
+    await waitFor(/disconnected/); await done;
+  } finally { adapter.close(); upstream.kill('SIGKILL'); }
+});

--- a/packages/client/src/claude-broker-spawn.test.ts
+++ b/packages/client/src/claude-broker-spawn.test.ts
@@ -6,8 +6,41 @@ import { once } from 'node:events';
 import { createClaudeBrokerSpawn } from './claude-broker-spawn.js';
 
 // Exercise the real relay/HTTP parser through OS pipes, with no Docker needed.
+// The wrapper mirrors successful supervisor cleanup (transport exit 0) even
+// when the relay exits on EOF. Actual root supervision is tested in Docker.
 const localSpawn: typeof spawn = ((_cmd: string, args: string[], opts: object) =>
-  spawn(process.execPath, ['-e', args[args.length - 1]], { ...opts, env: { PATH: process.env.PATH } })) as typeof spawn;
+  spawn('/bin/sh', ['-c', '"$@"; exit 0', 'supervisor-stand-in', process.execPath, '-e', args[args.length - 1]],
+    { ...opts, env: { PATH: process.env.PATH } })) as typeof spawn;
+
+test('cancellation closes trusted input even when kill frames are ignored', async () => {
+  for (const signal of ['SIGTERM','SIGKILL'] as const) {
+    let ready!: () => void;
+    const started=new Promise<void>(resolve=>{ready=resolve;});
+    const ignoringRelay: typeof spawn = ((_cmd: string, _args: string[], opts: object) => {
+      const processChild=spawn(process.execPath,['-e',`
+        process.stdin.on('data',()=>{});
+        process.stdin.on('end',()=>process.exit(0));
+        console.log(JSON.stringify({t:'ready'}));
+      `],{...opts,env:{PATH:process.env.PATH}});
+      processChild.stdout!.once('data',ready);
+      return processChild;
+    }) as typeof spawn;
+    const adapter=createClaudeBrokerSpawn('fixture',{spawnImpl:ignoringRelay,
+      credential:()=>({kind:'oauth',secret:'mock-only'})});
+    const child=adapter.spawn('unused',[],{});
+    child.stdout!.resume();child.stderr!.resume();
+    const closed=new Promise<number|null>(resolve=>child.on('close',resolve));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await started;
+      child.kill(signal);
+      const code=await Promise.race([closed,new Promise<never>((_,reject)=>{
+        timer=setTimeout(()=>reject(new Error('cancellation did not close supervisor input')),1000);
+      })]);
+      assert.equal(code,1);
+    } finally {clearTimeout(timer);adapter.close();await closed;}
+  }
+});
 
 test('an exit frame cannot report completion before the supervisor transport exits', async () => {
   let transportClosed = false;

--- a/packages/client/src/claude-broker-spawn.test.ts
+++ b/packages/client/src/claude-broker-spawn.test.ts
@@ -83,3 +83,27 @@ test('cancellation closes an active upstream transport, observed by an independe
     await waitFor(/disconnected/); await done;
   } finally { adapter.close(); upstream.kill('SIGKILL'); }
 });
+
+test('host prompt files are staged for the workload and removed after execution', async () => {
+  const {mkdtempSync,writeFileSync,existsSync,rmSync} = await import('node:fs');
+  const {tmpdir} = await import('node:os'); const {join} = await import('node:path');
+  const hostDir=mkdtempSync(join(tmpdir(),'host-prompt-'));
+  const hostFile=join(hostDir,'prompt.txt');
+  // Larger than one frame, including Unicode and newlines.
+  const content='system instruction 한글\n'.repeat(20000);
+  writeFileSync(hostFile,content);
+  const adapter=createClaudeBrokerSpawn('fixture',{spawnImpl:localSpawn,credential:()=>({kind:'oauth',secret:'host-secret'})});
+  try {
+    const child=adapter.spawn('node',['-e',`const fs=require('fs'); const path=process.argv[2]; console.log(JSON.stringify({path,bytes:fs.statSync(path).size,tail:fs.readFileSync(path,'utf8').slice(-22)}));`,'--','--append-system-prompt-file',hostFile],{});
+    let output='';child.stdout!.on('data',c=>output+=c);child.stderr!.resume();
+    const done=new Promise<number|null>(r=>child.on('close',r));child.stdin!.end();
+    assert.equal(await done,0);
+    const result=JSON.parse(output);
+    assert.notEqual(result.path,hostFile);
+    assert.equal(result.bytes,Buffer.byteLength(content));
+    assert.equal(result.tail,content.slice(-22));
+    // The relay flushes its exit frame before its own cleanup completes.
+    for(let n=0;n<30 && existsSync(result.path);n++) await new Promise(r=>setTimeout(r,10));
+    assert.ok(!existsSync(result.path));assert.ok(existsSync(hostFile));
+  } finally {adapter.close();rmSync(hostDir,{recursive:true,force:true});}
+});

--- a/packages/client/src/claude-broker-spawn.ts
+++ b/packages/client/src/claude-broker-spawn.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'node:events';
 import { Duplex, PassThrough, Writable } from 'node:stream';
 import { createClaudeAuthBroker, type BrokerOptions } from './claude-auth-broker.js';
 import { CLAUDE_BROKER_RELAY } from './claude-broker-relay.js';
+import { CLAUDE_BROKER_SUPERVISOR } from './claude-broker-supervisor.js';
 import type { ChildHandle, SpawnFn } from './spawn-adapter.js';
 
 // The Docker channel itself binds a grant to this execution and runtime.
@@ -35,7 +36,12 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
       promptFiles.push({argIndex:i,content:readFileSync(path)});
     }
     const broker = createClaudeAuthBroker(opts);
-    const relay = (opts.spawnImpl ?? nodeSpawn)('docker', ['exec', '-i', container, 'node', '-e', CLAUDE_BROKER_RELAY], { stdio: ['pipe', 'pipe', 'pipe'] });
+    // Absolute trusted binaries; disable runtime injection into the privileged
+    // supervisor. The last argument is opaque relay source, run only as node.
+    const relay = (opts.spawnImpl ?? nodeSpawn)('docker', ['exec', '-i', '--user', '0',
+      '-e', 'NODE_OPTIONS=', '-e', 'NODE_PATH=', '-e', 'LD_PRELOAD=', '-e', 'LD_LIBRARY_PATH=',
+      container, '/usr/bin/tini', '-s', '--', '/usr/local/bin/node', '-e',
+      CLAUDE_BROKER_SUPERVISOR, String(opts.ttlMs ?? 60 * 60_000), CLAUDE_BROKER_RELAY], { stdio: ['pipe', 'pipe', 'pipe'] });
     const events = new EventEmitter();
     const stdout = new PassThrough();
     const stderr = new PassThrough();
@@ -43,6 +49,8 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
     let pending = '';
     let ready = false;
     let ended = false;
+    let terminating = false;
+    let resultCode: number | undefined;
     let readyWrite: (() => void) | undefined;
     let readyEnd: (() => void) | undefined;
     const send = (frame: object) => {
@@ -67,7 +75,12 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
       stdout.end(); stderr.end();
       events.emit('close', code, signal);
     };
-    const fail = () => finish(1, null);
+    const fail = () => {
+      if (ended || terminating) return;
+      terminating = true;
+      resultCode = 1;
+      stop();
+    };
     const startup = setTimeout(fail, 15_000);
     const lifetime = setTimeout(fail, opts.ttlMs ?? 60 * 60_000);
     running.add(stop);
@@ -86,7 +99,25 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
     });
     relay.stdin?.on('error', fail);
     relay.on('error', fail);
-    relay.on('close', () => fail());
+    relay.on('close', (code) => {
+      // A successful supervisor exit proves descendant cleanup, irrespective
+      // of the untrusted relay's claimed exit frame. Never finish on that frame.
+      if (code === 0) { finish(resultCode ?? 1, null); return; }
+      // Supervisor/Docker failure leaves cleanup uncertain. Fail closed for the
+      // shared runtime through the independent Docker control plane.
+      stopped = true;
+      for (const stop of running) stop();
+      const cleanup = nodeSpawn('docker', ['stop', '-t', '0', container], {stdio:'ignore'});
+      let cleanupReported = false;
+      const cleanupFinished = (confirmed: boolean) => {
+        if (cleanupReported) return;
+        cleanupReported = true;
+        if (!confirmed) console.error('Claude runtime cleanup could not be confirmed; new executions are disabled. Restore Docker access and stop the runtime before restarting.');
+        finish(1, null);
+      };
+      cleanup.on('error', () => cleanupFinished(false));
+      cleanup.on('close', (code) => cleanupFinished(code === 0));
+    });
     // Docker diagnostics can include command lines; keep them off task output.
     relay.stderr?.resume();
     relay.stdout?.on('data', (chunk: Buffer) => {
@@ -99,7 +130,7 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
         try {
           const m = JSON.parse(line);
           if (m.t === 'ready') { ready = true; clearTimeout(startup); readyWrite?.(); readyWrite = undefined; readyEnd?.(); readyEnd = undefined; }
-          else if (m.t === 'exit') { finish(Number.isInteger(m.code) ? m.code : 1, null); return; }
+          else if (m.t === 'exit') { resultCode ??= Number.isInteger(m.code) ? m.code : 1; return; }
           else if (m.t === 'error') { fail(); return; }
           else if (m.t === 'stdout' || m.t === 'stderr') {
             const stream = m.t === 'stdout' ? stdout : stderr;

--- a/packages/client/src/claude-broker-spawn.ts
+++ b/packages/client/src/claude-broker-spawn.ts
@@ -60,8 +60,9 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
     };
     const stop = () => {
       broker.revoke();
-      send({ t: 'kill', signal: 'SIGKILL' });
-      relay.stdin?.end();
+      // Close the trusted supervisor input, discarding queued workload frames.
+      // A stopped relay cannot process a kill frame or drain its input queue.
+      relay.stdin?.destroy();
     };
     const finish = (code: number | null, signal: NodeJS.Signals | null) => {
       if (ended) return;
@@ -177,10 +178,10 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
     })().catch(fail);
     return Object.assign(events, {
       stdin, stdout, stderr,
-      kill(signal: NodeJS.Signals = 'SIGTERM') {
-        broker.revoke();
-        send({ t: 'kill', signal });
-        return !ended;
+      kill(_signal: NodeJS.Signals = 'SIGTERM') {
+        if (ended) return false;
+        fail();
+        return true;
       },
     }) as ChildHandle;
   };

--- a/packages/client/src/claude-broker-spawn.ts
+++ b/packages/client/src/claude-broker-spawn.ts
@@ -1,0 +1,132 @@
+import { spawn as nodeSpawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { Duplex, PassThrough, Writable } from 'node:stream';
+import { createClaudeAuthBroker, type BrokerOptions } from './claude-auth-broker.js';
+import { CLAUDE_BROKER_RELAY } from './claude-broker-relay.js';
+import type { ChildHandle, SpawnFn } from './spawn-adapter.js';
+
+// The Docker channel itself binds a grant to this execution and runtime.
+// A grant stolen by runtime B is useless on B's separate HTTP parser; there
+// is no host TCP listener to address and A listens on container loopback only.
+export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions & {
+  spawnImpl?: typeof nodeSpawn;
+}) {
+  const running = new Set<() => void>();
+  let stopped = false;
+  const spawn: SpawnFn = (command, args, options) => {
+    if (stopped) throw new Error('Claude authentication transport is stopped');
+    const env = options.env ?? {};
+    // Per-spawn backend knobs only. Never carry arbitrary host environment.
+    for (const key of Object.keys(env)) {
+      if (!['ENABLE_PROMPT_CACHING_1H', 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'MAX_THINKING_TOKENS', 'CLAUDE_CODE_EFFORT_LEVEL', 'CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING'].includes(key)) {
+        throw new Error(`Unsupported Claude container spawn environment: ${key}`);
+      }
+    }
+    const broker = createClaudeAuthBroker(opts);
+    const relay = (opts.spawnImpl ?? nodeSpawn)('docker', ['exec', '-i', container, 'node', '-e', CLAUDE_BROKER_RELAY], { stdio: ['pipe', 'pipe', 'pipe'] });
+    const events = new EventEmitter();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const sockets = new Map<number, Duplex>();
+    let pending = '';
+    let ready = false;
+    let ended = false;
+    let readyWrite: (() => void) | undefined;
+    let readyEnd: (() => void) | undefined;
+    const send = (frame: object) => {
+      if (ended || !relay.stdin || relay.stdin.destroyed || relay.stdin.writableEnded) return;
+      if (relay.stdin.writableLength > 8 * 1024 * 1024) { fail(); return; }
+      relay.stdin.write(JSON.stringify(frame) + '\n');
+    };
+    const stop = () => {
+      broker.revoke();
+      send({ t: 'kill', signal: 'SIGKILL' });
+      relay.stdin?.end();
+    };
+    const finish = (code: number | null, signal: NodeJS.Signals | null) => {
+      if (ended) return;
+      // Mark closed before destroying sockets: their callbacks may call send(),
+      // including while a full transport queue is failing this execution.
+      ended = true;
+      stop();
+      clearTimeout(startup);
+      clearTimeout(lifetime);
+      running.delete(stop);
+      stdout.end(); stderr.end();
+      events.emit('close', code, signal);
+    };
+    const fail = () => finish(1, null);
+    const startup = setTimeout(fail, 15_000);
+    const lifetime = setTimeout(fail, opts.ttlMs ?? 60 * 60_000);
+    running.add(stop);
+    const stdin = new Writable({
+      write(chunk, _encoding, callback) {
+        const write = () => {
+          for (let offset = 0; offset < chunk.length; offset += 48 * 1024) send({ t: 'stdin', data: chunk.subarray(offset, offset + 48 * 1024).toString('base64') });
+          callback();
+        };
+        if (ready) write(); else readyWrite = write;
+      },
+      final(callback) {
+        const end = () => { send({ t: 'end' }); callback(); };
+        if (ready) end(); else readyEnd = end;
+      },
+    });
+    relay.stdin?.on('error', fail);
+    relay.on('error', fail);
+    relay.on('close', () => fail());
+    // Docker diagnostics can include command lines; keep them off task output.
+    relay.stderr?.resume();
+    relay.stdout?.on('data', (chunk: Buffer) => {
+      if (ended) return;
+      pending += chunk.toString('utf8');
+      let end: number;
+      while ((end = pending.indexOf('\n')) !== -1) {
+        if (end > 256 * 1024) { fail(); return; }
+        const line = pending.slice(0, end); pending = pending.slice(end + 1);
+        try {
+          const m = JSON.parse(line);
+          if (m.t === 'ready') { ready = true; clearTimeout(startup); readyWrite?.(); readyWrite = undefined; readyEnd?.(); readyEnd = undefined; }
+          else if (m.t === 'exit') { finish(Number.isInteger(m.code) ? m.code : 1, null); return; }
+          else if (m.t === 'error') { fail(); return; }
+          else if (m.t === 'stdout' || m.t === 'stderr') {
+            const stream = m.t === 'stdout' ? stdout : stderr;
+            if (stream.readableLength > 8 * 1024 * 1024) { fail(); return; }
+            stream.write(Buffer.from(m.data, 'base64'));
+          } else if (m.t === 'open') {
+            if (!Number.isSafeInteger(m.id) || m.id < 1 || sockets.has(m.id) || sockets.size >= 16) { fail(); return; }
+            const socket = new Duplex({
+              read() {},
+              write(data, _encoding, callback) {
+                for (let offset = 0; offset < data.length; offset += 48 * 1024) send({ t: 'data', id: m.id, data: data.subarray(offset, offset + 48 * 1024).toString('base64') });
+                callback();
+              },
+              destroy(_err, callback) { send({ t: 'close', id: m.id }); sockets.delete(m.id); callback(); },
+            });
+            socket.on('error', () => socket.destroy());
+            sockets.set(m.id, socket);
+            broker.attach(socket);
+          } else if (m.t === 'data') {
+            const socket = sockets.get(m.id);
+            if (socket) {
+              if (socket.readableLength > 1024 * 1024) socket.destroy();
+              else socket.push(Buffer.from(m.data, 'base64'));
+            }
+          } else if (m.t === 'close') sockets.get(m.id)?.destroy();
+          else { fail(); return; }
+        } catch { fail(); return; }
+      }
+      if (pending.length > 256 * 1024) fail();
+    });
+    send({ t: 'start', command, args, cwd: options.cwd, env, token: broker.token, authentication: opts.authentication ?? 'oauth' });
+    return Object.assign(events, {
+      stdin, stdout, stderr,
+      kill(signal: NodeJS.Signals = 'SIGTERM') {
+        broker.revoke();
+        send({ t: 'kill', signal });
+        return !ended;
+      },
+    }) as ChildHandle;
+  };
+  return { spawn, close() { stopped = true; for (const stop of running) stop(); } };
+}

--- a/packages/client/src/claude-broker-spawn.ts
+++ b/packages/client/src/claude-broker-spawn.ts
@@ -1,4 +1,5 @@
 import { spawn as nodeSpawn } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 import { Duplex, PassThrough, Writable } from 'node:stream';
 import { createClaudeAuthBroker, type BrokerOptions } from './claude-auth-broker.js';
@@ -21,6 +22,17 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
       if (!['ENABLE_PROMPT_CACHING_1H', 'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'MAX_THINKING_TOKENS', 'CLAUDE_CODE_EFFORT_LEVEL', 'CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING'].includes(key)) {
         throw new Error(`Unsupported Claude container spawn environment: ${key}`);
       }
+    }
+    const promptFiles: Array<{argIndex:number; content:Buffer}> = [];
+    let stagedBytes = 0;
+    for (let i = 0; i < args.length; i++) {
+      if (!['--append-system-prompt-file', '--system-prompt-file'].includes(args[i])) continue;
+      const path = args[++i];
+      if (!path || promptFiles.length >= 2) throw new Error('Invalid Claude prompt-file arguments');
+      const stat = statSync(path);
+      stagedBytes += stat.size;
+      if (!stat.isFile() || stagedBytes > 16 * 1024 * 1024) throw new Error('Claude prompt files exceed the staging limit');
+      promptFiles.push({argIndex:i,content:readFileSync(path)});
     }
     const broker = createClaudeAuthBroker(opts);
     const relay = (opts.spawnImpl ?? nodeSpawn)('docker', ['exec', '-i', container, 'node', '-e', CLAUDE_BROKER_RELAY], { stdio: ['pipe', 'pipe', 'pipe'] });
@@ -118,7 +130,20 @@ export function createClaudeBrokerSpawn(container: string, opts: BrokerOptions &
       }
       if (pending.length > 256 * 1024) fail();
     });
-    send({ t: 'start', command, args, cwd: options.cwd, env, token: broker.token, authentication: opts.authentication ?? 'oauth' });
+    // Only host-generated CLI prompt-file arguments are read here. Workload
+    // frames cannot request host files. Transfer in bounded chunks before ready.
+    void (async () => {
+      for (let id = 0; id < promptFiles.length; id++) {
+        const content = promptFiles[id].content;
+        for (let offset = 0; offset < content.length; offset += 48 * 1024) {
+          if (ended || !relay.stdin || relay.stdin.destroyed) return;
+          const frame = {t:'file',id,data:content.subarray(offset,offset + 48 * 1024).toString('base64')};
+          await new Promise<void>((resolve,reject) => relay.stdin!.write(JSON.stringify(frame) + '\n', err => err ? reject(err) : resolve()));
+        }
+      }
+      send({ t: 'start', command, args, cwd: options.cwd, env, token: broker.token,
+        authentication: opts.authentication ?? 'oauth', files:promptFiles.map((file,id)=>({id,argIndex:file.argIndex})) });
+    })().catch(fail);
     return Object.assign(events, {
       stdin, stdout, stderr,
       kill(signal: NodeJS.Signals = 'SIGTERM') {

--- a/packages/client/src/claude-broker-supervisor.ts
+++ b/packages/client/src/claude-broker-supervisor.ts
@@ -1,0 +1,87 @@
+// Root control-plane process under a private tini subreaper. It never parses
+// workload frames or executes workload-supplied commands as root. The relay
+// and all agent tools run as uid/gid 1000. Even setsid/double-fork descendants
+// are adopted by this execution's tini, not container PID 1.
+export const CLAUDE_BROKER_SUPERVISOR = String.raw`
+'use strict';
+const fs = require('node:fs');
+const {spawn} = require('node:child_process');
+const reaper = process.ppid;
+const ttl = Number(process.argv[1]);
+if (process.getuid() !== 0 || !Number.isSafeInteger(ttl) || ttl < 1) process.exit(125);
+let closing = false;
+const relay = spawn('/usr/local/bin/node', ['-e', process.argv[2]], {
+  uid:1000, gid:1000, stdio:['pipe','pipe','pipe'],
+  env:{...process.env, HOME:'/home/node', USER:'node', LOGNAME:'node'},
+});
+const relayClosed = new Promise(resolve=>relay.once('close',resolve));
+// No frame interpretation here: this process only supervises pipes/lifetime.
+process.stdin.pipe(relay.stdin);
+relay.stdout.pipe(process.stdout, {end:false});
+relay.stderr.pipe(process.stderr, {end:false});
+function descendants() {
+  const rows = [];
+  for (const entry of fs.readdirSync('/proc')) {
+    if (!/^\d+$/.test(entry)) continue;
+    try {
+      const stat = fs.readFileSync('/proc/'+entry+'/stat','utf8');
+      const fields = stat.slice(stat.lastIndexOf(')')+2).split(' ');
+      rows.push({pid:Number(entry),parent:Number(fields[1]),state:fields[0]});
+    } catch {}
+  }
+  const owned = new Set([reaper]);
+  let changed;
+  do {
+    changed = false;
+    for (const row of rows) if (owned.has(row.parent) && !owned.has(row.pid)) {
+      owned.add(row.pid); changed = true;
+    }
+  } while (changed);
+  return rows.filter(r=>owned.has(r.pid) && r.pid!==process.pid && r.pid!==reaper && r.state!=='Z');
+}
+function signal(pid, sig) { try { process.kill(pid,sig); } catch(e) { if(e.code!=='ESRCH') throw e; } }
+function hasRemainingRoots() {
+  // Read supervisor first, then reaper: a child can move only toward reaper.
+  // Require empty raw child lists (including zombies). Checking stat again
+  // would reintroduce a fork+exit race; tini/Node reap on the next iteration.
+  for (const parent of [process.pid,reaper]) {
+    const children=fs.readFileSync('/proc/'+parent+'/task/'+parent+'/children','utf8').trim();
+    if (children.split(/\s+/).filter(Boolean).some(id=>Number(id)!==process.pid)) return true;
+  }
+  return false;
+}
+async function shutdown() {
+  if (closing) return;
+  closing = true;
+  clearTimeout(timer);
+  process.stdin.unpipe(relay.stdin);
+  relay.stdin.destroy();
+  try {
+    // Freeze before killing so an adversarial process cannot keep forking.
+    // Repeat snapshots: a child forked during a scan is adopted by our tini.
+    for (;;) {
+      const owned = descendants();
+      if (!owned.length && !hasRemainingRoots()) break;
+      for (const p of owned) signal(p.pid,'SIGSTOP');
+      for (const p of owned) signal(p.pid,'SIGKILL');
+      await new Promise(r=>setTimeout(r,10));
+    }
+    // exit can precede stdout/stderr close; drain the final frames after killing
+    // descendants that might have inherited and kept these pipes open.
+    await relayClosed;
+    if (process.stdout.destroyed || process.stderr.destroyed) process.exit(0);
+    process.stdout.write('',()=>process.stderr.write('',()=>process.exit(0)));
+  } catch { process.exit(125); }
+}
+const timer = setTimeout(()=>shutdown(),ttl);
+process.stdin.on('end',()=>shutdown());
+process.stdin.on('error',()=>shutdown());
+process.stdout.on('error',()=>shutdown());
+process.stderr.on('error',()=>shutdown());
+process.on('SIGTERM',()=>shutdown());
+process.on('SIGINT',()=>shutdown());
+relay.stdin.on('error',()=>shutdown());
+relay.on('error',()=>shutdown());
+// exit, not close: descendants may retain relay stdio after killing it.
+relay.on('exit',()=>shutdown());
+`;

--- a/packages/client/src/claude-broker-supervisor.ts
+++ b/packages/client/src/claude-broker-supervisor.ts
@@ -16,7 +16,13 @@ const relay = spawn('/usr/local/bin/node', ['-e', process.argv[2]], {
 });
 const relayClosed = new Promise(resolve=>relay.once('close',resolve));
 // No frame interpretation here: this process only supervises pipes/lifetime.
-process.stdin.pipe(relay.stdin);
+// Keep consuming the trusted input even when a workload has stopped the relay.
+// pipe() backpressure would pause stdin and hide EOF/cancellation indefinitely.
+process.stdin.on('data',chunk=>{
+  if (closing) return;
+  if (relay.stdin.writableLength > 8*1024*1024) { shutdown(); return; }
+  relay.stdin.write(chunk);
+});
 relay.stdout.pipe(process.stdout, {end:false});
 relay.stderr.pipe(process.stderr, {end:false});
 function descendants() {
@@ -54,7 +60,6 @@ async function shutdown() {
   if (closing) return;
   closing = true;
   clearTimeout(timer);
-  process.stdin.unpipe(relay.stdin);
   relay.stdin.destroy();
   try {
     // Freeze before killing so an adversarial process cannot keep forking.

--- a/packages/client/src/claude-runtime-boundary.test.ts
+++ b/packages/client/src/claude-runtime-boundary.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { assertClaudeBrokerContainer } from './claude-runtime-boundary.js';
+import { RuntimeContainer } from './runtime-container.js';
+const container = () => ({ Config: { User: 'node', Labels: { 'vicoop.claude-auth': 'stdio-v1', 'vicoop.name': 'work' },
+  Env: ['CLAUDE_CONFIG_DIR=/data/sessions/claude/config'] },
+  HostConfig: { NetworkMode: 'default', SecurityOpt: ['no-new-privileges'] },
+  Mounts: [{ Type: 'volume', Name: 'vicoop-sessions-work', Destination: '/data/sessions/claude' }] });
+
+test('reject legacy/unsafe runtime inspect without leaking credentials in diagnostics', () => {
+  assert.doesNotThrow(() => assertClaudeBrokerContainer(JSON.stringify(container())));
+  for (const mutate of [
+    (c: any) => c.Config.Labels = {},
+    (c: any) => c.Config.Env.push('ANTHROPIC_API_KEY=SECRET_VALUE'),
+    (c: any) => c.Mounts.push({Type:'volume',Destination:'/data/creds/claude'}),
+    (c: any) => c.Mounts[0].Name = 'vicoop-creds-work',
+    (c: any) => c.Mounts.push({Type:'bind',Destination:'/var/run/docker.sock'}),
+    (c: any) => c.Config.User = '0',
+    (c: any) => c.HostConfig.NetworkMode = 'container:other',
+    (c: any) => c.HostConfig.CapAdd = ['SYS_ADMIN'],
+    (c: any) => c.HostConfig.SecurityOpt = [],
+  ]) {
+    const c = container(); mutate(c);
+    assert.throws(() => assertClaudeBrokerContainer(JSON.stringify(c)), e => e instanceof Error && /migration/.test(e.message) && !e.message.includes('SECRET_VALUE'));
+  }
+});
+
+test('new Claude runtime mounts only agent/session volumes and applies firewall before returning', async () => {
+  const calls: string[][] = [];
+  const runtime = new RuntimeContainer({ backendKind:'claude', runtimeName:'work', createIfMissing:true,
+    dockerRun(args) {
+      calls.push([...args]);
+      const stdout = args[0] === 'version' ? '27' : args.includes('{{json .}}') ? JSON.stringify(container()) : args.includes('{{.State.Status}}') ? 'running' : '';
+      return {exitCode:0,stdout,stderr:''};
+    } });
+  await runtime.start();
+  const create = calls.find(c => c[0] === 'create')!;
+  assert.ok(!create.some(c => c.includes('source=vicoop-creds-')));
+  assert.ok(create.includes('CLAUDE_CONFIG_DIR=/data/sessions/claude/config'));
+  assert.ok(create.includes('no-new-privileges'));
+  const firewall = calls.at(-1)!;
+  assert.deepEqual(firewall.slice(0,4), ['exec','--user','0','vicoop-runtime-work']);
+  assert.match(firewall.at(-1)!, /ip6tables -w -P OUTPUT DROP/);
+});
+
+test('legacy runtime is rejected before start or any credential probe', async () => {
+  const calls: string[][] = [];
+  const runtime = new RuntimeContainer({backendKind:'claude', dockerRun(args) {
+    calls.push([...args]);
+    return {exitCode:0,stdout: args[0] === 'version' ? '27' : args[0] === 'ps' ? 'container-id' : '{}',stderr:''};
+  }});
+  await assert.rejects(runtime.start(), /migration/);
+  assert.ok(!calls.some(c => c[0] === 'start' || c[0] === 'exec'));
+});

--- a/packages/client/src/claude-runtime-boundary.test.ts
+++ b/packages/client/src/claude-runtime-boundary.test.ts
@@ -41,6 +41,9 @@ test('new Claude runtime mounts only agent/session volumes and applies firewall 
   const firewall = calls.at(-1)!;
   assert.deepEqual(firewall.slice(0,4), ['exec','--user','0','vicoop-runtime-work']);
   assert.match(firewall.at(-1)!, /ip6tables -w -P OUTPUT DROP/);
+  const script = firewall.at(-1)!;
+  assert.ok(script.indexOf('--dport 53 -j ACCEPT') < script.indexOf('-d 192.168.0.0/16 -j REJECT'));
+  assert.match(script, /-p tcp --dport 53 -j ACCEPT/);
 });
 
 test('legacy runtime is rejected before start or any credential probe', async () => {

--- a/packages/client/src/claude-runtime-boundary.test.ts
+++ b/packages/client/src/claude-runtime-boundary.test.ts
@@ -40,8 +40,10 @@ test('new Claude runtime mounts only agent/session volumes and applies firewall 
   assert.ok(create.includes('no-new-privileges'));
   const firewall = calls.at(-1)!;
   assert.deepEqual(firewall.slice(0,4), ['exec','--user','0','vicoop-runtime-work']);
+  assert.equal(firewall[4], '/bin/sh');
   assert.match(firewall.at(-1)!, /ip6tables -w -P OUTPUT DROP/);
   const script = firewall.at(-1)!;
+  assert.ok(script.indexOf('PATH=/usr/sbin:/usr/bin:/sbin:/bin') < script.indexOf('iptables -w -N'));
   assert.ok(script.indexOf('--dport 53 -j ACCEPT') < script.indexOf('-d 192.168.0.0/16 -j REJECT'));
   assert.match(script, /-p tcp --dport 53 -j ACCEPT/);
 });

--- a/packages/client/src/claude-runtime-boundary.ts
+++ b/packages/client/src/claude-runtime-boundary.ts
@@ -1,0 +1,51 @@
+import { networkInterfaces } from 'node:os';
+
+export const CLAUDE_BROKER_LABEL = 'vicoop.claude-auth=stdio-v1';
+
+// Inspect output stays host-side: never include it in an exception/log because
+// rejected legacy containers can contain actual credentials in Config.Env.
+export function assertClaudeBrokerContainer(raw: string): void {
+  let c;
+  try { c = JSON.parse(raw); } catch { throw new Error('Cannot inspect Claude runtime authentication boundary'); }
+  const invalid = () => { throw new Error('Claude runtime requires host-broker migration; see docs/claude-auth-broker.md. Existing credentials and volumes have not been deleted.'); };
+  if (c.Config?.Labels?.['vicoop.claude-auth'] !== 'stdio-v1' || !['node', '1000:1000', '1000'].includes(c.Config?.User) ||
+      c.HostConfig?.Privileged || !['default', 'bridge'].includes(c.HostConfig?.NetworkMode) || c.HostConfig?.PidMode || c.HostConfig?.IpcMode === 'host' ||
+      c.HostConfig?.Devices?.length || c.HostConfig?.VolumesFrom?.length ||
+      c.HostConfig?.CapAdd?.some((v: string) => !['NET_ADMIN', 'NET_RAW'].includes(v.replace(/^CAP_/, ''))) ||
+      !c.HostConfig?.SecurityOpt?.some((v: string) => v === 'no-new-privileges' || v === 'no-new-privileges=true')) invalid();
+  const env: string[] = c.Config?.Env ?? [];
+  if (env.some(v => /^(ANTHROPIC_|CLAUDE_CODE_OAUTH|CLAUDE_CODE_USE_|AWS_|AZURE_|GOOGLE_APPLICATION_CREDENTIALS=)/.test(v))) invalid();
+  if (!env.includes('CLAUDE_CONFIG_DIR=/data/sessions/claude/config')) invalid();
+  for (const mount of c.Mounts ?? []) {
+    if (mount.Type === 'tmpfs' && ['/tmp', '/data/creds/claude'].includes(mount.Destination)) continue;
+    if (mount.Type === 'volume' && mount.Destination === '/data/agents/claude' && mount.Name === `vicoop-agents-${c.Config.Labels['vicoop.name']}`) continue;
+    if (mount.Type === 'volume' && mount.Destination === '/data/sessions/claude' && mount.Name === `vicoop-sessions-${c.Config.Labels['vicoop.name']}`) continue;
+    if (mount.Type === 'bind' && mount.Destination === '/workspace') continue;
+    invalid();
+  }
+}
+
+// Install before any workload spawn, as root via the trusted Docker control
+// plane. Workload execs run as node with no-new-privileges and cannot modify it.
+// Public internet remains available to tools; private/local host services do not.
+export function claudeBrokerFirewallScript(): string {
+  const hostIPs = Object.values(networkInterfaces()).flatMap(v => v ?? [])
+    .filter(v => v.family === 'IPv4').map(v => v.address)
+    .filter(v => /^\d+\.\d+\.\d+\.\d+$/.test(v));
+  const blocked = [...new Set(['0.0.0.0/8', '10.0.0.0/8', '100.64.0.0/10', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16', '224.0.0.0/4', '240.0.0.0/4', ...hostIPs.filter(v => !v.startsWith('127.'))])];
+  return `set -eu
+iptables -w -N VICOOP_BROKER 2>/dev/null || true
+iptables -w -F VICOOP_BROKER
+iptables -w -A VICOOP_BROKER -o lo -j ACCEPT
+${blocked.map(ip => `iptables -w -A VICOOP_BROKER -d ${ip} -j REJECT`).join('\n')}
+# Docker Desktop's host alias can resolve outside the ordinary gateway subnet.
+for ip in $(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1}' | sort -u); do
+  iptables -w -A VICOOP_BROKER -d "$ip" -j REJECT
+done
+iptables -w -A VICOOP_BROKER -j RETURN
+iptables -w -C OUTPUT -j VICOOP_BROKER 2>/dev/null || iptables -w -I OUTPUT 1 -j VICOOP_BROKER
+# No IPv6 egress bypass; retain container-local HTTP support.
+ip6tables -w -P OUTPUT DROP
+ip6tables -w -C OUTPUT -o lo -j ACCEPT 2>/dev/null || ip6tables -w -I OUTPUT 1 -o lo -j ACCEPT
+`;
+}

--- a/packages/client/src/claude-runtime-boundary.ts
+++ b/packages/client/src/claude-runtime-boundary.ts
@@ -34,6 +34,9 @@ export function claudeBrokerFirewallScript(): string {
     .filter(v => /^\d+\.\d+\.\d+\.\d+$/.test(v));
   const blocked = [...new Set(['0.0.0.0/8', '10.0.0.0/8', '100.64.0.0/10', '169.254.0.0/16', '172.16.0.0/12', '192.168.0.0/16', '224.0.0.0/4', '240.0.0.0/4', ...hostIPs.filter(v => !v.startsWith('127.'))])];
   return `set -eu
+# Never resolve privileged commands from workload-writable agent volumes.
+PATH=/usr/sbin:/usr/bin:/sbin:/bin
+export PATH
 iptables -w -N VICOOP_BROKER 2>/dev/null || true
 iptables -w -F VICOOP_BROKER
 iptables -w -A VICOOP_BROKER -o lo -j ACCEPT

--- a/packages/client/src/claude-runtime-boundary.ts
+++ b/packages/client/src/claude-runtime-boundary.ts
@@ -37,6 +37,14 @@ export function claudeBrokerFirewallScript(): string {
 iptables -w -N VICOOP_BROKER 2>/dev/null || true
 iptables -w -F VICOOP_BROKER
 iptables -w -A VICOOP_BROKER -o lo -j ACCEPT
+# The default Docker bridge can use a private host DNS resolver rather than
+# 127.0.0.11. Permit DNS only to those configured IPv4 resolvers, not their
+# other services. Validate addresses before passing them to iptables.
+for resolver in $(awk '/^nameserver / {print $2}' /etc/resolv.conf); do
+  case "$resolver" in *[!0-9.]*|'') continue ;; esac
+  iptables -w -A VICOOP_BROKER -d "$resolver" -p udp --dport 53 -j ACCEPT
+  iptables -w -A VICOOP_BROKER -d "$resolver" -p tcp --dport 53 -j ACCEPT
+done
 ${blocked.map(ip => `iptables -w -A VICOOP_BROKER -d ${ip} -j REJECT`).join('\n')}
 # Docker Desktop's host alias can resolve outside the ordinary gateway subnet.
 for ip in $(getent ahostsv4 host.docker.internal 2>/dev/null | awk '{print $1}' | sort -u); do

--- a/packages/client/src/claude-session-migration.test.ts
+++ b/packages/client/src/claude-session-migration.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { CLAUDE_SESSION_MIGRATION } from './claude-session-migration.js';
+
+test('migration preserves sessions without credentials, settings, symlinks or overwrites', () => {
+  const temp = mkdtempSync(join(tmpdir(), 'claude-migrate-'));
+  try {
+    const source = join(temp, 'source'), dest = join(temp, 'dest');
+    mkdirSync(join(source, 'projects'), {recursive:true});
+    mkdirSync(join(dest, 'projects'), {recursive:true});
+    writeFileSync(join(source, '.credentials.json'), 'SECRET');
+    writeFileSync(join(source, 'settings.json'), '{"apiKeyHelper":"secret"}');
+    writeFileSync(join(source, 'projects', 'session.jsonl'), 'conversation');
+    writeFileSync(join(source, 'projects', 'existing.jsonl'), 'legacy');
+    writeFileSync(join(dest, 'projects', 'existing.jsonl'), 'current');
+    symlinkSync(join(source, '.credentials.json'), join(source, 'projects', 'link.jsonl'));
+    const result = spawnSync('node', ['-e', CLAUDE_SESSION_MIGRATION, source, dest], {encoding:'utf8'});
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(readFileSync(join(dest,'projects','session.jsonl'),'utf8'), 'conversation');
+    assert.equal(readFileSync(join(dest,'projects','existing.jsonl'),'utf8'), 'current');
+    for (const name of ['.credentials.json','settings.json','projects/link.jsonl']) assert.ok(!existsSync(join(dest,name)));
+    assert.equal(readFileSync(join(source,'.credentials.json'),'utf8'), 'SECRET');
+  } finally { rmSync(temp,{recursive:true,force:true}); }
+});

--- a/packages/client/src/claude-session-migration.ts
+++ b/packages/client/src/claude-session-migration.ts
@@ -1,0 +1,33 @@
+// Trusted one-shot maintenance code, run in a networkless helper, never in the
+// workload. Only conversations and todos cross from the detached legacy volume.
+// No settings, login JSON, caches, environment snapshots or symlinks are copied.
+export const CLAUDE_SESSION_MIGRATION = String.raw`
+const fs = require('node:fs'), path = require('node:path');
+const source = process.argv[1] || '/legacy';
+const target = process.argv[2] || '/sessions/config';
+let copied = 0;
+function directory(p) {
+  if (fs.existsSync(p)) {
+    const s = fs.lstatSync(p);
+    if (!s.isDirectory() || s.isSymbolicLink()) throw Error('Unsafe migration destination');
+  } else fs.mkdirSync(p, {recursive:false,mode:0o700});
+}
+function copy(src, dst, extension) {
+  const st = fs.lstatSync(src);
+  if (st.isSymbolicLink()) return;
+  if (st.isDirectory()) {
+    directory(dst);
+    for (const name of fs.readdirSync(src)) copy(path.join(src,name),path.join(dst,name),extension);
+  } else if (st.isFile() && src.endsWith(extension)) {
+    // Exclusive create prevents overwriting current state or following links.
+    try { fs.copyFileSync(src,dst,fs.constants.COPYFILE_EXCL); copied++; }
+    catch(e) { if(e.code !== 'EEXIST') throw e; }
+  }
+}
+directory(target);
+for (const [name,extension] of [['projects','.jsonl'],['todos','.json']]) {
+  const src = path.join(source,name);
+  if (fs.existsSync(src)) copy(src,path.join(target,name),extension);
+}
+console.log(JSON.stringify({copied}));
+`;

--- a/packages/client/src/cli.ts
+++ b/packages/client/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { createClaudeCredentialReader, assertClaudeBrokerSettings } from './claude-auth-broker.js';
+import { createClaudeBrokerSpawn } from './claude-broker-spawn.js';
 import { closeSync, existsSync, openSync, readFileSync } from 'node:fs';
 import { spawn as spawnProcess, type ChildProcess } from 'node:child_process';
 import { AgentCard } from '@vicoop-bridge/protocol';
@@ -400,6 +402,7 @@ async function pickBackend(name: string, args: Args): Promise<PickedBackend> {
       const baseSettings = args.claudeSettingsFile
         ? readClaudeSettingsFile(args.claudeSettingsFile)
         : backends.claude?.settings;
+      if (args.runtime === 'container') assertClaudeBrokerSettings(baseSettings);
       const { spawn, cwd, runtime } = await resolveRuntime({
         kind: 'claude',
         runtime: args.runtime,
@@ -495,7 +498,7 @@ async function resolveRuntime(args: {
   runtimeName: string | undefined;
   cwd: string | undefined;
   bridgeUrl: string;
-}): Promise<{ spawn?: SpawnFn; cwd?: string; runtime?: RuntimeContainer }> {
+}): Promise<{ spawn?: SpawnFn; cwd?: string; runtime?: Pick<RuntimeContainer, 'stop'> }> {
   if ((args.runtime ?? 'host') !== 'container') {
     return { cwd: args.cwd };
   }
@@ -512,6 +515,15 @@ async function resolveRuntime(args: {
   // yet. Without this check the daemon would happily accept tasks until
   // the first spawn, then surface a backend-specific auth error.
   try {
+    if (args.kind === 'claude') {
+      const credential = createClaudeCredentialReader();
+      const selectedCredential = await credential();
+      const broker = createClaudeBrokerSpawn(runtime.getContainerName(), {
+        credential, authentication: selectedCredential.kind, onCredentialFailure: () => console.error('Claude host authentication unavailable; renew the selected host login or key. No fallback was attempted.'),
+      });
+      return { runtime: { stop: async () => { broker.close(); await runtime.stop(); } },
+        spawn: broker.spawn, cwd: args.cwd ? '/workspace' : undefined };
+    }
     await assertContainerCredsPresent(runtime.getContainerName(), args.kind);
   } catch (err) {
     await runtime.stop();

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -140,7 +140,7 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     // state takes over at mount time. This is the documented
     // workaround.
     await dockerExecStream(containerName, {
-      cmd: ['chown', '-R', 'node:node', `/data/agents/${opts.kind}`, `/data/creds/${opts.kind}`, `/data/sessions/${opts.kind}`],
+      cmd: ['/bin/chown', '-R', 'node:node', `/data/agents/${opts.kind}`, `/data/creds/${opts.kind}`, `/data/sessions/${opts.kind}`],
       user: '0',
       label: 'chown',
       log,

--- a/packages/client/src/container-init.ts
+++ b/packages/client/src/container-init.ts
@@ -1,16 +1,13 @@
+import { CLAUDE_SESSION_MIGRATION } from './claude-session-migration.js';
+import { createClaudeCredentialReader } from './claude-auth-broker.js';
 // `vicoop-client container init <kind>` — operator one-shot
 // bootstrap for the external-runtime profile (#249 PR C).
 //
 // Boots the per-backend runtime container, runs the shared
 // install-backend.sh recipe inside it, sanity-checks the resulting
 // binary against this client's supportedRange manifest, and
-// (with --from-host) copies the operator's existing agent CLI
-// creds into the container-scoped named volume so the operator can
-// immediately go daemon. Without --from-host: if stdin is a TTY,
-// runs the agent CLI's interactive auth (claude setup-token /
-// codex login --device-auth) in the running container right then;
-// otherwise falls back to printing the docker-exec incantation
-// the operator can run themselves.
+// uses host-broker authentication for Claude. Codex can copy host credentials
+// with --from-host or log in interactively inside its runtime.
 //
 // Companion to RuntimeContainer (lifecycle) + SpawnAdapter
 // (per-task spawn). RuntimeContainer is the unit of state that
@@ -19,7 +16,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { execSync, spawn } from 'node:child_process';
 import semver from 'semver';
 import { longestMatch, object } from '@optique/core/constructs';
@@ -48,10 +45,11 @@ import { createLogger, type Logger } from './logger.js';
 export interface ContainerInitOptions {
   kind: InstallableBackendKind;
   runtimeName?: string;
-  // When true, copy the operator's existing host creds into the
-  // container creds volume. When false, leave creds empty and let
-  // the operator run an interactive auth flow themselves.
+  // Codex: opt into host credential copying. Claude always uses the broker;
+  // this flag is accepted for compatibility and never copies Claude secrets.
   fromHost: boolean;
+  reuseState?: boolean;
+  workspaceDir?: string;
   // Image override mirrors the daemon path (cli.ts:resolveRuntime).
   // Precedence is applied inside runContainerInit:
   //   opts.image > VICOOP_RUNTIME_IMAGE env > DEFAULT_RUNTIME_IMAGE.
@@ -123,10 +121,13 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     bridgeUrl: opts.bridgeUrl,
     createIfMissing: true,
     failIfExists: true,
+    reuseState: opts.reuseState,
+    workspaceDir: opts.workspaceDir ? resolve(opts.workspaceDir) : undefined,
     logger: opts.logger,
   });
 
   try {
+    if (opts.kind === 'claude') await createClaudeCredentialReader()();
     await runtime.start();
 
     const runtimeName = runtimeInstanceName(opts.kind, opts.runtimeName);
@@ -139,11 +140,15 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
     // state takes over at mount time. This is the documented
     // workaround.
     await dockerExecStream(containerName, {
-      cmd: ['chown', '-R', 'node:node', `/data/agents/${opts.kind}`, `/data/creds/${opts.kind}`],
+      cmd: ['chown', '-R', 'node:node', `/data/agents/${opts.kind}`, `/data/creds/${opts.kind}`, `/data/sessions/${opts.kind}`],
       user: '0',
       label: 'chown',
       log,
     });
+
+    if (opts.kind === 'claude' && opts.reuseState) {
+      await migrateClaudeSessions(runtimeName, opts.image ?? process.env.VICOOP_RUNTIME_IMAGE ?? DEFAULT_RUNTIME_IMAGE, log);
+    }
 
     // (2) install the agent CLI into /data/agents/<kind>/ via the
     // shared shell recipe baked into the runtime image. node user;
@@ -181,7 +186,9 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
 
     // (4) creds. Either copy from host or leave empty for an
     // operator-driven OAuth flow.
-    if (opts.fromHost) {
+    if (opts.kind === 'claude') {
+      log.info('Claude uses host authentication through the built-in broker; no credentials were copied into the runtime.');
+    } else if (opts.fromHost) {
       try {
         await copyHostCreds(containerName, opts.kind, log);
       } catch (err) {
@@ -216,6 +223,20 @@ export async function runContainerInit(opts: ContainerInitOptions): Promise<numb
   } finally {
     await runtime.stop();
   }
+}
+
+// Credentials remain in their original volume. A restricted, networkless
+// maintenance helper copies selected session records into the new config dir.
+export async function migrateClaudeSessions(runtimeName: string, image: string, log: Logger): Promise<void> {
+  const legacy = credsVolumeName('claude', runtimeName);
+  if (defaultDockerRun(['volume', 'inspect', legacy]).exitCode !== 0) return;
+  const result = defaultDockerRun(['run', '--rm', '--network', 'none', '--read-only',
+    '--cap-drop', 'ALL', '--security-opt', 'no-new-privileges', '--user', '1000:1000',
+    '--mount', `type=volume,source=${legacy},target=/legacy,readonly`,
+    '--mount', `type=volume,source=${sessionsVolumeName('claude', runtimeName)},target=/sessions`,
+    '--entrypoint', 'node', image, '-e', CLAUDE_SESSION_MIGRATION]);
+  if (result.exitCode !== 0) throw new Error('Claude session migration failed; legacy volume is unchanged. Inspect the destination for incompatible files or permissions.');
+  log.info('Legacy Claude conversations/todos copied where absent; credentials and settings remain detached.');
 }
 
 function authCommandFor(containerName: string, kind: InstallableBackendKind): string {
@@ -408,8 +429,8 @@ async function copyHostCreds(
   log: Logger,
   env: HostCredsEnv = {},
 ): Promise<void> {
-  const files =
-    kind === 'claude' ? collectClaudeHostCreds(env) : collectCodexHostCreds(env);
+  if (kind === 'claude') throw new Error('Claude credentials must remain on the host; use the authentication broker');
+  const files = collectCodexHostCreds(env);
   if (files.length === 0) {
     throw new Error(
       `no host creds found for ${kind}. Expected ${expectedHostCredsHint(kind)}.`,
@@ -903,9 +924,15 @@ const containerInitSubCmd = command(
         description: message`Runtime instance name. Omit to use the backend kind as the generated name.`,
       }),
     ),
+    workspaceDir: optional(option('--workspace', string({ metavar: 'PATH' }), {
+      description: message`Host directory to bind at /workspace. Supply the original path when migrating a runtime with a workspace mount.`,
+    })),
+    reuseState: withDefault(flag('--reuse-state', {
+      description: message`Reuse existing agent/session volumes after removing the old container with --preserve-volumes. Claude credentials volumes remain detached.`,
+    }), false),
     fromHost: withDefault(
       flag('--from-host', {
-        description: message`Copy the operator's existing host creds into the container's per-backend creds volume (macOS keychain for claude, ~/.codex for codex). Off by default — explicit opt-in for the runtime-isolation tradeoff.`,
+        description: message`Claude always uses host authentication without copying credentials. For Codex, copy ~/.codex into its credentials volume.`,
       }),
       false,
     ),
@@ -922,7 +949,7 @@ const containerInitSubCmd = command(
   }),
   {
     brief: message`Bootstrap a per-backend runtime container.`,
-    description: message`One-shot setup for the container-runtime profile: creates \`vicoop-runtime-<name>\`, where --name defaults to the backend kind, fails if that runtime already exists, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and (with --from-host) copies the operator's existing host creds into the container creds volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container --runtime-name <name>\`.`,
+    description: message`One-shot setup for the container-runtime profile: creates \`vicoop-runtime-<name>\`, where --name defaults to the backend kind, fails if that runtime already exists, runs install-backend.sh inside it, verifies the installed CLI version against this client's supportedRange, and uses the host authentication broker for Claude. Codex --from-host copies host credentials into its credentials volume. After this, launch the daemon with \`vicoop-client --backend <kind> --runtime container --runtime-name <name>\`.`,
   },
 );
 
@@ -1004,6 +1031,8 @@ export async function runContainerInitCli(args: ContainerInitArgs): Promise<numb
       kind: args.kind,
       runtimeName: args.name,
       fromHost: args.fromHost,
+      reuseState: args.reuseState,
+      workspaceDir: args.workspaceDir,
       ...(args.image ? { image: args.image } : {}),
       ...(args.bridgeUrl ? { bridgeUrl: args.bridgeUrl } : {}),
     });

--- a/packages/client/src/runtime-container.test.ts
+++ b/packages/client/src/runtime-container.test.ts
@@ -2,6 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { RuntimeContainer, type DockerResult } from './runtime-container.js';
 
+// Generic volume lifecycle tests use Codex; Claude authentication boundaries
+// have dedicated coverage in claude-runtime-boundary.test.ts.
 // Test seam fixture. Each `dockerRun` call is matched against the
 // next response in the queue and pushed onto `calls` for assertion.
 // Missing fixtures fall back to a successful zero-output result so
@@ -54,7 +56,7 @@ function happyCreateResponses(): RunResponse[] {
 test('start: with createIfMissing pulls nothing when image is cached, creates+starts a fresh container', async () => {
   const { run, calls } = makeDockerFixture(happyCreateResponses());
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     image: 'test/runtime:latest',
     workspaceDir: '/host/workspace',
     bridgeUrl: 'wss://bridge.example',
@@ -73,13 +75,13 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   const volumeCreates = calls.filter((c) => c[0] === 'volume' && c[1] === 'create');
   assert.deepEqual(
     volumeCreates.map((c) => c[c.length - 1]).sort(),
-    ['vicoop-agents-claude', 'vicoop-creds-claude', 'vicoop-sessions-claude'].sort(),
+    ['vicoop-agents-codex', 'vicoop-creds-codex', 'vicoop-sessions-codex'].sort(),
   );
   for (const v of volumeCreates) {
-    assert.ok(v.includes('vicoop.kind=claude'), `label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.kind=codex'), `label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.managed-by=vicoop-bridge'), `managed label on ${v.join(' ')}`);
     assert.ok(v.includes('vicoop.component=runtime'), `component label on ${v.join(' ')}`);
-    assert.ok(v.includes('vicoop.name=claude'), `instance label on ${v.join(' ')}`);
+    assert.ok(v.includes('vicoop.name=codex'), `instance label on ${v.join(' ')}`);
   }
 
   // Container create argv: --name, --restart unless-stopped, NET_ADMIN+RAW,
@@ -87,7 +89,7 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   const createCmd = calls.find((c) => c[0] === 'create');
   assert.ok(createCmd, 'create call present');
   const argv = createCmd as readonly string[];
-  assert.ok(argv.includes('vicoop-runtime-claude'), 'container name');
+  assert.ok(argv.includes('vicoop-runtime-codex'), 'container name');
   assert.equal(argv[argv.length - 1], 'test/runtime:latest', 'image last');
   const restartIdx = argv.indexOf('--restart');
   assert.equal(argv[restartIdx + 1], 'unless-stopped');
@@ -95,14 +97,14 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   assert.ok(argv.includes('NET_RAW'));
   assert.ok(argv.includes('vicoop.managed-by=vicoop-bridge'));
   assert.ok(argv.includes('vicoop.component=runtime'));
-  assert.ok(argv.includes('vicoop.kind=claude'));
-  assert.ok(argv.includes('vicoop.name=claude'));
+  assert.ok(argv.includes('vicoop.kind=codex'));
+  assert.ok(argv.includes('vicoop.name=codex'));
   assert.ok(
     argv.some((a) => a === 'type=bind,source=/host/workspace,target=/workspace'),
     'host workspace mounted',
   );
   assert.ok(
-    argv.some((a) => a === 'type=volume,source=vicoop-creds-claude,target=/data/creds/claude'),
+    argv.some((a) => a === 'type=volume,source=vicoop-creds-codex,target=/data/creds/codex'),
     'creds volume mounted',
   );
   assert.ok(
@@ -111,12 +113,12 @@ test('start: with createIfMissing pulls nothing when image is cached, creates+st
   );
 
   // Start sequence
-  assert.deepEqual(calls[calls.length - 2], ['start', 'vicoop-runtime-claude']);
+  assert.deepEqual(calls[calls.length - 2], ['start', 'vicoop-runtime-codex']);
   assert.deepEqual(calls[calls.length - 1], [
     'inspect',
     '--format',
     '{{.State.Status}}',
-    'vicoop-runtime-claude',
+    'vicoop-runtime-codex',
   ]);
 });
 
@@ -128,7 +130,7 @@ test('start: reuses an existing running container (no create, no start)', async 
     ok('running'), // wait poll
   ]);
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     image: 'test/runtime:latest',
     dockerRun: run,
   });
@@ -177,7 +179,7 @@ test('start: failIfExists rejects existing volumes before creating a container',
     fail('volume not found', 1), // sessions absent
   ]);
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     image: 'test/runtime:latest',
     createIfMissing: true,
     failIfExists: true,
@@ -186,7 +188,7 @@ test('start: failIfExists rejects existing volumes before creating a container',
 
   await assert.rejects(
     rc.start(),
-    /runtime volumes already exist: vicoop-creds-claude.*container rm claude/s,
+    /runtime volumes already exist: vicoop-creds-codex.*container rm codex/s,
   );
   assert.equal(calls.filter((c) => c[0] === 'image').length, 0);
   assert.equal(calls.filter((c) => c[0] === 'create').length, 0);
@@ -238,7 +240,7 @@ test('start: docker daemon unreachable surfaces an actionable error', async () =
     fail('Cannot connect to the Docker daemon at unix:///var/run/docker.sock', 1),
   ]);
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     image: 'test/runtime:latest',
     dockerRun: run,
   });
@@ -247,10 +249,10 @@ test('start: docker daemon unreachable surfaces an actionable error', async () =
 
 test('stop: tolerates already-stopped containers', async () => {
   const { run } = makeDockerFixture([
-    fail('Error: No such container: vicoop-runtime-claude', 1),
+    fail('Error: No such container: vicoop-runtime-codex', 1),
   ]);
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     dockerRun: run,
   });
   // Should not throw despite docker stop's non-zero exit.
@@ -260,7 +262,7 @@ test('stop: tolerates already-stopped containers', async () => {
 test('Env carries VICOOP_BRIDGE_URL and optional skip-firewall toggle', async () => {
   const { run, calls } = makeDockerFixture(happyCreateResponses());
   const rc = new RuntimeContainer({
-    backendKind: 'claude',
+    backendKind: 'codex',
     image: 'test/runtime:latest',
     bridgeUrl: 'wss://bridge.example',
     skipFirewall: true,

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -27,6 +27,7 @@
 // `docker context` is resolved by the CLI itself — no custom socket
 // path lookup needed.
 
+import { assertClaudeBrokerContainer, claudeBrokerFirewallScript, CLAUDE_BROKER_LABEL } from './claude-runtime-boundary.js';
 import { spawnSync, spawn } from 'node:child_process';
 import { createLogger, type Logger } from './logger.js';
 
@@ -64,6 +65,8 @@ export interface RuntimeContainerOptions {
   // fresh-create command instead of silently reinstalling into an
   // existing runtime.
   failIfExists?: boolean;
+  // Explicit migration: reuse agent/session volumes after removing only the old container.
+  reuseState?: boolean;
   logger?: Logger;
   // Test seam — inject a custom docker CLI runner so tests can
   // capture argv + script responses without shelling out.
@@ -153,6 +156,7 @@ export class RuntimeContainer {
             `Remove it first with \`${this.removeHint()}\`, then rerun init.`,
         );
       }
+      if (this.opts.backendKind === 'claude') this.verifyClaudeBoundary(name);
       if (this.inspectRunning(name)) {
         this.log.info(`runtime container '${name}' already running — reusing`);
       } else {
@@ -167,7 +171,7 @@ export class RuntimeContainer {
             `then retry \`vicoop-client --backend ${this.opts.backendKind} --runtime container --runtime-name ${this.opts.runtimeName}\`.`,
         );
       }
-      if (this.opts.failIfExists) {
+      if (this.opts.failIfExists && !this.opts.reuseState) {
         this.ensureFreshVolumes();
       }
       await this.ensureImage();
@@ -178,6 +182,12 @@ export class RuntimeContainer {
     }
 
     await this.waitUntilRunning(name);
+    if (this.opts.backendKind === 'claude') {
+      try {
+        this.verifyClaudeBoundary(name);
+        this.runDocker(['exec', '--user', '0', name, 'sh', '-c', claudeBrokerFirewallScript()]);
+      } catch (err) { await this.stop(); throw err; }
+    }
     this.started = true;
   }
 
@@ -203,6 +213,12 @@ export class RuntimeContainer {
   // `docker exec` argv for each per-task spawn.
   getContainerName(): string {
     return containerName(this.opts.backendKind, this.opts.runtimeName);
+  }
+
+  private verifyClaudeBoundary(name: string): void {
+    const result = this.run(['inspect', '--format', '{{json .}}', name]);
+    if (result.exitCode !== 0) throw new Error('Cannot inspect Claude runtime authentication boundary');
+    assertClaudeBrokerContainer(result.stdout);
   }
 
   // ──────────────────────────────────────────────────────────────────
@@ -286,7 +302,7 @@ export class RuntimeContainer {
     const runtimeName = this.opts.runtimeName;
     return [
       agentsVolumeName(kind, runtimeName),
-      credsVolumeName(kind, runtimeName),
+      ...(kind === 'claude' ? [] : [credsVolumeName(kind, runtimeName)]),
       sessionsVolumeName(kind, runtimeName),
     ];
   }
@@ -350,11 +366,16 @@ export class RuntimeContainer {
     args.push(
       '--mount',
       `type=volume,source=${agentsVolumeName(kind, runtimeName)},target=/data/agents/${kind}`,
-      '--mount',
-      `type=volume,source=${credsVolumeName(kind, runtimeName)},target=/data/creds/${kind}`,
+      ...(kind === 'claude' ? [] : ['--mount', `type=volume,source=${credsVolumeName(kind, runtimeName)},target=/data/creds/${kind}`]),
       '--mount',
       `type=volume,source=${sessionsVolumeName(kind, runtimeName)},target=/data/sessions/${kind}`,
     );
+    if (kind === 'claude') {
+      args.push('--label', CLAUDE_BROKER_LABEL, '--user', 'node',
+        '--security-opt', 'no-new-privileges',
+        '--tmpfs', '/data/creds/claude:rw,nosuid,nodev,size=16777216,uid=1000,gid=1000,mode=0700',
+        '-e', 'CLAUDE_CONFIG_DIR=/data/sessions/claude/config');
+    }
     if (this.opts.workspaceDir) {
       // Workspace as a host bind-mount. Per-context branching
       // (a different workspace per task) is intentionally out of

--- a/packages/client/src/runtime-container.ts
+++ b/packages/client/src/runtime-container.ts
@@ -185,7 +185,7 @@ export class RuntimeContainer {
     if (this.opts.backendKind === 'claude') {
       try {
         this.verifyClaudeBoundary(name);
-        this.runDocker(['exec', '--user', '0', name, 'sh', '-c', claudeBrokerFirewallScript()]);
+        this.runDocker(['exec', '--user', '0', name, '/bin/sh', '-c', claudeBrokerFirewallScript()]);
       } catch (err) { await this.stop(); throw err; }
     }
     this.started = true;

--- a/packages/client/src/spawn-adapter.ts
+++ b/packages/client/src/spawn-adapter.ts
@@ -50,6 +50,7 @@ export interface ChildHandle {
 
 export interface SpawnOptions {
   cwd?: string;
+  env?: Record<string, string>;
 }
 
 export type SpawnFn = (


### PR DESCRIPTION
Claude external runtimes currently mount provider credentials where agent tools can read them. This change routes Claude `runtime=container` authentication through a built-in host broker: each spawn receives a temporary OAuth/API-key grant, while the real provider credential stays on the host.

The broker uses a private host Unix socket and a Docker stdio relay with a container-loopback endpoint. It enforces a fixed Anthropic upstream, endpoint/header/model/resource policies, pins the selected host credential store, and revokes grants and active connections on completion, cancellation, transport loss, or shutdown. Each execution has a root-owned tini subreaper and supervisor that runs the relay as UID/GID 1000 and cleans up all descendants before reporting close, including after relay SIGKILL or detached child creation. Privileged startup uses an absolute shell and a fixed system PATH so agent-writable binaries cannot execute as root on restart. An uncertain supervisor exit disables new executions and attempts a Docker stop of the shared runtime.

Existing Claude runtimes require migration. The replacement runtime detaches the legacy credentials volume, preserves agent/session state, and copies only selected conversations and todos through a networkless maintenance helper. `container init --reuse-state` and `--workspace` support this transition. Claude workloads also lose access to private/host-network services. Operator documentation covers supported authentication, migration, historical-secret limitations, rollback, and resource limits; a client-only minor changeset records the behavior change.

Validation on macOS Docker Desktop:

- `pnpm -r build` and `pnpm -r typecheck` passed.
- Client suite: 943 tests passed; focused Bun suite: 17 tests passed.
- Node/tsx and Bun-compiled Docker smoke passed for OAuth/API-key mock forwarding, migration, host-service access blocking, cancellation, abrupt bridge death, and stolen-grant rejection across runtimes.
- Real Claude OAuth inference and session continuation passed through Docker, including the Bun-compiled smoke. Workload environment/process arguments and inference diagnostics were checked for the host provider credential.
- Adversarial Docker regressions passed for privileged PATH shadowing, relay SIGKILL, detached-child cancellation, supervisor signal protection, preservation of concurrent executions, and cancellation of a SIGSTOP'd relay with blocked input. Cancellation directly closes the supervisor input; bounded input draining prevents relay backpressure from hiding EOF. Independent review verified relay-death cleanup and 30 runs of complete 2 MiB output drainage.
- Active upstream disconnection was observed by an independent Node process. The complete client also compiled with Bun and its new CLI options were checked.

A production-server single-runtime A2A smoke with the Bun-compiled client and freshly installed Claude 2.1.267 also passed: Write/Read created a workspace file, a separate task lookup confirmed completion, and a second request in the same context edited/read the file. The launch uncovered and fixed two integration gaps: permit DNS only to the configured private Docker resolvers, and stage host-generated system-prompt files through the bounded Docker channel with per-execution cleanup.

Actual API-key inference and native Linux-host operation still require release validation. OAuth refresh is not implemented: expired credentials fail closed and must be renewed on the host. Codex, host mode, and bundled-direct authentication retain their existing behavior.

Related to #500. This is the main-first single-runtime implementation; it does **not** close #500 or #497. R2 still needs authorized caller scope/lease/generation integration and real A/B/A, replay/checkpoint, and full A2A acceptance evidence.




A further independent review of the cancellation/input-queue fix found no additional reproducible issues. Its separate Docker probe stopped the relay and supplied 12 MiB without closing stdin; the supervisor enforced the queue limit and exited in 0.17 seconds.
